### PR TITLE
Remove redundant prereq from Nova Bomb, substitute Stellar Tomography

### DIFF
--- a/default/scripting/techs/ship_weapons/SHP_NOVA_BOMB.focs.txt
+++ b/default/scripting/techs/ship_weapons/SHP_NOVA_BOMB.focs.txt
@@ -7,7 +7,7 @@ Tech
     researchturns = 12
     tags = [ "PEDIA_SHIP_WEAPONS_CATEGORY" ]
     prerequisites = [
-        "LRN_TIME_MECH"
+        "LRN_STELLAR_TOMOGRAPHY"
         "PRO_ZERO_GEN"
     ]
     unlock = [


### PR DESCRIPTION
Nova Bomb has Temporal Mechanics and Zero Point Generation as its prereqs.

Temporal Mechanics is redundant in this case, as it is a prereq for
Zero Point Generatio (via Singularity Generation).

Stellar Tomography substituted.

Before:

![image](https://user-images.githubusercontent.com/35944068/84562417-fd29a380-ad43-11ea-9ab3-a445d836b145.png)

After:

![image](https://user-images.githubusercontent.com/35944068/84562430-0fa3dd00-ad44-11ea-83d8-ebe905a9637e.png)

[Forum Thread](https://www.freeorion.org/forum/viewtopic.php?f=15&t=11698)

Signed-off-by: Rob Gill <rrobgill@protonmail.com>