### PR TITLE
Reference Named ValueRefs in stringtables

### DIFF
--- a/UI/CUILinkTextBlock.cpp
+++ b/UI/CUILinkTextBlock.cpp
@@ -60,6 +60,7 @@ std::shared_ptr<GG::BlockControl> CUILinkTextBlock::Factory::CreateFromTag(const
     block->m_link_text->SetDecorator(VarText::SHIP_ID_TAG, new ColorByOwner());
     block->m_link_text->SetDecorator(VarText::PLANET_ID_TAG, new ColorByOwner());
     block->m_link_text->SetDecorator(TextLinker::BROWSE_PATH_TAG, new PathTypeDecorator());
+    block->m_link_text->SetDecorator(VarText::FOCS_VALUE_TAG, new ValueRefDecorator());
 
     return block;
 }

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -75,6 +75,8 @@ int         ClientUI::TitlePts()                { return GetOptionsDB().Get<int>
 GG::Clr     ClientUI::TextColor()               { return GetOptionsDB().Get<GG::Clr>("ui.font.color"); }
 GG::Clr     ClientUI::DefaultLinkColor()        { return GetOptionsDB().Get<GG::Clr>("ui.font.link.color"); }
 GG::Clr     ClientUI::RolloverLinkColor()       { return GetOptionsDB().Get<GG::Clr>("ui.font.link.rollover.color"); }
+GG::Clr     ClientUI::DefaultTooltipColor()        { return GetOptionsDB().Get<GG::Clr>("ui.font.tooltip.color"); }
+GG::Clr     ClientUI::RolloverTooltipColor()       { return GetOptionsDB().Get<GG::Clr>("ui.font.tooltip.rollover.color"); }
 
 
 GG::Clr     ClientUI::WndColor()                { return GetOptionsDB().Get<GG::Clr>("ui.window.background.color"); }
@@ -546,6 +548,8 @@ namespace {
         db.Add("ui.font.color",                                         UserStringNop("OPTIONS_DB_UI_TEXT_COLOR"),                  GG::Clr(255, 255, 255, 255),    Validator<GG::Clr>());
         db.Add("ui.font.link.color",                                    UserStringNop("OPTIONS_DB_UI_DEFAULT_LINK_COLOR"),          GG::Clr(80, 255, 128, 255),     Validator<GG::Clr>());
         db.Add("ui.font.link.rollover.color",                           UserStringNop("OPTIONS_DB_UI_ROLLOVER_LINK_COLOR"),         GG::Clr(192, 80, 255, 255),     Validator<GG::Clr>());
+        db.Add("ui.font.tooltip.color",                                 UserStringNop("OPTIONS_DB_UI_DEFAULT_TOOLTIP_COLOR"),       GG::Clr(180, 220, 200, 255),     Validator<GG::Clr>());
+        db.Add("ui.font.tooltip.rollover.color",                        UserStringNop("OPTIONS_DB_UI_ROLLOVER_TOOLTIP_COLOR"),      GG::Clr(200, 100, 255, 255),     Validator<GG::Clr>());
 
         db.Add("ui.research.status.completed.background.color",         UserStringNop("OPTIONS_DB_UI_KNOWN_TECH"),                  GG::Clr(72, 72, 72, 255),       Validator<GG::Clr>());
         db.Add("ui.research.status.completed.border.color",             UserStringNop("OPTIONS_DB_UI_KNOWN_TECH_BORDER"),           GG::Clr(164, 164, 164, 255),    Validator<GG::Clr>());

--- a/UI/ClientUI.h
+++ b/UI/ClientUI.h
@@ -152,6 +152,8 @@ public:
     static GG::Clr  TextColor();                //!< color of UI text
     static GG::Clr  DefaultLinkColor();         //!< default color of UI links
     static GG::Clr  RolloverLinkColor();        //!< rollover color of UI links
+    static GG::Clr  DefaultTooltipColor();      //!< default color of UI text with hover tooltip
+    static GG::Clr  RolloverTooltipColor();     //!< rollover color of UI text with hover tooltip
     static GG::Clr  WndColor();                 //!< background color of a UI window
     static GG::Clr  WndOuterBorderColor();      //!< color of the outermost border
     static GG::Clr  WndInnerBorderColor();      //!< color of the innermost border

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -30,6 +30,7 @@
 #include "../universe/Field.h"
 #include "../universe/FieldType.h"
 #include "../universe/Fleet.h"
+#include "../universe/NamedValueRefManager.h"
 #include "../universe/Planet.h"
 #include "../universe/ShipDesign.h"
 #include "../universe/Ship.h"
@@ -145,7 +146,7 @@ namespace {
             "ENC_METER_TYPE",   "ENC_EMPIRE",       "ENC_SHIP_DESIGN",  "ENC_SHIP",
             "ENC_MONSTER",      "ENC_MONSTER_TYPE", "ENC_FLEET",        "ENC_PLANET",
             "ENC_BUILDING",     "ENC_SYSTEM",       "ENC_FIELD",        "ENC_GRAPH",
-            "ENC_GALAXY_SETUP", "ENC_GAME_RULES"};
+            "ENC_GALAXY_SETUP", "ENC_GAME_RULES",   "ENC_NAMED_VALUE_REF"};
         //  "ENC_HOMEWORLDS" omitted due to weird formatting of article titles
         return dir_names;
     }
@@ -496,6 +497,18 @@ namespace {
         else if (dir_name == "ENC_STRINGS") {
             // TODO: show all stringable keys and values
             //for (auto str : GetStringTable().
+
+        }
+        else if  (dir_name == "ENC_NAMED_VALUE_REF")
+        {
+            sorted_entries_list.emplace("ENC_NAMED_VALUE_REF_DESC", std::make_pair(UserString("ENC_NAMED_VALUE_REF_DESC") + "\n\n", dir_name));
+
+            for (const auto& entry : GetNamedValueRefManager().GetItems()) {
+                sorted_entries_list.emplace(
+                    entry.first,
+                    std::make_pair(entry.first + " " + LinkTaggedPresetText(VarText::FOCS_VALUE_TAG, entry.first, entry.second.get().Description()) +
+                                   " '" + UserString(entry.first)  + "'\n", dir_name));
+            }
 
         }
         else {

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -510,7 +510,7 @@ namespace {
                 sorted_entries_list.emplace(
                     entry.first,
                     std::make_pair(entry.first + pre + LinkTaggedPresetText(VarText::FOCS_VALUE_TAG, entry.first, vref.Description()) +
-                                   " '" + UserString(entry.first)  + "'\n", dir_name));
+                                   " '" + UserString(entry.first) + "' " + vref.InvariancePattern() + "\n", dir_name));
             }
 
         }

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -504,9 +504,12 @@ namespace {
             sorted_entries_list.emplace("ENC_NAMED_VALUE_REF_DESC", std::make_pair(UserString("ENC_NAMED_VALUE_REF_DESC") + "\n\n", dir_name));
 
             for (const auto& entry : GetNamedValueRefManager().GetItems()) {
+                auto& vref = entry.second.get();
+                std::string pre = dynamic_cast<ValueRef::ValueRef<int>*>(&vref)? " int " : (dynamic_cast<ValueRef::ValueRef<double>*>(&vref)?" real ":" any ");
+
                 sorted_entries_list.emplace(
                     entry.first,
-                    std::make_pair(entry.first + " " + LinkTaggedPresetText(VarText::FOCS_VALUE_TAG, entry.first, entry.second.get().Description()) +
+                    std::make_pair(entry.first + pre + LinkTaggedPresetText(VarText::FOCS_VALUE_TAG, entry.first, vref.Description()) +
                                    " '" + UserString(entry.first)  + "'\n", dir_name));
             }
 

--- a/UI/LinkText.cpp
+++ b/UI/LinkText.cpp
@@ -119,7 +119,7 @@ namespace {
 
             std::string value_ref_name{match[1]};
             auto*       value_ref = GetValueRefBase(value_ref_name);
-            auto        value_str{value_ref ? value_ref->StringResult() : value_ref_name};
+            auto        value_str{value_ref ? value_ref->EvalAsString() : value_ref_name};
             std::string explanation_str{
                 value_ref && (use_description_instead_of_user_string || (match[2].length()==0)) ?
                     (" (" + value_ref->Description() + ")") :

--- a/UI/LinkText.cpp
+++ b/UI/LinkText.cpp
@@ -3,12 +3,14 @@
 #include "ClientUI.h"
 #include "CUIControls.h"
 #include "../Empire/Empire.h"
+#include "../universe/NamedValueRefManager.h"
 #include "../universe/UniverseObject.h"
 #include "../util/AppInterface.h"
 #include "../util/Logger.h"
 #include "../util/VarText.h"
 #include "../util/i18n.h"
 #include "../util/Directories.h"
+#include "../universe/ValueRefs.h"
 
 #include <GG/WndEvent.h>
 #include <GG/GUI.h>
@@ -86,6 +88,46 @@ namespace {
             auto resolved_link = BROWSEPATH_TAG_OPEN_PRE + " " + link_arg + ">" + link_label + BROWSEPATH_TAG_CLOSE;
 
             retval.replace(text_it + match.position(), text_it + match.position() + match.length(), resolved_link);
+
+            text_it = retval.end() - match.suffix().length();
+        }
+
+        return retval;
+    }
+
+    const std::string FOCS_VALUE_TAG_OPEN_PRE("<" + VarText::FOCS_VALUE_TAG);
+    const std::string FOCS_VALUE_TAG_CLOSE("</" + VarText::FOCS_VALUE_TAG + ">");
+    const xpr::sregex FOCS_VALUE_SEARCH = FOCS_VALUE_TAG_OPEN_PRE >> xpr::_s >> (xpr::s1 = REGEX_NON_BRACKET) >> ">" >>
+                                          (xpr::s2 = REGEX_NON_BRACKET) >> FOCS_VALUE_TAG_CLOSE;
+
+    /** Parses VarText::FOCS_VALUE_TAG%s within @p text, replacing value ref name%s with
+     *  the evaluation result of that value ref.
+     *  Given tag content (i.e. the stringtable content for the tag name) gets added as explanation.
+     *  If the tag content is empty or @p use_description_instead_of_user_string is true,
+     *  the value ref description gets added as explanation instead. */
+    std::string ValueRefLinkText(const std::string& text, const bool use_description_instead_of_user_string) {
+        if (!boost::contains(text, FOCS_VALUE_TAG_CLOSE))
+            return text;
+
+        std::string retval(text);
+        auto text_it = retval.begin();
+        xpr::smatch match;
+
+        while (true) {
+            if (!xpr::regex_search(text_it, retval.end(), match, FOCS_VALUE_SEARCH, xpr::regex_constants::match_default))
+                break;
+
+            std::string value_ref_name{match[1]};
+            auto*       value_ref = GetValueRefBase(value_ref_name);
+            auto        value_str{value_ref ? value_ref->StringResult() : value_ref_name};
+            std::string explanation_str{
+                value_ref && (use_description_instead_of_user_string || (match[2].length()==0)) ?
+                    (" (" + value_ref->Description() + ")") :
+                    ((match[2].length()==0) ? "" : " (" + match[2] + ")")};
+
+            auto resolved_tooltip = FOCS_VALUE_TAG_OPEN_PRE + " " + value_ref_name + ">" + value_str + explanation_str + FOCS_VALUE_TAG_CLOSE;
+
+            retval.replace(text_it + match.position(), text_it + match.position() + match.length(), resolved_tooltip);
 
             text_it = retval.end() - match.suffix().length();
         }
@@ -221,6 +263,14 @@ std::string PathTypeDecorator::Decorate(const std::string& path_type, const std:
 
 std::string PathTypeDecorator::DecorateRollover(const std::string& path_type, const std::string& content) const {
     return LinkDecorator::DecorateRollover(path_type, BrowsePathLinkText(content));
+}
+
+std::string ValueRefDecorator::Decorate(const std::string& value_ref_name, const std::string& content) const {
+    return GG::RgbaTag(ClientUI::DefaultTooltipColor()) + ValueRefLinkText(content, false) + LINK_FORMAT_CLOSE;
+}
+
+std::string ValueRefDecorator::DecorateRollover(const std::string& value_ref_name, const std::string& content) const {
+    return GG::RgbaTag(ClientUI::RolloverTooltipColor()) + ValueRefLinkText(content, true) + LINK_FORMAT_CLOSE;
 }
 
 
@@ -382,6 +432,7 @@ void TextLinker::FindLinks() {
                     tag->tag_name == VarText::SPECIES_TAG ||
                     tag->tag_name == VarText::FIELD_TYPE_TAG ||
                     tag->tag_name == VarText::METER_TYPE_TAG ||
+                    tag->tag_name == VarText::FOCS_VALUE_TAG ||
                     tag->tag_name == TextLinker::ENCYCLOPEDIA_TAG ||
                     tag->tag_name == TextLinker::GRAPH_TAG ||
                     tag->tag_name == TextLinker::URL_TAG ||
@@ -581,6 +632,8 @@ void RegisterLinkTags() {
     GG::Font::RegisterKnownTag(VarText::SPECIES_TAG);
     GG::Font::RegisterKnownTag(VarText::FIELD_TYPE_TAG);
     GG::Font::RegisterKnownTag(VarText::METER_TYPE_TAG);
+
+    GG::Font::RegisterKnownTag(VarText::FOCS_VALUE_TAG);
 
     GG::Font::RegisterKnownTag(TextLinker::ENCYCLOPEDIA_TAG);
     GG::Font::RegisterKnownTag(TextLinker::GRAPH_TAG);

--- a/UI/LinkText.h
+++ b/UI/LinkText.h
@@ -51,6 +51,12 @@ public:
     std::string DecorateRollover(const std::string& path_type, const std::string& content) const override;
 };
 
+class ValueRefDecorator : public LinkDecorator {
+public:
+    std::string Decorate(const std::string& value_ref_name, const std::string& content) const override;
+    std::string DecorateRollover(const std::string& value_ref_name, const std::string& content) const override;
+};
+
 class TextLinker {
 public:
     TextLinker();

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -662,10 +662,12 @@ void OptionsWnd::CompleteConstruction() {
 
     // Colors tab
     current_page = CreatePage(UserString("OPTIONS_PAGE_COLORS"));
-    CreateSectionHeader(current_page, 0,                        UserString("OPTIONS_GENERAL_COLORS"));
-    ColorOption(current_page, 0, "ui.font.color",               UserString("OPTIONS_TEXT_COLOR"));
-    ColorOption(current_page, 0, "ui.font.link.color",          UserString("OPTIONS_DEFAULT_LINK_COLOR"));
-    ColorOption(current_page, 0, "ui.font.link.rollover.color", UserString("OPTIONS_ROLLOVER_LINK_COLOR"));
+    CreateSectionHeader(current_page, 0,                           UserString("OPTIONS_GENERAL_COLORS"));
+    ColorOption(current_page, 0, "ui.font.color",                  UserString("OPTIONS_TEXT_COLOR"));
+    ColorOption(current_page, 0, "ui.font.link.color",             UserString("OPTIONS_DEFAULT_LINK_COLOR"));
+    ColorOption(current_page, 0, "ui.font.link.rollover.color",    UserString("OPTIONS_ROLLOVER_LINK_COLOR"));
+    ColorOption(current_page, 0, "ui.font.tooltip.color",          UserString("OPTIONS_DEFAULT_TOOLTIP_COLOR"));
+    ColorOption(current_page, 0, "ui.font.tooltip.rollover.color", UserString("OPTIONS_ROLLOVER_TOOLTIP_COLOR"));
 
     CreateSectionHeader(current_page, 0,                        UserString("OPTIONS_WINDOW_COLORS"));
     ColorOption(current_page, 0, "ui.window.background.color",  UserString("OPTIONS_FILL_COLOR"));

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -248,6 +248,7 @@ namespace {
                 GG::FORMAT_LEFT | GG::FORMAT_VCENTER | GG::FORMAT_WORDBREAK, ClientUI::TextColor());
             m_link_text->SetDecorator(VarText::EMPIRE_ID_TAG, new ColorEmpire());
             m_link_text->SetDecorator(TextLinker::BROWSE_PATH_TAG, new PathTypeDecorator());
+            m_link_text->SetDecorator(VarText::FOCS_VALUE_TAG, new ValueRefDecorator());
             AttachChild(m_link_text);
 
             namespace ph = boost::placeholders;

--- a/check/st-tool.py
+++ b/check/st-tool.py
@@ -18,7 +18,7 @@ from collections import namedtuple, OrderedDict
 
 STRING_TABLE_KEY_PATTERN = r'^[A-Z0-9_]+$'
 # Provides the named capture groups 'ref_type' and 'key'
-INTERNAL_REFERENCE_PATTERN = r'\[\[(?P<ref_type>(?:(?:encyclopedia|(?:building|field|meter)type|predefinedshipdesign|ship(?:hull|part)|special|species|tech|policy) )?)(?P<key>{})\]\]'
+INTERNAL_REFERENCE_PATTERN = r'\[\[(?P<ref_type>(?:(?:encyclopedia|(?:building|field|meter)type|predefinedshipdesign|ship(?:hull|part)|special|species|tech|policy|value) )?)(?P<key>{})\]\]'
 # Provides the named capture groups 'sha', 'old_line', 'new_line' and 'range'
 GIT_BLAME_INCREMENTAL_PATTERN = r'^(?P<sha>[0-9a-f]{40}) (?P<old_line>[1-9][0-9]*) (?P<new_line>[1-9][0-9]*)(?P<range> [1-9][0-9]*)?$'
 

--- a/default/customizations/custom_sitreps.txt
+++ b/default/customizations/custom_sitreps.txt
@@ -103,7 +103,7 @@ EffectsGroup
                 tag = "planet" data = Target.ID
             ]
             empire = Source.Owner
-
+    
 // Tell all the others that you have better detection tech (the information is public anyway)
 EffectsGroup
     scope = And [

--- a/default/scripting/common/named_values.focs.txt
+++ b/default/scripting/common/named_values.focs.txt
@@ -1,0 +1,7 @@
+NamedReal name = "SHP_REINFORCED_HULL_BONUS" value = (5 * [[SHIP_STRUCTURE_FACTOR]]) 
+
+NamedInteger name = "NUM_COMBAT_ROUNDS" value = (GameRule name = "RULE_NUM_COMBAT_ROUNDS")
+
+NamedInteger name = "NUM_COMBAT_ROUNDS_FIGHTERS" value = (GameRule name = "RULE_NUM_COMBAT_ROUNDS") - 1
+
+#include "/scripting/common/misc.macros"

--- a/default/scripting/techs/ship_parts/damage_control/SHP_REINFORCED_HULL.focs.txt
+++ b/default/scripting/techs/ship_parts/damage_control/SHP_REINFORCED_HULL.focs.txt
@@ -13,7 +13,7 @@ Tech
                 Ship
                 OwnedBy empire = Source.Owner
             ]
-            effects = SetMaxStructure value = Value + (5 * [[SHIP_STRUCTURE_FACTOR]])
+            effects = SetMaxStructure value = Value + NamedRealLookup name = "SHP_REINFORCED_HULL_BONUS"
     graphic = "icons/tech/structural_integrity_fields.png"
 
 #include "/scripting/common/base_prod.macros"

--- a/default/scripting/techs/ship_parts/fuel/fuel.macros
+++ b/default/scripting/techs/ship_parts/fuel/fuel.macros
@@ -14,6 +14,6 @@ PART_UPGRADE_MAXFUEL_EFFECTS
             ]
             accountinglabel = "@1@"
             effects = [
-                SetMaxFuel value = Value + (@2@ * (PartsInShipDesign Name = "FU_BASIC_TANK" design = Target.DesignID))
+                SetMaxFuel value = Value + ((NamedReal name = "@1@_MULT" value = @2@) * (PartsInShipDesign Name = "FU_BASIC_TANK" design = Target.DesignID))
             ]
 '''

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5019,7 +5019,7 @@ ENC_BUILDING_TYPE
 Building Type
 
 ENC_NAMED_VALUE_REF
-Named Value Refs
+[Test - Named Value Refs]
 
 ENC_NAMED_VALUE_REF_DESC
 '''Some value calculations get named so the resulting values can be used in the pedia or by the AI empires. This is often used to present values which depend on game rules.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1117,6 +1117,10 @@ Cheap and Fast Ships
 RULE_CHEAP_AND_FAST_SHIP_PRODUCTION_DESC
 Ships cost 1 PP and take 1 turn to produce.
 
+# value ref description
+NUM_COMBAT_ROUNDS
+per combat
+
 RULE_NUM_COMBAT_ROUNDS
 Combat Rounds
 
@@ -5014,6 +5018,15 @@ OBJECTS_WITH_SPECIAL
 ENC_BUILDING_TYPE
 Building Type
 
+ENC_NAMED_VALUE_REF
+Named Value Refs
+
+ENC_NAMED_VALUE_REF_DESC
+'''Some value calculations get named so the resulting values can be used in the pedia or by the AI empires. This is often used to present values which depend on game rules.
+
+The following values show the name, the calculated value, (the calculation), and 'the stringtable description for the calculation'.
+'''
+
 ENC_SPECIES
 Species
 
@@ -6320,7 +6333,7 @@ DAMAGE_TITLE
 Damage
 
 DAMAGE_TEXT
-'''Defines the base amount that a weapon will reduce the [[metertype METER_STRUCTURE]] of another ship (or the [[metertype METER_SHIELD]], [[metertype METER_DEFENSE]] and [[metertype METER_CONSTRUCTION]] of a planet), in one combat round (of which there are four in each turn of battle). If a target ship is equipped with [[metertype METER_SHIELD]], the actual damage caused by each hit will be the base damage reduced by the strength rating of the ship's [[metertype METER_SHIELD]].
+'''Defines the base amount that a weapon will reduce the [[metertype METER_STRUCTURE]] of another ship (or the [[metertype METER_SHIELD]], [[metertype METER_DEFENSE]] and [[metertype METER_CONSTRUCTION]] of a planet), in one combat round (of which there are [[value NUM_COMBAT_ROUNDS]]). If a target ship is equipped with [[metertype METER_SHIELD]], the actual damage caused by each hit will be the base damage reduced by the strength rating of the ship's [[metertype METER_SHIELD]].
 
 Note: [[encyclopedia FIGHTER_TECHS]] inflict damage ignoring [[metertype METER_SHIELD]] on ships, as fighters fire from within the enemy shields. Fighters need one turn for launching so damage estimation takes that into account.'''
 
@@ -12597,9 +12610,13 @@ SHP_REINFORCED_HULL
 Reinforced Hull
 
 SHP_REINFORCED_HULL_DESC
-'''Increases max [[metertype METER_STRUCTURE]] of all ships by 40.
+'''Increases max [[metertype METER_STRUCTURE]] of all ships by [[value SHP_REINFORCED_HULL_BONUS]].
 
 Standard ship hulls are designed and constructed with advanced microgravity architectural techniques and highly resistant materials. However, the limitations of physical matter impose a severe limitation on the strength of hulls. By enhancing the hull with structural integrity fields, a sizable increase in strength can be obtained.'''
+
+# value ref description
+SHP_REINFORCED_HULL_BONUS
+''''''
 
 SHP_BASIC_DAM_CONT
 Basic Damage Control
@@ -12973,22 +12990,30 @@ SHP_SINGULARITY_ENGINE_CORE_DESC
 A smaller cousin of the [[buildingtype BLD_HYPER_DAM]] outfitted for ships, the Singularity Engine Core drastically boosts power generation. Increases [[metertype METER_SPEED]] by 80.'''
 
 SHP_DEUTERIUM_TANK
-Deuterium Tank
+Deuterium Fuel
 
 SHP_DEUTERIUM_TANK_DESC
-Small upgrade to each of [[shippart FU_BASIC_TANK]] ship parts. Increases [[metertype METER_FUEL]] capacity and thereby the number of jumps ships can do without refueling.
+Small upgrade to each of [[shippart FU_BASIC_TANK]] ship parts. Increases [[metertype METER_FUEL]] capacity by [[value SHP_DEUTERIUM_TANK_EFFECT_MULT]]  and thereby the number of jumps ships can do without refueling.
 
 SHP_DEUTERIUM_TANK_EFFECT
-Tech <i>Deuterium Tank</i>
+Tech <i>Deuterium Fuel</i>
+
+# value ref description
+SHP_DEUTERIUM_TANK_EFFECT_MULT
+'''per tank part'''
 
 SHP_ANTIMATTER_TANK
-Antimatter Tank
+Antimatter Fuel
 
 SHP_ANTIMATTER_TANK_DESC
-Moderate upgrade to each of [[shippart FU_BASIC_TANK]] ship parts. Increases [[metertype METER_FUEL]] capacity and thereby the number of jumps ships can do without refueling.
+Moderate upgrade to each of [[shippart FU_BASIC_TANK]] ship parts. Increases [[metertype METER_FUEL]] capacity by [[value SHP_ANTIMATTER_TANK_EFFECT_MULT]] and thereby the number of jumps ships can do without refueling.
 
 SHP_ANTIMATTER_TANK_EFFECT
-Tech <i>Antimatter Tank</i>
+Tech <i>Antimatter Fuel</i>
+
+# value ref description
+SHP_ANTIMATTER_TANK_EFFECT_MULT
+'''per tank part'''
 
 SHP_ZERO_POINT
 Zero-Point Fuel Generator
@@ -14316,7 +14341,10 @@ FU_BASIC_TANK
 Extra Fuel Tank
 
 FU_BASIC_TANK_DESC
-Increases [[metertype METER_FUEL]] capacity, allowing additional jumps depending on [[encyclopedia FUEL_EFFICIENCY_TITLE]]. Later technologies further increase the number of additional jumps per tank.
+'''Increases [[metertype METER_FUEL]] capacity, allowing additional jumps depending on [[encyclopedia FUEL_EFFICIENCY_TITLE]]. Later technologies further increase the number of additional jumps per tank.
+Fuel boosts from tech for a hull with average fuel efficiency:
+- [[tech SHP_DEUTERIUM_TANK]]: [[value SHP_DEUTERIUM_TANK_EFFECT_MULT]]
+- [[tech SHP_ANTIMATTER_TANK]]: [[value SHP_ANTIMATTER_TANK_EFFECT_MULT]].'''
 
 FU_ZERO_FUEL
 Zero-Point Fuel Generator

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5024,7 +5024,7 @@ ENC_NAMED_VALUE_REF
 ENC_NAMED_VALUE_REF_DESC
 '''Some value calculations get named so the resulting values can be used in the pedia or by the AI empires. This is often used to present values which depend on game rules.
 
-The following values show the name, the registration type (int/real/any), the calculated value, (the calculation), and 'the stringtable description for the calculation'.
+The following values show the name, the registration type (int/real/any), the calculated value, (the calculation), 'the stringtable description for the calculation', and the invariance pattern.
 '''
 
 ENC_SPECIES

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5024,7 +5024,7 @@ Named Value Refs
 ENC_NAMED_VALUE_REF_DESC
 '''Some value calculations get named so the resulting values can be used in the pedia or by the AI empires. This is often used to present values which depend on game rules.
 
-The following values show the name, the calculated value, (the calculation), and 'the stringtable description for the calculation'.
+The following values show the name, the registration type (int/real/any), the calculated value, (the calculation), and 'the stringtable description for the calculation'.
 '''
 
 ENC_SPECIES

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -13000,7 +13000,7 @@ Tech <i>Deuterium Fuel</i>
 
 # value ref description
 SHP_DEUTERIUM_TANK_EFFECT_MULT
-'''per tank part'''
+per tank part
 
 SHP_ANTIMATTER_TANK
 Antimatter Fuel
@@ -13013,7 +13013,7 @@ Tech <i>Antimatter Fuel</i>
 
 # value ref description
 SHP_ANTIMATTER_TANK_EFFECT_MULT
-'''per tank part'''
+per tank part
 
 SHP_ZERO_POINT
 Zero-Point Fuel Generator

--- a/msvc2017/Common/Common.vcxproj
+++ b/msvc2017/Common/Common.vcxproj
@@ -219,6 +219,7 @@
     <ClInclude Include="..\..\universe\ValueRef.h" />
     <ClInclude Include="..\..\util\blocking_combiner.h" />
     <ClInclude Include="..\..\universe\Meter.h" />
+    <ClInclude Include="..\..\universe\NamedValueRefManager.h" />
     <ClInclude Include="..\..\universe\ObjectMap.h" />
     <ClInclude Include="..\..\universe\Planet.h" />
     <ClInclude Include="..\..\universe\PopCenter.h" />
@@ -300,6 +301,7 @@
     <ClCompile Include="..\..\universe\IDAllocator.cpp" />
     <ClCompile Include="..\..\universe\Meter.cpp" />
     <ClCompile Include="..\..\universe\ObjectMap.cpp" />
+    <ClCompile Include="..\..\universe\NamedValueRefManager.cpp" />
     <ClCompile Include="..\..\universe\Planet.cpp" />
     <ClCompile Include="..\..\universe\PopCenter.cpp" />
     <ClCompile Include="..\..\universe\UniverseObjectVisitors.cpp" />

--- a/msvc2017/Common/Common.vcxproj.filters
+++ b/msvc2017/Common/Common.vcxproj.filters
@@ -115,6 +115,9 @@
     <ClInclude Include="..\..\universe\Meter.h">
       <Filter>Header Files\universe</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\universe\NamedValueRefManager.h">
+      <Filter>Header Files\universe</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\universe\ObjectMap.h">
       <Filter>Header Files\universe</Filter>
     </ClInclude>
@@ -407,6 +410,9 @@
       <Filter>Source Files\universe</Filter>
     </ClCompile>
     <ClCompile Include="..\..\universe\ObjectMap.cpp">
+      <Filter>Source Files\universe</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\universe\NamedValueRefManager.cpp">
       <Filter>Source Files\universe</Filter>
     </ClCompile>
     <ClCompile Include="..\..\universe\Planet.cpp">

--- a/msvc2017/Parsers/Parsers.vcxproj
+++ b/msvc2017/Parsers/Parsers.vcxproj
@@ -211,6 +211,7 @@
     <ClCompile Include="..\..\parse\ItemsParser.cpp" />
     <ClCompile Include="..\..\parse\Lexer.cpp" />
     <ClCompile Include="..\..\parse\MonsterFleetPlansParser.cpp" />
+    <ClCompile Include="..\..\parse\NamedValueRefParser.cpp" />
     <ClCompile Include="..\..\parse\Parse.cpp">
       <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4091;4099;4101;4146;4244;4251;4258;4267;4275;4311;4312;4351;4396;4503;4800;4996;4018</DisableSpecificWarnings>
       <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4091;4099;4101;4146;4244;4251;4258;4267;4275;4311;4312;4351;4396;4503;4800;4996;4018</DisableSpecificWarnings>

--- a/msvc2017/Parsers/Parsers.vcxproj.filters
+++ b/msvc2017/Parsers/Parsers.vcxproj.filters
@@ -68,6 +68,9 @@
     <ClCompile Include="..\..\parse\PlanetTypeValueRefParser.cpp">
       <Filter>Source Files\parse</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\parse\NamedValueRefParser.cpp">
+      <Filter>Source Files\parse</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\parse\ReportParseError.cpp">
       <Filter>Source Files\parse</Filter>
     </ClCompile>

--- a/parse/ArithmeticRules.cpp
+++ b/parse/ArithmeticRules.cpp
@@ -5,6 +5,17 @@
 
 #include <boost/spirit/include/phoenix.hpp>
 
+namespace parse {
+
+  void errorlog_hello(const std::string& name) // TODO remove this
+    {
+       ErrorLogger() << "trying constructing a NamedRef for : " << name << " !";
+    }
+
+      BOOST_PHOENIX_ADAPT_FUNCTION(void, errorlog_hello_, errorlog_hello, 1)
+}
+
+
 namespace parse { namespace detail {
 
     template <typename T>
@@ -23,6 +34,7 @@ namespace parse { namespace detail {
 
         boost::spirit::qi::_1_type _1;
         boost::spirit::qi::_2_type _2;
+        boost::spirit::qi::_4_type _4;
         boost::spirit::qi::_a_type _a;
         boost::spirit::qi::_b_type _b;
         boost::spirit::qi::_c_type _c;
@@ -33,6 +45,17 @@ namespace parse { namespace detail {
         const boost::phoenix::function<construct_movable> construct_movable_;
         const boost::phoenix::function<deconstruct_movable> deconstruct_movable_;
         const boost::phoenix::function<deconstruct_movable_vector> deconstruct_movable_vector_;
+
+        named_lookup_expr
+          =   (
+                   tok.Named_ >> tok.Value_ >> tok.Lookup_
+                >> label(tok.Name_)
+                >> tok.string
+              ) [
+                     ::parse::errorlog_hello_(_2),
+                     _val = construct_movable_(new_<ValueRef::NamedRef<T>>(_4))
+              ]
+            ;
 
         functional_expr
             =   (
@@ -195,6 +218,7 @@ namespace parse { namespace detail {
             ;
 
     #if DEBUG_VALUEREF_PARSERS
+	debug(named_lookup_expr);
         debug(functional_expr);
         debug(exponential_expr);
         debug(multiplicative_expr);
@@ -207,6 +231,7 @@ namespace parse { namespace detail {
         debug(expr);
     #endif
 
+        named_lookup_expr.name(type_name + " nominal lookup expression");
         functional_expr.name(type_name + " function expression");
         exponential_expr.name(type_name + " exponential expression");
         multiplicative_expr.name(type_name + " multiplication expression");

--- a/parse/ArithmeticRules.cpp
+++ b/parse/ArithmeticRules.cpp
@@ -5,17 +5,6 @@
 
 #include <boost/spirit/include/phoenix.hpp>
 
-namespace parse {
-
-  void errorlog_hello(const std::string& name) // TODO remove this
-    {
-       ErrorLogger() << "trying constructing a NamedRef for : " << name << " !";
-    }
-
-      BOOST_PHOENIX_ADAPT_FUNCTION(void, errorlog_hello_, errorlog_hello, 1)
-}
-
-
 namespace parse { namespace detail {
 
     template <typename T>
@@ -51,10 +40,7 @@ namespace parse { namespace detail {
                    tok.Named_ >> tok.Value_ >> tok.Lookup_
                 >> label(tok.Name_)
                 >> tok.string
-              ) [
-                     ::parse::errorlog_hello_(_2),
-                     _val = construct_movable_(new_<ValueRef::NamedRef<T>>(_4))
-              ]
+              ) [ _val = construct_movable_(new_<ValueRef::NamedRef<T>>(_4)) ]
             ;
 
         functional_expr

--- a/parse/ArithmeticRules.cpp
+++ b/parse/ArithmeticRules.cpp
@@ -218,7 +218,7 @@ namespace parse { namespace detail {
             ;
 
     #if DEBUG_VALUEREF_PARSERS
-	debug(named_lookup_expr);
+        debug(named_lookup_expr);
         debug(functional_expr);
         debug(exponential_expr);
         debug(multiplicative_expr);

--- a/parse/CMakeLists.txt
+++ b/parse/CMakeLists.txt
@@ -1,5 +1,6 @@
 target_sources(freeorionparseobj
     PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}/MovableEnvelope.h
         ${CMAKE_CURRENT_LIST_DIR}/Parse.h
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/CommonParamsParser.h
@@ -22,7 +23,6 @@ target_sources(freeorionparseobj
         ${CMAKE_CURRENT_LIST_DIR}/EnumParser.h
         ${CMAKE_CURRENT_LIST_DIR}/EnumValueRefRules.h
         ${CMAKE_CURRENT_LIST_DIR}/Lexer.h
-        ${CMAKE_CURRENT_LIST_DIR}/MovableEnvelope.h
         ${CMAKE_CURRENT_LIST_DIR}/ParseImpl.h
         ${CMAKE_CURRENT_LIST_DIR}/ReportParseError.h
         ${CMAKE_CURRENT_LIST_DIR}/Tokens.h
@@ -57,6 +57,7 @@ target_sources(freeorionparseobj
         ${CMAKE_CURRENT_LIST_DIR}/ItemsParser.cpp
         ${CMAKE_CURRENT_LIST_DIR}/Lexer.cpp
         ${CMAKE_CURRENT_LIST_DIR}/MonsterFleetPlansParser.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/NamedValueRefParser.cpp
         ${CMAKE_CURRENT_LIST_DIR}/Parse.cpp
         ${CMAKE_CURRENT_LIST_DIR}/PlanetEnvironmentValueRefParser.cpp
         ${CMAKE_CURRENT_LIST_DIR}/PlanetSizeValueRefParser.cpp

--- a/parse/EnumValueRefRules.h
+++ b/parse/EnumValueRefRules.h
@@ -32,6 +32,7 @@ namespace parse {
         variable_rule<T> unwrapped_bound_variable_expr;
         variable_rule<T> value_wrapped_bound_variable_expr;
         expression_rule<T> functional_expr;
+        value_ref_rule<T> named_lookup_expr;
         value_ref_rule<T> primary_expr;
         value_ref_rule<T> statistic_sub_value_ref;
         statistic_rule<T> statistic_expr;
@@ -84,6 +85,7 @@ namespace parse {
 
         boost::spirit::qi::_1_type _1;
         boost::spirit::qi::_2_type _2;
+        boost::spirit::qi::_4_type _4;
         boost::spirit::qi::_val_type _val;
         boost::spirit::qi::_pass_type _pass;
         boost::spirit::qi::lit_type lit;
@@ -118,6 +120,16 @@ namespace parse {
             = (selection_operator > '(' > (expr % ',') > ')')
             [ _val = construct_movable_(new_<ValueRef::Operation<T>>(_1, deconstruct_movable_vector_(_2, _pass))) ];
 
+        named_lookup_expr
+          =   (
+                   tok.Named_ >> tok.Value_ >> tok.Lookup_
+                >> label(tok.Name_)
+                >> tok.string
+              ) [
+                     _val = construct_movable_(new_<ValueRef::NamedRef<T>>(_4))
+              ]
+            ;
+
         functional_expr %=  selection_expr | primary_expr;
 
         expr
@@ -133,6 +145,7 @@ namespace parse {
             |   free_variable_expr
             |   statistic_expr
             |   complex_expr
+            |   named_lookup_expr
             ;
 
 #if DEBUG_VALUEREF_PARSERS
@@ -144,6 +157,7 @@ namespace parse {
         debug(statistic_value_ref_expr);
         debug(statistic_expr);
         debug(functional_expr);
+        debug(named_lookup_expr);
         debug(primary_expr);
         debug(expr);
 #endif
@@ -155,6 +169,7 @@ namespace parse {
         bound_variable_expr.name(type_name + " variable");
         statistic_sub_value_ref.name(type_name + " statistic subvalue");
         statistic_expr.name(type_name + " statistic");
+        named_lookup_expr.name(type_name + " named valueref");
         primary_expr.name(type_name + " expression");
         expr.name(type_name + " expression");
     }

--- a/parse/IntComplexValueRefParser.cpp
+++ b/parse/IntComplexValueRefParser.cpp
@@ -27,7 +27,6 @@ namespace parse {
         namespace phoenix = boost::phoenix;
         namespace qi = boost::spirit::qi;
 
-        using phoenix::construct;
         using phoenix::new_;
 
         qi::_1_type _1;

--- a/parse/NamedValueRefParser.cpp
+++ b/parse/NamedValueRefParser.cpp
@@ -32,11 +32,11 @@ namespace parse {
                           const parse::detail::MovableEnvelope<ValueRef::ValueRef<T>>& ref_envelope,
                           bool& pass)
     {
-        ErrorLogger() << "Registering from named_values.focs.txt : " << name << " ! ValueRef<" << typeid(T).name() << ">";
+        DebugLogger() << "Registering from named_values.focs.txt : " << name << " ! ValueRef<" << typeid(T).name() << ">";
         // Note: Other parsers might also register value refs, so the normal pending mechanism does not suffice.
         //       So we do not collect the value refs in the given named_refs reference but register directly.
         std::unique_ptr<ValueRef::ValueRef<T>> vref = ref_envelope.OpenEnvelope(pass);
-        // Let it throw if CurrentContent is used
+        // Log an error if CurrentContent is used
         vref->SetTopLevelContent("THERE_IS_NO_TOP_LEVEL_CONTENT");
         ::RegisterValueRef<T>(name, std::move(vref));
     }

--- a/parse/NamedValueRefParser.cpp
+++ b/parse/NamedValueRefParser.cpp
@@ -35,7 +35,10 @@ namespace parse {
         ErrorLogger() << "Registering from named_values.focs.txt : " << name << " ! ValueRef<" << typeid(T).name() << ">";
         // Note: Other parsers might also register value refs, so the normal pending mechanism does not suffice.
         //       So we do not collect the value refs in the given named_refs reference but register directly.
-        ::RegisterValueRef<T>(name, ref_envelope.OpenEnvelope(pass));
+        std::unique_ptr<ValueRef::ValueRef<T>> vref = ref_envelope.OpenEnvelope(pass);
+        // Let it throw if CurrentContent is used
+        vref->SetTopLevelContent("THERE_IS_NO_TOP_LEVEL_CONTENT");
+        ::RegisterValueRef<T>(name, std::move(vref));
     }
 
     BOOST_PHOENIX_ADAPT_FUNCTION(void, insert_named_ref_, insert_named_ref, 4)

--- a/parse/NamedValueRefParser.cpp
+++ b/parse/NamedValueRefParser.cpp
@@ -1,0 +1,135 @@
+#include "Parse.h"
+
+#include "ParseImpl.h"
+#include "ConditionParser.h"
+#include "ValueRefParser.h"
+#include "EnumValueRefRules.h"
+
+#include "MovableEnvelope.h"
+#include "../universe/ValueRefs.h"
+#include "../universe/ValueRef.h"
+#include "../util/Directories.h"
+
+#include <boost/spirit/include/qi.hpp>
+#include <boost/spirit/include/phoenix_core.hpp>
+
+#include <typeinfo>
+
+#define DEBUG_PARSERS 0
+
+#if DEBUG_PARSERS
+namespace std {
+    inline ostream& operator<<(ostream& os, const std::map<int, int>&) { return os; }
+    inline ostream& operator<<(ostream& os, const std::map<std::string, std::map<int, int>>&) { return os; }
+}
+#endif
+
+namespace parse {
+
+    template <typename T>
+    void insert_named_ref(std::map<std::string, std::unique_ptr<ValueRef::ValueRefBase>>& named_refs,
+                          const std::string& name,
+                          const parse::detail::MovableEnvelope<ValueRef::ValueRef<T>>& ref_envelope,
+                          bool& pass)
+    {
+        ErrorLogger() << "Registering from named_values.focs.txt : " << name << " ! ValueRef<" << typeid(T).name() << ">";
+        // Note: Other parsers might also register value refs, so the normal pending mechanism does not suffice.
+        //       So we do not collect the value refs in the given named_refs reference but register directly.
+        ::RegisterValueRef<T>(name, ref_envelope.OpenEnvelope(pass));
+    }
+
+    BOOST_PHOENIX_ADAPT_FUNCTION(void, insert_named_ref_, insert_named_ref, 4)
+
+    using start_rule_payload = std::map<std::string, std::unique_ptr<ValueRef::ValueRefBase>>;
+    using start_rule_signature = void(start_rule_payload&);
+
+    struct grammar : public parse::detail::grammar<start_rule_signature> {
+        grammar(const parse::lexer& tok,
+                const std::string& filename,
+                const parse::text_iterator& first,
+                const parse::text_iterator& last) :
+            grammar::base_type(start, "named_value_ref_grammar"),
+            condition_parser(tok, label),
+            planet_type_rules(tok, label, condition_parser),
+            planet_environment_rules(tok, label, condition_parser),
+            string_grammar(tok, label, condition_parser),
+            int_rules(tok, label, condition_parser, string_grammar),
+            double_rules(tok, label, condition_parser, string_grammar)
+        {
+            namespace phoenix = boost::phoenix;
+            namespace qi = boost::spirit::qi;
+
+            qi::_1_type _1;
+            qi::_2_type _2;
+            qi::_3_type _3;
+            qi::_4_type _4;
+            qi::_pass_type _pass;
+            qi::omit_type omit_;
+            qi::_r1_type _r1;
+
+            named_ref
+               =
+                    ( omit_[tok.Named_]   >> tok.Integer_
+                   > label(tok.Name_) > tok.string
+                   > label(tok.Value_) >  qi::as<parse::detail::MovableEnvelope<ValueRef::ValueRef<int>>>()[int_rules.expr]
+                    ) [ insert_named_ref_(_r1, _2, _3, _pass) ]
+                    |
+                    ( omit_[tok.Named_]   >> tok.Real_
+                   > label(tok.Name_) > tok.string
+                   > label(tok.Value_) >  qi::as<parse::detail::MovableEnvelope<ValueRef::ValueRef<double>>>()[double_rules.expr]
+                    ) [ insert_named_ref_(_r1, _2, _3, _pass) ]
+                    |
+                    ( omit_[tok.Named_]  >> tok.PlanetType_ > label(tok.Name_) > tok.string > label(tok.Value_) > planet_type_rules.expr
+                    ) [ insert_named_ref_(_r1, _2, _3, _pass) ]
+                    |
+                    ( omit_[tok.Named_]  >> tok.Environment_ > label(tok.Name_) > tok.string > label(tok.Value_) >  planet_environment_rules.expr
+                    ) [ insert_named_ref_(_r1, _2, _3, _pass) ] 
+                ;
+
+
+            start
+              = +named_ref(_r1)
+                ;
+
+            named_ref.name("NamedValueRef");
+
+#if DEBUG_PARSERS
+            debug(named_ref);
+#endif
+
+	    qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
+        }
+
+        using named_value_ref_rule = parse::detail::rule<
+            void (std::map<std::string, std::unique_ptr<ValueRef::ValueRefBase>>&)>;
+
+        using start_rule = parse::detail::rule<start_rule_signature>;
+
+        parse::detail::Labeller                         label;
+        const parse::conditions_parser_grammar          condition_parser;
+        parse::detail::planet_type_parser_rules         planet_type_rules;
+        parse::detail::planet_environment_parser_rules  planet_environment_rules;
+        const parse::string_parser_grammar              string_grammar;
+        const parse::int_arithmetic_rules               int_rules;
+        const parse::double_parser_rules                double_rules;
+        named_value_ref_rule                            named_ref;
+        start_rule                                      start;
+    };
+}
+
+namespace parse {
+    start_rule_payload named_value_refs(const boost::filesystem::path& path) {
+        const lexer lexer;
+        start_rule_payload named_value_refs;
+
+        ScopedTimer timer("Named ValueRef Parsing", true);
+
+        for (const auto& file : ListDir(path, IsFOCScript))
+            detail::parse_file<grammar, start_rule_payload>(lexer, file, named_value_refs);
+
+        for (auto& k_v : named_value_refs )
+            ErrorLogger() << "Should have not returned anything: named_value_refs : " << k_v.first;
+
+        return named_value_refs;
+    }
+}

--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -29,6 +29,7 @@ struct UnlockableItem;
 class Policy;
 
 namespace ValueRef {
+    struct ValueRefBase;
     template <typename T>
     struct ValueRef;
 }
@@ -36,6 +37,7 @@ namespace ValueRef {
 namespace parse {
     FO_PARSE_API std::map<std::string, std::unique_ptr<BuildingType>> buildings(const boost::filesystem::path& path);
     FO_PARSE_API std::map<std::string, std::unique_ptr<FieldType>> fields(const boost::filesystem::path& path);
+    FO_PARSE_API std::map<std::string, std::unique_ptr<ValueRef::ValueRefBase>> named_value_refs(const boost::filesystem::path& path);
     FO_PARSE_API std::map<std::string, std::unique_ptr<Special>> specials(const boost::filesystem::path& path);
 
     FO_PARSE_API std::map<std::string, std::unique_ptr<Policy>> policies(const boost::filesystem::path& path);

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -221,6 +221,7 @@
     (LocalCandidate)                            \
     (Location)                                  \
     (Log)                                       \
+    (Lookup)                                    \
     (Low)                                       \
     (LowestCostEnqueuedTech)                    \
     (LowestCostResearchableTech)                \
@@ -261,6 +262,7 @@
     (MoveTo)                                    \
     (MoveTowards)                               \
     (Name)                                      \
+    (Named)                                     \
     (Native)                                    \
     (NearestSystemID)                           \
     (Neutron)                                   \

--- a/parse/ValueRefParser.h
+++ b/parse/ValueRefParser.h
@@ -5,6 +5,7 @@
 #include "MovableEnvelope.h"
 
 #include "../universe/ValueRefs.h"
+#include "../universe/NamedValueRefManager.h"
 #include "../universe/EnumsFwd.h"
 
 #include <boost/spirit/include/qi.hpp>
@@ -104,6 +105,7 @@ namespace parse { namespace detail {
         expression_rule<T>              exponential_expr;
         expression_rule<T>              multiplicative_expr;
         expression_rule<T>              additive_expr;
+        detail::value_ref_rule<T>       named_lookup_expr;
         detail::value_ref_rule<T>       primary_expr;
         detail::value_ref_rule<T>       statistic_value_ref_expr;
         statistic_rule<T>               statistic_collection_expr;
@@ -190,6 +192,20 @@ namespace parse { namespace detail {
             |   unwrapped_bound_variable [ _val = _1 ]
             ;
     }
+
+    template <typename T>
+    void open_and_register_as_string(std::string& nameref, ::parse::detail::MovableEnvelope<ValueRef::ValueRef<T>>& obj, bool& pass)
+    {
+        if (obj.IsEmptiedEnvelope()) {
+            ErrorLogger() <<
+                "The parser attempted to extract the unique_ptr from a MovableEnvelope more than once - while looking at a valueref envelope for use in ValueRef registration ";
+            pass = false;
+            return;
+        }
+        ::RegisterValueRef<T>(nameref, obj.OpenEnvelope(pass));
+    }
+
+    BOOST_PHOENIX_ADAPT_FUNCTION(void, open_and_register_as_string_, open_and_register_as_string, 3)
 }}
 
 namespace parse {
@@ -249,7 +265,8 @@ namespace parse {
             const detail::condition_parser_grammar& condition_parser,
             const detail::value_ref_grammar<std::string>& string_grammar);
         detail::simple_int_parser_rules simple_int_rules;
-        int_complex_parser_grammar int_complex_grammar;
+        int_complex_parser_grammar      int_complex_grammar;
+        detail::value_ref_rule<int>     named_int_valueref;
     };
 
     struct double_complex_parser_grammar : public detail::complex_variable_grammar<double> {
@@ -291,6 +308,7 @@ namespace parse {
         detail::value_ref_rule<double>      int_free_variable_cast;
         detail::value_ref_rule<double>      int_statistic_cast;
         detail::value_ref_rule<double>      int_complex_variable_cast;
+        detail::value_ref_rule<double>      named_real_valueref;
     };
 
     struct castable_as_int_parser_rules {

--- a/universe/CMakeLists.txt
+++ b/universe/CMakeLists.txt
@@ -18,6 +18,7 @@ target_sources(freeorioncommon
         ${CMAKE_CURRENT_LIST_DIR}/FleetPlan.h
         ${CMAKE_CURRENT_LIST_DIR}/IDAllocator.h
         ${CMAKE_CURRENT_LIST_DIR}/Meter.h
+        ${CMAKE_CURRENT_LIST_DIR}/NamedValueRefManager.h
         ${CMAKE_CURRENT_LIST_DIR}/ObjectMap.h
         ${CMAKE_CURRENT_LIST_DIR}/Planet.h
         ${CMAKE_CURRENT_LIST_DIR}/PopCenter.h
@@ -54,6 +55,7 @@ target_sources(freeorioncommon
         ${CMAKE_CURRENT_LIST_DIR}/FleetPlan.cpp
         ${CMAKE_CURRENT_LIST_DIR}/IDAllocator.cpp
         ${CMAKE_CURRENT_LIST_DIR}/Meter.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/NamedValueRefManager.cpp
         ${CMAKE_CURRENT_LIST_DIR}/ObjectMap.cpp
         ${CMAKE_CURRENT_LIST_DIR}/Planet.cpp
         ${CMAKE_CURRENT_LIST_DIR}/PopCenter.cpp

--- a/universe/NamedValueRefManager.cpp
+++ b/universe/NamedValueRefManager.cpp
@@ -242,7 +242,7 @@ void NamedRef<T>::SetTopLevelContent(const std::string& content_name)
     if ( GetValueRef() )
         const_cast<ValueRef<T>*>(GetValueRef())->SetTopLevelContent(content_name);
     else
-        ErrorLogger() << "Unexpected call of SetTopLevelContent on a NamedRef - unexpected because no value ref registered yet. This should not happen";
+        ErrorLogger() << "Unexpected call of SetTopLevelContent(" << content_name << ") on a NamedRef - unexpected because no value ref registered yet. This should not happen";
 }
 
 template <typename T>

--- a/universe/NamedValueRefManager.cpp
+++ b/universe/NamedValueRefManager.cpp
@@ -199,22 +199,31 @@ NamedRef<T>::NamedRef(std::string value_ref_name) :
     m_value_ref_name(value_ref_name)
 {
     DebugLogger() << "ctor(NamedRef<T>): " << typeid(*this).name() << " value_ref_name: " << m_value_ref_name;
-    // not invariant value refs are not supported currently as we do not need those yet
-    if (auto ref = GetValueRef()) {
-        this->m_root_candidate_invariant = ref->RootCandidateInvariant();
-        this->m_local_candidate_invariant = ref->LocalCandidateInvariant();
-        this->m_target_invariant = ref->TargetInvariant();
-        this->m_source_invariant = ref->SourceInvariant();;
-        if (!(this->m_root_candidate_invariant && this->m_local_candidate_invariant
-              && this->m_target_invariant && this->m_source_invariant))
-            ErrorLogger() << "Currently only invariant value refs can be named. " << m_value_ref_name;
-    } else {
-        this->m_root_candidate_invariant = true;
-        this->m_local_candidate_invariant = true;
-        this->m_target_invariant = true;
-        this->m_source_invariant = true;
-    }
 }
+
+template <typename T>
+bool NamedRef<T>::RootCandidateInvariant() const
+{ return GetValueRef() ? GetValueRef()->RootCandidateInvariant() : false; }
+
+template <typename T>
+bool NamedRef<T>::LocalCandidateInvariant() const
+{ return GetValueRef() ? GetValueRef()->LocalCandidateInvariant() : false; }
+
+template <typename T>
+bool NamedRef<T>::TargetInvariant() const
+{ return GetValueRef() ? GetValueRef()->TargetInvariant() : false; }
+
+template <typename T>
+bool NamedRef<T>::SourceInvariant() const
+{ return GetValueRef() ? GetValueRef()->SourceInvariant() : false; }
+
+template <typename T>
+bool NamedRef<T>::SimpleIncrement() const
+{ return GetValueRef() ? GetValueRef()->SimpleIncrement() : false; }
+
+template <typename T>
+bool NamedRef<T>::ConstantExpr() const
+{ return GetValueRef() ? GetValueRef()->ConstantExpr() : false; }
 
 template <typename T>
 bool NamedRef<T>::operator==(const ValueRef<T>& rhs) const

--- a/universe/NamedValueRefManager.cpp
+++ b/universe/NamedValueRefManager.cpp
@@ -283,5 +283,4 @@ template class NamedRef<PlanetType>;
 template class NamedRef<StarType>;
 template class NamedRef<UniverseObjectType>;
 template class NamedRef<Visibility>;
-    
 } // ValueRef namespace

--- a/universe/NamedValueRefManager.cpp
+++ b/universe/NamedValueRefManager.cpp
@@ -1,0 +1,287 @@
+#include "NamedValueRefManager.h"
+#include "ValueRefs.h"
+
+#include <functional>
+#include <iomanip>
+#include <iterator>
+#include <mutex>
+#include <unordered_map>
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include "Enums.h"
+#include "Field.h"
+#include "Fighter.h"
+#include "Fleet.h"
+#include "Pathfinder.h"
+#include "Planet.h"
+#include "ShipDesign.h"
+#include "ShipHull.h"
+#include "ShipPart.h"
+#include "Ship.h"
+#include "Species.h"
+#include "System.h"
+#include "Tech.h"
+#include "UniverseObjectVisitors.h"
+#include "UniverseObject.h"
+#include "Universe.h"
+#include "../Empire/EmpireManager.h"
+#include "../Empire/Empire.h"
+#include "../Empire/Supply.h"
+#include "../util/GameRules.h"
+#include "../util/Logger.h"
+#include "../util/MultiplayerCommon.h"
+#include "../util/Random.h"
+
+NamedValueRefManager* NamedValueRefManager::s_instance = nullptr;
+
+NamedValueRefManager::NamedValueRefManager() {
+    if (s_instance)
+        throw std::runtime_error("Attempted to create more than one NamedValueRefManager.");
+
+    // Only update the global pointer on sucessful construction.
+    InfoLogger() << "NamedValueRefManager::NameValueRefManager constructs singleton " << this;
+    s_instance = this;
+}
+
+template <typename V>
+V* const NamedValueRefManager::GetValueRefImpl(std::map<NamedValueRefManager::key_type, std::unique_ptr<V>>& registry, const std::string& label, const std::string& name) /*const*/ {
+    DebugLogger() << "NamedValueRefManager::GetValueRef look for registered " << label << " valueref for \"" << name << '"';
+    TraceLogger() << "Number of registered " << label << " ValueRefs: " << registry.size();
+    const auto it = registry.find(name);
+    if (it != registry.end())
+        return it->second.get();
+    ErrorLogger() << "NamedValueRefManager::GetValueRef found no registered " << label << " valueref for \"" << name << '"';
+    return nullptr;
+}
+
+// default implementation - queries the untyped registry
+// will return nullptr if no such entry in the generic registry exists or if it has a different type than requested
+template <typename T>
+ValueRef::ValueRef<T>* const NamedValueRefManager::GetValueRef(const std::string& name) /*const*/ {
+    return dynamic_cast<ValueRef::ValueRef<T>*>(this->GetValueRefImpl(m_value_refs, "generic", name));
+}
+
+// int specialisation - queries the ValueRef<int> registry
+template <>
+ValueRef::ValueRef<int>* const NamedValueRefManager::GetValueRef(const std::string& name) /*const*/ {
+    return this->GetValueRefImpl(m_value_refs_int, "int", name);
+}
+
+// double specialisation - queries the ValueRef<double> registry
+template <>
+ValueRef::ValueRef<double>* const NamedValueRefManager::GetValueRef(const std::string& name) /*const*/ {
+    return this->GetValueRefImpl(m_value_refs_double, "double", name);
+}
+
+ValueRef::ValueRefBase* const NamedValueRefManager::GetValueRefBase(const std::string& name) const {
+    /* TODO straighten out const shtuff */
+    auto* drefp = const_cast<NamedValueRefManager*>(this)->GetValueRef<double>(name);
+    //if (auto* drefp = const_cast<NamedValueRefManager*>(this)->GetValueRef<double>(name)) // TODO C++17
+    if (drefp)
+        return drefp;
+    auto* irefp = const_cast<NamedValueRefManager*>(this)->GetValueRef<int>(name);
+    //if (auto* irefp = const_cast<NamedValueRefManager*>(this)->GetValueRef<int>(name)) // TODO C++17
+    if (irefp)
+        return irefp;
+    const auto it = m_value_refs.find(name);
+    return it != m_value_refs.end() ? it->second.get() : nullptr;
+}
+
+NamedValueRefManager& NamedValueRefManager::GetNamedValueRefManager() {
+    DebugLogger() << "NamedValueRefManager::GetNamedValueRefManager starts (check the thread)";
+    
+    static NamedValueRefManager manager; // function local 
+    InfoLogger() << "NamedValueRefManager::GetNamedValueRefManager at " << &manager;
+    return manager;
+}
+
+
+unsigned int NamedValueRefManager::GetCheckSum() const {
+    unsigned int retval{0};
+    for (auto const& name_type_pair : m_value_refs)
+        CheckSums::CheckSumCombine(retval, name_type_pair);
+    for (auto const& name_type_pair : m_value_refs_int)
+        CheckSums::CheckSumCombine(retval, name_type_pair);
+    for (auto const& name_type_pair : m_value_refs_double)
+        CheckSums::CheckSumCombine(retval, name_type_pair);
+    //CheckSums::CheckSumCombine(retval, m_value_refs.size()); // why also add size?
+    
+    DebugLogger() << "NamedValueRefManager checksum: " << retval;
+    return retval;
+}
+
+
+NamedValueRefManager::any_container_type  NamedValueRefManager::GetItems() const {
+    auto base_to_any{[](const entry_type& kv) { return any_entry_type(kv.first, *(kv.second.get())); }};
+    auto double_to_any{[](const double_entry_type& kv) { return any_entry_type(kv.first, *(kv.second.get())); }};
+    auto int_to_any{[](const int_entry_type& kv) { return any_entry_type(kv.first, *(kv.second.get())); }};
+
+    // should use C++20 ranges (or C++14, C++17 boost Range-v3 library) to avoid copying
+    any_container_type aet;
+    std::transform(m_value_refs_double.begin(), m_value_refs_double.end(), std::inserter(aet, aet.end()), double_to_any);
+    std::transform(m_value_refs_int.begin(), m_value_refs_int.end(), std::inserter(aet, aet.end()), int_to_any);
+    std::transform(m_value_refs.begin(), m_value_refs.end(), std::inserter(aet, aet.end()), base_to_any);
+    return aet;
+}
+
+template <typename R, typename VR>
+void NamedValueRefManager::RegisterValueRefImpl(R& container, std::mutex& mutex, const std::string& label, std::string&& valueref_name, std::unique_ptr<VR>&& vref) {
+    InfoLogger() << "Register " << label << " valueref for " << valueref_name << ": " << vref->Description();
+    if (container.count(valueref_name)>0) {
+        DebugLogger() << "Skip registration for already registered " << label << " valueref for " << valueref_name;
+        DebugLogger() << "Number of registered " << label << " ValueRefs: " << m_value_refs.size();
+        return;
+    }
+    const std::lock_guard<std::mutex> lock(mutex);
+    if (!(vref->RootCandidateInvariant() && vref->LocalCandidateInvariant() && vref->TargetInvariant() && vref->SourceInvariant()))
+            ErrorLogger() << "Currently only invariant value refs can be named. " << valueref_name;
+    container.emplace(std::move(valueref_name), std::move(vref));
+    DebugLogger() << "Number of registered " << label << " ValueRefs: " << container.size();
+}
+
+template <typename T>
+void NamedValueRefManager::RegisterValueRef(std::string&& valueref_name, std::unique_ptr<ValueRef::ValueRef<T>>&& vref) {
+    this->RegisterValueRefImpl(m_value_refs, m_value_refs_mutex, "generic", std::move(valueref_name), std::move(vref));
+}
+
+// specialisation for registering to the ValueRef<int> registry
+template <>
+void NamedValueRefManager::RegisterValueRef(std::string&& valueref_name, std::unique_ptr<ValueRef::ValueRef<int>>&& vref) {
+    this->RegisterValueRefImpl(m_value_refs_int, m_value_refs_int_mutex, "int", std::move(valueref_name), std::move(vref));
+}
+
+// specialisation for registering to the ValueRef<double> registry
+template <>
+void NamedValueRefManager::RegisterValueRef(std::string&& valueref_name, std::unique_ptr<ValueRef::ValueRef<double>>&& vref) {
+    this->RegisterValueRefImpl(m_value_refs_double, m_value_refs_double_mutex, "double", std::move(valueref_name), std::move(vref));
+}
+
+NamedValueRefManager& GetNamedValueRefManager()
+{ return NamedValueRefManager::GetNamedValueRefManager(); }
+
+ValueRef::ValueRefBase* const GetValueRefBase(const std::string& name)
+{
+    DebugLogger() << "NamedValueRefManager::GetValueRefBase look for registered valueref for \"" << name << '"';
+    auto* vref = GetNamedValueRefManager().GetValueRefBase(name);
+    if (vref)
+        return vref;
+    InfoLogger() << "NamedValueRefManager::GetValueRefBase could not find registered valueref for \"" << name << '"';
+    return nullptr;
+}
+
+template <typename T>
+ValueRef::ValueRef<T>* const GetValueRef(const std::string& name)
+{ return GetNamedValueRefManager().GetValueRef<T>(name); }
+
+template <typename T>
+void RegisterValueRef(std::string name, std::unique_ptr<ValueRef::ValueRef<T>>&& vref)
+{ return GetNamedValueRefManager().RegisterValueRef<T>(std::move(name), std::move(vref)); }
+
+// trigger instantiations
+template ValueRef::ValueRef<int>*    const GetValueRef(const std::string& name);
+template ValueRef::ValueRef<double>* const GetValueRef(const std::string& name);
+template void RegisterValueRef(std::string name, std::unique_ptr<ValueRef::ValueRef<int>>&& vref);
+template void RegisterValueRef(std::string name, std::unique_ptr<ValueRef::ValueRef<double>>&& vref);
+template void RegisterValueRef(std::string name, std::unique_ptr<ValueRef::ValueRef<PlanetEnvironment>>&& vref);
+template void RegisterValueRef(std::string name, std::unique_ptr<ValueRef::ValueRef<PlanetSize>>&& vref);
+template void RegisterValueRef(std::string name, std::unique_ptr<ValueRef::ValueRef<PlanetType>>&& vref);
+template void RegisterValueRef(std::string name, std::unique_ptr<ValueRef::ValueRef<StarType>>&& vref);
+template void RegisterValueRef(std::string name, std::unique_ptr<ValueRef::ValueRef<UniverseObjectType>>&& vref);
+template void RegisterValueRef(std::string name, std::unique_ptr<ValueRef::ValueRef<Visibility>>&& vref);
+
+///////////////////////////////////////////////////////////
+// NamedRef                                              //
+///////////////////////////////////////////////////////////
+namespace ValueRef {
+template <typename T>
+NamedRef<T>::NamedRef(std::string value_ref_name) :
+    m_value_ref_name(value_ref_name)
+{
+    DebugLogger() << "ctor(NamedRef<T>): " << typeid(*this).name() << " value_ref_name: " << m_value_ref_name;
+    // not invariant value refs are not supported currently as we do not need those yet
+    if (auto ref = GetValueRef()) {
+        this->m_root_candidate_invariant = ref->RootCandidateInvariant();
+        this->m_local_candidate_invariant = ref->LocalCandidateInvariant();
+        this->m_target_invariant = ref->TargetInvariant();
+        this->m_source_invariant = ref->SourceInvariant();;
+        if (!(this->m_root_candidate_invariant && this->m_local_candidate_invariant
+              && this->m_target_invariant && this->m_source_invariant))
+            ErrorLogger() << "Currently only invariant value refs can be named. " << m_value_ref_name;
+    } else {
+        this->m_root_candidate_invariant = true;
+        this->m_local_candidate_invariant = true;
+        this->m_target_invariant = true;
+        this->m_source_invariant = true;
+    }
+}
+
+template <typename T>
+bool NamedRef<T>::operator==(const ValueRef<T>& rhs) const
+{
+    if (&rhs == this)
+        return true;
+    if (typeid(rhs) != typeid(*this))
+        return false;
+    const NamedRef<T>& rhs_ = static_cast<const NamedRef<T>&>(rhs);
+    return (m_value_ref_name == rhs_.m_value_ref_name);
+}
+
+template <typename T>
+std::string NamedRef<T>::Description() const
+{ return GetValueRef() ? GetValueRef()->Description() : UserString("NAMED_REF_UNKNOWN"); }
+
+template <typename T>
+std::string NamedRef<T>::Dump(unsigned short ntabs) const
+{ return GetValueRef() ? GetValueRef()->Dump() : "NAMED_REF_UNKNOWN"; }
+
+template <typename T>
+void NamedRef<T>::SetTopLevelContent(const std::string& content_name)
+{}//{ if ( GetValueRef() ) GetValueRef()->SetTopLevelContent(content_name); } // TODO decide what to do. also setter does not fit to const return of GetValueRef
+
+template <typename T>
+const ValueRef<T>* NamedRef<T>::GetValueRef() const
+{
+    DebugLogger() << "NamedRef<T>::GetValueRef() look for registered valueref for \"" << m_value_ref_name << '"';
+    return ::GetValueRef<T>(m_value_ref_name);
+}
+
+template <typename T>
+unsigned int NamedRef<T>::GetCheckSum() const
+{
+    unsigned int retval{0};
+
+    CheckSums::CheckSumCombine(retval, "ValueRef::NamedRef");
+    CheckSums::CheckSumCombine(retval, m_value_ref_name);
+    TraceLogger() << "GetCheckSum(NamedRef<T>): " << typeid(*this).name() << " retval: " << retval;
+    return retval;
+}
+
+template <typename T>
+T NamedRef<T>::Eval(const ScriptingContext& context) const
+{
+    DebugLogger() << "NamedRef<" << typeid(T).name() << ">::Eval()";
+    const ValueRef<T>* value_ref = ::GetValueRef<T>(m_value_ref_name);
+    if (!value_ref) {
+        ErrorLogger() << "NamedRef<" << typeid(T).name() << ">::Eval did not find " << m_value_ref_name;
+        throw std::runtime_error(std::string("NamedValueLookup referenced unknown ValueRef<") + typeid(T).name() + "> named '" + m_value_ref_name + "'");
+    }
+
+    auto retval = value_ref->Eval(context);
+    TraceLogger() << "NamedRef<" << typeid(T).name() << "> name: " << m_value_ref_name << "  retval: " << retval;
+    return retval;
+}
+
+// trigger instantiations - was not necessary when NamedRef was living in ValueRefs.h/.cpp
+// it would be better if the parser would trigger instantiation implicitly
+template class NamedRef<double>;
+template class NamedRef<int>;
+// Enums
+template class NamedRef<PlanetEnvironment>;
+template class NamedRef<PlanetSize>;
+template class NamedRef<PlanetType>;
+template class NamedRef<StarType>;
+template class NamedRef<UniverseObjectType>;
+template class NamedRef<Visibility>;
+    
+} // ValueRef namespace

--- a/universe/NamedValueRefManager.cpp
+++ b/universe/NamedValueRefManager.cpp
@@ -78,7 +78,6 @@ ValueRef::ValueRef<double>* const NamedValueRefManager::GetValueRef(const std::s
 }
 
 ValueRef::ValueRefBase* const NamedValueRefManager::GetValueRefBase(const std::string& name) const {
-    /* TODO straighten out const shtuff */
     auto* drefp = const_cast<NamedValueRefManager*>(this)->GetValueRef<double>(name);
     //if (auto* drefp = const_cast<NamedValueRefManager*>(this)->GetValueRef<double>(name)) // TODO C++17
     if (drefp)

--- a/universe/NamedValueRefManager.cpp
+++ b/universe/NamedValueRefManager.cpp
@@ -237,7 +237,13 @@ std::string NamedRef<T>::Dump(unsigned short ntabs) const
 
 template <typename T>
 void NamedRef<T>::SetTopLevelContent(const std::string& content_name)
-{}//{ if ( GetValueRef() ) GetValueRef()->SetTopLevelContent(content_name); } // TODO decide what to do. also setter does not fit to const return of GetValueRef
+{
+    // only supposed to work for named-in-the-middle-case
+    if ( GetValueRef() )
+        const_cast<ValueRef<T>*>(GetValueRef())->SetTopLevelContent(content_name);
+    else
+        ErrorLogger() << "Unexpected call of SetTopLevelContent on a NamedRef - unexpected because no value ref registered yet. This should not happen";
+}
 
 template <typename T>
 const ValueRef<T>* NamedRef<T>::GetValueRef() const

--- a/universe/NamedValueRefManager.h
+++ b/universe/NamedValueRefManager.h
@@ -17,6 +17,13 @@ struct FO_COMMON_API NamedRef final : public ValueRef<T>
 {
     NamedRef(std::string value_ref_name);
 
+    bool RootCandidateInvariant() const override;
+    bool LocalCandidateInvariant() const override;
+    bool TargetInvariant() const override;
+    bool SourceInvariant() const override;
+    bool SimpleIncrement() const override;
+    bool ConstantExpr() const override;
+
     bool operator==(const ValueRef<T>& rhs) const override;
     T  Eval(const ScriptingContext& context) const override;
 

--- a/universe/NamedValueRefManager.h
+++ b/universe/NamedValueRefManager.h
@@ -1,0 +1,127 @@
+#ifndef _ValueRefManager_h_
+#define _ValueRefManager_h_
+
+//#include <mutex>
+#include "ValueRef.h"
+//#include "ScriptingContext.h"
+//#include "../util/Export.h"
+
+/** The NamedRef class. Looks up a named ValueRef from the NamedValueRefManager
+  */
+namespace ValueRef {
+    
+/** The NamedRef class. Looks up a named ValueRef from the NamedValueRefManager
+  */
+template <typename T>
+struct FO_COMMON_API NamedRef final : public ValueRef<T>
+{
+    NamedRef(std::string value_ref_name);
+
+    bool operator==(const ValueRef<T>& rhs) const override;
+    T  Eval(const ScriptingContext& context) const override;
+
+    std::string Description() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
+    void SetTopLevelContent(const std::string& content_name) override;
+
+    const ValueRef<T>* GetValueRef() const;
+    unsigned int GetCheckSum() const override;
+
+private:
+    std::string m_value_ref_name;
+};
+}
+
+//! Holds all FreeOrion named ValueRef%s.  ValueRef%s may be looked up by name.
+class FO_COMMON_API NamedValueRefManager {
+public:
+    //using container_type = std::map<const std::string, const std::unique_ptr<ValueRef::ValueRefBase>>;
+    using key_type = const std::string;
+    using value_type = std::unique_ptr<ValueRef::ValueRefBase>;
+    using int_value_type = std::unique_ptr<ValueRef::ValueRef<int>>;
+    using double_value_type = std::unique_ptr<ValueRef::ValueRef<double>>;
+    using container_type = std::map<key_type, value_type>;
+    using int_container_type = std::map<key_type, int_value_type>;
+    using double_container_type = std::map<key_type, double_value_type>;
+    using entry_type        = std::pair<key_type, value_type>;
+    using int_entry_type    = std::pair<key_type, int_value_type>;
+    using double_entry_type = std::pair<key_type, double_value_type>;
+    using any_container_type = std::map<key_type, std::reference_wrapper<ValueRef::ValueRefBase>>;
+    using any_entry_type     = std::pair<key_type, std::reference_wrapper<ValueRef::ValueRefBase>>;
+
+    using iterator = container_type::const_iterator;
+
+    //! Returns the ValueRef with the name @p name or nullptr if there is nov ValueRef with such a name or of the wrong type
+    //! use the free function GetValueRef(...) instead, mainly to save some typing.
+    template <typename T>
+    auto GetValueRef(const std::string& name) -> ValueRef::ValueRef<T>* const;
+
+    //! Returns the ValueRef with the name @p name; you should use the
+    //! free function GetValueRef(...) instead, mainly to save some typing.
+    auto GetValueRefBase(const std::string& name) const -> ValueRef::ValueRefBase* const;
+
+    /** returns a map with all named value refs */
+    auto GetItems() const -> any_container_type;
+
+    // Singleton
+    NamedValueRefManager&  operator=(NamedValueRefManager const&) = delete; // no copy via assignment
+
+    NamedValueRefManager(NamedValueRefManager const&) = delete;            // no copies via construction
+
+    ~NamedValueRefManager() = default;
+
+    //! Returns the instance of this singleton class; you should use the free
+    //! function GetNamedValueRefManager() instead
+    static NamedValueRefManager& GetNamedValueRefManager();
+
+    //! Returns a number, calculated from the contained data, which should be
+    //! different for different contained data, and must be the same for
+    //! the same contained data, and must be the same on different platforms
+    //! and executions of the program and the function. Useful to verify that
+    //! the parsed content is consistent without sending it all between
+    //! clients and server.
+    auto GetCheckSum() const -> unsigned int;
+
+    //! Register the @p value_ref under the evaluated @p name.
+    template <typename T>
+    void RegisterValueRef(std::string&& name, std::unique_ptr<ValueRef::ValueRef<T>>&& vref);
+
+private:
+    NamedValueRefManager();
+
+    /** helper function for GetValueRef */
+    template <typename V>
+    V* const GetValueRefImpl(std::map<key_type, std::unique_ptr<V>>& registry, const std::string& label, const std::string& name);
+
+    /** helper function for RegisterValueRef */
+    template <typename R, typename VR>
+    void RegisterValueRefImpl(R& registry, std::mutex& mutex, const std::string& label, std::string&& valueref_name, std::unique_ptr<VR>&& vref);
+
+    //! Map of ValueRef%s identified by a name and mutexes for those to allow asynchronous registration
+    double_container_type m_value_refs_double; // int value refs
+    std::mutex            m_value_refs_double_mutex;
+    int_container_type    m_value_refs_int; // int value refs
+    std::mutex            m_value_refs_int_mutex;
+    container_type        m_value_refs; // everything else
+    std::mutex            m_value_refs_mutex;
+
+    // The s_instance creation is lazily triggered via a function local.
+    // There is exactly one for all translation units.
+    static NamedValueRefManager* s_instance;
+};
+
+//! Returns the singleton manager for named value refs
+FO_COMMON_API auto GetNamedValueRefManager() -> NamedValueRefManager&;
+
+//! Returns the ValueRef object registered with the given
+//! @p name.  If no such ValueRef exists, nullptr is returned instead.
+FO_COMMON_API auto GetValueRefBase(const std::string& name) -> ValueRef::ValueRefBase* const;
+
+template <typename T>
+FO_COMMON_API auto GetValueRef(const std::string& name) -> ValueRef::ValueRef<T>* const;
+
+//! Register and take possesion of the ValueRef object @p vref under the given @p name.
+template <typename T>
+FO_COMMON_API void RegisterValueRef(std::string name, std::unique_ptr<ValueRef::ValueRef<T>>&& vref);
+
+#endif // _ValueRefManager_h_

--- a/universe/NamedValueRefManager.h
+++ b/universe/NamedValueRefManager.h
@@ -3,8 +3,6 @@
 
 #include "ValueRef.h"
 
-/** The NamedRef class. Looks up a named ValueRef from the NamedValueRefManager
-  */
 namespace ValueRef {
     
 /** The NamedRef class. Looks up a named ValueRef from the NamedValueRefManager

--- a/universe/NamedValueRefManager.h
+++ b/universe/NamedValueRefManager.h
@@ -1,10 +1,7 @@
 #ifndef _ValueRefManager_h_
 #define _ValueRefManager_h_
 
-//#include <mutex>
 #include "ValueRef.h"
-//#include "ScriptingContext.h"
-//#include "../util/Export.h"
 
 /** The NamedRef class. Looks up a named ValueRef from the NamedValueRefManager
   */
@@ -96,14 +93,6 @@ public:
 private:
     NamedValueRefManager();
 
-    /** helper function for GetValueRef */
-    template <typename V>
-    V* const GetValueRefImpl(std::map<key_type, std::unique_ptr<V>>& registry, const std::string& label, const std::string& name);
-
-    /** helper function for RegisterValueRef */
-    template <typename R, typename VR>
-    void RegisterValueRefImpl(R& registry, std::mutex& mutex, const std::string& label, std::string&& valueref_name, std::unique_ptr<VR>&& vref);
-
     //! Map of ValueRef%s identified by a name and mutexes for those to allow asynchronous registration
     double_container_type m_value_refs_double; // int value refs
     std::mutex            m_value_refs_double_mutex;
@@ -124,6 +113,8 @@ FO_COMMON_API auto GetNamedValueRefManager() -> NamedValueRefManager&;
 //! @p name.  If no such ValueRef exists, nullptr is returned instead.
 FO_COMMON_API auto GetValueRefBase(const std::string& name) -> ValueRef::ValueRefBase* const;
 
+//! Returns the ValueRef object registered with the given
+//! @p name in the registry matching the given type T.  If no such ValueRef exists, nullptr is returned instead.
 template <typename T>
 FO_COMMON_API auto GetValueRef(const std::string& name) -> ValueRef::ValueRef<T>* const;
 

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -12,6 +12,7 @@
 #include "FleetPlan.h"
 #include "Fleet.h"
 #include "IDAllocator.h"
+#include "NamedValueRefManager.h"
 #include "Pathfinder.h"
 #include "Planet.h"
 #include "ShipDesign.h"
@@ -3120,6 +3121,7 @@ std::map<std::string, unsigned int> CheckSumContent() {
     checksums["BuildingTypeManager"] = GetBuildingTypeManager().GetCheckSum();
     checksums["Encyclopedia"] = GetEncyclopedia().GetCheckSum();
     checksums["FieldTypeManager"] = GetFieldTypeManager().GetCheckSum();
+    checksums["NamedValueRefManager"] = GetNamedValueRefManager().GetCheckSum();
     checksums["ShipHullManager"] = GetShipHullManager().GetCheckSum();
     checksums["ShipPartManager"] = GetShipPartManager().GetCheckSum();
     checksums["PredefinedShipDesignManager"] = GetPredefinedShipDesignManager().GetCheckSum();

--- a/universe/ValueRef.h
+++ b/universe/ValueRef.h
@@ -20,7 +20,7 @@ struct FO_COMMON_API ValueRefBase {
     virtual bool ConstantExpr() const            { return false; }
 
     virtual std::string Description() const = 0;                    //! Returns a user-readable text description of this ValueRef
-    virtual std::string StringResult() const = 0;                   //! Returns a textual representation of the evaluation result of this ValueRef
+    virtual std::string EvalAsString() const = 0;                   //! Returns a textual representation of the evaluation result  with an empty/default context
     virtual std::string Dump(unsigned short ntabs = 0) const = 0;   //! Returns a textual representation that should be parseable to recreate this ValueRef
 
     virtual void SetTopLevelContent(const std::string& content_name) {}
@@ -62,7 +62,7 @@ struct FO_COMMON_API ValueRef : public ValueRefBase
       * a string representation of the result value iff the result type is
       * supported (currently std::string, int, float, double, enum).
       * See ValueRefs.cpp for specialisation implementations. */
-    std::string StringResult() const;
+    std::string EvalAsString() const final;
 };
 
 enum StatisticType : int {

--- a/universe/ValueRef.h
+++ b/universe/ValueRef.h
@@ -60,7 +60,7 @@ struct FO_COMMON_API ValueRef : public ValueRefBase
 
     /** Evaluates the expression tree with an empty context and retuns the
       * a string representation of the result value iff the result type is
-      * supported (currently std::string, int, float, double).
+      * supported (currently std::string, int, float, double, enum).
       * See ValueRefs.cpp for specialisation implementations. */
     std::string StringResult() const;
 };

--- a/universe/ValueRef.h
+++ b/universe/ValueRef.h
@@ -1,10 +1,8 @@
 #ifndef _ValueRef_h_
 #define _ValueRef_h_
 
-
 #include "ScriptingContext.h"
 #include "../util/Export.h"
-
 
 namespace ValueRef {
 
@@ -22,6 +20,7 @@ struct FO_COMMON_API ValueRefBase {
     virtual bool ConstantExpr() const    { return false; }
 
     virtual std::string Description() const = 0;                    //! Returns a user-readable text description of this ValueRef
+    virtual std::string StringResult() const = 0;                   //! Returns a textual representation of the evaluation result of this ValueRef
     virtual std::string Dump(unsigned short ntabs = 0) const = 0;   //! Returns a textual representation that should be parseable to recreate this ValueRef
 
     virtual void SetTopLevelContent(const std::string& content_name) {}
@@ -58,6 +57,12 @@ struct FO_COMMON_API ValueRef : public ValueRefBase
       * to objects such as the source, effect target, or condition candidates
       * that exist in the tree. */
     virtual T Eval(const ScriptingContext& context) const = 0;
+
+    /** Evaluates the expression tree with an empty context and retuns the
+      * a string representation of the result value iff the result type is
+      * supported (currently std::string, int, float, double).
+      * See ValueRefs.cpp for specialisation implementations. */
+    std::string StringResult() const;
 };
 
 enum StatisticType : int {
@@ -83,5 +88,4 @@ enum StatisticType : int {
 
 }
 
-
-#endif
+#endif // _ValueRef_h_

--- a/universe/ValueRef.h
+++ b/universe/ValueRef.h
@@ -12,12 +12,12 @@ struct FO_COMMON_API ValueRefBase {
     ValueRefBase() = default;
     virtual ~ValueRefBase() = default;
 
-    bool RootCandidateInvariant() const  { return m_root_candidate_invariant; }
-    bool LocalCandidateInvariant() const { return m_local_candidate_invariant; }
-    bool TargetInvariant() const         { return m_target_invariant; }
-    bool SourceInvariant() const         { return m_source_invariant; }
-    virtual bool SimpleIncrement() const { return false; }
-    virtual bool ConstantExpr() const    { return false; }
+    virtual bool RootCandidateInvariant() const  { return m_root_candidate_invariant; }
+    virtual bool LocalCandidateInvariant() const { return m_local_candidate_invariant; }
+    virtual bool TargetInvariant() const         { return m_target_invariant; }
+    virtual bool SourceInvariant() const         { return m_source_invariant; }
+    virtual bool SimpleIncrement() const         { return false; }
+    virtual bool ConstantExpr() const            { return false; }
 
     virtual std::string Description() const = 0;                    //! Returns a user-readable text description of this ValueRef
     virtual std::string StringResult() const = 0;                   //! Returns a textual representation of the evaluation result of this ValueRef

--- a/universe/ValueRef.h
+++ b/universe/ValueRef.h
@@ -19,6 +19,7 @@ struct FO_COMMON_API ValueRefBase {
     virtual bool SimpleIncrement() const         { return false; }
     virtual bool ConstantExpr() const            { return false; }
 
+    std::string InvariancePattern() const;
     virtual std::string Description() const = 0;                    //! Returns a user-readable text description of this ValueRef
     virtual std::string EvalAsString() const = 0;                   //! Returns a textual representation of the evaluation result  with an empty/default context
     virtual std::string Dump(unsigned short ntabs = 0) const = 0;   //! Returns a textual representation that should be parseable to recreate this ValueRef

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -48,10 +48,10 @@ namespace {
         ValueRef::ReferenceType ref_type,
         const ScriptingContext& context)
     {
-        DebugLogger() << "FollowReference: source: " << (context.source ? context.source->Name() : "0")
-                      << " target: " << (context.effect_target ? context.effect_target->Name() : "0")
-                      << " local c: " << (context.condition_local_candidate ? context.condition_local_candidate->Name() : "0")
-                      << " root c: " << (context.condition_root_candidate ? context.condition_root_candidate->Name() : "0");
+        // DebugLogger() << "FollowReference: source: " << (context.source ? context.source->Name() : "0")
+        //               << " target: " << (context.effect_target ? context.effect_target->Name() : "0")
+        //               << " local c: " << (context.condition_local_candidate ? context.condition_local_candidate->Name() : "0")
+        //               << " root c: " << (context.condition_root_candidate ? context.condition_root_candidate->Name() : "0");
 
         std::shared_ptr<const UniverseObject> obj;
         switch (ref_type) {
@@ -2481,6 +2481,12 @@ std::string ComplexVariable<int>::Dump(unsigned short ntabs) const
     const std::string& variable_name = m_property_name.back();
     std::string retval = variable_name;
     // todo: implement like <double> case
+    if (variable_name == "GameRule")
+    {
+        if (m_string_ref1)
+            retval += " name = " + m_string_ref1->Dump(ntabs);
+    }
+
     return retval;
 }
 
@@ -2490,6 +2496,12 @@ std::string ComplexVariable<std::string>::Dump(unsigned short ntabs) const
     const std::string& variable_name = m_property_name.back();
     std::string retval = variable_name;
     // todo: implement like <double> case
+    if (variable_name == "GameRule")
+    {
+        if (m_string_ref1)
+            retval += " name = " + m_string_ref1->Dump(ntabs);
+    }
+
     return retval;
 }
 
@@ -2499,6 +2511,12 @@ std::string ComplexVariable<std::vector<std::string>>::Dump(unsigned short ntabs
     const std::string& variable_name = m_property_name.back();
     std::string retval = variable_name;
     // todo: implement like <double> case
+    if (variable_name == "GameRule")
+    {
+        if (m_string_ref1)
+            retval += " name = " + m_string_ref1->Dump(ntabs);
+    }
+
     return retval;
 }
 

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -48,10 +48,10 @@ namespace {
         ValueRef::ReferenceType ref_type,
         const ScriptingContext& context)
     {
-        // DebugLogger() << "FollowReference: source: " << (context.source ? context.source->Name() : "0")
-        //               << " target: " << (context.effect_target ? context.effect_target->Name() : "0")
-        //               << " local c: " << (context.condition_local_candidate ? context.condition_local_candidate->Name() : "0")
-        //               << " root c: " << (context.condition_root_candidate ? context.condition_root_candidate->Name() : "0");
+        //DebugLogger() << "FollowReference: source: " << (context.source ? context.source->Name() : "0")
+        //              << " target: " << (context.effect_target ? context.effect_target->Name() : "0")
+        //              << " local c: " << (context.condition_local_candidate ? context.condition_local_candidate->Name() : "0")
+        //              << " root c: " << (context.condition_root_candidate ? context.condition_root_candidate->Name() : "0");
 
         std::shared_ptr<const UniverseObject> obj;
         switch (ref_type) {
@@ -274,7 +274,7 @@ std::string ValueRef<std::string>::StringResult() const {
 template <>
 std::string ValueRef<std::vector<std::string>>::StringResult() const {
     std::string s;
-    for (const auto &piece : Eval()) s += piece;
+    for (const auto& piece : Eval()) s += piece;
     return s;
 }
 
@@ -2492,8 +2492,7 @@ std::string ComplexVariable<int>::Dump(unsigned short ntabs) const
     const std::string& variable_name = m_property_name.back();
     std::string retval = variable_name;
     // todo: implement like <double> case
-    if (variable_name == "GameRule")
-    {
+    if (variable_name == "GameRule") {
         if (m_string_ref1)
             retval += " name = " + m_string_ref1->Dump(ntabs);
     }
@@ -2507,8 +2506,7 @@ std::string ComplexVariable<std::string>::Dump(unsigned short ntabs) const
     const std::string& variable_name = m_property_name.back();
     std::string retval = variable_name;
     // todo: implement like <double> case
-    if (variable_name == "GameRule")
-    {
+    if (variable_name == "GameRule") {
         if (m_string_ref1)
             retval += " name = " + m_string_ref1->Dump(ntabs);
     }
@@ -2522,8 +2520,7 @@ std::string ComplexVariable<std::vector<std::string>>::Dump(unsigned short ntabs
     const std::string& variable_name = m_property_name.back();
     std::string retval = variable_name;
     // todo: implement like <double> case
-    if (variable_name == "GameRule")
-    {
+    if (variable_name == "GameRule") {
         if (m_string_ref1)
             retval += " name = " + m_string_ref1->Dump(ntabs);
     }

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -249,8 +249,8 @@ namespace {
     const std::string EMPTY_STRING;
 }
 
-// helper: support enums in ValueRef<T>::StringResult() via ADL
-// c++11 direct use of std::enable_if would confuse the signature of StringResult
+// helper: support enums in ValueRef<T>::EvalAsString() via ADL
+// c++11 direct use of std::enable_if would confuse the signature of EvalAsString
 // c++17 could use: if constexpr (std::is_enum<T>::value
 template <typename T>
 typename std::enable_if<std::is_enum<T>::value, std::string>::type to_string(T val) {
@@ -261,33 +261,33 @@ namespace ValueRef {
     
 // enums and arithmetics
 template <typename T>
-std::string ValueRef<T>::StringResult() const {
+std::string ValueRef<T>::EvalAsString() const {
     using std::to_string;
     return to_string(Eval()); // uses ::to_string or std::to_string per ADL (argument dependent lookup)
 }
 
 template <>
-std::string ValueRef<std::string>::StringResult() const {
+std::string ValueRef<std::string>::EvalAsString() const {
     return Eval();
 }
 
 template <>
-std::string ValueRef<std::vector<std::string>>::StringResult() const {
+std::string ValueRef<std::vector<std::string>>::EvalAsString() const {
     std::string s;
     for (const auto& piece : Eval()) s += piece;
     return s;
 }
 
-// instantiations of StringResult implementation
-template std::string ValueRef<int>::StringResult() const;
-template std::string ValueRef<float>::StringResult() const;
-template std::string ValueRef<double>::StringResult() const;
-template std::string ValueRef<PlanetEnvironment>::StringResult() const;
-template std::string ValueRef<PlanetSize>::StringResult() const;
-template std::string ValueRef<PlanetType>::StringResult() const;
-template std::string ValueRef<StarType>::StringResult() const;
-template std::string ValueRef<UniverseObjectType>::StringResult() const;
-template std::string ValueRef<Visibility>::StringResult() const;
+// instantiations of EvalAsString implementation
+template std::string ValueRef<int>::EvalAsString() const;
+template std::string ValueRef<float>::EvalAsString() const;
+template std::string ValueRef<double>::EvalAsString() const;
+template std::string ValueRef<PlanetEnvironment>::EvalAsString() const;
+template std::string ValueRef<PlanetSize>::EvalAsString() const;
+template std::string ValueRef<PlanetType>::EvalAsString() const;
+template std::string ValueRef<StarType>::EvalAsString() const;
+template std::string ValueRef<UniverseObjectType>::EvalAsString() const;
+template std::string ValueRef<Visibility>::EvalAsString() const;
 
 
 MeterType NameToMeter(const std::string& name) {

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -258,7 +258,12 @@ typename std::enable_if<std::is_enum<T>::value, std::string>::type to_string(T v
 }
 
 namespace ValueRef {
-    
+    std::string ValueRefBase::InvariancePattern() const {
+        return std::string(RootCandidateInvariant()?"R":"r") + (LocalCandidateInvariant()?"L":"l")
+            + (SourceInvariant()?"S":"s") + (TargetInvariant()?"T":"t")
+            + (SimpleIncrement()?"I":"i") + (ConstantExpr()?"C":"c");
+    }
+
 // enums and arithmetics
 template <typename T>
 std::string ValueRef<T>::EvalAsString() const {

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -602,9 +602,12 @@ std::string Constant<std::string>::Eval(const ScriptingContext& context) const
 template <>
 void Constant<std::string>::SetTopLevelContent(const std::string& content_name)
 {
-    m_top_level_content = content_name;
     if (m_value == "CurrentContent" && content_name == "THERE_IS_NO_TOP_LEVEL_CONTENT")
-        ErrorLogger() << "Constant<std::string>::SetTopLevelContent() Scripted Content illegal. Trying to set THERE_IS_NO_TOP_LEVEL_CONTENT for CurrentContent (maybe you tried to use CurrentContent in named_values.focs.txt)";
+        ErrorLogger() << "Constant<std::string>::SetTopLevelContent()  Scripted Content illegal. Trying to set THERE_IS_NO_TOP_LEVEL_CONTENT for CurrentContent (maybe you tried to use CurrentContent in named_values.focs.txt)";
+    if (!m_top_level_content.empty()) // expected to happen if this value ref is part of a non-named-in-the-middle named value ref 
+        DebugLogger() << "Constant<std::string>::SetTopLevelContent()  Skip overwriting top level content from '" << m_top_level_content << "' to '" << content_name << "'";
+    else
+        m_top_level_content = content_name;
 }
 
 ///////////////////////////////////////////////////////////

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -599,6 +599,14 @@ std::string Constant<std::string>::Eval(const ScriptingContext& context) const
     return m_value;
 }
 
+template <>
+void Constant<std::string>::SetTopLevelContent(const std::string& content_name)
+{
+    m_top_level_content = content_name;
+    if (m_value == "CurrentContent" && content_name == "THERE_IS_NO_TOP_LEVEL_CONTENT")
+        ErrorLogger() << "Constant<std::string>::SetTopLevelContent() Scripted Content illegal. Trying to set THERE_IS_NO_TOP_LEVEL_CONTENT for CurrentContent (maybe you tried to use CurrentContent in named_values.focs.txt)";
+}
+
 ///////////////////////////////////////////////////////////
 // Variable                                              //
 ///////////////////////////////////////////////////////////

--- a/universe/ValueRefs.h
+++ b/universe/ValueRefs.h
@@ -522,6 +522,8 @@ FO_COMMON_API std::string Constant<std::string>::Dump(unsigned short ntabs) cons
 template <>
 FO_COMMON_API std::string Constant<std::string>::Eval(const ScriptingContext& context) const;
 
+template <>
+FO_COMMON_API void Constant<std::string>::SetTopLevelContent(const std::string& content_name);
 
 ///////////////////////////////////////////////////////////
 // Variable                                              //

--- a/universe/ValueRefs.h
+++ b/universe/ValueRefs.h
@@ -470,7 +470,7 @@ std::string Constant<T>::Description() const
 
 template <typename T>
 void Constant<T>::SetTopLevelContent(const std::string& content_name)
-{ m_top_level_content = content_name; }
+{}
 
 template <typename T>
 unsigned int Constant<T>::GetCheckSum() const

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -17,6 +17,7 @@
 #include "../util/Pending.h"
 
 #include <boost/filesystem.hpp>
+#include <boost/optional.hpp>
 
 #include <future>
 
@@ -59,6 +60,16 @@ void IApp::StartBackgroundParsing() {
         ErrorLogger() << "Background parse given non-existant resources directory!";
         return;
     }
+
+    // named value ref parsing can be done in parallel as the referencing happens after parsing
+    using named_value_ref_pending_type = Pending::Pending<std::map<std::string, std::unique_ptr<ValueRef::ValueRefBase>>>;
+    boost::optional<named_value_ref_pending_type> named_value_ref_parser_future;
+    if (fs::exists(rdir / "scripting/common")) {
+        // we ignore the parse result, the parser uses the ::RegisterValueRef function instead of the Pending mechanic
+        named_value_ref_parser_future = Pending::StartParsing(parse::named_value_refs, rdir / "scripting/common");
+        ErrorLogger() << "Background parse path for NamedValueRefs does exist: " << (rdir / "scripting/common").string();
+    } else
+        ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/common").string();
 
     if (fs::exists(rdir / "scripting/buildings"))
         GetBuildingTypeManager().SetBuildingTypes(Pending::StartParsing(parse::buildings, rdir / "scripting/buildings"));
@@ -124,4 +135,7 @@ void IApp::StartBackgroundParsing() {
         InitEmpireColors(rdir / "empire_colors.xml");
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "empire_colors.xml").string();
+
+    if (named_value_ref_parser_future)
+        Pending::WaitForPending(named_value_ref_parser_future);
 }

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -67,7 +67,6 @@ void IApp::StartBackgroundParsing() {
     if (fs::exists(rdir / "scripting/common")) {
         // we ignore the parse result, the parser uses the ::RegisterValueRef function instead of the Pending mechanic
         named_value_ref_parser_future = Pending::StartParsing(parse::named_value_refs, rdir / "scripting/common");
-        ErrorLogger() << "Background parse path for NamedValueRefs does exist: " << (rdir / "scripting/common").string();
     } else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/common").string();
 

--- a/util/VarText.cpp
+++ b/util/VarText.cpp
@@ -1,5 +1,6 @@
 #include "VarText.h"
 
+#include "../universe/ValueRefs.h"
 #include "../universe/Universe.h"
 #include "../universe/ShipDesign.h"
 #include "../universe/System.h"
@@ -31,6 +32,7 @@ const Species*      GetSpecies(const std::string& name);
 const FieldType*    GetFieldType(const std::string& name);
 const ShipHull*     GetShipHull(const std::string& name);
 const ShipPart*     GetShipPart(const std::string& name);
+ValueRef::ValueRefBase* const  GetValueRefBase(const std::string& name);
 
 namespace {
     //! Return @p content surrounded by the given @p tags.
@@ -172,6 +174,12 @@ namespace {
             {VarText::PREDEFINED_DESIGN_TAG, PredefinedShipDesignString},
             {VarText::EMPIRE_ID_TAG, [](const std::string& data)
                 { return IDString<Empire, GetEmpire>(data, VarText::EMPIRE_ID_TAG); }},
+            {VarText::FOCS_VALUE_TAG, [](const std::string& data) -> boost::optional<std::string>
+             { const ValueRef::ValueRefBase* vr = GetValueRefBase(data);
+               if (vr) {
+                   return WithTags(UserString(data), VarText::FOCS_VALUE_TAG, vr->StringResult());
+               } else
+                   return WithTags(data, VarText::FOCS_VALUE_TAG, UserString("UNKNOWN_VALUE_REF_NAME")); }},
         };
 
         return substitute_map;
@@ -234,6 +242,8 @@ const std::string VarText::COMBAT_ID_TAG = "combat";
 const std::string VarText::EMPIRE_ID_TAG = "empire";
 const std::string VarText::DESIGN_ID_TAG = "shipdesign";
 const std::string VarText::PREDEFINED_DESIGN_TAG = "predefinedshipdesign";
+
+const std::string VarText::FOCS_VALUE_TAG = "value";
 
 const std::string VarText::TECH_TAG = "tech";
 const std::string VarText::POLICY_TAG = "policy";

--- a/util/VarText.cpp
+++ b/util/VarText.cpp
@@ -177,7 +177,7 @@ namespace {
             {VarText::FOCS_VALUE_TAG, [](const std::string& data) -> boost::optional<std::string>
              { const ValueRef::ValueRefBase* vr = GetValueRefBase(data);
                if (vr) {
-                   return WithTags(UserString(data), VarText::FOCS_VALUE_TAG, vr->StringResult());
+                   return WithTags(UserString(data), VarText::FOCS_VALUE_TAG, vr->EvalAsString());
                } else
                    return WithTags(data, VarText::FOCS_VALUE_TAG, UserString("UNKNOWN_VALUE_REF_NAME")); }},
         };

--- a/util/VarText.h
+++ b/util/VarText.h
@@ -186,6 +186,8 @@ public:
     static const std::string FIELD_TYPE_TAG;
     //! Variable value is a predefined MeterType string representation.
     static const std::string METER_TYPE_TAG;
+    //! Variable value is the name of a registed ValueRef.
+    static const std::string FOCS_VALUE_TAG;
 
     //! @}
 


### PR DESCRIPTION
This implements a solution to [A single source for default values - forum thread](https://www.freeorion.org/forum/viewtopic.php?f=6&t=11427)

This adds 
- a configuration file `default/scripting/common/named_values.focs.txt` for defining named value refs
- a `NamedInteger` definition in that file that takes a `string` name and a `ValueRef<int>` value as parameter.
- a `NamedReal` definition in that file that takes a `string` name and a `ValueRef<double>` value as parameter.
- a `NamedEnvironment` definition in that file that takes a `string` name and a `ValueRef<PlanetEnvironment>` value as parameter. (this and the following NamedPlanetType are mostly proof-of-concept how this works with enums).
- a `NamedPlanetType` definition in that file that takes a `string` name and a `ValueRef<PlanetType>` value as parameter.
- a encyclopedia `[Test - Named Value Refs]` entry which lists all the named value refs in the game (name/ID, registration type, stringtable entry, calculation, calculated value, and pattern of invariances)

Also in normal focs and macro files one can use:
- a `NamedRef` ValueRef called `Lookup` in FOCS which takes a string name as parameter. This can be used to look up and eval a registered value ref.
- a name-in-the-middle-ValueRef definition named `NamedReal` which takes a `string` name and a `ValueRef<double>` value as parameters. This registers the given value ref and inserts a `NamedRef`instead.
- a name-in-the-middle-ValueRef definition named `NamedInteger` which takes a `string` name and a `ValueRef<integer>` value as parameters. This registers the given value ref and inserts a `NamedRef`instead.

Currently use is showcased for fuel and reinforced hull techs. The named_values.focs.txt is used for the reinforced hull bonus (although that tech should use a name-in-the-middle valuref as that tech is the single place where the value is used). The name-in-the-middle functionality is shown for fuel tech in `fuel.macros`-using named_values one would have to make an explicit entry for each of the techs.
```
default/scripting/techs/ship_parts/damage_control/SHP_REINFORCED_HULL.focs.txt:            effects = SetMaxStructure value = Value + Lookup name = "SHP_REINFORCED_HULL_BONUS"
default/scripting/common/named_values.focs.txt:NamedReal name = "SHP_REINFORCED_HULL_BONUS" value = (5 * [[SHIP_STRUCTURE_FACTOR]]) 
```

Registed value refs can be shown via `[[value REGISTERED_VALUEREF_NAME]]` in encyclopedia/stringtables  (e.g. `[[value SHP_REINFORCED_HULL_BONUS]]`). 
Also one can show these in sitrep messages (e.g. `[[value SHP_REINFORCED_HULL_BONUS]]` or sitrep tags in stringtables: `%value%`, `%value:tagnamedifferentfromvalue%`, ) with a mouseover effect. The mouseover shows the `ValueRef->Description`. 

Note: Currently one also needs to define the relevant sitrep entry (e.g. `SHP_REINFORCED_HULL_BONUS`) - else you get errors. This might be the right thing. I use it to give some textual extra info which might be the wrong thing.

OPTIONS_DEFAULT_TOOLTIP_COLOR and OPTIONS_ROLLOVER_TOOLTIP_COLOR define the colors used for showing the tags.

In some cases rendering fails/is inconsistent, e.g. the tooltip for the fuel tank part. 

AI support is not implemented, probably that will go into a followup PR once this is finished.