### PR TITLE
Add ROBOTIC_HULL tag to Space Flux Bubble hull

### DIFF
--- a/default/scripting/ship_hulls/robotic/SH_SPACE_FLUX_BUBBLE.focs.txt
+++ b/default/scripting/ship_hulls/robotic/SH_SPACE_FLUX_BUBBLE.focs.txt
@@ -9,7 +9,7 @@ Hull
     slots = Slot type = Internal position = (0.50, 0.50)
     buildCost = 17 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_HULL_COST_MULTIPLIER]]
     buildTime = 2
-    tags = [ "PEDIA_HULL_LINE_ROBOTIC" "GREAT_FUEL_EFFICIENCY" ]
+    tags = [ "ROBOTIC_HULL" "PEDIA_HULL_LINE_ROBOTIC" "GREAT_FUEL_EFFICIENCY" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_BASE"


### PR DESCRIPTION
Hull is part of the Robotic Hull line, and already has the
PEDIA_HULL_LINE_ROBOTIC tag, but missing ROBOTIC_HULL

( Bug #2775 )

Signed-off-by: Rob Gill <rrobgill@protonmail.com>