### PR TITLE
Fields affect target meter, add standard meter change for ships

### DIFF
--- a/default/scripting/fields/FLD_METEOR_BLIZZARD.focs.txt
+++ b/default/scripting/fields/FLD_METEOR_BLIZZARD.focs.txt
@@ -29,10 +29,11 @@ FieldType
             scope = And [
                 Ship
                 WithinDistance distance = Source.Size * 0.9 condition = Source
+                Not Monster
             ]
             stackinggroup = "METEOR_BLIZZARD_SHIP_EFFECTS"
             effects = [
-                SetResearch value = max(1, Value)
+                SetTargetResearch value = Value + 1
             ]
 
         EffectsGroup    // after reaching a certain age, dissipate when small

--- a/default/scripting/fields/FLD_NANITE_SWARM.focs.txt
+++ b/default/scripting/fields/FLD_NANITE_SWARM.focs.txt
@@ -25,15 +25,16 @@ FieldType
             activation = (Source.Age >= max((UniverseWidth ^ 1.1) / 50, 20))
             effects = SetSize value = Value - min(max(Value * RandomNumber(0.05, 0.1), 1.0), 3.0)
 
-        EffectsGroup    // increase ship structure
+        EffectsGroup    // increase ship structure, grant industry
             scope = And [
                 Ship
                 WithinDistance distance = Source.Size * 0.9 condition = Source
+                Not Monster
             ]
             stackinggroup = "NANITE_SWARM_SHIP_REPAIR"
             effects = [
                 SetStructure value = Value + 5
-                SetIndustry value = max(1, Value)
+                SetTargetIndustry value = Value + 1
             ]
 
         EffectsGroup    // after reaching a certain age, dissipate when small

--- a/default/scripting/species/common/general.macros
+++ b/default/scripting/species/common/general.macros
@@ -1,6 +1,6 @@
 STANDARD_METER_GROWTH
 '''
-        // increase or decrease towards target meter, when not recently conquered
+        // increase or decrease towards target meter of planets, when not recently conquered
         EffectsGroup
             scope = Source
             activation = And [
@@ -11,6 +11,16 @@ STANDARD_METER_GROWTH
             effects = [
                 SetResearch value = Value + min(max(Value(Target.TargetResearch) - Value, -1), min(1, Value(Target.Happiness) - 4))
                 SetIndustry value = Value + min(max(Value(Target.TargetIndustry) - Value, -1), min(1, Value(Target.Happiness) - 4))
+            ]
+
+        // increase or decrease towards target meter of ships
+        EffectsGroup
+            scope = Source
+            activation = Ship
+            priority = [[AFTER_ALL_TARGET_MAX_METERS_PRIORITY]]
+            effects = [
+                SetResearch value = Value + min(max(Value(Target.TargetResearch) - Value, -1), 1)
+                SetIndustry value = Value + min(max(Value(Target.TargetIndustry) - Value, -1), 1)
             ]
 
         // removes residual production from a dead planet


### PR DESCRIPTION
Makes Nanite and Meteor fields affect Target meters of ships (not monsters) instead of current meter.
Adds standard meter growth/decay for ships.

Fixes #3048 

Tested with the save file in the linked issue. Works fine for ships with species.
Monsters in that save that already had PP output won't lose it outside of fields, but new monsters won't get the resource output with this fix.