### PR TITLE
Remove unused serialization code from ValueRef, Condition and Effect …

### DIFF
--- a/universe/Condition.h
+++ b/universe/Condition.h
@@ -5,7 +5,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <boost/serialization/access.hpp>
 #include "../util/Export.h"
 
 
@@ -104,10 +103,6 @@ private:
     friend struct MatchHelper;
 
     virtual bool Match(const ScriptingContext& local_context) const;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 }

--- a/universe/ConditionAll.h
+++ b/universe/ConditionAll.h
@@ -22,11 +22,6 @@ struct FO_COMMON_API All final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override
     {}
     unsigned int GetCheckSum() const override;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 } // namespace Condition

--- a/universe/ConditionSource.h
+++ b/universe/ConditionSource.h
@@ -25,10 +25,6 @@ struct FO_COMMON_API Source final : public Condition {
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 } // namespace Condition

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -5,7 +5,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <boost/serialization/nvp.hpp>
 #include "ConditionAll.h"
 #include "ConditionSource.h"
 #include "Condition.h"
@@ -90,10 +89,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_low;
     std::unique_ptr<ValueRef::ValueRef<int>> m_high;
     std::unique_ptr<Condition> m_condition;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects if the current game turn is >= \a low and < \a high. */
@@ -114,10 +109,6 @@ private:
 
     std::unique_ptr<ValueRef::ValueRef<int>> m_low;
     std::unique_ptr<ValueRef::ValueRef<int>> m_high;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches a specified \a number of objects that match Condition \a condition
@@ -155,10 +146,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<double>> m_sort_key;
     SortingMethod m_sorting_method;
     std::unique_ptr<Condition> m_condition;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches no objects. Currently only has an experimental use for efficient immediate rejection as the top-line condition.
@@ -176,11 +163,6 @@ struct FO_COMMON_API None final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override
     {}
     unsigned int GetCheckSum() const override;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects that are owned (if \a exclusive == false) or only owned
@@ -204,10 +186,6 @@ private:
 
     std::unique_ptr<ValueRef::ValueRef<int>> m_empire_id;
     EmpireAffiliationType m_affiliation;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches the root candidate object in a condition tree.  This is useful
@@ -227,10 +205,6 @@ struct FO_COMMON_API RootCandidate final : public Condition {
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** There is no LocalCandidate condition. To match any local candidate object,
@@ -250,10 +224,6 @@ struct FO_COMMON_API Target final : public Condition {
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches planets that are a homeworld for any of the species specified in
@@ -277,10 +247,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>> m_names;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches planets that are an empire's capital. */
@@ -297,10 +263,6 @@ struct FO_COMMON_API Capital final : public Condition {
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches space monsters. */
@@ -317,10 +279,6 @@ struct FO_COMMON_API Monster final : public Condition {
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches armed ships and monsters. */
@@ -335,10 +293,6 @@ struct FO_COMMON_API Armed final : public Condition {
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects that are of UniverseObjectType \a type. */
@@ -360,10 +314,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::unique_ptr<ValueRef::ValueRef<UniverseObjectType>> m_type;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all Building objects that are one of the building types specified
@@ -385,10 +335,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>> m_names;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects that have an attached Special named \a name. */
@@ -419,10 +365,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<double>>         m_capacity_high;
     std::unique_ptr<ValueRef::ValueRef<int>>            m_since_turn_low;
     std::unique_ptr<ValueRef::ValueRef<int>>            m_since_turn_high;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects that have the tag \a tag. */
@@ -443,10 +385,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_name;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects that were created on turns within the specified range. */
@@ -467,10 +405,6 @@ private:
 
     std::unique_ptr<ValueRef::ValueRef<int>> m_low;
     std::unique_ptr<ValueRef::ValueRef<int>> m_high;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects that contain an object that matches Condition
@@ -492,10 +426,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::unique_ptr<Condition> m_condition;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects that are contained by an object that matches Condition
@@ -517,10 +447,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::unique_ptr<Condition> m_condition;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects that are in the system with the indicated \a system_id
@@ -543,10 +469,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::unique_ptr<ValueRef::ValueRef<int>> m_system_id;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects that are on the planet with the indicated \a planet_id
@@ -569,10 +491,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::unique_ptr<ValueRef::ValueRef<int>> m_planet_id;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches the object with the id \a object_id */
@@ -593,10 +511,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::unique_ptr<ValueRef::ValueRef<int>> m_object_id;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all Planet objects that have one of the PlanetTypes in \a types.
@@ -619,10 +533,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::vector<std::unique_ptr<ValueRef::ValueRef<::PlanetType>>> m_types;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all Planet objects that have one of the PlanetSizes in \a sizes.
@@ -645,10 +555,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::vector<std::unique_ptr<ValueRef::ValueRef<::PlanetSize>>> m_sizes;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all Planet objects that have one of the PlanetEnvironments in
@@ -673,10 +579,6 @@ private:
 
     std::vector<std::unique_ptr<ValueRef::ValueRef<::PlanetEnvironment>>> m_environments;
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_species_name;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all planets or ships that have one of the species in \a species.
@@ -700,10 +602,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>> m_names;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches planets where the indicated number of the indicated building type
@@ -739,10 +637,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>>            m_empire_id;
     std::unique_ptr<ValueRef::ValueRef<int>>            m_low;
     std::unique_ptr<ValueRef::ValueRef<int>>            m_high;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all ProdCenter objects that have one of the FocusTypes in \a foci. */
@@ -763,10 +657,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>> m_names;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all System objects that have one of the StarTypes in \a types.  Note that all objects
@@ -786,10 +676,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::vector<std::unique_ptr<ValueRef::ValueRef<::StarType>>> m_types;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all ships whose ShipDesign has the hull specified by \a name. */
@@ -810,10 +696,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_name;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all ships whose ShipDesign has >= \a low and < \a high of the ship
@@ -839,10 +721,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_low;
     std::unique_ptr<ValueRef::ValueRef<int>> m_high;
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_name;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches ships whose ShipDesign has >= \a low and < \a high of ship parts of
@@ -868,10 +746,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_low;
     std::unique_ptr<ValueRef::ValueRef<int>> m_high;
     ShipPartClass m_class;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches ships who ShipDesign is a predefined shipdesign with the name
@@ -891,10 +765,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_name;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches ships whose design id \a id. */
@@ -913,10 +783,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::unique_ptr<ValueRef::ValueRef<int>> m_design_id;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches ships or buildings produced by the empire with id \a empire_id.*/
@@ -935,10 +801,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::unique_ptr<ValueRef::ValueRef<int>> m_empire_id;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches a given object with a linearly distributed probability of \a chance. */
@@ -957,10 +819,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::unique_ptr<ValueRef::ValueRef<double>> m_chance;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects that have a meter of type \a meter, and whose current
@@ -984,10 +842,6 @@ private:
     MeterType m_meter;
     std::unique_ptr<ValueRef::ValueRef<double>> m_low;
     std::unique_ptr<ValueRef::ValueRef<double>> m_high;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches ships that have a ship part meter of type \a meter for part \a part
@@ -1069,10 +923,6 @@ private:
     ResourceType                                m_stockpile;
     std::unique_ptr<ValueRef::ValueRef<double>> m_low;
     std::unique_ptr<ValueRef::ValueRef<double>> m_high;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects if the empire with id \a empire_id has adopted the
@@ -1099,10 +949,6 @@ private:
 
     std::unique_ptr<ValueRef::ValueRef<std::string>>    m_name;
     std::unique_ptr<ValueRef::ValueRef<int>>            m_empire_id;
-
-    friend class boost::serialization::access;
-    template <class Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects whose owner who has tech \a name. */
@@ -1124,10 +970,6 @@ private:
 
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_name;
     std::unique_ptr<ValueRef::ValueRef<int>>         m_empire_id;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects whose owner who has the building type \a name available. */
@@ -1150,10 +992,6 @@ private:
 
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_name;
     std::unique_ptr<ValueRef::ValueRef<int>>         m_empire_id;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects whose owner who has the ship design \a id available. */
@@ -1176,10 +1014,6 @@ private:
 
     std::unique_ptr<ValueRef::ValueRef<int>> m_id;
     std::unique_ptr<ValueRef::ValueRef<int>> m_empire_id;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects whose owner who has the ship part @a name available. */
@@ -1202,10 +1036,6 @@ private:
 
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_name;
     std::unique_ptr<ValueRef::ValueRef<int>>         m_empire_id;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects that are visible to the Empire with id \a empire_id */
@@ -1224,10 +1054,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::unique_ptr<ValueRef::ValueRef<int>> m_empire_id;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects that are within \a distance units of at least one
@@ -1251,10 +1077,6 @@ private:
 
     std::unique_ptr<ValueRef::ValueRef<double>> m_distance;
     std::unique_ptr<Condition> m_condition;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects that are within \a jumps starlane jumps of at least one
@@ -1278,10 +1100,6 @@ private:
 
     std::unique_ptr<ValueRef::ValueRef<int>> m_jumps;
     std::unique_ptr<Condition> m_condition;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches objects that are in systems that could have starlanes added between
@@ -1305,10 +1123,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::unique_ptr<Condition> m_condition;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches systems that have been explored by at least one Empire
@@ -1328,10 +1142,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::unique_ptr<ValueRef::ValueRef<int>> m_empire_id;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches objects that are moving. ... What does that mean?  Departing this
@@ -1348,10 +1158,6 @@ struct FO_COMMON_API Stationary final : public Condition {
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches objects that are aggressive fleets or are in aggressive fleets. */
@@ -1372,10 +1178,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     bool m_aggressive;   // false to match passive ships/fleets
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches objects that are in systems that can be fleet supplied by the
@@ -1395,10 +1197,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::unique_ptr<ValueRef::ValueRef<int>> m_empire_id;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches objects that are in systems that are connected by resource-sharing
@@ -1421,10 +1219,6 @@ private:
 
     std::unique_ptr<ValueRef::ValueRef<int>> m_empire_id;
     std::unique_ptr<Condition> m_condition;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches objects whose species has the ability to found new colonies. */
@@ -1440,10 +1234,6 @@ struct FO_COMMON_API CanColonize final : public Condition {
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches objects whose species has the ability to produce ships. */
@@ -1459,10 +1249,6 @@ struct FO_COMMON_API CanProduceShips final : public Condition {
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches the objects that have been targeted for bombardment by at least one
@@ -1482,10 +1268,6 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     std::unique_ptr<Condition> m_by_object_condition;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects if the comparisons between values of ValueRefs meet the
@@ -1532,10 +1314,6 @@ private:
 
     ComparisonType m_compare_type1 = INVALID_COMPARISON;
     ComparisonType m_compare_type2 = INVALID_COMPARISON;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches objects that match the location condition of the specified
@@ -1560,10 +1338,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_name1;
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_name2;
     ContentType m_content_type;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches objects that match the combat targeting condition of the specified
@@ -1586,10 +1360,6 @@ private:
 
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_name;
     ContentType m_content_type;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects that match every Condition in \a operands. */
@@ -1613,10 +1383,6 @@ struct FO_COMMON_API And final : public Condition {
 
 private:
     std::vector<std::unique_ptr<Condition>> m_operands;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects that match at least one Condition in \a operands. */
@@ -1639,10 +1405,6 @@ struct FO_COMMON_API Or final : public Condition {
 
 private:
     std::vector<std::unique_ptr<Condition>> m_operands;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches all objects that do not match the Condition \a operand. */
@@ -1659,10 +1421,6 @@ struct FO_COMMON_API Not final : public Condition {
 
 private:
     std::unique_ptr<Condition> m_operand;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Tests conditions in \a operands in order, to find the first condition that 
@@ -1683,10 +1441,6 @@ struct FO_COMMON_API OrderedAlternativesOf final : public Condition {
 
 private:
     std::vector<std::unique_ptr<Condition>> m_operands;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Matches whatever its subcondition matches, but has a customized description
@@ -1706,491 +1460,8 @@ struct FO_COMMON_API Described final : public Condition {
 private:
     std::unique_ptr<Condition> m_condition;
     std::string m_desc_stringtable_key;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
-
-// template implementations
-template <typename Archive>
-void Condition::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_NVP(m_root_candidate_invariant)
-        & BOOST_SERIALIZATION_NVP(m_target_invariant)
-        & BOOST_SERIALIZATION_NVP(m_source_invariant);
-}
-
-template <typename Archive>
-void Number::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_low)
-        & BOOST_SERIALIZATION_NVP(m_high)
-        & BOOST_SERIALIZATION_NVP(m_condition);
-}
-
-template <typename Archive>
-void Turn::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_low)
-        & BOOST_SERIALIZATION_NVP(m_high);
-}
-
-template <typename Archive>
-void SortedNumberOf::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_number)
-        & BOOST_SERIALIZATION_NVP(m_sort_key)
-        & BOOST_SERIALIZATION_NVP(m_sorting_method)
-        & BOOST_SERIALIZATION_NVP(m_condition);
-}
-
-template <typename Archive>
-void All::serialize(Archive& ar, const unsigned int version)
-{ ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition); }
-
-template <typename Archive>
-void None::serialize(Archive& ar, const unsigned int version)
-{ ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition); }
-
-template <typename Archive>
-void EmpireAffiliation::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_affiliation);
-}
-
-template <typename Archive>
-void Source::serialize(Archive& ar, const unsigned int version)
-{ ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition); }
-
-template <typename Archive>
-void RootCandidate::serialize(Archive& ar, const unsigned int version)
-{ ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition); }
-
-template <typename Archive>
-void Target::serialize(Archive& ar, const unsigned int version)
-{ ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition); }
-
-template <typename Archive>
-void Homeworld::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_names);
-}
-
-template <typename Archive>
-void Capital::serialize(Archive& ar, const unsigned int version)
-{ ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition); }
-
-template <typename Archive>
-void Monster::serialize(Archive& ar, const unsigned int version)
-{ ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition); }
-
-template <typename Archive>
-void Armed::serialize(Archive& ar, const unsigned int version)
-{ ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition); }
-
-template <typename Archive>
-void Type::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_type);
-}
-
-template <typename Archive>
-void Building::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_names);
-}
-
-template <typename Archive>
-void HasSpecial::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_capacity_low)
-        & BOOST_SERIALIZATION_NVP(m_capacity_high)
-        & BOOST_SERIALIZATION_NVP(m_since_turn_low)
-        & BOOST_SERIALIZATION_NVP(m_since_turn_high);
-}
-
-template <typename Archive>
-void HasTag::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_name);
-}
-
-template <typename Archive>
-void CreatedOnTurn::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_low)
-        & BOOST_SERIALIZATION_NVP(m_high);
-}
-
-template <typename Archive>
-void Contains::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_condition);
-}
-
-template <typename Archive>
-void ContainedBy::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_condition);
-}
-
-template <typename Archive>
-void InOrIsSystem::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_system_id);
-}
-
-template <typename Archive>
-void OnPlanet::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_planet_id);
-}
-
-template <typename Archive>
-void ObjectID::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_object_id);
-}
-
-template <typename Archive>
-void PlanetType::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_types);
-}
-
-template <typename Archive>
-void PlanetSize::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_sizes);
-}
-
-template <typename Archive>
-void PlanetEnvironment::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_environments)
-        & BOOST_SERIALIZATION_NVP(m_species_name);
-}
-
-template <typename Archive>
-void Species::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_names);
-}
-
-template <typename Archive>
-void Enqueued::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_build_type)
-        & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_design_id)
-        & BOOST_SERIALIZATION_NVP(m_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_low)
-        & BOOST_SERIALIZATION_NVP(m_high);
-}
-
-template <typename Archive>
-void FocusType::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_names);
-}
-
-template <typename Archive>
-void StarType::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_types);
-}
-
-template <typename Archive>
-void DesignHasHull::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_name);
-}
-
-template <typename Archive>
-void DesignHasPart::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_low)
-        & BOOST_SERIALIZATION_NVP(m_high)
-        & BOOST_SERIALIZATION_NVP(m_name);
-}
-
-template <typename Archive>
-void DesignHasPartClass::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_low)
-        & BOOST_SERIALIZATION_NVP(m_high)
-        & BOOST_SERIALIZATION_NVP(m_class);
-}
-
-template <typename Archive>
-void PredefinedShipDesign::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_name);
-}
-
-template <typename Archive>
-void NumberedShipDesign::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_design_id);
-}
-
-template <typename Archive>
-void ProducedByEmpire::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_empire_id);
-}
-
-template <typename Archive>
-void Chance::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_chance);
-}
-
-template <typename Archive>
-void MeterValue::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_meter)
-        & BOOST_SERIALIZATION_NVP(m_low)
-        & BOOST_SERIALIZATION_NVP(m_high);
-}
-
-template <typename Archive>
-void EmpireStockpileValue::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_stockpile)
-        & BOOST_SERIALIZATION_NVP(m_low)
-        & BOOST_SERIALIZATION_NVP(m_high);
-}
-
-template <class Archive>
-void EmpireHasAdoptedPolicy::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_empire_id);
-}
-
-template <typename Archive>
-void OwnerHasTech::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_empire_id);
-}
-
-template <typename Archive>
-void OwnerHasBuildingTypeAvailable::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_empire_id);
-}
-
-template <typename Archive>
-void OwnerHasShipDesignAvailable::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_id)
-        & BOOST_SERIALIZATION_NVP(m_empire_id);
-}
-
-template <typename Archive>
-void OwnerHasShipPartAvailable::serialize(Archive& ar,
-                                          const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_empire_id);
-}
-
-template <typename Archive>
-void VisibleToEmpire::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_empire_id);
-}
-
-template <typename Archive>
-void WithinDistance::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_distance)
-        & BOOST_SERIALIZATION_NVP(m_condition);
-}
-
-template <typename Archive>
-void WithinStarlaneJumps::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_jumps)
-        & BOOST_SERIALIZATION_NVP(m_condition);
-}
-
-template <typename Archive>
-void CanAddStarlaneConnection::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_condition);
-}
-
-template <typename Archive>
-void ExploredByEmpire::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_empire_id);
-}
-
-template <typename Archive>
-void Stationary::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition);
-}
-
-template <typename Archive>
-void Aggressive::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_aggressive);
-}
-
-template <typename Archive>
-void FleetSupplyableByEmpire::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_empire_id);
-}
-
-template <typename Archive>
-void ResourceSupplyConnectedByEmpire::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_condition);
-}
-
-template <typename Archive>
-void CanColonize::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition);
-}
-
-template <typename Archive>
-void CanProduceShips::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition);
-}
-
-template <typename Archive>
-void OrderedBombarded::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_by_object_condition);
-}
-
-template <typename Archive>
-void ValueTest::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_value_ref1)
-        & BOOST_SERIALIZATION_NVP(m_value_ref2)
-        & BOOST_SERIALIZATION_NVP(m_value_ref3)
-        & BOOST_SERIALIZATION_NVP(m_string_value_ref1)
-        & BOOST_SERIALIZATION_NVP(m_string_value_ref2)
-        & BOOST_SERIALIZATION_NVP(m_string_value_ref3)
-        & BOOST_SERIALIZATION_NVP(m_int_value_ref1)
-        & BOOST_SERIALIZATION_NVP(m_int_value_ref2)
-        & BOOST_SERIALIZATION_NVP(m_int_value_ref3)
-        & BOOST_SERIALIZATION_NVP(m_compare_type1)
-        & BOOST_SERIALIZATION_NVP(m_compare_type2);
-}
-
-template <typename Archive>
-void Location::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_name1)
-        & BOOST_SERIALIZATION_NVP(m_name2)
-        & BOOST_SERIALIZATION_NVP(m_content_type);
-}
-
-template <typename Archive>
-void CombatTarget::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_content_type);
-}
-
-template <typename Archive>
-void And::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_operands);
-}
-
-template <typename Archive>
-void Or::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_operands);
-}
-
-template <typename Archive>
-void Not::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_operand);
-}
-
-template <typename Archive>
-void OrderedAlternativesOf::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_operands);
-}
-
-template <typename Archive>
-void Described::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
-        & BOOST_SERIALIZATION_NVP(m_condition)
-        & BOOST_SERIALIZATION_NVP(m_desc_stringtable_key);
-}
 } // namespace Condition
+
 
 #endif // _Conditions_h_

--- a/universe/Effect.h
+++ b/universe/Effect.h
@@ -8,7 +8,6 @@
 #include <unordered_map>
 #include <vector>
 #include <boost/container/flat_map.hpp>
-#include <boost/serialization/access.hpp>
 #include "EnumsFwd.h"
 #include "../util/Export.h"
 
@@ -101,11 +100,6 @@ namespace Effect {
 
         virtual void            SetTopLevelContent(const std::string& content_name) = 0;
         virtual unsigned int    GetCheckSum() const;
-
-    private:
-        friend class boost::serialization::access;
-        template <typename Archive>
-        void serialize(Archive& ar, const unsigned int version);
     };
 
     /** Accounting information about what the causes are and changes produced
@@ -180,11 +174,6 @@ namespace Effect {
         int                                     m_priority; // constructor sets this, so don't need a default value here
         std::string                             m_description;
         std::string                             m_content_name;
-
-    private:
-        friend class boost::serialization::access;
-        template <typename Archive>
-        void serialize(Archive& ar, const unsigned int version);
     };
 
     /** Returns a single string which `Dump`s a vector of EffectsGroups. */

--- a/universe/Effects.h
+++ b/universe/Effects.h
@@ -3,7 +3,6 @@
 
 
 #include <boost/optional/optional.hpp>
-#include <boost/serialization/nvp.hpp>
 #include "Effect.h"
 #include "../util/Export.h"
 
@@ -28,11 +27,6 @@ public:
     std::string     Dump(unsigned short ntabs = 0) const override;
     void            SetTopLevelContent(const std::string& content_name) override {}
     unsigned int    GetCheckSum() const override;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Sets the meter of the given kind to \a value.  The max value of the meter
@@ -69,10 +63,6 @@ private:
     MeterType m_meter;
     std::unique_ptr<ValueRef::ValueRef<double>> m_value;
     std::string m_accounting_label;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Sets the indicated meter on all ship parts in the indicated subset.  This
@@ -111,10 +101,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<std::string>>    m_part_name;
     MeterType                                           m_meter;
     std::unique_ptr<ValueRef::ValueRef<double>>         m_value;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Sets the indicated meter on the empire with the indicated id to the
@@ -148,10 +134,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>>    m_empire_id;
     std::string                                 m_meter;
     std::unique_ptr<ValueRef::ValueRef<double>> m_value;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Sets the empire stockpile of the target's owning empire to \a value.  If
@@ -173,10 +155,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>>    m_empire_id;
     ResourceType                                m_stockpile;
     std::unique_ptr<ValueRef::ValueRef<double>> m_value;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Makes the target planet the capital of its owner's empire.  If the target
@@ -194,10 +172,6 @@ public:
 
 private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_empire_id;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Sets the planet type of the target to \a type.  This has no effect on non-Planet targets.  Note that changing the
@@ -215,10 +189,6 @@ public:
 
 private:
     std::unique_ptr<ValueRef::ValueRef<PlanetType>> m_type;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Sets the planet size of the target to \a size.  This has no effect on non-
@@ -237,10 +207,6 @@ public:
 
 private:
     std::unique_ptr<ValueRef::ValueRef<PlanetSize>> m_size;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Sets the species on the target to \a species_name.  This works on planets
@@ -256,10 +222,6 @@ public:
 
 private:
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_species_name;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Sets empire \a empire_id as the owner of the target.  This has no effect if
@@ -275,10 +237,6 @@ public:
 
 private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_empire_id;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Sets the opinion of Species \a species for empire with id \a empire_id to
@@ -298,10 +256,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<std::string>>    m_species_name;
     std::unique_ptr<ValueRef::ValueRef<int>>            m_empire_id;
     std::unique_ptr<ValueRef::ValueRef<double>>         m_opinion;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Sets the opinion of Species \a opinionated_species for other species
@@ -321,10 +275,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<std::string>>    m_opinionated_species_name;
     std::unique_ptr<ValueRef::ValueRef<std::string>>    m_rated_species_name;
     std::unique_ptr<ValueRef::ValueRef<double>>         m_opinion;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Creates a new Planet with specified \a type and \a size at the system with
@@ -346,10 +296,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<PlanetSize>>     m_size;
     std::unique_ptr<ValueRef::ValueRef<std::string>>    m_name;
     std::vector<std::unique_ptr<Effect>>                m_effects_to_apply_after;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Creates a new Building with specified \a type on the \a target Planet. */
@@ -368,10 +314,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<std::string>>    m_building_type_name;
     std::unique_ptr<ValueRef::ValueRef<std::string>>    m_name;
     std::vector<std::unique_ptr<Effect>>                m_effects_to_apply_after;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Creates a new Ship with specified \a predefined_ship_design_name design
@@ -403,10 +345,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<std::string>>    m_species_name;
     std::unique_ptr<ValueRef::ValueRef<std::string>>    m_name;
     std::vector<std::unique_ptr<Effect>>                m_effects_to_apply_after;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Creates a new Field with specified \a field_type_name FieldType
@@ -437,10 +375,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<double>>         m_size;
     std::unique_ptr<ValueRef::ValueRef<std::string>>    m_name;
     std::vector<std::unique_ptr<Effect>>                m_effects_to_apply_after;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Creates a new system with the specified \a colour and at the specified
@@ -469,10 +403,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<double>>         m_y;
     std::unique_ptr<ValueRef::ValueRef<std::string>>    m_name;
     std::vector<std::unique_ptr<Effect>>                m_effects_to_apply_after;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Destroys the target object.  When executed on objects that contain other
@@ -488,11 +418,6 @@ public:
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override {}
     unsigned int GetCheckSum() const override;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Adds the Special with the name \a name to the target object. */
@@ -512,10 +437,6 @@ public:
 private:
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_name;
     std::unique_ptr<ValueRef::ValueRef<double>> m_capacity;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Removes the Special with the name \a name to the target object.  This has
@@ -532,10 +453,6 @@ public:
 
 private:
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_name;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Creates starlane(s) between the target system and systems that match
@@ -551,10 +468,6 @@ public:
 
 private:
     std::unique_ptr<Condition::Condition> m_other_lane_endpoint_condition;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Removes starlane(s) between the target system and systems that match
@@ -570,10 +483,6 @@ public:
 
 private:
     std::unique_ptr<Condition::Condition> m_other_lane_endpoint_condition;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Sets the star type of the target to \a type.  This has no effect on
@@ -589,10 +498,6 @@ public:
 
 private:
     std::unique_ptr<ValueRef::ValueRef<StarType>> m_type;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Moves an UniverseObject to a location of another UniverseObject that matches
@@ -610,10 +515,6 @@ public:
 
 private:
     std::unique_ptr<Condition::Condition> m_location_condition;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Moves an UniverseObject to a location as though it was moving in orbit of
@@ -637,10 +538,6 @@ private:
     std::unique_ptr<Condition::Condition>       m_focal_point_condition;
     std::unique_ptr<ValueRef::ValueRef<double>> m_focus_x;
     std::unique_ptr<ValueRef::ValueRef<double>> m_focus_y;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Moves an UniverseObject a specified distance towards some object or
@@ -663,10 +560,6 @@ private:
     std::unique_ptr<Condition::Condition>       m_dest_condition;
     std::unique_ptr<ValueRef::ValueRef<double>> m_dest_x;
     std::unique_ptr<ValueRef::ValueRef<double>> m_dest_y;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Sets the route of the target fleet to move to an UniverseObject that
@@ -684,10 +577,6 @@ public:
 
 private:
     std::unique_ptr<Condition::Condition> m_location_condition;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Sets aggression level of the target object. */
@@ -702,10 +591,6 @@ public:
 
 private:
     bool m_aggressive;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Causes the owner empire of the target object to win the game.  If the
@@ -721,10 +606,6 @@ public:
 
 private:
     std::string m_reason_string;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Sets whether an empire has researched at tech, and how much research
@@ -744,10 +625,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<std::string>>    m_tech_name;
     std::unique_ptr<ValueRef::ValueRef<double>>         m_research_progress;
     std::unique_ptr<ValueRef::ValueRef<int>>            m_empire_id;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 class FO_COMMON_API GiveEmpireTech final : public Effect {
@@ -763,10 +640,6 @@ public:
 private:
     std::unique_ptr<ValueRef::ValueRef<std::string>>    m_tech_name;
     std::unique_ptr<ValueRef::ValueRef<int>>            m_empire_id;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Generates a sitrep message for the empire with id \a recipient_empire_id.
@@ -824,10 +697,6 @@ private:
     EmpireAffiliationType   m_affiliation;
     std::string             m_label;
     bool                    m_stringtable_lookup;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Applies an overlay texture to Systems. */
@@ -845,10 +714,6 @@ public:
 private:
     std::string m_texture;
     std::unique_ptr<ValueRef::ValueRef<double>> m_size;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Applies a texture to Planets. */
@@ -865,10 +730,6 @@ public:
 
 private:
     std::string m_texture;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Sets visibility of an object for an empire, independent of standard
@@ -903,10 +764,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_empire_id;
     EmpireAffiliationType m_affiliation;
     std::unique_ptr<Condition::Condition> m_condition;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Executes a set of effects if an execution-time condition is met, or an
@@ -947,314 +804,7 @@ private:
     std::unique_ptr<Condition::Condition> m_target_condition; // condition to apply to each target object to determine which effects to execute
     std::vector<std::unique_ptr<Effect>> m_true_effects;      // effects to execute if m_target_condition matches target object
     std::vector<std::unique_ptr<Effect>> m_false_effects;     // effects to execute if m_target_condition does not match target object
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
-
-
-// template implementations
-template <typename Archive>
-void EffectsGroup::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_NVP(m_scope)
-        & BOOST_SERIALIZATION_NVP(m_activation)
-        & BOOST_SERIALIZATION_NVP(m_stacking_group)
-        & BOOST_SERIALIZATION_NVP(m_effects)
-        & BOOST_SERIALIZATION_NVP(m_description)
-        & BOOST_SERIALIZATION_NVP(m_content_name);
-}
-
-template <typename Archive>
-void Effect::serialize(Archive& ar, const unsigned int version)
-{}
-
-template <typename Archive>
-void NoOp::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect);
-}
-
-template <typename Archive>
-void SetMeter::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_meter)
-        & BOOST_SERIALIZATION_NVP(m_value)
-        & BOOST_SERIALIZATION_NVP(m_accounting_label);
-}
-
-template <typename Archive>
-void SetShipPartMeter::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_part_name)
-        & BOOST_SERIALIZATION_NVP(m_meter)
-        & BOOST_SERIALIZATION_NVP(m_value);
-}
-
-template <typename Archive>
-void SetEmpireMeter::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_meter)
-        & BOOST_SERIALIZATION_NVP(m_value);
-}
-
-template <typename Archive>
-void SetEmpireStockpile::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_stockpile)
-        & BOOST_SERIALIZATION_NVP(m_value);
-}
-
-template <typename Archive>
-void SetEmpireCapital::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_empire_id);
-}
-
-template <typename Archive>
-void SetPlanetType::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_type);
-}
-
-template <typename Archive>
-void SetPlanetSize::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_size);
-}
-
-template <typename Archive>
-void SetSpecies::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_species_name);
-}
-
-template <typename Archive>
-void SetOwner::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_empire_id);
-}
-
-template <typename Archive>
-void CreatePlanet::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_type)
-        & BOOST_SERIALIZATION_NVP(m_size)
-        & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_effects_to_apply_after);
-}
-
-template <typename Archive>
-void CreateBuilding::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_building_type_name)
-        & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_effects_to_apply_after);
-}
-
-template <typename Archive>
-void CreateShip::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_design_name)
-        & BOOST_SERIALIZATION_NVP(m_design_id)
-        & BOOST_SERIALIZATION_NVP(m_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_species_name)
-        & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_effects_to_apply_after);
-}
-
-template <typename Archive>
-void CreateField::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_field_type_name)
-        & BOOST_SERIALIZATION_NVP(m_x)
-        & BOOST_SERIALIZATION_NVP(m_y)
-        & BOOST_SERIALIZATION_NVP(m_size)
-        & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_effects_to_apply_after);
-}
-
-template <typename Archive>
-void CreateSystem::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_type)
-        & BOOST_SERIALIZATION_NVP(m_x)
-        & BOOST_SERIALIZATION_NVP(m_y)
-        & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_effects_to_apply_after);
-}
-
-template <typename Archive>
-void Destroy::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect);
-}
-
-template <typename Archive>
-void AddSpecial::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_capacity);
-}
-
-template <typename Archive>
-void RemoveSpecial::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_name);
-}
-
-template <typename Archive>
-void AddStarlanes::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_other_lane_endpoint_condition);
-}
-
-template <typename Archive>
-void RemoveStarlanes::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_other_lane_endpoint_condition);
-}
-
-template <typename Archive>
-void SetStarType::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_type);
-}
-
-template <typename Archive>
-void MoveTo::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_location_condition);
-}
-
-template <typename Archive>
-void MoveInOrbit::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_speed)
-        & BOOST_SERIALIZATION_NVP(m_focal_point_condition)
-        & BOOST_SERIALIZATION_NVP(m_focus_x)
-        & BOOST_SERIALIZATION_NVP(m_focus_y);
-}
-
-template <typename Archive>
-void MoveTowards::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_speed)
-        & BOOST_SERIALIZATION_NVP(m_dest_condition)
-        & BOOST_SERIALIZATION_NVP(m_dest_x)
-        & BOOST_SERIALIZATION_NVP(m_dest_y);
-}
-
-template <typename Archive>
-void SetDestination::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_location_condition);
-}
-
-template <typename Archive>
-void SetAggression::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_aggressive);
-}
-
-template <typename Archive>
-void Victory::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_reason_string);
-}
-
-template <typename Archive>
-void SetEmpireTechProgress::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_tech_name)
-        & BOOST_SERIALIZATION_NVP(m_research_progress)
-        & BOOST_SERIALIZATION_NVP(m_empire_id);
-}
-
-template <typename Archive>
-void GiveEmpireTech::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_tech_name)
-        & BOOST_SERIALIZATION_NVP(m_empire_id);
-}
-
-template <typename Archive>
-void GenerateSitRepMessage::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_message_string)
-        & BOOST_SERIALIZATION_NVP(m_icon)
-        & BOOST_SERIALIZATION_NVP(m_message_parameters)
-        & BOOST_SERIALIZATION_NVP(m_recipient_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_condition)
-        & BOOST_SERIALIZATION_NVP(m_affiliation)
-        & BOOST_SERIALIZATION_NVP(m_label)
-        & BOOST_SERIALIZATION_NVP(m_stringtable_lookup);
-}
-
-template <typename Archive>
-void SetOverlayTexture::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_texture)
-        & BOOST_SERIALIZATION_NVP(m_size);
-}
-
-template <typename Archive>
-void SetTexture::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_texture);
-}
-
-template <typename Archive>
-void SetVisibility::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_vis)
-        & BOOST_SERIALIZATION_NVP(m_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_affiliation)
-        & BOOST_SERIALIZATION_NVP(m_condition);
-}
-
-template <typename Archive>
-void Conditional::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
-        & BOOST_SERIALIZATION_NVP(m_target_condition)
-        & BOOST_SERIALIZATION_NVP(m_true_effects)
-        & BOOST_SERIALIZATION_NVP(m_false_effects);
-}
 } // namespace Effect
 
 #endif // _Effects_h_

--- a/universe/ValueRef.h
+++ b/universe/ValueRef.h
@@ -61,11 +61,6 @@ struct FO_COMMON_API ValueRef
 
     virtual unsigned int GetCheckSum() const
     { return 0; }
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 enum StatisticType : int {

--- a/universe/ValueRefs.h
+++ b/universe/ValueRefs.h
@@ -65,10 +65,6 @@ struct FO_COMMON_API Constant final : public ValueRef<T>
 private:
     T           m_value;
     std::string m_top_level_content;    // in the special case that T is std::string and m_value is "CurrentContent", return this instead
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 enum ReferenceType : int {
@@ -124,11 +120,6 @@ protected:
     ReferenceType               m_ref_type = INVALID_REFERENCE_TYPE;
     std::vector<std::string>    m_property_name;
     bool                        m_return_immediate_value = false;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** The variable statistic class.   The value returned by this node is
@@ -182,10 +173,6 @@ private:
     StatisticType                         m_stat_type;
     std::unique_ptr<Condition::Condition> m_sampling_condition;
     std::unique_ptr<ValueRef<T>>          m_value_ref;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** The complex variable ValueRef class. The value returned by this node
@@ -232,11 +219,6 @@ protected:
     std::unique_ptr<ValueRef<int>> m_int_ref3;
     std::unique_ptr<ValueRef<std::string>> m_string_ref1;
     std::unique_ptr<ValueRef<std::string>> m_string_ref2;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** The variable static_cast class.  The value returned by this node is taken
@@ -272,10 +254,6 @@ struct FO_COMMON_API StaticCast final : public Variable<ToType>
 
 private:
     std::unique_ptr<ValueRef<FromType>> m_value_ref;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** The variable lexical_cast to string class.  The value returned by this node
@@ -303,10 +281,6 @@ struct FO_COMMON_API StringCast final : public Variable<std::string>
 
 private:
     std::unique_ptr<ValueRef<FromType>> m_value_ref;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Looks up a string ValueRef or vector of string ValueRefs, and returns
@@ -332,10 +306,6 @@ struct FO_COMMON_API UserStringLookup final : public Variable<std::string> {
 
 private:
     std::unique_ptr<ValueRef<FromType>> m_value_ref;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Returns the in-game name of the object / empire / etc. with a specified id. */
@@ -370,10 +340,6 @@ struct FO_COMMON_API NameLookup final : public Variable<std::string> {
 private:
     std::unique_ptr<ValueRef<int>> m_value_ref;
     LookupType m_lookup_type;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 enum OpType : int {
@@ -454,10 +420,6 @@ private:
     std::vector<std::unique_ptr<ValueRef<T>>>   m_operands;
     bool                                        m_constant_expr = false;
     T                                           m_cached_const_value = T();
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 FO_COMMON_API MeterType             NameToMeter(const std::string& name);
@@ -503,11 +465,6 @@ bool ValueRef<T>::operator==(const ValueRef<T>& rhs) const
         return false;
     return true;
 }
-
-template <typename T>
-template <typename Archive>
-void ValueRef<T>::serialize(Archive& ar, const unsigned int version)
-{}
 
 ///////////////////////////////////////////////////////////
 // Constant                                              //
@@ -595,14 +552,6 @@ FO_COMMON_API std::string Constant<std::string>::Dump(unsigned short ntabs) cons
 template <>
 FO_COMMON_API std::string Constant<std::string>::Eval(const ScriptingContext& context) const;
 
-template <typename T>
-template <typename Archive>
-void Constant<T>::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ValueRef)
-        & BOOST_SERIALIZATION_NVP(m_value)
-        & BOOST_SERIALIZATION_NVP(m_top_level_content);
-}
 
 ///////////////////////////////////////////////////////////
 // Variable                                              //
@@ -750,15 +699,6 @@ FO_COMMON_API std::string Variable<std::string>::Eval(const ScriptingContext& co
 template <>
 FO_COMMON_API std::vector<std::string> Variable<std::vector<std::string>>::Eval(const ScriptingContext& context) const;
 
-template <typename T>
-template <typename Archive>
-void Variable<T>::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ValueRef)
-        & BOOST_SERIALIZATION_NVP(m_ref_type)
-        & BOOST_SERIALIZATION_NVP(m_property_name)
-        & BOOST_SERIALIZATION_NVP(m_return_immediate_value);
-}
 
 ///////////////////////////////////////////////////////////
 // Statistic                                             //
@@ -1155,15 +1095,6 @@ T Statistic<T>::ReduceData(const std::map<std::shared_ptr<const UniverseObject>,
     }
 }
 
-template <typename T>
-template <typename Archive>
-void Statistic<T>::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Variable)
-        & BOOST_SERIALIZATION_NVP(m_stat_type)
-        & BOOST_SERIALIZATION_NVP(m_sampling_condition)
-        & BOOST_SERIALIZATION_NVP(m_value_ref);
-}
 
 ///////////////////////////////////////////////////////////
 // ComplexVariable                                       //
@@ -1425,17 +1356,6 @@ FO_COMMON_API std::string ComplexVariable<int>::Dump(unsigned short ntabs) const
 template <>
 FO_COMMON_API std::string ComplexVariable<std::string>::Dump(unsigned short ntabs) const;
 
-template <typename T>
-template <typename Archive>
-void ComplexVariable<T>::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Variable)
-        & BOOST_SERIALIZATION_NVP(m_int_ref1)
-        & BOOST_SERIALIZATION_NVP(m_int_ref2)
-        & BOOST_SERIALIZATION_NVP(m_int_ref3)
-        & BOOST_SERIALIZATION_NVP(m_string_ref1)
-        & BOOST_SERIALIZATION_NVP(m_string_ref2);
-}
 
 ///////////////////////////////////////////////////////////
 // StaticCast                                            //
@@ -1528,13 +1448,6 @@ unsigned int StaticCast<FromType, ToType>::GetCheckSum() const
     return retval;
 }
 
-template <typename FromType, typename ToType>
-template <typename Archive>
-void StaticCast<FromType, ToType>::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ValueRef)
-        & BOOST_SERIALIZATION_NVP(m_value_ref);
-}
 
 ///////////////////////////////////////////////////////////
 // StringCast                                            //
@@ -1639,13 +1552,6 @@ void StringCast<FromType>::SetTopLevelContent(const std::string& content_name) {
         m_value_ref->SetTopLevelContent(content_name);
 }
 
-template <typename FromType>
-template <typename Archive>
-void StringCast<FromType>::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ValueRef)
-        & BOOST_SERIALIZATION_NVP(m_value_ref);
-}
 
 ///////////////////////////////////////////////////////////
 // UserStringLookup                                      //
@@ -1756,24 +1662,6 @@ unsigned int UserStringLookup<FromType>::GetCheckSum() const
     return retval;
 }
 
-template <typename FromType>
-template <typename Archive>
-void UserStringLookup<FromType>::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ValueRef<std::string>)
-        & BOOST_SERIALIZATION_NVP(m_value_ref);
-}
-
-///////////////////////////////////////////////////////////
-// NameLookup                                            //
-///////////////////////////////////////////////////////////
-template <typename Archive>
-void NameLookup::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ValueRef<std::string>)
-        & BOOST_SERIALIZATION_NVP(m_value_ref)
-        & BOOST_SERIALIZATION_NVP(m_lookup_type);
-}
 
 ///////////////////////////////////////////////////////////
 // Operation                                             //
@@ -2315,16 +2203,6 @@ void Operation<T>::SetTopLevelContent(const std::string& content_name) {
     }
 }
 
-template <typename T>
-template <typename Archive>
-void Operation<T>::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ValueRef)
-        & BOOST_SERIALIZATION_NVP(m_op_type)
-        & BOOST_SERIALIZATION_NVP(m_operands)
-        & BOOST_SERIALIZATION_NVP(m_constant_expr)
-        & BOOST_SERIALIZATION_NVP(m_cached_const_value);
-}
 
 } // namespace ValueRef
 


### PR DESCRIPTION
…subclasses

The serialization code for those class hierachies is never called anywhere and predates the usage of FOCS.  As far as I can see none of those trees is sent between server and client and it is not stored in the savegames.