### PR TITLE
Sly & Gaia special - prevent type cycling, reweight colonization

### DIFF
--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -133,8 +133,8 @@ def calc_max_pop(planet, species, detail):
         detail.append("%s (maxPop%+.1f)" % (_special, this_mod))
         base_pop_not_modified_by_species += this_mod
 
-    #  exobots can't ever get to good environ so no gaia bonus, for others we'll assume they'll get there
-    if "GAIA_SPECIAL" in planet_specials and species.name != "SP_EXOBOT":
+    #  exobots and sly can't ever get to good environ so no gaia bonus, for others we'll assume they'll get there
+    if "GAIA_SPECIAL" in planet_specials and species.name != "SP_EXOBOT" and species.name != "SP_SLY":
         base_pop_not_modified_by_species += 3
         detail.append("Gaia_PSM_late(3)")
 

--- a/default/scripting/specials/planet/GAIA.focs.txt
+++ b/default/scripting/specials/planet/GAIA.focs.txt
@@ -25,11 +25,7 @@ Special
                 Not Planet environment = Good
                 Population low = 0.01
                 OwnedBy affiliation = AnyEmpire
-                Not And [
-                    Species name = "SP_EXOBOT"
-                    Planet environment = adequate
-                ]
-                Not Species name = "SP_SLY"
+                Not Planet type = Source.NextBetterPlanetType
                 Random probability = 0.5
             ]
             effects = [

--- a/default/scripting/specials/planet/GAIA.focs.txt
+++ b/default/scripting/specials/planet/GAIA.focs.txt
@@ -29,6 +29,7 @@ Special
                     Species name = "SP_EXOBOT"
                     Planet environment = adequate
                 ]
+                Not Species name = "SP_SLY"
                 Random probability = 0.5
             ]
             effects = [

--- a/universe/Species.cpp
+++ b/universe/Species.cpp
@@ -268,16 +268,19 @@ PlanetType Species::NextBetterPlanetType(PlanetType initial_planet_type) const {
     if (m_planet_environments.empty())
         return initial_planet_type;
 
-    // determine which environment rating is the best available for this species
+    // determine which environment rating is the best available for this species,
+    // excluding gas giants and asteroids
     PlanetEnvironment best_environment = PE_UNINHABITABLE;
     //std::set<PlanetType> best_types;
     for (const auto& entry : m_planet_environments) {
-        if (entry.second == best_environment) {
-            //best_types.insert(entry.first);
-        } else if (entry.second > best_environment) {
-            best_environment = entry.second;
-            //best_types.clear();
-            //best_types.insert(entry.first);
+        if (entry.first < PT_ASTEROIDS) {
+            if (entry.second == best_environment) {
+                //best_types.insert(entry.first);
+            } else if (entry.second > best_environment) {
+                best_environment = entry.second;
+                //best_types.clear();
+                //best_types.insert(entry.first);
+            }
         }
     }
 


### PR DESCRIPTION
1.  alter the Gaia special to prevent it from cycling through
    planet types when occupied by Sly (similar to Exobots)

2.  alter the Colonization AI to devalue the Gaia special as Sly derive
   no benefit from it (similar to Exobots)

Related Issue #3001 

Signed-off-by: Rob Gill <rrobgill@protonmail.com>