### PR TITLE
Groom UniverseObject and subclasses

### DIFF
--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4620,9 +4620,11 @@ void MapWnd::SetProjectedFleetMovementLine(int fleet_id, const std::list<int>& t
     // We need the route to contain the current system
     // even when it is empty to switch between non appending
     // and appending projections on shift changes
-    if (path.empty()) {
-        path.push_back(MovePathNode(fleet->X(), fleet->Y(), true, 0, fleet->SystemID(), INVALID_OBJECT_ID, INVALID_OBJECT_ID));
-    }
+    if (path.empty())
+        path.emplace_back(MovePathNode{
+            fleet->X(), fleet->Y(),
+            true, 0, fleet->SystemID(),
+            INVALID_OBJECT_ID, INVALID_OBJECT_ID});
 
     auto route_it = travel_route.begin();
     if (!travel_route.empty() && (++route_it) != travel_route.end()) {

--- a/universe/Building.cpp
+++ b/universe/Building.cpp
@@ -9,8 +9,7 @@
 #include "../util/i18n.h"
 
 
-Building::Building(int empire_id, const std::string& building_type,
-                   int produced_by_empire_id/* = ALL_EMPIRES*/) :
+Building::Building(int empire_id, std::string const& building_type, int produced_by_empire_id) :
     m_building_type(building_type),
     m_produced_by_empire_id(produced_by_empire_id)
 {
@@ -24,7 +23,12 @@ Building::Building(int empire_id, const std::string& building_type,
     UniverseObject::Init();
 }
 
-Building* Building::Clone(int empire_id) const {
+Building::Building() = default;
+
+Building::~Building() = default;
+
+auto Building::Clone(int empire_id) const -> Building*
+{
     Visibility vis = GetUniverse().GetObjectVisibilityByEmpire(this->ID(), empire_id);
 
     if (!(vis >= VIS_BASIC_VISIBILITY && vis <= VIS_FULL_VISIBILITY))
@@ -35,7 +39,8 @@ Building* Building::Clone(int empire_id) const {
     return retval;
 }
 
-void Building::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire_id) {
+void Building::Copy(std::shared_ptr<UniverseObject const> copied_object, int empire_id)
+{
     if (copied_object.get() == this)
         return;
     auto copied_building = std::dynamic_pointer_cast<const Building>(copied_object);
@@ -66,34 +71,39 @@ void Building::Copy(std::shared_ptr<const UniverseObject> copied_object, int emp
     }
 }
 
-bool Building::HostileToEmpire(int empire_id) const {
+auto Building::HostileToEmpire(int empire_id) const -> bool
+{
     if (OwnedBy(empire_id))
         return false;
     return empire_id == ALL_EMPIRES || Unowned() ||
            Empires().GetDiplomaticStatus(Owner(), empire_id) == DIPLO_WAR;
 }
 
-std::set<std::string> Building::Tags() const {
+auto Building::Tags() const -> std::set<std::string>
+{
     if (const BuildingType* type = ::GetBuildingType(m_building_type))
         return type->Tags();
     return {};
 }
 
-bool Building::HasTag(const std::string& name) const {
+auto Building::HasTag(std::string const& name) const -> bool
+{
     const BuildingType* type = GetBuildingType(m_building_type);
     return type && type->Tags().count(name);
 }
 
-UniverseObjectType Building::ObjectType() const
+auto Building::ObjectType() const -> UniverseObjectType
 { return OBJ_BUILDING; }
 
-bool Building::ContainedBy(int object_id) const {
+auto Building::ContainedBy(int object_id) const -> bool
+{
     return object_id != INVALID_OBJECT_ID
         && (    object_id == m_planet_id
             ||  object_id == this->SystemID());
 }
 
-std::string Building::Dump(unsigned short ntabs) const {
+auto Building::Dump(unsigned short ntabs) const -> std::string
+{
     std::stringstream os;
     os << UniverseObject::Dump(ntabs);
     os << " building type: " << m_building_type
@@ -101,33 +111,30 @@ std::string Building::Dump(unsigned short ntabs) const {
     return os.str();
 }
 
-std::shared_ptr<UniverseObject> Building::Accept(const UniverseObjectVisitor& visitor) const
+auto Building::Accept(UniverseObjectVisitor const& visitor) const -> std::shared_ptr<UniverseObject>
 { return visitor.Visit(std::const_pointer_cast<Building>(std::static_pointer_cast<const Building>(shared_from_this()))); }
 
-void Building::SetPlanetID(int planet_id) {
+void Building::SetPlanetID(int planet_id)
+{
     if (planet_id != m_planet_id) {
         m_planet_id = planet_id;
         StateChangedSignal();
     }
 }
 
-void Building::ResetTargetMaxUnpairedMeters() {
-    UniverseObject::ResetTargetMaxUnpairedMeters();
+void Building::ResetTargetMaxUnpairedMeters()
+{ UniverseObject::ResetTargetMaxUnpairedMeters(); }
 
-    //// give buildings base stealth slightly above 0, so that they can't be seen from a distance without high detection ability
-    //if (Meter* stealth = GetMeter(METER_STEALTH))
-    //    stealth->AddToCurrent(0.01f);
-}
-
-void Building::Reset() {
+void Building::Reset()
+{
     UniverseObject::SetOwner(ALL_EMPIRES);
     m_ordered_scrapped = false;
 }
 
-void Building::SetOrderedScrapped(bool b) {
+void Building::SetOrderedScrapped(bool b)
+{
     bool initial_status = m_ordered_scrapped;
     if (b == initial_status) return;
     m_ordered_scrapped = b;
     StateChangedSignal();
 }
-

--- a/universe/Building.h
+++ b/universe/Building.h
@@ -2,9 +2,7 @@
 #define _Building_h_
 
 
-#include "ObjectMap.h"
 #include "UniverseObject.h"
-#include "../util/Export.h"
 
 
 //! A Building UniverseObject type.

--- a/universe/Building.h
+++ b/universe/Building.h
@@ -7,54 +7,61 @@
 #include "../util/Export.h"
 
 
-/** A Building UniverseObject type. */
+//! A Building UniverseObject type.
 class FO_COMMON_API Building : public UniverseObject {
 public:
-    /** \name Accessors */ //@{
-    bool                    HostileToEmpire(int empire_id) const override;
-    std::set<std::string>   Tags() const override;
-    bool                    HasTag(const std::string& name) const override;
-    UniverseObjectType      ObjectType() const override;
-    std::string             Dump(unsigned short ntabs = 0) const override;
-    int                     ContainerObjectID() const override { return m_planet_id; }
-    bool                    ContainedBy(int object_id) const override;
+    Building(int empire_id, std::string const& building_type, int produced_by_empire_id = ALL_EMPIRES);
 
-    std::shared_ptr<UniverseObject> Accept(const UniverseObjectVisitor& visitor) const override;
+    ~Building();
 
-    /** Returns the name of the BuildingType object for this building. */
-    const std::string&      BuildingTypeName() const    { return m_building_type; };
-    int                     PlanetID() const            { return m_planet_id; }             ///< returns the ID number of the planet this building is on
-    int                     ProducedByEmpireID() const  { return m_produced_by_empire_id; } ///< returns the empire ID of the empire that produced this building
-    bool                    OrderedScrapped() const     { return m_ordered_scrapped; }
-    //@}
+    auto HostileToEmpire(int empire_id) const -> bool override;
 
-    /** \name Mutators */ //@{
-    void Copy(std::shared_ptr<const UniverseObject> copied_object, int empire_id = ALL_EMPIRES) override;
-    void SetPlanetID(int planet_id);         ///< sets the planet on which the building is located
-    void Reset();                            ///< resets any building state, and removes owners
-    void SetOrderedScrapped(bool b = true);  ///< flags building for scrapping
+    auto Tags() const -> std::set<std::string> override;
+
+    auto HasTag(std::string const& name) const -> bool override;
+
+    auto ObjectType() const -> UniverseObjectType override;
+
+    auto Dump(unsigned short ntabs = 0) const -> std::string override;
+
+    auto ContainerObjectID() const -> int override
+    { return m_planet_id; }
+
+    auto ContainedBy(int object_id) const -> bool override;
+
+    auto Accept(UniverseObjectVisitor const& visitor) const -> std::shared_ptr<UniverseObject> override;
+
+    auto BuildingTypeName() const -> std::string const&
+    { return m_building_type; };
+
+    auto PlanetID() const -> int
+    { return m_planet_id; }
+
+    void SetPlanetID(int planet_id);
+
+    auto ProducedByEmpireID() const -> int
+    { return m_produced_by_empire_id; }
+
+    auto OrderedScrapped() const -> bool
+    { return m_ordered_scrapped; }
+
+    void SetOrderedScrapped(bool b = true);
+
+    void Copy(std::shared_ptr<UniverseObject const> copied_object, int empire_id = ALL_EMPIRES) override;
+
+    //! Resets any building state, and removes owners
+    void Reset();
+
     void ResetTargetMaxUnpairedMeters() override;
-    //@}
 
 protected:
     friend class Universe;
-    /** \name Structors */ //@{
-    Building() {}
+    Building();
 
-public:
-    Building(int empire_id, const std::string& building_type,
-             int produced_by_empire_id = ALL_EMPIRES);
+    template <typename T>
+    friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
 
-protected:
-    template <typename T> friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
-
-public:
-    ~Building() {}
-
-protected:
-    /** Returns new copy of this Building. */
-    Building* Clone(int empire_id = ALL_EMPIRES) const override;
-    //@}
+    auto Clone(int empire_id = ALL_EMPIRES) const -> Building* override;
 
 private:
     std::string m_building_type;

--- a/universe/Field.cpp
+++ b/universe/Field.cpp
@@ -9,16 +9,11 @@
 #include "../util/i18n.h"
 
 
-/////////////////////////////////////////////////
-// Field                                       //
-/////////////////////////////////////////////////
-Field::Field()
-{}
+Field::Field() = default;
 
-Field::~Field()
-{}
+Field::~Field() = default;
 
-Field::Field(const std::string& field_type, double x, double y, double radius) :
+Field::Field(std::string const& field_type, double x, double y, double radius) :
     UniverseObject("", x, y),
     m_type_name(field_type)
 {
@@ -35,7 +30,8 @@ Field::Field(const std::string& field_type, double x, double y, double radius) :
     UniverseObject::GetMeter(METER_SIZE)->Set(radius, radius);
 }
 
-Field* Field::Clone(int empire_id) const {
+auto Field::Clone(int empire_id) const -> Field*
+{
     Visibility vis = GetUniverse().GetObjectVisibilityByEmpire(this->ID(), empire_id);
 
     if (!(vis >= VIS_BASIC_VISIBILITY && vis <= VIS_FULL_VISIBILITY))
@@ -46,7 +42,8 @@ Field* Field::Clone(int empire_id) const {
     return retval;
 }
 
-void Field::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire_id) {
+void Field::Copy(std::shared_ptr<UniverseObject const> copied_object, int empire_id)
+{
     if (copied_object.get() == this)
         return;
     std::shared_ptr<const Field> copied_field = std::dynamic_pointer_cast<const Field>(copied_object);
@@ -67,49 +64,55 @@ void Field::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire
     }
 }
 
-std::set<std::string> Field::Tags() const {
+auto Field::Tags() const -> std::set<std::string>
+{
     const FieldType* type = GetFieldType(m_type_name);
     if (!type)
         return {};
     return type->Tags();
 }
 
-bool Field::HasTag(const std::string& name) const {
+auto Field::HasTag(std::string const& name) const -> bool
+{
     const FieldType* type = GetFieldType(m_type_name);
 
     return type && type->Tags().count(name);
 }
 
-UniverseObjectType Field::ObjectType() const
+auto Field::ObjectType() const -> UniverseObjectType
 { return OBJ_FIELD; }
 
-std::string Field::Dump(unsigned short ntabs) const {
+auto Field::Dump(unsigned short ntabs) const -> std::string
+{
     std::stringstream os;
     os << UniverseObject::Dump(ntabs);
     os << " field type: " << m_type_name;
     return os.str();
 }
 
-const std::string& Field::PublicName(int empire_id) const {
+auto Field::PublicName(int empire_id) const -> std::string const&
+{
     // always just return name since fields (as of this writing) don't have owners
     return UserString(m_type_name);
 }
 
-std::shared_ptr<UniverseObject> Field::Accept(const UniverseObjectVisitor& visitor) const
+auto Field::Accept(UniverseObjectVisitor const& visitor) const -> std::shared_ptr<UniverseObject>
 { return visitor.Visit(std::const_pointer_cast<Field>(std::static_pointer_cast<const Field>(shared_from_this()))); }
 
-int Field::ContainerObjectID() const
+auto Field::ContainerObjectID() const -> int
 { return this->SystemID(); }
 
-bool Field::ContainedBy(int object_id) const {
+auto Field::ContainedBy(int object_id) const -> bool
+{
     return object_id != INVALID_OBJECT_ID
         && object_id == this->SystemID();
 }
 
-bool Field::InField(std::shared_ptr<const UniverseObject> obj) const
+auto Field::InField(std::shared_ptr<UniverseObject const> obj) const -> bool
 { return obj && InField(obj->X(), obj->Y()); }
 
-bool Field::InField(double x, double y) const {
+auto Field::InField(double x, double y) const -> bool
+{
     const Meter* size_meter = GetMeter(METER_SIZE);
     double radius = 1.0;
     if (size_meter)
@@ -119,14 +122,16 @@ bool Field::InField(double x, double y) const {
     return dist2 < radius*radius;
 }
 
-void Field::ResetTargetMaxUnpairedMeters() {
+void Field::ResetTargetMaxUnpairedMeters()
+{
     UniverseObject::ResetTargetMaxUnpairedMeters();
 
     GetMeter(METER_SPEED)->ResetCurrent();
     // intentionally not resetting size, so that it is presistant
 }
 
-void Field::ClampMeters() {
+void Field::ClampMeters()
+{
     UniverseObject::ClampMeters();
 
     // intentionally not clamping METER_SPEED, to allow negative speeds

--- a/universe/Field.cpp
+++ b/universe/Field.cpp
@@ -2,9 +2,7 @@
 
 #include "Enums.h"
 #include "FieldType.h"
-#include "Meter.h"
 #include "UniverseObjectVisitor.h"
-#include "Universe.h"
 #include "../util/AppInterface.h"
 #include "../util/i18n.h"
 

--- a/universe/Field.h
+++ b/universe/Field.h
@@ -3,8 +3,6 @@
 
 
 #include "UniverseObject.h"
-#include "../util/Export.h"
-#include "../util/Pending.h"
 
 
 //! A class representing a region of space

--- a/universe/Field.h
+++ b/universe/Field.h
@@ -7,65 +7,60 @@
 #include "../util/Pending.h"
 
 
-namespace Effect {
-    class EffectsGroup;
-}
-
-/** a class representing a region of space */
+//! A class representing a region of space
 class FO_COMMON_API Field : public UniverseObject {
 public:
-    /** \name Accessors */ //@{
-    std::set<std::string>   Tags() const override;
-    bool                    HasTag(const std::string& name) const override;
+    Field(std::string const& field_type, double x, double y, double radius);
 
-    UniverseObjectType  ObjectType() const override;
+    ~Field();
 
-    std::string         Dump(unsigned short ntabs = 0) const override;
+    auto Tags() const -> std::set<std::string> override;
 
-    int                 ContainerObjectID() const override;
-    bool                ContainedBy(int object_id) const override;
+    auto HasTag(std::string const& name) const -> bool override;
 
-    const std::string&  PublicName(int empire_id) const override;
-    const std::string&  FieldTypeName() const { return m_type_name; }
+    auto ObjectType() const -> UniverseObjectType override;
 
-    /* Field is (presently) the only distributed UniverseObject that isn't just
-     * location at a single point in space. These functions check if locations
-     * or objecs are within this field's area. */
-    bool                InField(std::shared_ptr<const UniverseObject> obj) const;
-    bool                InField(double x, double y) const;
+    auto Dump(unsigned short ntabs = 0) const -> std::string override;
 
-    std::shared_ptr<UniverseObject> Accept(const UniverseObjectVisitor& visitor) const override;
-    //@}
+    auto ContainerObjectID() const -> int override;
 
-    /** \name Mutators */ //@{
-    void Copy(std::shared_ptr<const UniverseObject> copied_object, int empire_id = ALL_EMPIRES) override;
+    auto ContainedBy(int object_id) const -> bool override;
+
+    auto PublicName(int empire_id) const -> std::string const& override;
+
+    auto FieldTypeName() const -> std::string const&
+    { return m_type_name; }
+
+    //! Field is (presently) the only distributed UniverseObject that isn't
+    //! just location at a single point in space. These functions check if
+    //! locations or objecs are within this field's area.
+    auto InField(std::shared_ptr<UniverseObject const> obj) const -> bool;
+
+    auto InField(double x, double y) const -> bool;
+
+    auto Accept(UniverseObjectVisitor const& visitor) const -> std::shared_ptr<UniverseObject> override;
+
+    void Copy(std::shared_ptr<UniverseObject const> copied_object, int empire_id = ALL_EMPIRES) override;
 
     void ResetTargetMaxUnpairedMeters() override;
+
     void ClampMeters() override;
-    //@}
 
 protected:
     friend class Universe;
-    /** \name Structors */ //@{
     Field();
 
-public:
-    Field(const std::string& field_type, double x, double y, double radius);
-    ~Field();
+    template <typename T>
+    friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
 
-protected:
-    template <typename T> friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
-
-    /** Returns new copy of this Field. */
-    Field* Clone(int empire_id = ALL_EMPIRES) const override;
-    //@}
+    auto Clone(int empire_id = ALL_EMPIRES) const -> Field* override;
 
 private:
     std::string m_type_name;
 
     friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    void serialize(Archive& ar, unsigned int const version);
 };
 
 

--- a/universe/Fighter.cpp
+++ b/universe/Fighter.cpp
@@ -7,10 +7,7 @@
 #include "../util/Logger.h"
 
 
-Fighter::Fighter()
-{}
-
-Fighter::Fighter(int empire_id, int launched_from_id, const std::string& species_name, float damage, const ::Condition::Condition* combat_targets) :
+Fighter::Fighter(int empire_id, int launched_from_id, std::string const& species_name, float damage, Condition::Condition const* combat_targets) :
     UniverseObject(),
     m_damage(damage),
     m_launched_from_id(launched_from_id),
@@ -21,38 +18,26 @@ Fighter::Fighter(int empire_id, int launched_from_id, const std::string& species
     UniverseObject::Init();
 }
 
-Fighter::~Fighter()
-{}
+Fighter::Fighter() = default;
 
-bool Fighter::HostileToEmpire(int empire_id) const {
+Fighter::~Fighter() = default;
+
+auto Fighter::HostileToEmpire(int empire_id) const -> bool
+{
     if (OwnedBy(empire_id))
         return false;
     return empire_id == ALL_EMPIRES || Unowned() ||
            Empires().GetDiplomaticStatus(Owner(), empire_id) == DIPLO_WAR;
 }
 
-UniverseObjectType Fighter::ObjectType() const
+auto Fighter::ObjectType() const -> UniverseObjectType
 { return OBJ_FIGHTER; }
-
-const ::Condition::Condition* Fighter::CombatTargets() const
-{ return m_combat_targets; }
-
-float Fighter::Damage() const
-{ return m_damage; }
-
-bool Fighter::Destroyed() const
-{ return m_destroyed; }
-
-int Fighter::LaunchedFrom() const
-{ return m_launched_from_id; }
-
-const std::string& Fighter::SpeciesName() const
-{ return m_species_name; }
 
 void Fighter::SetDestroyed(bool destroyed)
 { m_destroyed = destroyed; }
 
-std::string Fighter::Dump(unsigned short ntabs) const {
+auto Fighter::Dump(unsigned short ntabs) const -> std::string
+{
     std::stringstream os;
     os << UniverseObject::Dump(ntabs);
     os << " (Combat Fighter) damage: " << m_damage;
@@ -61,16 +46,18 @@ std::string Fighter::Dump(unsigned short ntabs) const {
     return os.str();
 }
 
-std::shared_ptr<UniverseObject> Fighter::Accept(const UniverseObjectVisitor& visitor) const
+auto Fighter::Accept(UniverseObjectVisitor const& visitor) const -> std::shared_ptr<UniverseObject>
 { return visitor.Visit(std::const_pointer_cast<Fighter>(std::static_pointer_cast<const Fighter>(shared_from_this()))); }
 
-Fighter* Fighter::Clone(int empire_id) const {
+auto Fighter::Clone(int empire_id) const -> Fighter*
+{
     Fighter* retval = new Fighter();
     retval->Copy(shared_from_this(), empire_id);
     return retval;
 }
 
-void Fighter::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire_id) {
+void Fighter::Copy(std::shared_ptr<UniverseObject const> copied_object, int empire_id)
+{
     if (copied_object.get() == this)
         return;
     std::shared_ptr<const Fighter> copied_fighter = std::dynamic_pointer_cast<const Fighter>(copied_object);

--- a/universe/Fighter.cpp
+++ b/universe/Fighter.cpp
@@ -1,6 +1,5 @@
 #include "Fighter.h"
 
-#include "Enums.h"
 #include "UniverseObjectVisitor.h"
 #include "../Empire/EmpireManager.h"
 #include "../util/AppInterface.h"

--- a/universe/Fighter.h
+++ b/universe/Fighter.h
@@ -3,8 +3,11 @@
 
 
 #include "UniverseObject.h"
-#include "../universe/Condition.h"
-#include "../util/Export.h"
+
+
+namespace Condition {
+    struct Condition;
+}
 
 
 //! A class representing a Fighter in combat.

--- a/universe/Fighter.h
+++ b/universe/Fighter.h
@@ -7,38 +7,57 @@
 #include "../util/Export.h"
 
 
-////////////////////////////////////////////////
-// Fighter
-///////////////////////////////////////////////
-/** a class representing a Fighter in combat. Derived from UniverseObject so it
-  * can be stored in the same container as other combat objects. */
+//! A class representing a Fighter in combat.
+//!
+//! Derived from UniverseObject so it can be stored in the same container as
+//! other combat objects.
 class FO_COMMON_API Fighter : public UniverseObject {
 public:
-    Fighter(int empire_id, int launched_from_id, const std::string& species_name, float damage, const ::Condition::Condition* combat_targets);
+    Fighter(int empire_id, int launched_from_id, std::string const& species_name, float damage, Condition::Condition const* combat_targets);
+
     Fighter();
+
     ~Fighter();
 
-    bool HostileToEmpire(int empire_id) const override;
-    UniverseObjectType ObjectType() const override;
-    std::string Dump(unsigned short ntabs = 0) const override;
-    std::shared_ptr<UniverseObject> Accept(const UniverseObjectVisitor& visitor) const override;
-    void Copy(std::shared_ptr<const UniverseObject> copied_object, int empire_id = ALL_EMPIRES) override;
-    const ::Condition::Condition* CombatTargets() const;
-    float                       Damage() const;
-    bool                        Destroyed() const;
-    int                         LaunchedFrom() const;
-    const std::string&          SpeciesName() const;
-    void                        SetDestroyed(bool destroyed = true);
+    auto HostileToEmpire(int empire_id) const -> bool override;
+
+    auto ObjectType() const -> UniverseObjectType override;
+
+    auto Dump(unsigned short ntabs = 0) const -> std::string override;
+
+    auto Accept(UniverseObjectVisitor const& visitor) const -> std::shared_ptr<UniverseObject> override;
+
+    void Copy(std::shared_ptr<UniverseObject const> copied_object, int empire_id = ALL_EMPIRES) override;
+
+    auto CombatTargets() const -> Condition::Condition const*
+    { return m_combat_targets; }
+
+    auto Damage() const -> float
+    { return m_damage; }
+
+    auto Destroyed() const -> bool
+    { return m_destroyed; }
+
+    void SetDestroyed(bool destroyed = true);
+
+    auto LaunchedFrom() const -> int
+    { return m_launched_from_id; }
+
+    auto SpeciesName() const -> std::string const&
+    { return m_species_name; }
 
 protected:
-    Fighter* Clone(int empire_id = ALL_EMPIRES) const override;
+    auto Clone(int empire_id = ALL_EMPIRES) const -> Fighter* override;
 
 private:
-    float       m_damage = 0.0f;                        // strength of fighter's attack
-    bool        m_destroyed = false;                    // was attacked by anything -> destroyed
-    int         m_launched_from_id = INVALID_OBJECT_ID; // from what object (ship?) was this fighter launched
+    float       m_damage = 0.0f;
+    //! Was attacked by anything -> destroyed
+    bool        m_destroyed = false;
+    //! From what object (ship?) was this fighter launched
+    int         m_launched_from_id = INVALID_OBJECT_ID;
     std::string m_species_name;
-    const ::Condition::Condition* m_combat_targets = nullptr;
+    Condition::Condition const* m_combat_targets = nullptr;
 };
+
 
 #endif // _Fighter_h_

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -12,8 +12,6 @@
 #include "../Empire/Empire.h"
 #include "../Empire/Supply.h"
 #include "../util/AppInterface.h"
-#include "../util/Logger.h"
-#include "../util/ScopedTimer.h"
 #include "../util/i18n.h"
 
 

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -237,11 +237,12 @@ std::list<MovePathNode> Fleet::MovePath(const std::list<int>& route, bool flag_b
     if (route.size() == 2 && route.front() == route.back())
         return retval;                                      // nowhere to go => empty path
     if (this->Speed() < FLEET_MOVEMENT_EPSILON) {
-        retval.emplace_back(this->X(), this->Y(), true, ETA_NEVER,
-                            this->SystemID(),
-                            INVALID_OBJECT_ID,
-                            INVALID_OBJECT_ID,
-                            false);
+        retval.emplace_back(MovePathNode{
+            this->X(), this->Y(), true, ETA_NEVER,
+            this->SystemID(),
+            INVALID_OBJECT_ID,
+            INVALID_OBJECT_ID,
+            false});
         return retval;                                      // can't move => path is just this system with explanatory ETA
     }
 
@@ -268,10 +269,11 @@ std::list<MovePathNode> Fleet::MovePath(const std::list<int>& route, bool flag_b
         this->SystemID() != INVALID_OBJECT_ID &&
         !fleet_supplied_systems.count(this->SystemID()))
     {
-        retval.emplace_back(this->X(), this->Y(), true, ETA_OUT_OF_RANGE,
-                            this->SystemID(),
-                            INVALID_OBJECT_ID,
-                            INVALID_OBJECT_ID);
+        retval.emplace_back(MovePathNode{
+            this->X(), this->Y(), true, ETA_OUT_OF_RANGE,
+            this->SystemID(),
+            INVALID_OBJECT_ID,
+            INVALID_OBJECT_ID});
         return retval;      // can't move => path is just this system with explanatory ETA
     }
 
@@ -321,11 +323,12 @@ std::list<MovePathNode> Fleet::MovePath(const std::list<int>& route, bool flag_b
         }
     }
     // place initial position MovePathNode
-    retval.emplace_back(this->X(), this->Y(), false, 0,
-                        (cur_system  ? cur_system->ID()  : INVALID_OBJECT_ID),
-                        (prev_system ? prev_system->ID() : INVALID_OBJECT_ID),
-                        (next_system ? next_system->ID() : INVALID_OBJECT_ID),
-                        false);
+    retval.emplace_back(MovePathNode{
+        this->X(), this->Y(), false, 0,
+        (cur_system  ? cur_system->ID()  : INVALID_OBJECT_ID),
+        (prev_system ? prev_system->ID() : INVALID_OBJECT_ID),
+        (next_system ? next_system->ID() : INVALID_OBJECT_ID),
+        false});
 
 
     const int       TOO_LONG =              100;            // limit on turns to simulate.  99 turns max keeps ETA to two digits, making UI work better
@@ -510,11 +513,12 @@ std::list<MovePathNode> Fleet::MovePath(const std::list<int>& route, bool flag_b
                       << is_post_blockade << " and ETA " << turns_taken;
 
         // add MovePathNode for current position (end of turn position and/or system location)
-        retval.emplace_back(cur_x, cur_y, end_turn_at_cur_position, turns_taken,
-                            (cur_system  ? cur_system->ID()  : INVALID_OBJECT_ID),
-                            (prev_system ? prev_system->ID() : INVALID_OBJECT_ID),
-                            (next_system ? next_system->ID() : INVALID_OBJECT_ID),
-                            is_post_blockade);
+        retval.emplace_back(MovePathNode{
+            cur_x, cur_y, end_turn_at_cur_position, turns_taken,
+            (cur_system  ? cur_system->ID()  : INVALID_OBJECT_ID),
+            (prev_system ? prev_system->ID() : INVALID_OBJECT_ID),
+            (next_system ? next_system->ID() : INVALID_OBJECT_ID),
+            is_post_blockade});
 
 
         // if the turn ended at this position, increment the turns taken and
@@ -536,11 +540,12 @@ std::list<MovePathNode> Fleet::MovePath(const std::list<int>& route, bool flag_b
                   << (cur_system  ? cur_system->ID()  : INVALID_OBJECT_ID) << " with post blockade status "
                   << is_post_blockade << " and ETA " << turns_taken;
 
-    retval.emplace_back(cur_x, cur_y, true, turns_taken,
-                        (cur_system  ? cur_system->ID()  : INVALID_OBJECT_ID),
-                        (prev_system ? prev_system->ID() : INVALID_OBJECT_ID),
-                        (next_system ? next_system->ID() : INVALID_OBJECT_ID),
-                        is_post_blockade);
+    retval.emplace_back(MovePathNode{
+        cur_x, cur_y, true, turns_taken,
+        (cur_system  ? cur_system->ID()  : INVALID_OBJECT_ID),
+        (prev_system ? prev_system->ID() : INVALID_OBJECT_ID),
+        (next_system ? next_system->ID() : INVALID_OBJECT_ID),
+        is_post_blockade});
     TraceLogger() << "Fleet::MovePath for fleet " << this->Name() << "(" << this->ID() << ") is complete";
 
     return retval;

--- a/universe/Fleet.h
+++ b/universe/Fleet.h
@@ -1,11 +1,7 @@
 #ifndef _Fleet_h_
 #define _Fleet_h_
 
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/version.hpp>
-#include "ObjectMap.h"
 #include "UniverseObject.h"
-#include "../util/Export.h"
 
 
 //! Contains info about a single notable point on the move path of a fleet or

--- a/universe/Fleet.h
+++ b/universe/Fleet.h
@@ -11,10 +11,6 @@
 //! Contains info about a single notable point on the move path of a fleet or
 //! other UniverseObject.
 struct MovePathNode {
-    MovePathNode(double x_, double y_, bool turn_end_, int eta_, int id_, int lane_start_id_, int lane_end_id_, bool post_blockade_ = false) :
-        x(x_), y(y_), turn_end(turn_end_), eta(eta_), object_id(id_), lane_start_id(lane_start_id_), lane_end_id(lane_end_id_), post_blockade(post_blockade_)
-    {}
-
     //! Location in Universe of node
     double x, y;
 

--- a/universe/Fleet.h
+++ b/universe/Fleet.h
@@ -8,23 +8,39 @@
 #include "../util/Export.h"
 
 
-////////////////////////////////////////////////
-// MovePathNode
-////////////////////////////////////////////////
-/** Contains info about a single notable point on the move path of a fleet or
-  * other UniverseObject. */
+//! Contains info about a single notable point on the move path of a fleet or
+//! other UniverseObject.
 struct MovePathNode {
     MovePathNode(double x_, double y_, bool turn_end_, int eta_, int id_, int lane_start_id_, int lane_end_id_, bool post_blockade_ = false) :
-    x(x_), y(y_), turn_end(turn_end_), eta(eta_), object_id(id_), lane_start_id(lane_start_id_), lane_end_id(lane_end_id_), post_blockade(post_blockade_)
+        x(x_), y(y_), turn_end(turn_end_), eta(eta_), object_id(id_), lane_start_id(lane_start_id_), lane_end_id(lane_end_id_), post_blockade(post_blockade_)
     {}
-    double  x, y;           ///< location in Universe of node
-    bool    turn_end;       ///< true if the fleet will end a turn at this point
-    int     eta;            ///< estimated turns to reach this node
-    int     object_id;      ///< id of object (most likely a system) located at this node, or INVALID_OBJECT_ID if there is no object here
-    int     lane_start_id;  ///< id of object (most likely a system) at the start of the starlane on which this MovePathNode is located, or INVALID_OBJECT_ID if not on a starlane
-    int     lane_end_id;    ///< id of object (most likely a system) at the end of the starlane on which this MovePathNode is located, or INVALID_OBJECT_ID if not on a starlane
-    bool    post_blockade;  ///< estimation of whether this node is past a blockade for the subject fleet
+
+    //! Location in Universe of node
+    double x, y;
+
+    //! True if the fleet will end a turn at this point
+    bool turn_end;
+
+    //! Estimated turns to reach this node
+    int eta;
+
+    //! ID of object (most likely a system) located at this node, or
+    //! INVALID_OBJECT_ID if there is no object here
+    int object_id;
+
+    //! ID of object (most likely a system) at the start of the starlane on
+    //! which this MovePathNode is located, or INVALID_OBJECT_ID if not on
+    //! a starlane
+    int lane_start_id;
+
+    //! ID of object (most likely a system) at the end of the starlane on which
+    //! this MovePathNode is located, or INVALID_OBJECT_ID if not on a starlane
+    int lane_end_id;
+
+    //! Estimation of whether this node is past a blockade for the subject fleet
+    bool post_blockade;
 };
+
 
 /** Encapsulates data for a FreeOrion fleet.  Fleets are basically a group of
   * ships that travel together. */

--- a/universe/UniverseObject.cpp
+++ b/universe/UniverseObject.cpp
@@ -1,17 +1,12 @@
 #include "UniverseObject.h"
 
-#include <stdexcept>
-#include <boost/lexical_cast.hpp>
 #include "Enums.h"
 #include "Pathfinder.h"
-#include "Special.h"
 #include "System.h"
 #include "UniverseObjectVisitor.h"
-#include "Universe.h"
 #include "../Empire/EmpireManager.h"
 #include "../util/AppInterface.h"
 #include "../util/Logger.h"
-#include "../util/i18n.h"
 
 
 int const INVALID_OBJECT_ID      = -1;

--- a/universe/UniverseObject.h
+++ b/universe/UniverseObject.h
@@ -18,230 +18,314 @@
 
 using boost::container::flat_map;
 
-class System;
-class SitRepEntry;
 struct UniverseObjectVisitor;
 FO_COMMON_API extern const int ALL_EMPIRES;
 FO_COMMON_API extern const int INVALID_GAME_TURN;
 
-// The ID number assigned to a UniverseObject upon construction;
-// It is assigned an ID later when it is placed in the universe
-FO_COMMON_API extern const int INVALID_OBJECT_ID;
 
-// The ID number assigned to temporary universe objects
-FO_COMMON_API extern const int TEMPORARY_OBJECT_ID;
+//! The ID number assigned to a UniverseObject upon construction;
+//! It is assigned an ID later when it is placed in the universe
+FO_COMMON_API extern int const INVALID_OBJECT_ID;
 
-/** The abstract base class for all objects in the universe
-  * The UniverseObject class itself has an ID number, a name, a position, an ID
-  * of the system in which it is, a list of zero or more owners, and other
-  * common object data.
-  * Position in the Universe can range from 0 (left) to 1000 (right) in X, and
-  * 0 (top) to 1000 (bottom) in Y.  This coordinate system was chosen to help
-  * with conversion to and from screen coordinates, which originate at the
-  * upper-left corner of the screen and increase down and to the right.  Each
-  * UniverseObject-derived class inherits several pure virtual members that
-  * perform its actions during various game phases, such as the movement phase.
-  * These subclasses must define what actions to perform during those phases.
-  * UniverseObjects advertise changes to themselves via the StateChanged
-  * Signal.  This means that all mutators on UniverseObject and its subclasses
-  * need to emit this signal.  This is how the UI becomes aware that an object
-  * that is being displayed has changed.*/
+
+//! The ID number assigned to temporary universe objects
+FO_COMMON_API extern int const TEMPORARY_OBJECT_ID;
+
+
+//! The abstract base class for all objects in the universe
+//!
+//! The UniverseObject class itself has an ID number, a name, a position, an ID
+//! of the system in which it is, a list of zero or more owners, and other
+//! common object data.
+//!
+//! Position in the Universe can range from 0 (left) to 1000 (right) in X, and
+//! 0 (top) to 1000 (bottom) in Y.  This coordinate system was chosen to help
+//! with conversion to and from screen coordinates, which originate at the
+//! upper-left corner of the screen and increase down and to the right.
+//!
+//! Each UniverseObject-derived class inherits several pure virtual members
+//! that perform its actions during various game phases, such as the movement
+//! phase.  These subclasses must define what actions to perform during those
+//! phases.
+//!
+//! UniverseObjects advertise changes to themselves via the StateChanged
+//! Signal.  This means that all mutators on UniverseObject and its subclasses
+//! need to emit this signal.  This is how the UI becomes aware that an object
+//! that is being displayed has changed.
 class FO_COMMON_API UniverseObject : virtual public std::enable_shared_from_this<UniverseObject> {
 public:
-    //typedef flat_map<MeterType, Meter, std::less<MeterType>, std::vector<std::pair<MeterType, Meter>>> MeterMap;
-    typedef flat_map<MeterType, Meter, std::less<MeterType>> MeterMap;
+    using MeterMap = flat_map<MeterType, Meter, std::less<MeterType>>;
 
-    /** \name Signal Types */ //@{
-    typedef boost::signals2::signal<void (), blocking_combiner<boost::signals2::optional_last_value<void>>> StateChangedSignalType;
-    //@}
+    using StateChangedSignalType = boost::signals2::signal<void (), blocking_combiner<boost::signals2::optional_last_value<void>>>;
 
-    /** \name Slot Types */ //@{
-    typedef StateChangedSignalType::slot_type StateChangedSlotType;
-    //@}
+    using StateChangedSlotType = StateChangedSignalType::slot_type;
 
-    /** \name Accessors */ //@{
-    int                         ID() const;                         ///< returns the ID number of this object.  Each object in FreeOrion has a unique ID number.
-    const std::string&          Name() const;                       ///< returns the name of this object; some valid objects will have no name
-    virtual double              X() const;                          ///< the X-coordinate of this object
-    virtual double              Y() const;                          ///< the Y-coordinate of this object
+    virtual ~UniverseObject();
 
-    virtual int                 Owner() const;                      ///< returns the ID of the empire that owns this object, or ALL_EMPIRES if there is no owner
-    bool                        Unowned() const;                    ///< returns true iff there are no owners of this object
-    bool                        OwnedBy(int empire) const;          ///< returns true iff the empire with id \a empire owns this object; unowned objects always return false;
-    /** Object owner is at war with empire @p empire_id */
-    virtual bool                HostileToEmpire(int empire_id) const;
+    //! Returns the ID number of this object.  Each object in FreeOrion has
+    //! a unique ID number.
+    auto ID() const -> int
+    { return m_id; }
 
-    virtual int                 SystemID() const;                   ///< returns the ID number of the system in which this object can be found, or INVALID_OBJECT_ID if the object is not within any system
+    void SetID(int id);
 
-    const std::map<std::string, std::pair<int, float>>&   Specials() const;         ///< returns the Specials attached to this object
-    bool                        HasSpecial(const std::string& name) const;          ///< returns true iff this object has a special with the indicated \a name
-    int                         SpecialAddedOnTurn(const std::string& name) const;  ///< returns the turn on which the special with name \a name was added to this object, or INVALID_GAME_TURN if that special is not present
-    float                       SpecialCapacity(const std::string& name) const;     ///> returns the capacity of the special with name \a name or 0 if that special is not present
+    //! Returns the name of this object; some valid objects will have no name.
+    auto Name() const -> std::string const&
+    { return m_name; }
 
-    /** Returns all tags this object has. */
-    virtual std::set<std::string>   Tags() const;
+    //! Renames this object to @p name
+    void Rename(std::string const& name);
 
-    /** Returns true iff this object has the tag with the indicated \a name. */
-    virtual bool                HasTag(const std::string& name) const;
+    //! The X-coordinate of this object.
+    auto X() const -> double
+    { return m_x; }
 
-    virtual UniverseObjectType  ObjectType() const;
+    //! The Y-coordinate of this object.
+    auto Y() const -> double
+    { return m_y; }
 
-    /** Return human readable string description of object offset \p ntabs from
-        margin. */
-    virtual std::string         Dump(unsigned short ntabs = 0) const;
+    //! Moves this object by relative displacements x and y.
+    void Move(double x, double y);
 
-    /** Returns id of the object that directly contains this object, if any, or
-        INVALID_OBJECT_ID if this object is not contained by any other. */
-    virtual int                 ContainerObjectID() const;
+    //! Moves this object to exact map coordinates of the object identified by
+    //! @p object_id
+    void MoveTo(int object_id);
 
-    /** Returns ids of objects contained within this object. */
-    virtual const std::set<int>&ContainedObjectIDs() const;
+    //! Moves this object to exact map coordinates of specified @p object.
+    void MoveTo(std::shared_ptr<UniverseObject> object);
 
-    /** Returns true if there is an object with id \a object_id is contained
-        within this UniverseObject. */
-    virtual bool                Contains(int object_id) const;
+    //! Moves this object to map coordinates (x, y).
+    void MoveTo(double x, double y);
 
-    /* Returns true if there is an object with id \a object_id that contains
-       this UniverseObject. */
-    virtual bool                ContainedBy(int object_id) const;
+    //! Returns the ID of the empire that owns this object, or ALL_EMPIRES if
+    //! there is no owner.
+    virtual auto Owner() const -> int
+    { return m_owner_empire_id; }
 
-    std::set<int>               VisibleContainedObjectIDs(int empire_id) const; ///< returns the subset of contained object IDs that is visible to empire with id \a empire_id
+    //! Returns true iff there are no owners of this object.
+    auto Unowned() const -> bool
+    { return Owner() == ALL_EMPIRES; }
 
-    const MeterMap&             Meters() const { return m_meters; }             ///< returns this UniverseObject's meters
-    const Meter*                GetMeter(MeterType type) const;                 ///< returns the requested Meter, or 0 if no such Meter of that type is found in this object
+    //! Returns true iff the empire with id @p empire owns this object; unowned
+    //! objects always return false;
+    auto OwnedBy(int empire) const -> bool
+    { return empire != ALL_EMPIRES && empire == Owner(); }
 
-    Visibility                  GetVisibility(int empire_id) const; ///< returns the visibility status of this universe object relative to the input empire.
+    //! Sets the empire that owns this object.
+    virtual void SetOwner(int id);
 
-    /** Returns the name of this objectas it appears to empire \a empire_id .*/
-    virtual const std::string&  PublicName(int empire_id) const;
+    //! Object owner is at war with empire @p empire_id
+    virtual auto HostileToEmpire(int empire_id) const -> bool
+    { return false; }
 
-    /** Accepts a visitor object \see UniverseObjectVisitor */
-    virtual std::shared_ptr<UniverseObject> Accept(const UniverseObjectVisitor& visitor) const;
+    //! Returns the ID number of the system in which this object can be found,
+    //! or INVALID_OBJECT_ID if the object is not within any system
+    virtual auto SystemID() const -> int
+    { return m_system_id; }
 
-    int                         CreationTurn() const;               ///< returns game turn on which object was created
-    int                         AgeInTurns() const;                 ///< returns elapsed number of turns between turn object was created and current game turn
+    //! Assigns this object to a System.  Does not actually move object in
+    //! universe.
+    void SetSystem(int sys);
 
-    mutable StateChangedSignalType StateChangedSignal;              ///< emitted when the UniverseObject is altered in any way
-    //@}
+    //! Returns the Specials attached to this object
+    auto Specials() const -> std::map<std::string, std::pair<int, float>> const&
+    { return m_specials; }
 
-    /** \name Mutators */ //@{
-    /** copies data from \a copied_object to this object, limited to only copy
-      * data about the copied object that is known to the empire with id
-      * \a empire_id (or all data if empire_id is ALL_EMPIRES) */
-    virtual void    Copy(std::shared_ptr<const UniverseObject> copied_object, int empire_id) = 0;
+    //! Returns true iff this object has a special with the indicated @p name
+    auto HasSpecial(const std::string& name) const -> bool
+    { return m_specials.count(name); }
 
-    void            SetID(int id);                      ///< sets the ID number of the object to \a id
-    void            Rename(const std::string& name);    ///< renames this object to \a name
+    //! Returns the turn on which the special with name @p name was added to
+    //! this object, or INVALID_GAME_TURN if that special is not present
+    auto SpecialAddedOnTurn(std::string const& name) const -> int;
 
-    /** moves this object by relative displacements x and y. */
-    void            Move(double x, double y);
+    //! Returns the capacity of the special with name @p name or 0 if that
+    //! special is not present
+    auto SpecialCapacity(std::string const& name) const -> float;
 
-    /** calls MoveTo(std::shared_ptr<const UniverseObject>) with the object
-        pointed to by \a object_id. */
-    void            MoveTo(int object_id);
+    //! Adds the Special @p name to this object, if it is not already present
+    virtual void AddSpecial(std::string const& name, float capacity = 0.0f);
 
-    /** moves this object to exact map coordinates of specified \a object. */
-    void            MoveTo(std::shared_ptr<UniverseObject> object);
+    //! Removes the Special @p name from this object, if it is already present
+    virtual void RemoveSpecial(std::string const& name);
 
-    /** moves this object to map coordinates (x, y). */
-    void            MoveTo(double x, double y);
+    void SetSpecialCapacity(std::string const& name, float capacity);
 
-    MeterMap&       Meters() { return m_meters; }           ///< returns this UniverseObject's meters
-    Meter*          GetMeter(MeterType type);               ///< returns the requested Meter, or 0 if no such Meter of that type is found in this object
+    //! Returns all tags this object has.
+    virtual auto Tags() const -> std::set<std::string>
+    { return {}; }
 
-    /** Sets all this UniverseObject's meters' initial values equal to their
-        current values. */
-    virtual void    BackPropagateMeters();
+    //! Returns true iff this object has the tag with the indicated @p name.
+    virtual auto HasTag(const std::string& name) const -> bool
+    { return false; }
 
-    /** Sets the empire that owns this object. */
-    virtual void    SetOwner(int id);
+    virtual auto ObjectType() const -> UniverseObjectType;
 
-    void            SetSystem(int sys);                     ///< assigns this object to a System.  does not actually move object in universe
-    virtual void    AddSpecial(const std::string& name, float capacity = 0.0f); ///< adds the Special \a name to this object, if it is not already present
-    virtual void    RemoveSpecial(const std::string& name); ///< removes the Special \a name from this object, if it is already present
-    void            SetSpecialCapacity(const std::string& name, float capacity);
+    //! Return human readable string description of object offset @p ntabs from
+    //! margin.
+    virtual auto Dump(unsigned short ntabs = 0) const -> std::string;
 
-    /** Performs the movement that this object is responsible for this object's
-      * actions during the movement phase of a turn. */
-    virtual void    MovementPhase()
+    //! Returns id of the object that directly contains this object, if any, or
+    //! INVALID_OBJECT_ID if this object is not contained by any other.
+    virtual auto ContainerObjectID() const -> int
+    { return INVALID_OBJECT_ID; }
+
+    //! Returns ids of objects contained within this object.
+    virtual auto ContainedObjectIDs() const -> std::set<int> const&;
+
+    //! Returns true if there is an object with id @p object_id is contained
+    //! within this UniverseObject.
+    virtual auto Contains(int object_id) const -> bool
+    { return false; }
+
+    //! Returns true if there is an object with id @p object_id that contains
+    //!this UniverseObject.
+    virtual auto ContainedBy(int object_id) const -> bool
+    { return false; }
+
+    //! Returns the subset of contained object IDs that is visible to empire
+    //! with id @p empire_id
+    auto VisibleContainedObjectIDs(int empire_id) const -> std::set<int>;
+
+    //! Returns this UniverseObject's meters
+    // @{
+    auto Meters() -> MeterMap&
+    { return m_meters; }
+
+    auto Meters() const -> MeterMap const&
+    { return m_meters; }
+    // @}
+
+    //! Returns the requested Meter, or nullptr if no such Meter of that type
+    //! is found in this object
+    // @{
+    auto GetMeter(MeterType type) -> Meter*;
+    auto GetMeter(MeterType type) const -> Meter const*;
+    // @}
+
+    //! Sets all this UniverseObject's meters' initial values equal to their
+    //! current values.
+    virtual void BackPropagateMeters();
+
+    //! Sets current value of max, target and unpaired meters in in this
+    //! UniverseObject to Meter::DEFAULT_VALUE.  This should be done before any
+    //! Effects that alter these meter(s) act on the object.
+    virtual void ResetTargetMaxUnpairedMeters();
+
+    //! Sets current value of active paired meters (the non-max non-target
+    //! meters that have a max or target meter associated with them) back to
+    //! the initial value the meter had at the start of this turn.
+    virtual void ResetPairedActiveMeters();
+
+    //! calls Clamp(min, max) on meters each meter in this UniverseObject, to
+    //! ensure that meter current values aren't outside the valid range for
+    //! each meter.
+    virtual void ClampMeters();
+
+
+    //! Returns the visibility status of this universe object relative to the
+    //! input empire.
+    auto GetVisibility(int empire_id) const -> Visibility;
+
+    //! Returns the name of this object as it appears to empire @p empire_id.
+    virtual auto PublicName(int empire_id) const -> std::string const&
+    { return m_name; }
+
+    //! Accepts a visitor object @see UniverseObjectVisitor
+    virtual auto Accept(UniverseObjectVisitor const& visitor) const -> std::shared_ptr<UniverseObject>;
+
+    //! Returns game turn on which object was created
+    auto CreationTurn() const -> int
+    { return m_created_on_turn; }
+
+    //! The age value if the current turn is INVALID_GAME_TURN, or if the turn
+    //! on which an object was created is INVALID_GAME_TURN.
+    static int const INVALID_OBJECT_AGE;
+
+    //! The age value if an object was created on turn BEFORE_FIRST_TURN.
+    static int const SINCE_BEFORE_TIME_AGE;
+
+    //! Returns elapsed number of turns between turn object was created and
+    //! current game turn
+    auto AgeInTurns() const -> int;
+
+    //! Emitted when the UniverseObject is altered in any way
+    mutable StateChangedSignalType StateChangedSignal;
+
+    //! copies data from @p copied_object to this object, limited to only copy
+    //! data about the copied object that is known to the empire with id
+    //! @p empire_id (or all data if empire_id is ALL_EMPIRES)
+    virtual void Copy(std::shared_ptr<UniverseObject const> copied_object, int empire_id) = 0;
+
+    //! Performs the movement that this object is responsible for this object's
+    //! actions during the movement phase of a turn.
+    virtual void MovementPhase()
     {};
 
-    /** Sets current value of max, target and unpaired meters in in this
-      * UniverseObject to Meter::DEFAULT_VALUE.  This should be done before any
-      * Effects that alter these meter(s) act on the object. */
-    virtual void    ResetTargetMaxUnpairedMeters();
-
-    /** Sets current value of active paired meters (the non-max non-target
-      * meters that have a max or target meter associated with them) back to
-      * the initial value the meter had at the start of this turn. */
-    virtual void    ResetPairedActiveMeters();
-
-    /** calls Clamp(min, max) on meters each meter in this UniverseObject, to
-      * ensure that meter current values aren't outside the valid range for
-      * each meter. */
-    virtual void    ClampMeters();
-
-    /** performs the movement that this object is responsible for this object's
-        actions during the pop growth/production/research phase of a turn. */
-    virtual void    PopGrowthProductionResearchPhase()
+    //! Performs the movement that this object is responsible for this object's
+    //! actions during the pop growth/production/research phase of a turn.
+    virtual void PopGrowthProductionResearchPhase()
     {};
-    //@}
 
-    static const double INVALID_POSITION;       ///< the position in x and y at which default-constructed objects are placed
-    static const int    INVALID_OBJECT_AGE;     ///< the age returned by UniverseObject::AgeInTurns() if the current turn is INVALID_GAME_TURN, or if the turn on which an object was created is INVALID_GAME_TURN
-    static const int    SINCE_BEFORE_TIME_AGE;  ///< the age returned by UniverseObject::AgeInTurns() if an object was created on turn BEFORE_FIRST_TURN
+    //! The position in x and y at which default-constructed objects are placed
+    static double const INVALID_POSITION;
 
 protected:
     friend class Universe;
     friend class ObjectMap;
 
-    /** \name Structors */ //@{
     UniverseObject();
-    UniverseObject(const std::string name, double x, double y);
 
-    template <typename T> friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
+    UniverseObject(std::string const name, double x, double y);
 
-public:
-    virtual ~UniverseObject();
+    template <typename T>
+    friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
 
-protected:
-    /** returns new copy of this UniverseObject, limited to only copy data that
-      * is visible to the empire with the specified \a empire_id as determined
-      * by the detection and visibility system.  Caller takes ownership of
-      * returned pointee. */
-    virtual UniverseObject* Clone(int empire_id = ALL_EMPIRES) const = 0;
+    //! returns new copy of this UniverseObject, limited to only copy data that
+    //! is visible to the empire with the specified \a empire_id as determined
+    //! by the detection and visibility system.  Caller takes ownership of
+    //! returned pointee.
+    virtual auto Clone(int empire_id = ALL_EMPIRES) const -> UniverseObject* = 0;
     //@}
 
-    void                    AddMeter(MeterType meter_type); ///< inserts a meter into object as the \a meter_type meter.  Should be used by derived classes to add their specialized meters to objects
-    void                    Init();                         ///< adds stealth meter
+    //! Inserts a meter into object as the \a meter_type meter.  Should be used
+    //! by derived classes to add their specialized meters to objects
+    void AddMeter(MeterType meter_type);
 
-    /** Used by public UniverseObject::Copy and derived classes' ::Copy methods.
-      */
-    void Copy(std::shared_ptr<const UniverseObject> copied_object, Visibility vis,
-              const std::set<std::string>& visible_specials);
+    //! Adds meter
+    void Init();
+
+    //! Used by public UniverseObject::Copy and derived classes' ::Copy methods.
+    void Copy(std::shared_ptr<UniverseObject const> copied_object, Visibility vis,
+              std::set<std::string> const& visible_specials);
 
     std::string             m_name;
 
 private:
-    MeterMap                CensoredMeters(Visibility vis) const;   ///< returns set of meters of this object that are censored based on the specified Visibility \a vis
+    //! Returns set of meters of this object that are censored based on the
+    //! specified Visibility @p vis
+    auto CensoredMeters(Visibility vis) const -> MeterMap;
 
-    int                                             m_id = INVALID_OBJECT_ID;
-    double                                          m_x;
-    double                                          m_y;
-    int                                             m_owner_empire_id = ALL_EMPIRES;
-    int                                             m_system_id = INVALID_OBJECT_ID;
-    std::map<std::string, std::pair<int, float>>    m_specials; // map from special name to pair of (turn added, capacity)
-    MeterMap                                        m_meters;
-    int                                             m_created_on_turn = INVALID_GAME_TURN;
+    int                                           m_id = INVALID_OBJECT_ID;
+    double                                        m_x;
+    double                                        m_y;
+    int                                           m_owner_empire_id = ALL_EMPIRES;
+    int                                           m_system_id = INVALID_OBJECT_ID;
+    //! map from special name to pair of (turn added, capacity)
+    std::map<std::string, std::pair<int, float>>  m_specials;
+    MeterMap                                      m_meters;
+    int                                           m_created_on_turn = INVALID_GAME_TURN;
 
     friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    void serialize(Archive& ar, unsigned int const version);
 };
 
-/** A function that returns the correct amount of spacing for an indentation of
-  * \p ntabs during a dump. */
+
+//! A function that returns the correct amount of spacing for an indentation of
+//! @p ntabs during a dump.
 inline std::string DumpIndent(unsigned short ntabs = 1)
 { return std::string(ntabs * 4 /* conversion to size_t is safe */, ' '); }
+
 
 #endif // _UniverseObject_h_

--- a/universe/UniverseObject.h
+++ b/universe/UniverseObject.h
@@ -4,7 +4,6 @@
 
 #include <set>
 #include <string>
-#include <vector>
 #include <boost/container/flat_map.hpp>
 #include <boost/python/detail/destroy.hpp>
 #include <boost/serialization/access.hpp>


### PR DESCRIPTION
This PR grooms the following classes:

 * `UniverseObject`
 * `Building`
 * `Field`
 * `Fleet`

by applying the following changes:
 
  * Move primitive getters into header.
  * Remove dead code.
  * Use `//!` comments instead for documentation.
  * Rewrite some comments.
  * Use trailing return types.
  * Use east const for function parameters and return types.
  * Removing unused includes from both header and implementation file.

It also rewrites the `MovePathNode` struct to use aggregate initialization instead of user-provided constructors.