### PR TITLE
Simplify special-based population bonuses in AIDependencies.py

### DIFF
--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -208,7 +208,7 @@ for metab, boosts in metabolismBoostMap.items():
 # Regardless of whether the sub-dictionary here has PlanetSize keys, the final
 # value will be applied as a *fixed-size mod* to the max population
 POP_FIXED_MOD_SPECIALS = {
-    'DIM_RIFT_MASTER_SPECIAL': {-1: -4},
+    'DIM_RIFT_MASTER_SPECIAL': -4,
 }
 
 # Please see the Note at top of this file regarding PlanetSize-Dependent-Lookup
@@ -221,12 +221,8 @@ POP_FIXED_MOD_SPECIALS = {
 # Regardless of whether the sub-dictionary here has PlanetSize keys, the final
 # value will be applied as a fixed-size mod to the max population
 POP_PROPORTIONAL_MOD_SPECIALS = {
-    'TIDAL_LOCK_SPECIAL': {
-        -1: -1,
-    },
-    'TEMPORAL_ANOMALY_SPECIAL': {
-        -1: -5,
-    },
+    'TIDAL_LOCK_SPECIAL': -1,
+    'TEMPORAL_ANOMALY_SPECIAL': -5,
 }
 # </editor-fold>
 

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -122,14 +122,12 @@ def calc_max_pop(planet, species, detail):
             detail.append("%s_PCM(%d)" % (tech, POP_CONST_MOD_MAP[tech][planet_env]))
 
     for _special in planet_specials.intersection(AIDependencies.POP_FIXED_MOD_SPECIALS):
-        this_mod = sum(AIDependencies.POP_FIXED_MOD_SPECIALS[_special].get(int(psize), 0)
-                       for psize in [-1, planet.size])
+        this_mod = AIDependencies.POP_FIXED_MOD_SPECIALS[_special]
         detail.append("%s_PCM(%d)" % (_special, this_mod))
         pop_const_mod += this_mod
 
     for _special in planet_specials.intersection(AIDependencies.POP_PROPORTIONAL_MOD_SPECIALS):
-        this_mod = sum(AIDependencies.POP_PROPORTIONAL_MOD_SPECIALS[_special].get(int(psize), 0)
-                       for psize in [-1, planet.size])
+        this_mod = AIDependencies.POP_PROPORTIONAL_MOD_SPECIALS[_special]
         detail.append("%s (maxPop%+.1f)" % (_special, this_mod))
         base_pop_not_modified_by_species += this_mod
 


### PR DESCRIPTION
There are no planetsize dependent entries in current content, no need to complicate stuff