### PR TITLE
Fix Trith population target accounting

### DIFF
--- a/default/scripting/species/SP_TRITH.focs.txt
+++ b/default/scripting/species/SP_TRITH.focs.txt
@@ -32,7 +32,7 @@ Species
 
         [[XENOPHOBIC_SELF]]
         [[XENOPHOBIC_OTHER(TRITH)]]
-        [[TELEPATHIC_DETECTION(5)]]
+        [[TELEPATHIC_DETECTION(5,2)]]
 
         // not for description
         [[AVERAGE_PLANETARY_SHIELDS]]

--- a/default/scripting/species/common/telepathic.macros
+++ b/default/scripting/species/common/telepathic.macros
@@ -1,3 +1,17 @@
+PRECOGNITIVE_DETECTION
+'''     EffectsGroup
+            description = "PRECOGNITIVE_DETECTION_DESC"
+            scope = And [
+                PopulationCenter
+                Not VisibleToEmpire empire = Source.Owner
+                Not Source
+                Not OwnedBy empire = Source.Owner
+                WithinStarlaneJumps jumps = @1@ condition = Source
+            ]
+            activation = OwnedBy affiliation = AnyEmpire
+            effects = SetVisibility empire = Source.Owner visibility = max(Basic, Value)
+'''
+
 TELEPATHIC_DETECTION
 '''     EffectsGroup
             description = "TELEPATHIC_DETECTION_DESC"
@@ -10,5 +24,9 @@ TELEPATHIC_DETECTION
                 WithinStarlaneJumps jumps = @1@ condition = Source
             ]
             activation = OwnedBy affiliation = AnyEmpire
-            effects = SetVisibility empire = Source.Owner visibility = max(Basic, Value)
+            effects = [
+                SetVisibility empire = Source.Owner visibility = max(Basic, Value)
+                If Condition = WithinStarlaneJumps jumps = @2@ condition = Source
+                    effects = SetVisibility empire = Source.Owner visibility = max(Partial, Value)
+            ]
 '''

--- a/default/scripting/species/common/xenophobic.macros
+++ b/default/scripting/species/common/xenophobic.macros
@@ -31,7 +31,7 @@ XENOPHOBIC_SELF
                 SetTargetResearch value = Value * 0.9
                 SetTargetHappiness value = Value - (
                     Statistic Count condition = And [
-                        Planet
+                        PopulationCenter
                         OwnedBy empire = Source.Owner
                         Not OR [ 
                             Species name = Source.Species
@@ -58,39 +58,19 @@ XENOPHOBIC_SELF
                     max(Value, 0) * 0.4 * (1 - 0.8^[[XENOPHOBIC_SELFSUSTAINING_QUALIFYING_PLANET_COUNT]]),
                     3 * Target.HabitableSize  // Cap malus at the self-sustaining bonus
                 )
-
 '''
 
-
-// There is no way to determine empire detection strength directly, so it is evaluated backwards
-// from the currently available detection technology.
 XENOPHOBIC_SELFSUSTAINING_QUALIFYING_PLANET_COUNT
 '''
 Statistic Count condition = And [
-            PopulationCenter
-            Not OR [
-                Species name = Source.Species
-                Species name = "SP_EXOBOT"
-            ]
-            Not Population high = 0
-            OR [
-                And [ WithinStarlaneJumps jumps = 2 condition = Source OwnerHasTech name = "SPY_DETECT_1"
-                      Stealth high = 10
+                    PopulationCenter
+                    Not OR [
+                        Species name = Source.Species
+                        Species name = "SP_EXOBOT"
+                    ]
+                    Not Population high = 0
+                    WithinStarlaneJumps jumps = 2 condition = Source
                 ]
-                And [ WithinStarlaneJumps jumps = 2 condition = Source OwnerHasTech name = "SPY_DETECT_2"
-                      Stealth high = 30
-                ]
-                And [ WithinStarlaneJumps jumps = 2 condition = Source OwnerHasTech name = "SPY_DETECT_3"
-                      Stealth high = 50
-                ]
-                And [ WithinStarlaneJumps jumps = 2 condition = Source OwnerHasTech name = "SPY_DETECT_4"
-                      Stealth high = 700
-                ]
-                And [ WithinStarlaneJumps jumps = 2 condition = Source OwnerHasTech name = "SPY_DETECT_5"
-                      Stealth high = 200
-                ]
-            ]
-       ]
 '''
 
 // single argument should be the name of the species capitalized

--- a/default/scripting/species/common/xenophobic.macros
+++ b/default/scripting/species/common/xenophobic.macros
@@ -31,7 +31,7 @@ XENOPHOBIC_SELF
                 SetTargetResearch value = Value * 0.9
                 SetTargetHappiness value = Value - (
                     Statistic Count condition = And [
-                        PopulationCenter
+                        Planet
                         OwnedBy empire = Source.Owner
                         Not OR [ 
                             Species name = Source.Species
@@ -51,30 +51,46 @@ XENOPHOBIC_SELF
                 PopulationCenter
                 HasTag name = "SELF_SUSTAINING"
             ]
-            stackinggroup = "XENOPHOBIC_LABEL_SELF"
+            stackinggroup = "XENOPHOBIC_POP_SELF"
             accountinglabel = "XENOPHOBIC_LABEL_SELF"
             priority = [[TARGET_POPULATION_LAST_BEFORE_OVERRIDE_PRIORITY]]
             effects = SetTargetPopulation value = Value - min(
                     max(Value, 0) * 0.4 * (1 - 0.8^[[XENOPHOBIC_SELFSUSTAINING_QUALIFYING_PLANET_COUNT]]),
                     3 * Target.HabitableSize  // Cap malus at the self-sustaining bonus
                 )
+
 '''
 
+
+// There is no way to determine empire detection strength directly, so it is evaluated backwards
+// from the currently available detection technology.
 XENOPHOBIC_SELFSUSTAINING_QUALIFYING_PLANET_COUNT
 '''
 Statistic Count condition = And [
-                    PopulationCenter
-                    Not OR [
-                        Species name = Source.Species
-                        Species name = "SP_EXOBOT"
-                    ]
-                    Not Population high = 0
-                    WithinStarlaneJumps jumps = 5 condition = Source
-                    WithinStarlaneJumps
-                                  jumps = 2
-                              condition = ExploredByEmpire
-                                          empire = Source.Owner
+            PopulationCenter
+            Not OR [
+                Species name = Source.Species
+                Species name = "SP_EXOBOT"
+            ]
+            Not Population high = 0
+            OR [
+                And [ WithinStarlaneJumps jumps = 2 condition = Source OwnerHasTech name = "SPY_DETECT_1"
+                      Stealth high = 10
                 ]
+                And [ WithinStarlaneJumps jumps = 2 condition = Source OwnerHasTech name = "SPY_DETECT_2"
+                      Stealth high = 30
+                ]
+                And [ WithinStarlaneJumps jumps = 2 condition = Source OwnerHasTech name = "SPY_DETECT_3"
+                      Stealth high = 50
+                ]
+                And [ WithinStarlaneJumps jumps = 2 condition = Source OwnerHasTech name = "SPY_DETECT_4"
+                      Stealth high = 700
+                ]
+                And [ WithinStarlaneJumps jumps = 2 condition = Source OwnerHasTech name = "SPY_DETECT_5"
+                      Stealth high = 200
+                ]
+            ]
+       ]
 '''
 
 // single argument should be the name of the species capitalized

--- a/default/scripting/species/common/xenophobic.macros
+++ b/default/scripting/species/common/xenophobic.macros
@@ -51,7 +51,7 @@ XENOPHOBIC_SELF
                 PopulationCenter
                 HasTag name = "SELF_SUSTAINING"
             ]
-            stackinggroup = "XENOPHOBIC_POP_SELF"
+            stackinggroup = "XENOPHOBIC_LABEL_SELF"
             accountinglabel = "XENOPHOBIC_LABEL_SELF"
             priority = [[TARGET_POPULATION_LAST_BEFORE_OVERRIDE_PRIORITY]]
             effects = SetTargetPopulation value = Value - min(


### PR DESCRIPTION
As raised in Bug #2777, script contained incorrect accounting tag, leading to population malus
being attributed to 'unknown'.

Signed-off-by: Rob Gill <rrobgill@protonmail.com>