### PR TITLE
Colonization policy gives +3 base fuel to colonization-only ships.

### DIFF
--- a/default/scripting/policies/COLONIZATION.focs.txt
+++ b/default/scripting/policies/COLONIZATION.focs.txt
@@ -4,4 +4,21 @@ Policy
     short_description = "PLC_COLONIZATION_SHORT_DESC"
     category = "SOCIAL_CATEGORY"
     adoptioncost = floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population condition = And [ Planet OwnedBy empire = Source.Owner ])
+    effectsgroups =
+        EffectsGroup
+            scope = And [
+                Ship
+                OwnedBy empire = Source.Owner
+                DesignHasPartClass low = 1 class = Colony
+                DesignHasPartClass low = 0 high = 0 class = ShortRange
+                DesignHasPartClass low = 0 high = 0 class = FighterBay
+                DesignHasPartClass low = 0 high = 0 class = FighterHangar
+                DesignHasPartClass low = 0 high = 0 class = Troops
+                DesignHasPartClass low = 0 high = 0 class = General
+                DesignHasPartClass low = 0 high = 0 class = Bombard
+            ]
+            priority = [[LATE_PRIORITY]]
+            effects = SetMaxFuel value = Value + 3
     graphic = "icons/policies/colonization.png"
+
+#include "/scripting/common/priorities.macros"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -10941,7 +10941,7 @@ PLC_COLONIZATION
 Colonization
 
 PLC_COLONIZATION_DESC
-Decreases cost of colonization ship parts.
+Decreases cost of colonization ship parts and give ships with colony parts but no weapons, troops, bombard, or general parts +3 base fuel capacity.
 
 PLC_COLONIZATION_SHORT_DESC
 Discounts Colonization


### PR DESCRIPTION
As proposed [here](https://www.freeorion.org/forum/viewtopic.php?f=6&t=11444&start=15#p102203) or earlier in the thread, makes the colonization policy give bonus fuel to colony ships. Does not affect armed ships.