### PR TITLE
Use non-intrusive serialization for util/MultiplayerCommon.h structs

### DIFF
--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -5,8 +5,8 @@
 #include "../network/Networking.h"
 #include "Export.h"
 #include "OptionsDB.h"
+#include "OrderSet.h"
 #include "Pending.h"
-#include "Serialize.h"
 
 #include <GG/Clr.h>
 #include <GG/ClrConstants.h>
@@ -15,7 +15,6 @@
 #include <set>
 #include <vector>
 #include <map>
-#include <boost/serialization/access.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 
 
@@ -255,6 +254,5 @@ struct PlayerInfo {
     bool                    host = false;
 };
 
-// Note: *::serialize() implemented in SerializeMultiplayerCommon.cpp.
 
 #endif // _MultiplayerCommon_h_

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -243,14 +243,7 @@ struct FO_COMMON_API ChatHistoryEntity {
     std::string                 m_player_name;
     std::string                 m_text;
     GG::Clr                     m_text_color;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
-
-BOOST_CLASS_VERSION(ChatHistoryEntity, 1);
 
 /** Information about one player that other players are informed of.  Assembled by server and sent to players. */
 struct PlayerInfo {

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -235,14 +235,7 @@ struct FO_COMMON_API MultiplayerLobbyData : public GalaxySetupData {
 
     std::string                                 m_start_lock_cause;
     bool                                        m_in_game; ///< In-game lobby
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
-
-BOOST_CLASS_VERSION(MultiplayerLobbyData, 2);
 
 /** The data structure stores information about latest chat massages. */
 struct FO_COMMON_API ChatHistoryEntity {

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -111,11 +111,6 @@ struct FO_COMMON_API PlayerSaveHeaderData {
     std::string             m_name;
     int                     m_empire_id = ALL_EMPIRES;
     Networking::ClientType  m_client_type = Networking::INVALID_CLIENT_TYPE;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Contains data that must be saved for a single player. */

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -179,11 +179,6 @@ struct SinglePlayerSetupData : public GalaxySetupData {
     bool                            m_new_game;
     std::string                     m_filename;
     std::vector<PlayerSetupData>    m_players;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** The data structure that represents the state of the multiplayer lobby. */

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -92,14 +92,7 @@ struct FO_COMMON_API SaveGameUIData {
     std::vector<std::pair<int, boost::optional<std::pair<bool, int>>>> ordered_ship_design_ids_and_obsolete;
     std::vector<std::pair<std::string, std::pair<bool, int>>> ordered_ship_hull_and_obsolete;
     std::unordered_map<std::string, int> obsolete_ship_parts;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
-
-BOOST_CLASS_VERSION(SaveGameUIData, 4);
 
 
 /** The data for one empire necessary for game-setup during multiplayer loading. */

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -136,14 +136,7 @@ struct FO_COMMON_API PlayerSaveGameData : public PlayerSaveHeaderData {
     std::shared_ptr<OrderSet>       m_orders;
     std::shared_ptr<SaveGameUIData> m_ui_data;
     std::string                     m_save_state_string;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
-
-BOOST_CLASS_VERSION(PlayerSaveGameData, 2);
 
 /** Data that must be retained by the server when saving and loading a
   * game that isn't player data or the universe */

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -76,14 +76,7 @@ struct FO_COMMON_API GalaxySetupData {
       * have to rewrite any custom boost::serialization classes that implement
       * empire-dependent visibility. */
     int                 m_encoding_empire; ///< used during serialization to globally set what empire knowledge to use
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
-
-BOOST_CLASS_VERSION(GalaxySetupData, 3);
 
 
 /** Contains the UI data that must be saved in save game files in order to

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -253,10 +253,6 @@ struct PlayerInfo {
     Networking::ClientType  client_type = Networking::INVALID_CLIENT_TYPE;
     //! true iff this is the host player
     bool                    host = false;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 // Note: *::serialize() implemented in SerializeMultiplayerCommon.cpp.

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -142,11 +142,6 @@ struct FO_COMMON_API PlayerSaveGameData : public PlayerSaveHeaderData {
   * game that isn't player data or the universe */
 struct FO_COMMON_API ServerSaveGameData {
     int m_current_turn = INVALID_GAME_TURN;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** The data structure used to represent a single player's setup options for a

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -104,14 +104,7 @@ struct FO_COMMON_API SaveGameEmpireData {
     bool        m_authenticated = false;
     bool        m_eliminated = false;
     bool        m_won = false;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
-
-BOOST_CLASS_VERSION(SaveGameEmpireData, 2);
 
 /** Contains basic data about a player in a game. */
 struct FO_COMMON_API PlayerSaveHeaderData {

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -158,16 +158,10 @@ struct PlayerSetupData {
     bool                    m_player_ready = false;
     bool                    m_authenticated = false;
     int                     m_starting_team = Networking::NO_TEAM_ID;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
+
 bool FO_COMMON_API operator==(const PlayerSetupData& lhs, const PlayerSetupData& rhs);
 bool operator!=(const PlayerSetupData& lhs, const PlayerSetupData& rhs);
-
-BOOST_CLASS_VERSION(PlayerSetupData, 2);
 
 /** The data needed to establish a new single player game.  If \a m_new_game
   * is true, a new game is to be started, using the remaining members besides

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -115,4 +115,15 @@ extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_b
 extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, SaveGameUIData&, unsigned int const);
 
 
+struct ServerSaveGameData;
+
+template <typename Archive>
+void serialize(Archive&, ServerSaveGameData&, unsigned int const);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, ServerSaveGameData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, ServerSaveGameData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, ServerSaveGameData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, ServerSaveGameData&, unsigned int const);
+
+
 #endif // _Serialize_h_

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -139,4 +139,15 @@ extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_b
 extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, ServerSaveGameData&, unsigned int const);
 
 
+struct SinglePlayerSetupData;
+
+template <typename Archive>
+void serialize(Archive&, SinglePlayerSetupData&, unsigned int const);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, SinglePlayerSetupData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, SinglePlayerSetupData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, SinglePlayerSetupData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, SinglePlayerSetupData&, unsigned int const);
+
+
 #endif // _Serialize_h_

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -65,4 +65,17 @@ extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_x
 extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, GalaxySetupData&, unsigned int const);
 
 
+struct SaveGameUIData;
+
+BOOST_CLASS_VERSION(SaveGameUIData, 4);
+
+template <typename Archive>
+void serialize(Archive&, SaveGameUIData&, unsigned int const);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, SaveGameUIData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, SaveGameUIData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, SaveGameUIData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, SaveGameUIData&, unsigned int const);
+
+
 #endif // _Serialize_h_

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -65,6 +65,17 @@ extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_x
 extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, GalaxySetupData&, unsigned int const);
 
 
+struct PlayerSaveHeaderData;
+
+template <typename Archive>
+void serialize(Archive&, PlayerSaveHeaderData&, unsigned int const);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, PlayerSaveHeaderData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, PlayerSaveHeaderData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, PlayerSaveHeaderData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PlayerSaveHeaderData&, unsigned int const);
+
+
 struct SaveGameEmpireData;
 
 BOOST_CLASS_VERSION(SaveGameEmpireData, 2);

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -65,6 +65,19 @@ extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_x
 extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, GalaxySetupData&, unsigned int const);
 
 
+struct MultiplayerLobbyData;
+
+BOOST_CLASS_VERSION(MultiplayerLobbyData, 2);
+
+template <typename Archive>
+void serialize(Archive&, MultiplayerLobbyData&, unsigned int const);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, MultiplayerLobbyData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, MultiplayerLobbyData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, MultiplayerLobbyData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, MultiplayerLobbyData&, unsigned int const);
+
+
 struct PlayerSaveGameData;
 
 BOOST_CLASS_VERSION(PlayerSaveGameData, 2);

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -91,6 +91,17 @@ extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_x
 extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, MultiplayerLobbyData&, unsigned int const);
 
 
+struct PlayerInfo;
+
+template <typename Archive>
+void serialize(Archive&, PlayerInfo&, unsigned int const);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, PlayerInfo&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, PlayerInfo&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, PlayerInfo&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PlayerInfo&, unsigned int const);
+
+
 struct PlayerSaveGameData;
 
 BOOST_CLASS_VERSION(PlayerSaveGameData, 2);

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -51,4 +51,18 @@ void Deserialize(Archive& ia, std::map<int, std::shared_ptr<UniverseObject>>& ob
 template <typename Archive>
 void Deserialize(Archive& ia, OrderSet& order_set);
 
+
+struct GalaxySetupData;
+
+BOOST_CLASS_VERSION(GalaxySetupData, 3);
+
+template <typename Archive>
+void serialize(Archive&, GalaxySetupData&, unsigned int const);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, GalaxySetupData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, GalaxySetupData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, GalaxySetupData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, GalaxySetupData&, unsigned int const);
+
+
 #endif // _Serialize_h_

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -65,6 +65,19 @@ extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_x
 extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, GalaxySetupData&, unsigned int const);
 
 
+struct SaveGameEmpireData;
+
+BOOST_CLASS_VERSION(SaveGameEmpireData, 2);
+
+template <typename Archive>
+void serialize(Archive&, SaveGameEmpireData&, unsigned int const);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, SaveGameEmpireData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, SaveGameEmpireData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, SaveGameEmpireData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, SaveGameEmpireData&, unsigned int const);
+
+
 struct SaveGameUIData;
 
 BOOST_CLASS_VERSION(SaveGameUIData, 4);

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -65,6 +65,19 @@ extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_x
 extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, GalaxySetupData&, unsigned int const);
 
 
+struct PlayerSaveGameData;
+
+BOOST_CLASS_VERSION(PlayerSaveGameData, 2);
+
+template <typename Archive>
+void serialize(Archive&, PlayerSaveGameData&, unsigned int const);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, PlayerSaveGameData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, PlayerSaveGameData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, PlayerSaveGameData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PlayerSaveGameData&, unsigned int const);
+
+
 struct PlayerSaveHeaderData;
 
 template <typename Archive>

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -89,6 +89,19 @@ extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_x
 extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PlayerSaveHeaderData&, unsigned int const);
 
 
+struct PlayerSetupData;
+
+BOOST_CLASS_VERSION(PlayerSetupData, 2);
+
+template <typename Archive>
+void serialize(Archive&, PlayerSetupData&, unsigned int const);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, PlayerSetupData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, PlayerSetupData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, PlayerSetupData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PlayerSetupData&, unsigned int const);
+
+
 struct SaveGameEmpireData;
 
 BOOST_CLASS_VERSION(SaveGameEmpireData, 2);

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -5,6 +5,7 @@
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/xml_iarchive.hpp>
 #include <boost/archive/xml_oarchive.hpp>
+#include <boost/serialization/version.hpp>
 
 #include <map>
 

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -52,6 +52,19 @@ template <typename Archive>
 void Deserialize(Archive& ia, OrderSet& order_set);
 
 
+struct ChatHistoryEntity;
+
+BOOST_CLASS_VERSION(ChatHistoryEntity, 1);
+
+template <typename Archive>
+void serialize(Archive&, ChatHistoryEntity&, unsigned int const);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, ChatHistoryEntity&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, ChatHistoryEntity&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, ChatHistoryEntity&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, ChatHistoryEntity&, unsigned int const);
+
+
 struct GalaxySetupData;
 
 BOOST_CLASS_VERSION(GalaxySetupData, 3);

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -164,25 +164,27 @@ template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, SaveGam
 
 
 template <typename Archive>
-void SaveGameEmpireData::serialize(Archive& ar, const unsigned int version)
+void serialize(Archive& ar, SaveGameEmpireData& obj, unsigned int const version)
 {
-    ar  & BOOST_SERIALIZATION_NVP(m_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_empire_name)
-        & BOOST_SERIALIZATION_NVP(m_player_name)
-        & BOOST_SERIALIZATION_NVP(m_color);
+    using namespace boost::serialization;
+
+    ar  & make_nvp("m_empire_id", obj.m_empire_id)
+        & make_nvp("m_empire_name", obj.m_empire_name)
+        & make_nvp("m_player_name", obj.m_player_name)
+        & make_nvp("m_color", obj.m_color);
     if (version >= 1) {
-        ar & BOOST_SERIALIZATION_NVP(m_authenticated);
+        ar & make_nvp("m_authenticated", obj.m_authenticated);
     }
     if (version >= 2) {
-        ar & BOOST_SERIALIZATION_NVP(m_eliminated);
-        ar & BOOST_SERIALIZATION_NVP(m_won);
+        ar & make_nvp("m_eliminated", obj.m_eliminated);
+        ar & make_nvp("m_won", obj.m_won);
     }
 }
 
-template void SaveGameEmpireData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
-template void SaveGameEmpireData::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);
-template void SaveGameEmpireData::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
-template void SaveGameEmpireData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, SaveGameEmpireData&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, SaveGameEmpireData&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, SaveGameEmpireData&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, SaveGameEmpireData&, unsigned int const);
 
 
 template <typename Archive>

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -268,28 +268,30 @@ template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PlayerS
 
 
 template <typename Archive>
-void MultiplayerLobbyData::serialize(Archive& ar, const unsigned int version)
+void serialize(Archive& ar, MultiplayerLobbyData& obj, unsigned int const version)
 {
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(GalaxySetupData)
-        & BOOST_SERIALIZATION_NVP(m_new_game)
-        & BOOST_SERIALIZATION_NVP(m_players)
-        & BOOST_SERIALIZATION_NVP(m_save_game)
-        & BOOST_SERIALIZATION_NVP(m_save_game_empire_data)
-        & BOOST_SERIALIZATION_NVP(m_any_can_edit)
-        & BOOST_SERIALIZATION_NVP(m_start_locked)
-        & BOOST_SERIALIZATION_NVP(m_start_lock_cause);
+    using namespace boost::serialization;
+
+    ar  & make_nvp("GalaxySetupData", base_object<GalaxySetupData>(obj))
+        & make_nvp("m_new_game", obj.m_new_game)
+        & make_nvp("m_players", obj.m_players)
+        & make_nvp("m_save_game", obj.m_save_game)
+        & make_nvp("m_save_game_empire_data", obj.m_save_game_empire_data)
+        & make_nvp("m_any_can_edit", obj.m_any_can_edit)
+        & make_nvp("m_start_locked", obj.m_start_locked)
+        & make_nvp("m_start_lock_cause", obj.m_start_lock_cause);
     if (version >= 1) {
-        ar & BOOST_SERIALIZATION_NVP(m_save_game_current_turn);
+        ar & make_nvp("m_save_game_current_turn", obj.m_save_game_current_turn);
     }
     if (version >= 2) {
-        ar & BOOST_SERIALIZATION_NVP(m_in_game);
+        ar & make_nvp("m_in_game", obj.m_in_game);
     }
 }
 
-template void MultiplayerLobbyData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
-template void MultiplayerLobbyData::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);
-template void MultiplayerLobbyData::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
-template void MultiplayerLobbyData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, MultiplayerLobbyData&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, MultiplayerLobbyData&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, MultiplayerLobbyData&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, MultiplayerLobbyData&, unsigned int const);
 
 
 template <typename Archive>

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -188,17 +188,19 @@ template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, SaveGam
 
 
 template <typename Archive>
-void PlayerSaveHeaderData::serialize(Archive& ar, const unsigned int version)
+void serialize(Archive& ar, PlayerSaveHeaderData& obj, unsigned int const version)
 {
-    ar  & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_client_type);
+    using namespace boost::serialization;
+
+    ar  & make_nvp("m_name", obj.m_name)
+        & make_nvp("m_empire_id", obj.m_empire_id)
+        & make_nvp("m_client_type", obj.m_client_type);
 }
 
-template void PlayerSaveHeaderData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
-template void PlayerSaveHeaderData::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);
-template void PlayerSaveHeaderData::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
-template void PlayerSaveHeaderData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, PlayerSaveHeaderData&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, PlayerSaveHeaderData&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, PlayerSaveHeaderData&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PlayerSaveHeaderData&, unsigned int const);
 
 
 template <typename Archive>

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -55,18 +55,20 @@ template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, GalaxyS
 
 
 template <typename Archive>
-void SinglePlayerSetupData::serialize(Archive& ar, const unsigned int version)
+void serialize(Archive& ar, SinglePlayerSetupData& obj, unsigned int const version)
 {
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(GalaxySetupData)
-        & BOOST_SERIALIZATION_NVP(m_new_game)
-        & BOOST_SERIALIZATION_NVP(m_filename)
-        & BOOST_SERIALIZATION_NVP(m_players);
+    using namespace boost::serialization;
+
+    ar  & make_nvp("GalaxySetupData", base_object<GalaxySetupData>(obj))
+        & make_nvp("m_new_game", obj.m_new_game)
+        & make_nvp("m_filename", obj.m_filename)
+        & make_nvp("m_players", obj.m_players);
 }
 
-template void SinglePlayerSetupData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
-template void SinglePlayerSetupData::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);
-template void SinglePlayerSetupData::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
-template void SinglePlayerSetupData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, SinglePlayerSetupData&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, SinglePlayerSetupData&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, SinglePlayerSetupData&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, SinglePlayerSetupData&, unsigned int const);
 
 
 template <typename Archive>

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -239,28 +239,30 @@ template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, ServerS
 
 
 template <typename Archive>
-void PlayerSetupData::serialize(Archive& ar, const unsigned int version)
+void serialize(Archive& ar, PlayerSetupData& obj, unsigned int const version)
 {
-    ar  & BOOST_SERIALIZATION_NVP(m_player_name)
-        & BOOST_SERIALIZATION_NVP(m_player_id)
-        & BOOST_SERIALIZATION_NVP(m_empire_name)
-        & BOOST_SERIALIZATION_NVP(m_empire_color)
-        & BOOST_SERIALIZATION_NVP(m_starting_species_name)
-        & BOOST_SERIALIZATION_NVP(m_save_game_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_client_type)
-        & BOOST_SERIALIZATION_NVP(m_player_ready);
+    using namespace boost::serialization;
+
+    ar  & make_nvp("m_player_name", obj.m_player_name)
+        & make_nvp("m_player_id", obj.m_player_id)
+        & make_nvp("m_empire_name", obj.m_empire_name)
+        & make_nvp("m_empire_color", obj.m_empire_color)
+        & make_nvp("m_starting_species_name", obj.m_starting_species_name)
+        & make_nvp("m_save_game_empire_id", obj.m_save_game_empire_id)
+        & make_nvp("m_client_type", obj.m_client_type)
+        & make_nvp("m_player_ready", obj.m_player_ready);
     if (version >= 1) {
-        ar & BOOST_SERIALIZATION_NVP(m_authenticated);
+        ar & make_nvp("m_authenticated", obj.m_authenticated);
     }
     if (version >= 2) {
-        ar & BOOST_SERIALIZATION_NVP(m_starting_team);
+        ar & make_nvp("m_starting_team", obj.m_starting_team);
     }
 }
 
-template void PlayerSetupData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
-template void PlayerSetupData::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);
-template void PlayerSetupData::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
-template void PlayerSetupData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, PlayerSetupData&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, PlayerSetupData&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, PlayerSetupData&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PlayerSetupData&, unsigned int const);
 
 
 template <typename Archive>

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -126,8 +126,8 @@ void serialize(Archive& ar, SaveGameUIData& obj, unsigned int const version)
         // (attempt to) directly deserialize / load design ordering and obsolescence
         try {
             ar  & make_nvp("ordered_ship_design_ids_and_obsolete", obj.ordered_ship_design_ids_and_obsolete);
-        } catch (...) {
-            ErrorLogger() << "Deserializing ship design ids and obsoletes failed. Skipping hull order and obsoletion, and obsolete ship parts.";
+        } catch (const std::exception& e) {
+            ErrorLogger() << "Deserializing ship design ids and obsoletes failed with '" << e.what() << "'. Skipping hull order and obsoletion, and obsolete ship parts.";
             return;
         }
     }
@@ -151,8 +151,8 @@ void serialize(Archive& ar, SaveGameUIData& obj, unsigned int const version)
     } else {    // is_loading with version < 4
         try {
             ar  & make_nvp("obsolete_ship_parts", obj.obsolete_ship_parts);
-        } catch (...) {
-            ErrorLogger() << "Deserializing obsolete ship parts failed.";
+        } catch (const std::exception& e) {
+            ErrorLogger() << "Deserializing obsolete ship parts failed with '" << e.what() << "'.";
         }
     }
     TraceLogger() << "SaveGameUIData::serialize obsoleted ship parts processed " << obj.obsolete_ship_parts.size()

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -295,24 +295,26 @@ template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, Multipl
 
 
 template <typename Archive>
-void ChatHistoryEntity::serialize(Archive& ar, const unsigned int version)
+void serialize(Archive& ar, ChatHistoryEntity& obj, unsigned int const version)
 {
+    using namespace boost::serialization;
+
     if (version < 1) {
-        ar  & BOOST_SERIALIZATION_NVP(m_timestamp)
-            & BOOST_SERIALIZATION_NVP(m_player_name)
-            & BOOST_SERIALIZATION_NVP(m_text);
+        ar  & make_nvp("m_timestamp", obj.m_timestamp)
+            & make_nvp("m_player_name", obj.m_player_name)
+            & make_nvp("m_text", obj.m_text);
     } else {
-        ar  & BOOST_SERIALIZATION_NVP(m_text)
-            & BOOST_SERIALIZATION_NVP(m_player_name)
-            & BOOST_SERIALIZATION_NVP(m_text_color)
-            & BOOST_SERIALIZATION_NVP(m_timestamp);
+        ar  & make_nvp("m_text", obj.m_text)
+            & make_nvp("m_player_name", obj.m_player_name)
+            & make_nvp("m_text_color", obj.m_text_color)
+            & make_nvp("m_timestamp", obj.m_timestamp);
     }
 }
 
-template void ChatHistoryEntity::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
-template void ChatHistoryEntity::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);
-template void ChatHistoryEntity::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
-template void ChatHistoryEntity::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, ChatHistoryEntity&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, ChatHistoryEntity&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, ChatHistoryEntity&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, ChatHistoryEntity&, unsigned int const);
 
 
 template <typename Archive>

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -227,15 +227,15 @@ template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PlayerS
 
 
 template <typename Archive>
-void ServerSaveGameData::serialize(Archive& ar, const unsigned int version)
+void serialize(Archive& ar, ServerSaveGameData& obj, unsigned int const version)
 {
-    ar  & BOOST_SERIALIZATION_NVP(m_current_turn);
+    ar  & boost::serialization::make_nvp("m_current_turn", obj.m_current_turn);
 }
 
-template void ServerSaveGameData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
-template void ServerSaveGameData::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);
-template void ServerSaveGameData::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
-template void ServerSaveGameData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, ServerSaveGameData&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, ServerSaveGameData&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, ServerSaveGameData&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, ServerSaveGameData&, unsigned int const);
 
 
 template <typename Archive>

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -318,15 +318,17 @@ template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, ChatHis
 
 
 template <typename Archive>
-void PlayerInfo::serialize(Archive& ar, const unsigned int version)
+void serialize(Archive& ar, PlayerInfo& obj, unsigned int const version)
 {
-    ar  & BOOST_SERIALIZATION_NVP(name)
-        & BOOST_SERIALIZATION_NVP(empire_id)
-        & BOOST_SERIALIZATION_NVP(client_type)
-        & BOOST_SERIALIZATION_NVP(host);
+    using namespace boost::serialization;
+
+    ar  & make_nvp("name", obj.name)
+        & make_nvp("empire_id", obj.empire_id)
+        & make_nvp("client_type", obj.client_type)
+        & make_nvp("host", obj.host);
 }
 
-template void PlayerInfo::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
-template void PlayerInfo::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);
-template void PlayerInfo::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
-template void PlayerInfo::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, PlayerInfo&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, PlayerInfo&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, PlayerInfo&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PlayerInfo&, unsigned int const);

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -204,24 +204,26 @@ template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PlayerS
 
 
 template <typename Archive>
-void PlayerSaveGameData::serialize(Archive& ar, const unsigned int version)
+void serialize(Archive& ar, PlayerSaveGameData& obj, unsigned int const version)
 {
-    ar  & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_orders)
-        & BOOST_SERIALIZATION_NVP(m_ui_data)
-        & BOOST_SERIALIZATION_NVP(m_save_state_string)
-        & BOOST_SERIALIZATION_NVP(m_client_type);
+    using namespace boost::serialization;
+
+    ar  & make_nvp("m_name", obj.m_name)
+        & make_nvp("m_empire_id", obj.m_empire_id)
+        & make_nvp("m_orders", obj.m_orders)
+        & make_nvp("m_ui_data", obj.m_ui_data)
+        & make_nvp("m_save_state_string", obj.m_save_state_string)
+        & make_nvp("m_client_type", obj.m_client_type);
     if (version == 1) {
         bool ready{false};
-        ar & boost::serialization::make_nvp("m_ready", ready);
+        ar & make_nvp("m_ready", ready);
     }
 }
 
-template void PlayerSaveGameData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
-template void PlayerSaveGameData::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);
-template void PlayerSaveGameData::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
-template void PlayerSaveGameData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, PlayerSaveGameData&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, PlayerSaveGameData&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, PlayerSaveGameData&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PlayerSaveGameData&, unsigned int const);
 
 
 template <typename Archive>

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -14,42 +14,44 @@
 
 
 template <typename Archive>
-void GalaxySetupData::serialize(Archive& ar, const unsigned int version)
+void serialize(Archive& ar, GalaxySetupData& obj, unsigned int const version)
 {
-    if (Archive::is_saving::value && m_encoding_empire != ALL_EMPIRES && (!GetOptionsDB().Get<bool>("network.server.publish-seed"))) {
+    using namespace boost::serialization;
+
+    if (Archive::is_saving::value && obj.m_encoding_empire != ALL_EMPIRES && (!GetOptionsDB().Get<bool>("network.server.publish-seed"))) {
         std::string dummy = "";
-        ar  & boost::serialization::make_nvp("m_seed", dummy);
+        ar  & make_nvp("m_seed", dummy);
     } else {
-        ar  & BOOST_SERIALIZATION_NVP(m_seed);
+        ar  & make_nvp("m_seed", obj.m_seed);
     }
 
-    ar  & BOOST_SERIALIZATION_NVP(m_size)
-        & BOOST_SERIALIZATION_NVP(m_shape)
-        & BOOST_SERIALIZATION_NVP(m_age)
-        & BOOST_SERIALIZATION_NVP(m_starlane_freq)
-        & BOOST_SERIALIZATION_NVP(m_planet_density)
-        & BOOST_SERIALIZATION_NVP(m_specials_freq)
-        & BOOST_SERIALIZATION_NVP(m_monster_freq)
-        & BOOST_SERIALIZATION_NVP(m_native_freq)
-        & BOOST_SERIALIZATION_NVP(m_ai_aggr);
+    ar  & make_nvp("m_size", obj.m_size)
+        & make_nvp("m_shape", obj.m_shape)
+        & make_nvp("m_age", obj.m_age)
+        & make_nvp("m_starlane_freq", obj.m_starlane_freq)
+        & make_nvp("m_planet_density", obj.m_planet_density)
+        & make_nvp("m_specials_freq", obj.m_specials_freq)
+        & make_nvp("m_monster_freq", obj.m_monster_freq)
+        & make_nvp("m_native_freq", obj.m_native_freq)
+        & make_nvp("m_ai_aggr", obj.m_ai_aggr);
 
     if (version >= 1) {
-        ar & BOOST_SERIALIZATION_NVP(m_game_rules);
+        ar & make_nvp("m_game_rules", obj.m_game_rules);
     }
 
     if (version >= 2) {
-        ar & BOOST_SERIALIZATION_NVP(m_game_uid);
+        ar & make_nvp("m_game_uid", obj.m_game_uid);
     } else {
         if (Archive::is_loading::value) {
-            m_game_uid = boost::uuids::to_string(boost::uuids::random_generator()());
+            obj.m_game_uid = boost::uuids::to_string(boost::uuids::random_generator()());
         }
     }
 }
 
-template void GalaxySetupData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
-template void GalaxySetupData::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);
-template void GalaxySetupData::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
-template void GalaxySetupData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, GalaxySetupData&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, GalaxySetupData&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, GalaxySetupData&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, GalaxySetupData&, unsigned int const);
 
 
 template <typename Archive>


### PR DESCRIPTION
This PR removes the need for including any serialization related headers to `util/MultiplayerCommon.h` or exposing the implementation of the to-be-serialized classes to `util/Serialize.h` by using the non-intrusive `boost::serialization` interface.