### PR TITLE
 Remove Asteroid processor(s) after artificial planet creation

### DIFF
--- a/default/scripting/buildings/shipyards/ASTEROID.focs.txt
+++ b/default/scripting/buildings/shipyards/ASTEROID.focs.txt
@@ -18,7 +18,5 @@ BuildingType
     ]
     icon = "icons/building/shipyard-5.png"
 
-
-
 #include "/scripting/common/enqueue.macros"
 #include "/scripting/common/base_prod.macros"

--- a/default/scripting/buildings/shipyards/ASTEROID.focs.txt
+++ b/default/scripting/buildings/shipyards/ASTEROID.focs.txt
@@ -10,7 +10,15 @@ BuildingType
         OwnedBy empire = Source.Owner
     ]
     EnqueueLocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
+    effectsgroups = [
+        EffectsGroup
+            scope = Source
+            activation = Not Planet type = Asteroids
+            effects = Destroy
+    ]
     icon = "icons/building/shipyard-5.png"
+
+
 
 #include "/scripting/common/enqueue.macros"
 #include "/scripting/common/base_prod.macros"

--- a/default/scripting/buildings/shipyards/ASTEROID_REF.focs.txt
+++ b/default/scripting/buildings/shipyards/ASTEROID_REF.focs.txt
@@ -11,6 +11,12 @@ BuildingType
         [[LOCATION_ALLOW_BUILD_IF_PREREQ_ENQUEUED(BLD_SHIPYARD_AST)]]
     ]
     EnqueueLocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
+    effectsgroups = [
+        EffectsGroup
+            scope = Source
+            activation = Not Planet type = Asteroids
+            effects = Destroy
+    ]
     icon = "icons/building/shipyard-6.png"
 
 #include "/scripting/common/enqueue.macros"


### PR DESCRIPTION
* Asteroid processor and Asteroid Reformation processor now
detect if planet type is no longer asteroid, and destroy themselves.
(Similar to current handling of Gas Giant Generator).

Bug #3023 