### PR TITLE
Effect Condition Fixes

### DIFF
--- a/default/scripting/species/common/advanced_focus.macros
+++ b/default/scripting/species/common/advanced_focus.macros
@@ -159,7 +159,7 @@ ADVANCED_FOCUS_EFFECTS
             ]
             stackinggroup = "DISTORTION_MOVEMENT_STACK"
             effects = [
-                If condition = WithinDistance distance = 40 condition = Object id = Target.PreviousSystemID
+                If condition = WithinDistance distance = 40 condition = Object id = RootCandidate.PreviousSystemID
                     effects = [
                         GenerateSitrepMessage
                             message = "EFFECT_FLEET_MOVED_TO"

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1501,8 +1501,7 @@ unsigned int Target::GetCheckSum() const {
 // Homeworld                                             //
 ///////////////////////////////////////////////////////////
 Homeworld::Homeworld() :
-    Condition(),
-    m_names()
+    Homeworld(std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>>{})
 {}
 
 Homeworld::Homeworld(std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>>&& names) :
@@ -2215,8 +2214,8 @@ HasSpecial::HasSpecial() :
                std::unique_ptr<ValueRef::ValueRef<int>>{})
 {}
 
-HasSpecial::HasSpecial(const std::string& name) :
-    HasSpecial(std::make_unique<ValueRef::Constant<std::string>>(name),
+HasSpecial::HasSpecial(std::string name) :
+    HasSpecial(std::make_unique<ValueRef::Constant<std::string>>(std::move(name)),
                std::unique_ptr<ValueRef::ValueRef<int>>{},
                std::unique_ptr<ValueRef::ValueRef<int>>{})
 {}

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -339,8 +339,8 @@ private:
 
 /** Matches all objects that have an attached Special named \a name. */
 struct FO_COMMON_API HasSpecial final : public Condition {
-    explicit HasSpecial();
-    explicit HasSpecial(const std::string& name);
+    HasSpecial();
+    explicit HasSpecial(std::string name);
     explicit HasSpecial(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name);
     HasSpecial(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name,
                std::unique_ptr<ValueRef::ValueRef<int>>&& since_turn_low,
@@ -769,7 +769,7 @@ private:
 
 /** Matches ships whose design id \a id. */
 struct FO_COMMON_API NumberedShipDesign final : public Condition {
-    NumberedShipDesign(std::unique_ptr<ValueRef::ValueRef<int>>&& design_id);
+    explicit NumberedShipDesign(std::unique_ptr<ValueRef::ValueRef<int>>&& design_id);
 
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
@@ -787,7 +787,7 @@ private:
 
 /** Matches ships or buildings produced by the empire with id \a empire_id.*/
 struct FO_COMMON_API ProducedByEmpire final : public Condition {
-    ProducedByEmpire(std::unique_ptr<ValueRef::ValueRef<int>>&& empire_id);
+    explicit ProducedByEmpire(std::unique_ptr<ValueRef::ValueRef<int>>&& empire_id);
 
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
@@ -805,7 +805,7 @@ private:
 
 /** Matches a given object with a linearly distributed probability of \a chance. */
 struct FO_COMMON_API Chance final : public Condition {
-    Chance(std::unique_ptr<ValueRef::ValueRef<double>>&& chance);
+    explicit Chance(std::unique_ptr<ValueRef::ValueRef<double>>&& chance);
 
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
@@ -1147,7 +1147,7 @@ private:
 /** Matches objects that are moving. ... What does that mean?  Departing this
   * turn, or were located somewhere else last turn...? */
 struct FO_COMMON_API Stationary final : public Condition {
-    explicit Stationary();
+    Stationary();
 
     bool operator==(const Condition& rhs) const override;
     std::string Description(bool negated = false) const override;
@@ -1162,7 +1162,7 @@ private:
 
 /** Matches objects that are aggressive fleets or are in aggressive fleets. */
 struct FO_COMMON_API Aggressive final : public Condition {
-    explicit Aggressive();
+    Aggressive();
     explicit Aggressive(bool aggressive);
 
     bool operator==(const Condition& rhs) const override;
@@ -1223,7 +1223,7 @@ private:
 
 /** Matches objects whose species has the ability to found new colonies. */
 struct FO_COMMON_API CanColonize final : public Condition {
-    explicit CanColonize();
+    CanColonize();
 
     bool operator==(const Condition& rhs) const override;
     std::string Description(bool negated = false) const override;


### PR DESCRIPTION
-Homeworld condition wasn't setting its invariance in some cases
-A script was using a Target reference within a Conditional effect condition, which isn't allowed
-Moved test of Conditional effect condition target invariance into constructor instead of Eval