### PR TITLE
Fulver precog exploration

### DIFF
--- a/default/scripting/species/SP_FULVER.focs.txt
+++ b/default/scripting/species/SP_FULVER.focs.txt
@@ -36,6 +36,8 @@ Species
         [[GOOD_WEAPONS]]
         [[GREAT_FUEL]]
 
+        [[PRECOGNITIVE_DETECTION(2)]]
+
         // not for description
         [[AVERAGE_PLANETARY_SHIELDS]]
         [[AVERAGE_PLANETARY_DEFENSE]]

--- a/default/scripting/species/common/telepathic.macros
+++ b/default/scripting/species/common/telepathic.macros
@@ -1,3 +1,17 @@
+PRECOGNITIVE_DETECTION
+'''     EffectsGroup
+            description = "PRECOGNITIVE_DETECTION_DESC"
+            scope = And [
+                PopulationCenter
+                Not VisibleToEmpire empire = Source.Owner
+                Not Source
+                Not OwnedBy empire = Source.Owner
+                WithinStarlaneJumps jumps = @1@ condition = Source
+            ]
+            activation = OwnedBy affiliation = AnyEmpire
+            effects = SetVisibility empire = Source.Owner visibility = max(Basic, Value)
+'''
+
 TELEPATHIC_DETECTION
 '''     EffectsGroup
             description = "TELEPATHIC_DETECTION_DESC"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -8317,7 +8317,7 @@ SP_FULVER_DESC
 The Fulvers' appearance resembles that of large nervous ants. They possess quantum computing brains which effectively allows them to predict all possible near futures making them hard to surprise in combat.
 
 Name:
-The precognition ability is also unique to the Fulvers species on the Fulver homeworld. As such a "Fulver" is "One who can see" your possible reactions.
+No other species on the Fulver homeworld has this precognition ability. As such a "Fulver" is "One who can see" your possible reactions.
 
 Personality:
 Fulver prefer to concentrate on their strength and prefer to live from day to day. Fulver often favor the tools and decisions which allows for the highest number of future choices. Having a bad memory and no capability for long term future prediction they are bad at long term commitments like science and building up defensive structures. Feeling locked in by the limited number of choices they are restless and unsatisfied and constantly try to overcome their situation.
@@ -15101,6 +15101,9 @@ LIGHT_SENSITIVE_DESC
 
 TELEPATHIC_DETECTION_DESC
 +	Telepathic Detection: can sense nearby populated planets.
+
+PRECOGNITIVE_DETECTION_DESC
++	Procognitive Detection: can sense starlane connected planets.
 
 COMMUNAL_VISION_DESC
 '''	Communal Vision: shares visibility within the same species.'''


### PR DESCRIPTION
Adds precognitive detection(2) to Fulver species. Precog detection gives basic visibility to starlane connected planets.

[forum discussion](https://www.freeorion.org/forum/viewtopic.php?f=6&t=11485&p=101757#p101757)