### PR TITLE
Fix Python logging memory leak

### DIFF
--- a/python/LoggingWrapper.cpp
+++ b/python/LoggingWrapper.cpp
@@ -33,6 +33,7 @@ namespace {
 
         // If ss is good, store any partial line of text for the next call to send_to_log.
         if (ss.eof()) {
+            ss.str("");
             ss.clear();
             ss << line;
         }
@@ -40,6 +41,7 @@ namespace {
         // Report any errors
         else if (ss.bad() || ss.fail()) {
             ErrorLogger() << "Logger stream from python experienced an error " << ss.rdstate();
+            ss.str("");
             ss.clear();
         }
     }


### PR DESCRIPTION
The stringstream buffer was never cleared and eventually contained the entire log.

Note that this memory leak was recently amplified by malformed logs (see #3049) but already present in older versions. @Vezzra: This should subsequently be cherry-picked into release.

Resolves #3038