### PR TITLE
Nerf pop-based bonuses (-50% to -80%) to reduce snowballing

### DIFF
--- a/default/scripting/buildings/BLACK_HOLE_POW_GEN.focs.txt
+++ b/default/scripting/buildings/BLACK_HOLE_POW_GEN.focs.txt
@@ -22,7 +22,7 @@ BuildingType
             activation = Star type = BlackHole
             stackinggroup = "BLD_BLACK_HOLE_POW_GEN_PRIMARY_EFFECT"
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetIndustry value = Value + Target.Population * 5 * [[INDUSTRY_PER_POP]]
+            effects = SetTargetIndustry value = Value + Target.Population * 1.0 * [[INDUSTRY_PER_POP]]
     ]
     icon = "icons/building/blackhole.png"
 

--- a/default/scripting/buildings/COLLECTIVE_NET.focs.txt
+++ b/default/scripting/buildings/COLLECTIVE_NET.focs.txt
@@ -23,7 +23,7 @@ BuildingType
             ]
             stackinggroup = "BLD_COLLECTIVE_NET_INDUSTRY_EFFECT"
             priority = [[VERY_LATE_PRIORITY]]
-            effects = SetTargetIndustry value = Value + Target.Population * 2.5 * [[INDUSTRY_PER_POP]]
+            effects = SetTargetIndustry value = Value + Target.Population * 0.5 * [[INDUSTRY_PER_POP]]
 
         EffectsGroup
             scope = And [
@@ -37,7 +37,7 @@ BuildingType
             ]
             stackinggroup = "BLD_COLLECTIVE_NET_RESEARCH_EFFECT"
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 2.5 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Target.Population * 0.5 * [[RESEARCH_PER_POP]]
     ]
     icon = "icons/building/psi-corps.png"
 

--- a/default/scripting/buildings/ENCLAVE_VOID.focs.txt
+++ b/default/scripting/buildings/ENCLAVE_VOID.focs.txt
@@ -1,7 +1,7 @@
 BuildingType
     name = "BLD_ENCLAVE_VOID"
     description = "BLD_ENCLAVE_VOID_DESC"
-    buildcost = 100 * [[BUILDING_COST_MULTIPLIER]]
+    buildcost = 300 * [[BUILDING_COST_MULTIPLIER]]
     buildtime = 3
     location = AND [
         Not Contains Building name = "BLD_ENCLAVE_VOID"
@@ -17,7 +17,7 @@ BuildingType
             ]
             stackinggroup = "BLD_ENCLAVE_VOID_STACK"
             priority = [[EARLY_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 3.75 *  [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Target.Population * 0.75 *  [[RESEARCH_PER_POP]]
     ]
     icon = "icons/building/science-institute.png"
 

--- a/default/scripting/buildings/HYPER_DAM.focs.txt
+++ b/default/scripting/buildings/HYPER_DAM.focs.txt
@@ -25,7 +25,7 @@ BuildingType
             ]
             stackinggroup = "BLD_HYPER_DAM_BONUS"
             priority = [[VERY_LATE_PRIORITY]]
-            effects = SetTargetIndustry value = Value + Target.Population * 5 * [[INDUSTRY_PER_POP]]
+            effects = SetTargetIndustry value = Value + Target.Population * 1.0 * [[INDUSTRY_PER_POP]]
 
         EffectsGroup
             scope = And [

--- a/default/scripting/buildings/INDUSTRY_CENTER.focs.txt
+++ b/default/scripting/buildings/INDUSTRY_CENTER.focs.txt
@@ -24,7 +24,7 @@ BuildingType
             ]
             stackinggroup = "INDUSTRY_CENTER_STACK"
             priority = [[EARLY_PRIORITY]]
-            effects = SetTargetIndustry value = Value + Target.Population * 1.0 * [[INDUSTRY_PER_POP]]
+            effects = SetTargetIndustry value = Value + Target.Population * 0.25 * [[INDUSTRY_PER_POP]]
 
         EffectsGroup
             scope = And [
@@ -39,7 +39,7 @@ BuildingType
             ]
             stackinggroup = "INDUSTRY_CENTER_STACK"
             priority = [[EARLY_PRIORITY]]
-            effects = SetTargetIndustry value = Value + Target.Population * 2 * [[INDUSTRY_PER_POP]]
+            effects = SetTargetIndustry value = Value + Target.Population * 0.5 * [[INDUSTRY_PER_POP]]
 
         EffectsGroup
             scope = And [
@@ -51,7 +51,7 @@ BuildingType
             activation = OwnerHasTech name = "PRO_INDUSTRY_CENTER_III"
             stackinggroup = "INDUSTRY_CENTER_STACK"
             priority = [[EARLY_PRIORITY]]
-            effects = SetTargetIndustry value = Value + Target.Population * 3 * [[INDUSTRY_PER_POP]]
+            effects = SetTargetIndustry value = Value + Target.Population * 0.75 * [[INDUSTRY_PER_POP]]
     ]
     icon = "icons/tech/industrial_centre_ii.png"
 

--- a/default/scripting/buildings/SOL_ORB_GEN.focs.txt
+++ b/default/scripting/buildings/SOL_ORB_GEN.focs.txt
@@ -21,7 +21,7 @@ BuildingType
             activation = Star type = [Blue White]
             stackinggroup = "BLD_SOL_ORB_GEN_EFFECT"
             priority = [[VERY_LATE_PRIORITY]]
-            effects = SetTargetIndustry value = Value + Target.Population * 2 * [[INDUSTRY_PER_POP]]
+            effects = SetTargetIndustry value = Value + Target.Population * 0.75 * [[INDUSTRY_PER_POP]]
 
         EffectsGroup
             scope = And [
@@ -40,7 +40,7 @@ BuildingType
             ]
             stackinggroup = "BLD_SOL_ORB_GEN_EFFECT"
             priority = [[VERY_LATE_PRIORITY]]
-            effects = SetTargetIndustry value = Value + Target.Population * 1.0 * [[INDUSTRY_PER_POP]]
+            effects = SetTargetIndustry value = Value + Target.Population * 0.5 * [[INDUSTRY_PER_POP]]
 
         EffectsGroup
             scope = And [
@@ -59,7 +59,7 @@ BuildingType
             ]
             stackinggroup = "BLD_SOL_ORB_GEN_EFFECT"
             priority = [[VERY_LATE_PRIORITY]]
-            effects = SetTargetIndustry value = Value + Target.Population * 0.5 * [[INDUSTRY_PER_POP]]
+            effects = SetTargetIndustry value = Value + Target.Population * 0.25 * [[INDUSTRY_PER_POP]]
     ]
     icon = "icons/building/miniature_sun.png"
 

--- a/default/scripting/specials/planet/COMPUTRONIUM.focs.txt
+++ b/default/scripting/specials/planet/COMPUTRONIUM.focs.txt
@@ -29,10 +29,9 @@ Special
             activation = Focus type = "FOCUS_RESEARCH"
             stackinggroup = "COMPUTRONIUM_STACK"
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 1 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Target.Population * 0.25 * [[RESEARCH_PER_POP]]
 
-        [[CHANCE_OF_GUARD_1]]
-
+        [[CHANCE_OF_GUARD_2]]
     ]
     graphic = "icons/specials_huge/computronium.png"
 

--- a/default/scripting/specials/planet/HONEYCOMB.focs.txt
+++ b/default/scripting/specials/planet/HONEYCOMB.focs.txt
@@ -55,19 +55,6 @@ Special
                 SetPlanetType type = Barren
             ]
 
-        EffectsGroup     
-            scope = Source     
-            activation = AND [
-                Turn high = 0
-                (GalaxyMaxAIAggression >= 1)
-                (GalaxyMonsterFrequency >= 1)
-                Not ContainedBy Contains OR [
-                    Design name = "SM_EXP_OUTPOST"
-                    Building name = "BLD_EXPERIMENTOR_OUTPOST"
-                ]
-            ]
-            effects = CreateShip designname = "SM_GUARD_3"
-
         EffectsGroup
             scope = And [
                 Planet
@@ -78,10 +65,13 @@ Special
             activation = Focus type = "FOCUS_INDUSTRY"
             stackinggroup = "HONEYCOMB_STACK"
             priority = [[VERY_LATE_PRIORITY]]
-            effects = SetTargetIndustry value = Value + Target.Population * 2.5 * [[INDUSTRY_PER_POP]]
+            effects = SetTargetIndustry value = Value + Target.Population * 0.5 * [[INDUSTRY_PER_POP]]
 
+        [[CHANCE_OF_GUARD_2]]
     ]
     graphic = "icons/specials_huge/honeycomb.png"
+
+#include "monster_guard.macros"
 
 #include "/scripting/common/base_prod.macros"
 

--- a/default/scripting/specials/planet/monster_guard.macros
+++ b/default/scripting/specials/planet/monster_guard.macros
@@ -21,3 +21,55 @@ CHANCE_OF_GUARD_1
                 ]
             ]
 '''
+
+CHANCE_OF_GUARD_2
+'''        EffectsGroup
+            scope = Source
+            activation = AND [
+                Turn high = 0
+                Not ContainedBy Contains OR [
+                    Design name = "SM_EXP_OUTPOST"
+                    Building name = "BLD_EXPERIMENTOR_OUTPOST"
+                    And [ Planet HasSpecial name = "HIGH_TECH_NATIVES_SPECIAL" ]
+                ]
+            ]
+            effects = [
+                If condition = AND [
+                        (GalaxyMaxAIAggression >= 1)
+                        (GalaxyMonsterFrequency >= 1)
+                        Not Homeworld
+                    ]
+                    effects = CreateShip designname = "SM_GUARD_2"
+                else = [
+                    SetSpecies name = "SP_ANCIENT_GUARDIANS"
+                    SetPopulation value = Target.TargetPopulation
+                    AddSpecial name = "MODERATE_TECH_NATIVES_SPECIAL"
+                ]
+            ]
+'''
+
+CHANCE_OF_GUARD_3
+'''        EffectsGroup
+            scope = Source
+            activation = AND [
+                Turn high = 0
+                Not ContainedBy Contains OR [
+                    Design name = "SM_EXP_OUTPOST"
+                    Building name = "BLD_EXPERIMENTOR_OUTPOST"
+                    And [ Planet HasSpecial name = "HIGH_TECH_NATIVES_SPECIAL" ]
+                ]
+            ]
+            effects = [
+                If condition = AND [
+                        (GalaxyMaxAIAggression >= 1)
+                        (GalaxyMonsterFrequency >= 1)
+                        Not Homeworld
+                    ]
+                    effects = CreateShip designname = "SM_GUARD_3"
+                else = [
+                    SetSpecies name = "SP_ANCIENT_GUARDIANS"
+                    SetPopulation value = Target.TargetPopulation
+                    AddSpecial name = "HIGH_TECH_NATIVES_SPECIAL"
+                ]
+            ]
+'''

--- a/default/scripting/techs/growth/ENERGY_META.focs.txt
+++ b/default/scripting/techs/growth/ENERGY_META.focs.txt
@@ -45,7 +45,7 @@ Tech
 
             ]
             priority = [[EARLY_PRIORITY]]
-            effects = SetTargetIndustry value = Value + Target.Population * 1.0 * [[INDUSTRY_PER_POP]]
+            effects = SetTargetIndustry value = Value + Target.Population * 0.5 * [[INDUSTRY_PER_POP]]
 
         EffectsGroup
             scope = And [
@@ -55,7 +55,7 @@ Tech
 
             ]
             priority = [[EARLY_PRIORITY]]
-            effects = SetTargetResearch value = Value  + Target.Population * 2.5 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value  + Target.Population * 1.0 * [[RESEARCH_PER_POP]]
     ]
     graphic = "icons/tech/pure-energy_metabolism.png"
 

--- a/default/scripting/techs/learning/ALGO_ELEGANCE.focs.txt
+++ b/default/scripting/techs/learning/ALGO_ELEGANCE.focs.txt
@@ -14,7 +14,7 @@ Tech
                 Focus type = "FOCUS_RESEARCH"
             ]
             priority = [[EARLY_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 0.5 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Target.Population * 0.25 * [[RESEARCH_PER_POP]]
     ]
     graphic = "icons/tech/algorithmic_elegance.png"
 

--- a/default/scripting/techs/learning/QUANT_NET.focs.txt
+++ b/default/scripting/techs/learning/QUANT_NET.focs.txt
@@ -15,7 +15,7 @@ Tech
                 Focus type = "FOCUS_RESEARCH"
             ]
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 2.5 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Target.Population * 0.5 * [[RESEARCH_PER_POP]]
     ]
     graphic = "icons/tech/quantum_networking.png"
 

--- a/default/scripting/techs/learning/STELLAR_TOMOGRAPHY.focs.txt
+++ b/default/scripting/techs/learning/STELLAR_TOMOGRAPHY.focs.txt
@@ -16,7 +16,7 @@ Tech
                 Focus type = "FOCUS_RESEARCH"
             ]
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 5 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Target.Population * 1.0 * [[RESEARCH_PER_POP]]
 
         EffectsGroup
             scope = And [
@@ -26,7 +26,7 @@ Tech
                 Focus type = "FOCUS_RESEARCH"
             ]
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 3.75 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Target.Population * 0.75 * [[RESEARCH_PER_POP]]
 
         EffectsGroup
             scope = And [
@@ -36,7 +36,7 @@ Tech
                 Focus type = "FOCUS_RESEARCH"
             ]
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 2.5 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Target.Population * 0.5 * [[RESEARCH_PER_POP]]
 
         EffectsGroup
             scope = And [
@@ -46,7 +46,7 @@ Tech
                 Focus type = "FOCUS_RESEARCH"
             ]
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 1 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Target.Population * 0.25 * [[RESEARCH_PER_POP]]
     ]
     graphic = "icons/tech/stellar_tomography.png"
 

--- a/default/scripting/techs/production/FUSION_GEN.focs.txt
+++ b/default/scripting/techs/production/FUSION_GEN.focs.txt
@@ -15,7 +15,7 @@ Tech
                 Focus type = "FOCUS_INDUSTRY"
             ]
             priority = [[EARLY_PRIORITY]]
-            effects = SetTargetIndustry value = Value + Target.Population * 1.0 * [[INDUSTRY_PER_POP]]
+            effects = SetTargetIndustry value = Value + Target.Population * 0.25 * [[INDUSTRY_PER_POP]]
     ]
     graphic = "icons/tech/fusion_generation.png"
 

--- a/default/scripting/techs/production/ROBOTIC_PROD.focs.txt
+++ b/default/scripting/techs/production/ROBOTIC_PROD.focs.txt
@@ -14,7 +14,7 @@ Tech
                 Focus type = "FOCUS_INDUSTRY"
             ]
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetIndustry value = Value + Target.Population * 0.5 * [[INDUSTRY_PER_POP]]
+            effects = SetTargetIndustry value = Value + Target.Population * 0.25 * [[INDUSTRY_PER_POP]]
         ]
     graphic = "icons/tech/robotic_production.png"
 


### PR DESCRIPTION
Early, small bonuses are halved.
Big bonuses are divided by five.
Some are in between.

Techs like Quantum Networking or Solar Orb. Gen. (in blue star) no longer cause a sharp spike in the output graph.

Maximum pop-based bonus goes down from aprox. 3.2 to 1.0 (including the initial 0.2 per pop for average species).


In the following tables:
- RP prev. refers to the sum of RP required to unlock the tech/building.
- RP and turns refer to the actual tech that grants the bonus or unlocks the building that does it.
- Turns prev. refers to the minimum number of turns required to unlock the tech/building (hence it is not the sum of turns of all prerequisites). For Black Hole Power Generator this assumes PR #2940.
- Focus: needs research/industry focus.
- Bld.: it is a building.
- Rstrc.: special restrictions apply for the bonus to be granted.
- Bonus (and Before): calculated with respect to standard RESEARCH_PER_POP and INDUSTRY_PER_POP (currently both are 0.2).
- Total: sum of bonus for end-game considering the expected average in case of system-dependent bonuses and the best bonuses in case of mutually-exclusive (total accounts for the bonuses in italics).

RESEARCH

Tech or Building | RP prev. | Turns prev. | RP | Turns | Focus | Bld. | Rstrc. | Bonus | Before
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
*Algorithmic Elegance* | 0 | 0 | 24 | 3 | Yes | No | No | 0.05 | 0.1
*Quantum Networking* | 334 | 17 | 400 | 6 | Yes | No | No | 0.1 | 0.5
*Distrib. Thought Comp.* | 656 | 11 | 150 | 5 | No | No | No | 0.1 | 0.1
Distrib. Thought Comp. (psi) | 206 | 11 | 150 | 5 | No | No | No | 0.1 | 0.1
Stellar Tomography (black hole) | 1134 | 23 | 250 | 6 | Yes | No | No | 0.2 | 1
(neutron) | 1134 | 23 | 250 | 6 | Yes | No | No | 0.15 | 0.75
*(blue/white)* | 1134 | 23 | 250 | 6 | Yes | No | No | 0.1 | 0.5
(yellow/orange/red) | 1134 | 23 | 250 | 6 | Yes | No | No | 0.05 | 0.2
*Collective Thought Net.* | 1034 | 23 | 800 | 7 | Yes | One | Yes | 0.1 | 0.5
*Enclave of the Void* | 1856 | 28 | 300 | 5 | Yes | One | No | 0.15 | 0.75
*Energy Metabolism* | 2488 | 27 | 400 | 15 | Yes | No | No | 0.2 | 0.5
**Total** |   |   |   |   |   |   |   | 0.8 | 2.95


INDUSTRY

Tech or Building | RP prev. | Turns prev. | RP | Turns | Focus | Bld. | Rstrc. | Bonus | Before
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
*Robotic Production* | 0 | 0 | 24 | 3 | Yes | No | No | 0.05 | 0.1
*Fusion Generation* | 24 | 3 | 48 | 3 | Yes | No | No | 0.05 | 0.2
Solar Orbital Gen. *(blue/white)* | 260 | 10 | 200 | 8 | Yes | One | No | 0.15 | 0.4
(yellow/orange) | 260 | 10 | 200 | 8 | Yes | One | No | 0.1 | 0.2
(red) | 260 | 10 | 200 | 8 | Yes | One | No | 0.05 | 0.1
Industrial Center I | 24 | 3 | 60 | 4 | Yes | One | No | 0.05 | 0.2
II | 84 | 7 | 300 | 5 | Yes | One | No | 0.1 | 0.4
*III* | 384 | 12 | 1000 | 7 | Yes | One | No | 0.15 | 0.6
*Collective Thought Net.* | 1034 | 23 | 800 | 7 | Yes | One | Yes | 0.1 | 0.5
*Energy Metabolism* | 2488 | 27 | 400 | 15 | Yes | No | No | 0.1 | 0.2
Hyperspatial Dam | 334 | 17 | 400 | 5 | Yes | One | Yes | 0.2 | 1
*Black Hole Gen.* (available) | 1744 | 18 | 300 | 4 | Yes | One | No | 0.2 | 1
(create) | 2444 | 37 | 300 | 4 | Yes | One | No | 0.2 | 1
**Total** |   |   |   |   |   |   |   | 0.8 | 3


Edit: rebalanced also the pop-based, empire-wide specials:
- Computronium Moon: down to 0.05 from 0.2, monster buffed to SM_GUARD_2, or Moderate Tech Ancient Guardians when Specials:None or AI_Aggression:Beginner.
- Honeycomb: down to 0.1 from 0.5, defend them with High Tech Ancient Guardians when Specials:None or AI_Aggression:Beginner.