### PR TITLE
Artificial Black Hole - prevent multiple sitreps

### DIFF
--- a/default/scripting/buildings/ART_BLACK_HOLE.focs.txt
+++ b/default/scripting/buildings/ART_BLACK_HOLE.focs.txt
@@ -17,6 +17,7 @@ BuildingType
                 System
             ]
             activation = Star type = Red
+            stackinggroup = "ART_BLACK_HOLE"
             effects = [
                 SetStarType type = BlackHole
                 GenerateSitRepMessage


### PR DESCRIPTION
Stacking group added to prevent multiple sitreps if more than one artificial
black hole is completed simultaneously within a system ( Bug #3017 )

Signed-off-by: Rob Gill <rrobgill@protonmail.com>