### PR TITLE
Random Refactoring

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1792,7 +1792,7 @@ std::string Empire::NewShipName() {
         ship_names.push_back(UserString("OBJ_SHIP"));
 
     // select name randomly from list
-    int ship_name_idx = RandSmallInt(0, static_cast<int>(ship_names.size()) - 1);
+    int ship_name_idx = RandInt(0, static_cast<int>(ship_names.size()) - 1);
     std::string retval = ship_names[ship_name_idx];
     int times_name_used = ++m_ship_names_used[retval];
     if (1 < times_name_used)

--- a/UI/ClientUI.h
+++ b/UI/ClientUI.h
@@ -226,6 +226,10 @@ private:
     std::shared_ptr<SaveFileDialog>         m_savefile_dialog;
     std::shared_ptr<PasswordEnterWnd>       m_password_enter_wnd;   //!< the authentication window
 
+    //!< map key represents a directory and first part of a texture filename.
+    //!< when textures are looked up with GetPrefixedTextures, the specified
+    //!< dir is searched for filenames that start with the prefix. pointers
+    //!< to the Texture objects for these files are stored as the mapped value.
     std::map<std::string, std::vector<std::shared_ptr<GG::Texture>>>
                                             m_prefixed_textures;
 

--- a/UI/ClientUI.h
+++ b/UI/ClientUI.h
@@ -215,14 +215,6 @@ public:
     //!@}
 
 private:
-    typedef std::pair<std::vector<std::shared_ptr<GG::Texture>>,
-                      std::shared_ptr<SmallIntDistType>>    TexturesAndDist;
-    typedef std::map<std::string, TexturesAndDist>          PrefixedTextures;
-
-    TexturesAndDist PrefixedTexturesAndDist(const boost::filesystem::path& dir,
-                                            const std::string& prefix,
-                                            bool mipmap);
-
     void HandleSizeChange(bool fullscreen) const;
     void HandleFullscreenSwitch() const;
 
@@ -234,7 +226,8 @@ private:
     std::shared_ptr<SaveFileDialog>         m_savefile_dialog;
     std::shared_ptr<PasswordEnterWnd>       m_password_enter_wnd;   //!< the authentication window
 
-    PrefixedTextures                        m_prefixed_textures;
+    std::map<std::string, std::vector<std::shared_ptr<GG::Texture>>>
+                                            m_prefixed_textures;
 
     std::unique_ptr<ShipDesignManager>      m_ship_designs;         //!< ship designs the client knows about, and their ordering in the UI
 

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -744,7 +744,7 @@ public:
             const auto& atmosphere_data = GetPlanetAtmosphereData();
             auto it = atmosphere_data.find(rpd.filename);
             if (it != atmosphere_data.end()) {
-                const auto& atmosphere = it->second.atmospheres[RandSmallInt(0, it->second.atmospheres.size() - 1)];
+                const auto& atmosphere = it->second.atmospheres[RandInt(0, it->second.atmospheres.size() - 1)];
                 m_atmosphere_texture = ClientUI::GetTexture(ClientUI::ArtDir() / atmosphere.filename, true);
                 m_atmosphere_alpha = atmosphere.alpha;
                 m_atmosphere_planet_rect = GG::Rect(GG::X1, GG::Y1, m_atmosphere_texture->DefaultWidth() - 4, m_atmosphere_texture->DefaultHeight() - 4);
@@ -1150,7 +1150,7 @@ void SidePanel::PlanetPanel::RefreshPlanetGraphic() {
                                                                texture_width, texture_height, 0, textures,
                                                                GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE);
         m_planet_graphic->SetFPS(GetAsteroidsFPS());
-        m_planet_graphic->SetFrameIndex(RandSmallInt(0, textures.size() - 1));
+        m_planet_graphic->SetFrameIndex(RandInt(0, textures.size() - 1));
         AttachChild(m_planet_graphic);
         m_planet_graphic->Play();
     } else if (planet->Type() < NUM_PLANET_TYPES) {

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -243,9 +243,9 @@ namespace {
             GG::X icon_left(spacer.x);
             GG::X text_left(icon_left + GG::X(icon_dim) + sitrep_spacing);
             GG::X text_width(ClientWidth() - text_left - spacer.x);
-            m_link_text = GG::Wnd::Create<SitRepLinkText>(GG::X0, GG::Y0, text_width, m_sitrep_entry.GetText() + " ",
-                                             ClientUI::GetFont(),
-                                             GG::FORMAT_LEFT | GG::FORMAT_VCENTER | GG::FORMAT_WORDBREAK, ClientUI::TextColor());
+            m_link_text = GG::Wnd::Create<SitRepLinkText>(
+                GG::X0, GG::Y0, text_width, m_sitrep_entry.GetText() + " ", ClientUI::GetFont(),
+                GG::FORMAT_LEFT | GG::FORMAT_VCENTER | GG::FORMAT_WORDBREAK, ClientUI::TextColor());
             m_link_text->SetDecorator(VarText::EMPIRE_ID_TAG, new ColorEmpire());
             m_link_text->SetDecorator(TextLinker::BROWSE_PATH_TAG, new PathTypeDecorator());
             AttachChild(m_link_text);

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -305,7 +305,7 @@ void AIClientApp::HandleMessage(const Message& msg) {
 
             if (this_aggr > 0  && my_seed > 0) {
                 Seed(my_seed);
-                rand_num = RandSmallInt(0, 99);
+                rand_num = RandInt(0, 99);
                 // if it's in the top 25% then decrease aggression.
                 if (rand_num > 74) this_aggr--;
                 // Leaving the following as commented out code for now. Possibly for 0.4.4+?

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -1223,12 +1223,7 @@ namespace {
         void GetShuffledValidAttackerIDs(std::vector<int>& shuffled) {
             shuffled.clear();
             shuffled.insert(shuffled.begin(), valid_attacker_object_ids.begin(), valid_attacker_object_ids.end());
-
-            const unsigned swaps = shuffled.size();
-            for (unsigned i = 0; i < swaps; ++i) {
-                int pos2 = RandInt(i, swaps - 1);
-                std::swap(shuffled[i], shuffled[pos2]);
-            }
+            RandomShuffle(shuffled);
         }
 
         float EmpireDetectionStrength(int empire_id) {

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -143,7 +143,7 @@ namespace {
         }
         if (!valid_names.empty()) {
             // pick a name from the list of empire names
-            int empire_name_idx = RandSmallInt(0, static_cast<int>(valid_names.size()) - 1);
+            int empire_name_idx = RandInt(0, static_cast<int>(valid_names.size()) - 1);
             return *std::next(valid_names.begin(), empire_name_idx);
         }
         // use a player_name as it unique among players

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -674,11 +674,6 @@ bool SortedNumberOf::operator==(const Condition& rhs) const {
 }
 
 namespace {
-    /** Random number genrator function to use with random_shuffle */
-    int CustomRandInt(int max_plus_one)
-    { return RandSmallInt(0, max_plus_one - 1); }
-    int (*CRI)(int) = CustomRandInt;
-
     /** Transfers the indicated \a number of objects, randomly selected from from_set to to_set */
     void TransferRandomObjects(unsigned int number, ObjectSet& from_set, ObjectSet& to_set) {
         // ensure number of objects to be moved is within reasonable range
@@ -694,7 +689,7 @@ namespace {
         std::fill_n(transfer_flags.begin(), number, true);
 
         // shuffle flags to randomize which flags are set
-        std::random_shuffle(transfer_flags.begin(), transfer_flags.end(), CRI);
+        RandomShuffle(transfer_flags);
 
         // transfer objects that have been flagged
         int i = 0;

--- a/universe/Effects.cpp
+++ b/universe/Effects.cpp
@@ -1886,7 +1886,7 @@ void CreateSystem::Execute(ScriptingContext& context) const {
         star_type = m_type->Eval(context);
     } else {
         int max_type_idx = int(NUM_STAR_TYPES) - 1;
-        int type_idx = RandSmallInt(0, max_type_idx);
+        int type_idx = RandInt(0, max_type_idx);
         star_type = StarType(type_idx);
     }
 
@@ -2884,7 +2884,7 @@ void SetDestination::Execute(ScriptingContext& context) const {
         return;
 
     // "randomly" pick a destination
-    int destination_idx = RandSmallInt(0, valid_locations.size() - 1);
+    int destination_idx = RandInt(0, valid_locations.size() - 1);
     auto destination = std::const_pointer_cast<UniverseObject>(
         *std::next(valid_locations.begin(), destination_idx));
     int destination_system_id = destination->SystemID();

--- a/universe/IDAllocator.cpp
+++ b/universe/IDAllocator.cpp
@@ -226,7 +226,7 @@ void IDAllocator::ObfuscateBeforeSerialization() {
     // Advance each client to its own random offset.
     ID_t assigning_empire_offset_modulus = 0;
     for (const auto assigning_empire : m_offset_to_empire_id) {
-        auto empire_random_offset =  SmallIntDist(0, max_random_offset)();
+        auto empire_random_offset = RandInt(0, max_random_offset);
         auto new_next_id = empire_random_offset + m_zero;
 
         // Increment until it is at the correct offset

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -788,7 +788,7 @@ std::string NewMonsterName() {
         monster_names.push_back(UserString("MONSTER"));
 
     // select name randomly from list
-    int monster_name_index = RandSmallInt(0, static_cast<int>(monster_names.size()) - 1);
+    int monster_name_index = RandInt(0, static_cast<int>(monster_names.size()) - 1);
     std::string result = monster_names[monster_name_index];
     if (monster_names_used[result]++) {
         result += " " + RomanNumber(monster_names_used[result]);

--- a/universe/Species.cpp
+++ b/universe/Species.cpp
@@ -480,7 +480,7 @@ const std::string& SpeciesManager::RandomSpeciesName() const {
     if (m_species.empty())
         return EMPTY_STRING;
 
-    int species_idx = RandSmallInt(0, static_cast<int>(m_species.size()) - 1);
+    int species_idx = RandInt(0, static_cast<int>(m_species.size()) - 1);
     return std::next(begin(), species_idx)->first;
 }
 
@@ -488,7 +488,7 @@ const std::string& SpeciesManager::RandomPlayableSpeciesName() const {
     if (NumPlayableSpecies() <= 0)
         return EMPTY_STRING;
 
-    int species_idx = RandSmallInt(0, NumPlayableSpecies() - 1);
+    int species_idx = RandInt(0, NumPlayableSpecies() - 1);
     return std::next(playable_begin(), species_idx)->first;
 }
 

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -2162,7 +2162,7 @@ std::string ComplexVariable<std::string>::Eval(const ScriptingContext& context) 
         auto all_enqueued_techs = queue.AllEnqueuedProjects();
         if (all_enqueued_techs.empty())
             return "";
-        std::size_t idx = RandSmallInt(0, static_cast<int>(all_enqueued_techs.size()) - 1);
+        std::size_t idx = RandInt(0, static_cast<int>(all_enqueued_techs.size()) - 1);
         return *std::next(all_enqueued_techs.begin(), idx);
 
     } else if (variable_name == "RandomResearchableTech") {
@@ -2179,7 +2179,7 @@ std::string ComplexVariable<std::string>::Eval(const ScriptingContext& context) 
         auto researchable_techs = TechsResearchableByEmpire(empire_id);
         if (researchable_techs.empty())
             return "";
-        std::size_t idx = RandSmallInt(0, static_cast<int>(researchable_techs.size()) - 1);
+        std::size_t idx = RandInt(0, static_cast<int>(researchable_techs.size()) - 1);
         return *std::next(researchable_techs.begin(), idx);
     } else if (variable_name == "RandomCompleteTech") {
         int empire_id = ALL_EMPIRES;
@@ -2195,7 +2195,7 @@ std::string ComplexVariable<std::string>::Eval(const ScriptingContext& context) 
         auto complete_techs = TechsResearchedByEmpire(empire_id);
         if (complete_techs.empty())
             return "";
-        std::size_t idx = RandSmallInt(0, static_cast<int>(complete_techs.size()) - 1);
+        std::size_t idx = RandInt(0, static_cast<int>(complete_techs.size()) - 1);
         return *std::next(complete_techs.begin(), idx);
     } else if (variable_name == "LowestCostTransferrableTech") {
         int empire1_id = ALL_EMPIRES;
@@ -2215,7 +2215,7 @@ std::string ComplexVariable<std::string>::Eval(const ScriptingContext& context) 
         std::vector<std::string> sendable_techs = TransferrableTechs(empire1_id, empire2_id);
         if (sendable_techs.empty())
             return "";
-        std::size_t idx = RandSmallInt(0, static_cast<int>(sendable_techs.size()) - 1);
+        std::size_t idx = RandInt(0, static_cast<int>(sendable_techs.size()) - 1);
         return *std::next(sendable_techs.begin(), idx);
 
     } else if (variable_name == "HighestCostTransferrableTech") {
@@ -2714,7 +2714,7 @@ std::string Operation<std::string>::EvalImpl(const ScriptingContext& context) co
         // select one operand, evaluate it, return result
         if (m_operands.empty())
             return "";
-        unsigned int idx = RandSmallInt(0, m_operands.size() - 1);
+        unsigned int idx = RandInt(0, m_operands.size() - 1);
         auto& vr = *std::next(m_operands.begin(), idx);
         if (!vr)
             return "";
@@ -2859,7 +2859,7 @@ double Operation<double>::EvalImpl(const ScriptingContext& context) const
             // select one operand, evaluate it, return result
             if (m_operands.empty())
                 return 0.0;
-            unsigned int idx = RandSmallInt(0, m_operands.size() - 1);
+            unsigned int idx = RandInt(0, m_operands.size() - 1);
             auto& vr = *std::next(m_operands.begin(), idx);
             if (!vr)
                 return 0.0;
@@ -3010,7 +3010,7 @@ int Operation<int>::EvalImpl(const ScriptingContext& context) const
             // select one operand, evaluate it, return result
             if (m_operands.empty())
                 return 0;
-            unsigned int idx = RandSmallInt(0, m_operands.size() - 1);
+            unsigned int idx = RandInt(0, m_operands.size() - 1);
             auto& vr = *std::next(m_operands.begin(), idx);
             if (!vr)
                 return 0;

--- a/universe/ValueRefs.h
+++ b/universe/ValueRefs.h
@@ -1938,7 +1938,7 @@ T Operation<T>::EvalImpl(const ScriptingContext& context) const
         // select one operand, evaluate it, return result
         if (m_operands.empty())
             return T(-1);   // should be INVALID_T of enum types
-        unsigned int idx = RandSmallInt(0, m_operands.size() - 1);
+        unsigned int idx = RandInt(0, m_operands.size() - 1);
         auto& vr = *std::next(m_operands.begin(), idx);
         if (!vr)
             return T(-1);   // should be INVALID_T of enum types

--- a/universe/ValueRefs.h
+++ b/universe/ValueRefs.h
@@ -1938,7 +1938,7 @@ T Operation<T>::EvalImpl(const ScriptingContext& context) const
         // select one operand, evaluate it, return result
         if (m_operands.empty())
             return T(-1);   // should be INVALID_T of enum types
-        unsigned int idx = RandInt(0, m_operands.size() - 1);
+        auto idx = RandInt(0, m_operands.size() - 1);
         auto& vr = *std::next(m_operands.begin(), idx);
         if (!vr)
             return T(-1);   // should be INVALID_T of enum types

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -201,7 +201,7 @@ void GalaxySetupData::SetSeed(const std::string& seed) {
         ClockSeed();
         new_seed.clear();
         for (int i = 0; i < 8; ++i)
-            new_seed += alphanum[RandSmallInt(0, (sizeof(alphanum) - 2))];
+            new_seed += alphanum[RandInt(0, (sizeof(alphanum) - 2))];
         DebugLogger() << "Set empty or requested random seed to " << new_seed;
     }
     m_seed = std::move(new_seed);

--- a/util/Random.cpp
+++ b/util/Random.cpp
@@ -1,56 +1,72 @@
 #include "Random.h"
 
 #include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/thread/mutex.hpp>
+#include <boost/random/normal_distribution.hpp>
+#include <boost/random/uniform_01.hpp>
+#include <boost/random/uniform_real.hpp>
+#include <boost/random/uniform_smallint.hpp>
+
+#include <mutex>
+
+
+typedef std::lock_guard<std::mutex> lock_guard;
+typedef std::mt19937 GeneratorType;
+
 
 namespace {
-    GeneratorType gen; // the one random number generator driving the distributions below
-
-    static boost::mutex s_prng_mutex;
+    GeneratorType gen{2462343}; // the one random number generator driving the distributions below. arbitrarily chosen default seed
+    static std::mutex s_prng_mutex;
 }
 
 void Seed(unsigned int seed) {
-    boost::mutex::scoped_lock lock(s_prng_mutex);
-    gen.seed(static_cast<boost::mt19937::result_type>(seed));
+    lock_guard lock(s_prng_mutex);
+    gen.seed(static_cast<GeneratorType::result_type>(seed));
 }
 
 void ClockSeed() {
-    boost::mutex::scoped_lock lock(s_prng_mutex);
+    lock_guard lock(s_prng_mutex);
     boost::posix_time::time_duration diff = boost::posix_time::microsec_clock::local_time().time_of_day();
-    gen.seed(static_cast<boost::mt19937::result_type>(diff.total_milliseconds()));
+    gen.seed(static_cast<GeneratorType::result_type>(diff.total_milliseconds()));
 }
 
-SmallIntDistType SmallIntDist(int min, int max) {
-    boost::mutex::scoped_lock lock(s_prng_mutex);
-    return SmallIntDistType(gen, boost::uniform_smallint<>(min, max));
+int RandInt(int min, int max) {
+    if (min <= max)
+        return min;
+    boost::random::uniform_smallint<> dis(min, max);
+    {
+        lock_guard lock(s_prng_mutex);
+        return dis(gen);
+    }
 }
 
-IntDistType IntDist(int min, int max) {
-    boost::mutex::scoped_lock lock(s_prng_mutex);
-    return IntDistType(gen, boost::uniform_int<>(min, max));
+double RandZeroToOne() {
+    lock_guard lock(s_prng_mutex);
+    static boost::random::uniform_01<> dis;
+    return dis(gen);
 }
 
-DoubleDistType DoubleDist(double min, double max) {
-    boost::mutex::scoped_lock lock(s_prng_mutex);
-    return DoubleDistType(gen, boost::uniform_real<>(min, max));
+double RandDouble(double min, double max) {
+    if (min <= max)
+        return min;
+    boost::random::uniform_real_distribution<> dis(min, max);
+    {
+        lock_guard lock(s_prng_mutex);
+        return dis(gen);
+    }
 }
 
-GaussianDistType GaussianDist(double mean, double sigma) {
-    boost::mutex::scoped_lock lock(s_prng_mutex);
-    return GaussianDistType(gen, boost::normal_distribution<>(mean, sigma));
+double RandGaussian(double mean, double sigma) {
+    if (sigma <= 0.0)
+        return mean;
+    boost::random::normal_distribution<> dis(mean, sigma);
+    {
+        lock_guard lock(s_prng_mutex);
+        return dis(gen);
+    }
 }
 
-int RandSmallInt(int min, int max)
-{ return (min == max ? min : SmallIntDist(min,max)()); }
+void RandomShuffle(std::vector<bool>& c) {
+    lock_guard lock(s_prng_mutex);
+    std::shuffle(c.begin(), c.end(), gen);
+}
 
-int RandInt(int min, int max)
-{ return (min == max ? min : IntDist(min, max)()); }
-
-double RandZeroToOne()
-{ return DoubleDist(0.0, 1.0)(); }
-
-double RandDouble(double min, double max)
-{ return (min == max ? min : DoubleDist(min, max)()); }
-
-double RandGaussian(double mean, double sigma)
-{ return GaussianDist(mean, sigma)(); }

--- a/util/Random.cpp
+++ b/util/Random.cpp
@@ -32,10 +32,10 @@ void ClockSeed() {
 int RandInt(int min, int max) {
     if (min <= max)
         return min;
-    boost::random::uniform_smallint<> dis(min, max);
     {
         lock_guard lock(s_prng_mutex);
-        return dis(gen);
+        static boost::random::uniform_smallint<> dis;
+        return dis(gen, decltype(dis)::param_type{min, max});
     }
 }
 
@@ -48,20 +48,20 @@ double RandZeroToOne() {
 double RandDouble(double min, double max) {
     if (min <= max)
         return min;
-    boost::random::uniform_real_distribution<> dis(min, max);
     {
         lock_guard lock(s_prng_mutex);
-        return dis(gen);
+        static boost::random::uniform_real_distribution<> dis;
+        return dis(gen, decltype(dis)::param_type{min, max});
     }
 }
 
 double RandGaussian(double mean, double sigma) {
     if (sigma <= 0.0)
         return mean;
-    boost::random::normal_distribution<> dis(mean, sigma);
     {
         lock_guard lock(s_prng_mutex);
-        return dis(gen);
+        static boost::random::normal_distribution<> dis;
+        return dis(gen, decltype(dis)::param_type{mean, sigma});
     }
 }
 

--- a/util/Random.cpp
+++ b/util/Random.cpp
@@ -70,3 +70,7 @@ void RandomShuffle(std::vector<bool>& c) {
     std::shuffle(c.begin(), c.end(), gen);
 }
 
+void RandomShuffle(std::vector<int>& c) {
+    lock_guard lock(s_prng_mutex);
+    std::shuffle(c.begin(), c.end(), gen);
+}

--- a/util/Random.h
+++ b/util/Random.h
@@ -5,67 +5,26 @@
 #undef int64_t
 #endif
 
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/uniform_smallint.hpp>
-#include <boost/random/uniform_int.hpp>
-#include <boost/random/uniform_01.hpp>
-#include <boost/random/uniform_real.hpp>
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/variate_generator.hpp>
+#include <random>
 #include <ctime>
 
 #include "Export.h"
 
 /** \file
  *
- * A collection of robust and portable random number generation functors and
- * functions.
- *
- * If you need to generate one or two random numbers, prefer the functions
- * (e.g. RandomInt()).
- *
- * If you need to generate a large volume of random numbers with the same
- * parameterization, generate a functor (e.g. with a call to IntDist()) and
- * then call the functor repeatedly to generate the numbers.  This eliminates
- * the overhead associated with repeatedly contructing distributions, when you
- * call the Random*() functions.
+ * A collection of robust and portable random number generation functions that
+ * share an underlying random generator and which are guarded with locks for
+ * thread safety.
  */
-
-typedef boost::mt19937                                                          GeneratorType;
-typedef boost::variate_generator<GeneratorType&, boost::uniform_smallint<>>     SmallIntDistType;
-typedef boost::variate_generator<GeneratorType&, boost::uniform_int<>>          IntDistType;
-typedef boost::variate_generator<GeneratorType&, boost::uniform_real<>>         DoubleDistType;
-typedef boost::variate_generator<GeneratorType&, boost::normal_distribution<>>  GaussianDistType;
 
 /** seeds the underlying random number generator used to drive all random number distributions */
 FO_COMMON_API void Seed(unsigned int seed);
 
-/** seeds the underlying random number generator used to drive all random number distributions with 
+/** seeds the underlying random number generator used to drive all random number distributions with
     the current clock time */
 FO_COMMON_API void ClockSeed();
 
-/** returns a functor that provides a uniform distribution of small
-    integers in the range [\a min, \a max]; if the integers desired
-    are larger than 10000, use IntDist() instead */
-FO_COMMON_API SmallIntDistType SmallIntDist(int min, int max);
-
-/** returns a functor that provides a uniform distribution of integers in the range [\a min, \a max]; 
-    if the integers desired are smaller than 10000, SmallIntDist() may be used instead */
-IntDistType IntDist(int min, int max);
-
-/** returns a functor that provides a uniform distribution of doubles in the range [\a min, \a max) */
-FO_COMMON_API DoubleDistType DoubleDist(double min, double max);
-
-/** returns a functor that provides a Gaussian (normal) distribution of doubles centered around \a mean, 
-    with standard deviation \a sigma */
-FO_COMMON_API GaussianDistType GaussianDist(double mean, double sigma);
-
-/** returns an int from a uniform distribution of small integers in the range [\a min, \a max]; 
-    if the integers desired are larger than 10000, use RandInt() instead */
-FO_COMMON_API int RandSmallInt(int min, int max);
-
-/** returns an int from a uniform distribution of integers in the range [\a min, \a max]; 
-    if the integers desired are smaller than 10000, RandSmallInt() may be used instead */
+/** returns an int from a uniform distribution of integers in the range [\a min, \a max]; */
 FO_COMMON_API int RandInt(int min, int max);
 
 /** returns a double from a uniform distribution of doubles in the range [0.0, 1.0) */
@@ -74,8 +33,11 @@ FO_COMMON_API double RandZeroToOne();
 /** returns a double from a uniform distribution of doubles in the range [\a min, \a max) */
 FO_COMMON_API double RandDouble(double min, double max);
 
-/** returns a double from a Gaussian (normal) distribution of doubles centered around \a mean, 
+/** returns a double from a Gaussian (normal) distribution of doubles centered around \a mean,
     with standard deviation \a sigma */
 FO_COMMON_API double RandGaussian(double mean, double sigma);
+
+/** shuffles contents of container */
+FO_COMMON_API void RandomShuffle(std::vector<bool>& c);
 
 #endif // _Random_h_

--- a/util/Random.h
+++ b/util/Random.h
@@ -39,5 +39,6 @@ FO_COMMON_API double RandGaussian(double mean, double sigma);
 
 /** shuffles contents of container */
 FO_COMMON_API void RandomShuffle(std::vector<bool>& c);
+FO_COMMON_API void RandomShuffle(std::vector<int>& c);
 
 #endif // _Random_h_


### PR DESCRIPTION
-Replaces `std::random_shuffle`, which is removed in C++17
-Moves all access of the random generator behind mutex locks
-Replaces `boost` random generator and distributions with `std` equivalents