### PR TITLE
Hide some sensible info from enemy empires

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1249,12 +1249,6 @@ Drydocks and Fleet Field Repair repair allied ships
 RULE_ENABLE_ALLIED_REPAIR_DESC
 Allow Drydocks building and Fleet Field Repair tech to repair ships of allied empires.
 
-RULE_SHOW_DETAILED_EMPIRES_DATA
-Show detailed empires data
-
-RULE_SHOW_DETAILED_EMPIRES_DATA_DESC
-Show research and production, researched buildings, parts, and hulls of all empires.
-
 RULE_DIPLOMACY
 Allowed diplomacy
 

--- a/default/stringtables/es.txt
+++ b/default/stringtables/es.txt
@@ -1233,12 +1233,6 @@ Escalado de coste de partes
 #*RULE_ENABLE_ALLIED_REPAIR_DESC
 #* <not translated 1970-01-01 01:00:00>
 
-#*RULE_SHOW_DETAILED_EMPIRES_DATA
-#* <not translated 1970-01-01 01:00:00>
-
-#*RULE_SHOW_DETAILED_EMPIRES_DATA_DESC
-#* <not translated 1970-01-01 01:00:00>
-
 #*RULE_DIPLOMACY
 #* <not translated 1970-01-01 01:00:00>
 

--- a/default/stringtables/fr.txt
+++ b/default/stringtables/fr.txt
@@ -1249,12 +1249,6 @@ Réparation en Cale Sèche et Spatiale pour astronefs alliés
 RULE_ENABLE_ALLIED_REPAIR_DESC
 Autorise la structure Cale Sèche Orbitale et la technologie Réparation Spatiale à réparer les astronefs des empires alliés.
 
-RULE_SHOW_DETAILED_EMPIRES_DATA
-Afficher les données détaillées des empires
-
-RULE_SHOW_DETAILED_EMPIRES_DATA_DESC
-Afficher la recherche et la production, les structures acquises, coques et équipements, de tous les empires.
-
 RULE_DIPLOMACY
 Interactions Diplomatie
 

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -74,9 +74,6 @@ namespace {
 
         rules.Add<int>("RULE_CONCEDE_COLONIES_THRESHOLD", "RULE_CONCEDE_COLONIES_THRESHOLD_DESC",
                        "MULTIPLAYER", 1, true,  RangedValidator<int>(0, 9999));
-
-        rules.Add<bool>("RULE_SHOW_DETAILED_EMPIRES_DATA", "RULE_SHOW_DETAILED_EMPIRES_DATA_DESC",
-                       "MULTIPLAYER", true, true);
     }
     bool temp_bool2 = RegisterGameRules(&AddRules);
 }

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -137,8 +137,8 @@ void Empire::serialize(Archive& ar, const unsigned int version)
 
     bool visible = GetUniverse().AllObjectsVisible() ||
         GetUniverse().EncodingEmpire() == ALL_EMPIRES ||
-        m_id == GetUniverse().EncodingEmpire() ||
-        Empires().GetDiplomaticStatus(m_id, GetUniverse().EncodingEmpire()) == DIPLO_ALLIED;
+        m_id == GetUniverse().EncodingEmpire();
+    bool allied_visible = visible || Empires().GetDiplomaticStatus(m_id, GetUniverse().EncodingEmpire()) == DIPLO_ALLIED;
 
     if (Archive::is_loading::value && version < 1) {
         // adapt set to map
@@ -152,7 +152,7 @@ void Empire::serialize(Archive& ar, const unsigned int version)
     }
 
     ar  & BOOST_SERIALIZATION_NVP(m_meters);
-    if (Archive::is_saving::value && !visible) {
+    if (Archive::is_saving::value && !allied_visible) {
         // don't send what other empires building and researching
         // and which building and ship parts are available to them
         ResearchQueue empty_research_queue(m_id);


### PR DESCRIPTION
Partially solves https://github.com/freeorion/freeorion/issues/2964

Removes unneeded game rule.
Allows allies to see empire data.
Enemy techs are still used in ship meters calculation on the client.

Most notable thing is enemy won't see queued buildings.