### PR TITLE
further adjust minimum window sizes

### DIFF
--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -69,7 +69,9 @@ namespace {
     const GG::Y         PART_CONTROL_HEIGHT(54);
     const GG::X         SLOT_CONTROL_WIDTH(60);
     const GG::Y         SLOT_CONTROL_HEIGHT(60);
-    const GG::Pt        PALETTE_MIN_SIZE{GG::X{PART_CONTROL_WIDTH + 70}, GG::Y{PART_CONTROL_HEIGHT + 70}};
+    const GG::Pt        PALETTE_MIN_SIZE{GG::X{450}, GG::Y{400}};
+    const GG::Pt        MAIN_PANEL_MIN_SIZE{GG::X{400}, GG::Y{160}};
+    const GG::Pt        BASES_MIN_SIZE{GG::X{160}, GG::Y{160}};
     const int           PAD(3);
 
     /** Returns texture with which to render a SlotControl, depending on \a slot_type. */
@@ -3451,7 +3453,7 @@ void DesignWnd::BaseSelector::CompleteConstruction() {
 
     CUIWnd::CompleteConstruction();
 
-    SetMinSize(PALETTE_MIN_SIZE);
+    SetMinSize(BASES_MIN_SIZE);
 
     DoLayout();
     SaveDefaultedOptions();
@@ -4120,7 +4122,7 @@ void DesignWnd::MainPanel::CompleteConstruction() {
     DesignChanged(); // Initialize components that rely on the current state of the design.
 
     CUIWnd::CompleteConstruction();
-    SetMinSize(PALETTE_MIN_SIZE);
+    SetMinSize(MAIN_PANEL_MIN_SIZE);
 
     DoLayout();
     SaveDefaultedOptions();


### PR DESCRIPTION
Follow up to https://github.com/freeorion/freeorion/pull/3007

Makes minimum sizes a bit bigger in general and different for the different windows on the design screen.