### PR TITLE
Fix encyclopedia graph axis label precision.

### DIFF
--- a/UI/GraphControl.cpp
+++ b/UI/GraphControl.cpp
@@ -197,12 +197,10 @@ void GraphControl::Render() {
         auto font = ClientUI::GetFont();
         glColor(ClientUI::TextColor());
         for (auto label : m_y_scale_ticks) {
-            std::string labeltext = "";
             std::stringstream rndlabel;
             rndlabel.precision(12);
             rndlabel << label.second;
-            labeltext += rndlabel.str();
-            font->RenderText({ul.x + GG::X1, lr.y + label.first}, labeltext);
+            font->RenderText({ul.x + GG::X1, lr.y + label.first}, rndlabel.str());
         }
     }
 

--- a/UI/GraphControl.cpp
+++ b/UI/GraphControl.cpp
@@ -196,8 +196,14 @@ void GraphControl::Render() {
         glEnable(GL_TEXTURE_2D);
         auto font = ClientUI::GetFont();
         glColor(ClientUI::TextColor());
-        for (auto label : m_y_scale_ticks)
-            font->RenderText({ul.x + GG::X1, lr.y + label.first}, boost::lexical_cast<std::string>(label.second));
+        for (auto label : m_y_scale_ticks) {
+            std::string labeltext = "";
+            std::stringstream rndlabel;
+            rndlabel.precision(12);
+            rndlabel << label.second;
+            labeltext += rndlabel.str();
+            font->RenderText({ul.x + GG::X1, lr.y + label.first}, labeltext);
+        }
     }
 
     glPushMatrix();

--- a/UI/GraphControl.cpp
+++ b/UI/GraphControl.cpp
@@ -197,10 +197,8 @@ void GraphControl::Render() {
         auto font = ClientUI::GetFont();
         glColor(ClientUI::TextColor());
         for (auto label : m_y_scale_ticks) {
-            std::stringstream rndlabel;
-            rndlabel.precision(12);
-            rndlabel << label.second;
-            font->RenderText({ul.x + GG::X1, lr.y + label.first}, rndlabel.str());
+            auto roundedlabel = boost::format("%|1$.12|") % label.second;
+            font->RenderText({ul.x + GG::X1, lr.y + label.first}, roundedlabel.str());
         }
     }
 


### PR DESCRIPTION
Stringstream used to specify precision for output string, to
prevent extraneous decimals when converting axis label values
to text.

Solves bug #3016

![image](https://user-images.githubusercontent.com/35944068/84556728-17e42400-ad14-11ea-9340-de8660444311.png)


Signed-off-by: Rob Gill <rrobgill@protonmail.com>