### PR TITLE
Set minimum window sizes on design screen

### DIFF
--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1896,6 +1896,8 @@ void DesignWnd::PartPalette::CompleteConstruction() {
 
     CUIWnd::CompleteConstruction();
 
+    SetMinSize(GG::Pt(PART_CONTROL_WIDTH + 70 ,PART_CONTROL_HEIGHT + 70));
+
     DoLayout();
     SaveDefaultedOptions();
 }
@@ -3448,6 +3450,8 @@ void DesignWnd::BaseSelector::CompleteConstruction() {
 
     CUIWnd::CompleteConstruction();
 
+    SetMinSize(GG::Pt(PART_CONTROL_WIDTH + 70 ,PART_CONTROL_HEIGHT + 70));
+
     DoLayout();
     SaveDefaultedOptions();
 }
@@ -4115,6 +4119,7 @@ void DesignWnd::MainPanel::CompleteConstruction() {
     DesignChanged(); // Initialize components that rely on the current state of the design.
 
     CUIWnd::CompleteConstruction();
+    SetMinSize(GG::Pt(PART_CONTROL_WIDTH + 70 ,PART_CONTROL_HEIGHT + 70));
 
     DoLayout();
     SaveDefaultedOptions();

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -69,6 +69,7 @@ namespace {
     const GG::Y         PART_CONTROL_HEIGHT(54);
     const GG::X         SLOT_CONTROL_WIDTH(60);
     const GG::Y         SLOT_CONTROL_HEIGHT(60);
+    const GG::Pt        PALETTE_MIN_SIZE{GG::X{PART_CONTROL_WIDTH + 70}, GG::Y{PART_CONTROL_HEIGHT + 70}};
     const int           PAD(3);
 
     /** Returns texture with which to render a SlotControl, depending on \a slot_type. */
@@ -1896,7 +1897,7 @@ void DesignWnd::PartPalette::CompleteConstruction() {
 
     CUIWnd::CompleteConstruction();
 
-    SetMinSize(GG::Pt(PART_CONTROL_WIDTH + 70 ,PART_CONTROL_HEIGHT + 70));
+    SetMinSize(PALETTE_MIN_SIZE);
 
     DoLayout();
     SaveDefaultedOptions();
@@ -3450,7 +3451,7 @@ void DesignWnd::BaseSelector::CompleteConstruction() {
 
     CUIWnd::CompleteConstruction();
 
-    SetMinSize(GG::Pt(PART_CONTROL_WIDTH + 70 ,PART_CONTROL_HEIGHT + 70));
+    SetMinSize(PALETTE_MIN_SIZE);
 
     DoLayout();
     SaveDefaultedOptions();
@@ -4119,7 +4120,7 @@ void DesignWnd::MainPanel::CompleteConstruction() {
     DesignChanged(); // Initialize components that rely on the current state of the design.
 
     CUIWnd::CompleteConstruction();
-    SetMinSize(GG::Pt(PART_CONTROL_WIDTH + 70 ,PART_CONTROL_HEIGHT + 70));
+    SetMinSize(PALETTE_MIN_SIZE);
 
     DoLayout();
     SaveDefaultedOptions();

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -79,9 +79,6 @@ namespace {
     const std::string TAG_EXTINCT = "CTRL_EXTINCT";
     /** @content_tag{PEDIA_} Defines an encyclopedia category for the generated article of the containing content definition.  The category name should be postfixed to this tag. **/
     const std::string TAG_PEDIA_PREFIX = "PEDIA_";
-
-    const GG::X         CONTROL_WIDTH(54);
-    const GG::Y         CONTROL_HEIGHT(54);
 }
 
 namespace {
@@ -596,6 +593,9 @@ void EncyclopediaDetailPanel::CompleteConstruction() {
     const int PTS = ClientUI::Pts();
     const int NAME_PTS = PTS*3/2;
     const int SUMMARY_PTS = PTS*4/3;
+    const GG::X CONTROL_WIDTH(54);
+    const GG::Y CONTROL_HEIGHT(74);
+    const GG::Pt PALETTE_MIN_SIZE{GG::X{CONTROL_WIDTH + 70}, GG::Y{CONTROL_HEIGHT + 70}};
 
     m_name_text =    GG::Wnd::Create<CUILabel>("");
     m_cost_text =    GG::Wnd::Create<CUILabel>("");
@@ -677,7 +677,7 @@ void EncyclopediaDetailPanel::CompleteConstruction() {
     SetChildClippingMode(ClipToWindow);
     DoLayout();
 
-    SetMinSize(GG::Pt(CONTROL_WIDTH + 70, CONTROL_HEIGHT + 70));
+    SetMinSize(PALETTE_MIN_SIZE);
 
     MoveChildUp(m_graph);
     SaveDefaultedOptions();

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -79,6 +79,9 @@ namespace {
     const std::string TAG_EXTINCT = "CTRL_EXTINCT";
     /** @content_tag{PEDIA_} Defines an encyclopedia category for the generated article of the containing content definition.  The category name should be postfixed to this tag. **/
     const std::string TAG_PEDIA_PREFIX = "PEDIA_";
+
+    const GG::X         CONTROL_WIDTH(54);
+    const GG::Y         CONTROL_HEIGHT(54);
 }
 
 namespace {
@@ -673,6 +676,9 @@ void EncyclopediaDetailPanel::CompleteConstruction() {
 
     SetChildClippingMode(ClipToWindow);
     DoLayout();
+
+    SetMinSize(GG::Pt(CONTROL_WIDTH + 70, CONTROL_HEIGHT + 70));
+
     MoveChildUp(m_graph);
     SaveDefaultedOptions();
 


### PR DESCRIPTION
Fixes issue raised by bug #2997 (Several windows on the design screen had no minimum size specified, which caused issues of loss of resize control and rendering glitches if the window was inadvertently shrunk to very small sizes.)

Replaces PR #3006 

Signed-off-by: Rob Gill rrobgill@protonmail.com