### PR TITLE
Remove redundant prerequisite from Zero Point Generation

### DIFF
--- a/default/scripting/techs/production/ZERO_GEN.focs.txt
+++ b/default/scripting/techs/production/ZERO_GEN.focs.txt
@@ -9,7 +9,6 @@ Tech
     prerequisites = [
         "PRO_NDIM_ASSMB"
         "PRO_SINGULAR_GEN"
-        "LRN_EVERYTHING"
     ]
     graphic = "icons/tech/zero_point_energy.png"
 


### PR DESCRIPTION
Zero Point generation has Singularity Generation and N-Dimensional Assembly as prereqs.

It is not necessary to specify Theory of Everything, as this is a prereq of Singularity Generation (via Temporal Mechanics)

Before:
![image](https://user-images.githubusercontent.com/35944068/84561583-2266e380-ad3d-11ea-8f9b-11710906373b.png)

After:
![image](https://user-images.githubusercontent.com/35944068/84561614-6c4fc980-ad3d-11ea-832c-bffe31e129e5.png)


Signed-off-by: Rob Gill <rrobgill@protonmail.com>