### PR TITLE
ExtractJoinGameMessageData Safety

### DIFF
--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1138,7 +1138,14 @@ sc::result MPLobby::react(const JoinGame& msg) {
     Networking::ClientType client_type;
     std::string client_version_string;
     boost::uuids::uuid cookie;
-    ExtractJoinGameMessageData(message, player_name, client_type, client_version_string, cookie);
+    try {
+        ExtractJoinGameMessageData(message, player_name, client_type, client_version_string, cookie);
+    } catch (const std::exception& e) {
+        ErrorLogger(FSM) << "MPLobby::react(const JoinGame& msg): couldn't extract data from join game message";
+        player_connection->SendMessage(ErrorMessage(UserString("ERROR_INCOMPATIBLE_VERSION"), true));
+        server.Networking().Disconnect(player_connection);
+        return discard_event();
+    }
 
     Networking::AuthRoles roles;
     bool authenticated;


### PR DESCRIPTION
Try to prevent server crash upon receiving a malformed message. Might fix #2966