### PR TITLE
Ensure python log messages end with \n

### DIFF
--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -158,7 +158,9 @@ class _LoggerHandler(logging.Handler):
 
     def emit(self, record):
         msg = self.format(record)
-        self.logger(msg, str(record.filename), record.lineno)
+        if not msg.endswith("\n"):
+            msg += "\n"
+        self.logger(msg, record.filename, record.lineno)
 
 
 class FOLogFormatter(logging.Formatter):


### PR DESCRIPTION
Messages must end with newline to ensure log flushing.

Fixes defect introduced in #2910.