### PR TITLE
UI tweak - display planet wheel only for real planets

### DIFF
--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2680,8 +2680,10 @@ namespace {
             detailed_description += "\n";
         }
 
-        detailed_description += UserString("ENC_SUITABILITY_REPORT_WHEEL_INTRO")
-                                + "<img src=\"encyclopedia/EP_wheel.png\"></img>";
+        if (planet->Size() < SZ_ASTEROIDS) {
+            detailed_description += UserString("ENC_SUITABILITY_REPORT_WHEEL_INTRO")
+                                    + "<img src=\"encyclopedia/EP_wheel.png\"></img>";
+        }
     }
 
     void RefreshDetailPanelSearchResultsTag(const std::string& item_type, const std::string& item_name,

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2680,7 +2680,7 @@ namespace {
             detailed_description += "\n";
         }
 
-        if (planet->Size() < SZ_ASTEROIDS) {
+        if (planet->Type() < PT_ASTEROIDS && planet->Type() > INVALID_PLANET_TYPE) {
             detailed_description += UserString("ENC_SUITABILITY_REPORT_WHEEL_INTRO")
                                     + "<img src=\"encyclopedia/EP_wheel.png\"></img>";
         }


### PR DESCRIPTION
This patch hides the planet wheel and intro text when viewing the
encyclopedia planet suitability page for gas giants and asteroids.

Related Issue #3003

Signed-off-by: Rob Gill <rrobgill@protonmail.com>