### PR TITLE
Build gas giant generators only in inhabited systems

### DIFF
--- a/default/scripting/buildings/GAS_GIANT_GEN.focs.txt
+++ b/default/scripting/buildings/GAS_GIANT_GEN.focs.txt
@@ -9,6 +9,14 @@ BuildingType
         Not Contains Building name = "BLD_GAS_GIANT_GEN"
         OwnedBy empire = Source.Owner
         Planet type = GasGiant
+        ContainedBy And [
+            System
+            Contains And [
+                Planet
+                OwnedBy empire = Source.Owner
+                Not Population high = 0
+            ]
+        ]
     ]
     EnqueueLocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
     effectsgroups = [

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -13373,7 +13373,7 @@ BLD_GAS_GIANT_GEN
 Gas Giant Generator
 
 BLD_GAS_GIANT_GEN_DESC
-'''This building can only be constructed at a [[PT_GASGIANT]] and gives a +5 [[metertype METER_INDUSTRY]] bonus to planets with the Industry focus in the same system. If the [[BLD_GAS_GIANT_GEN]] is built on an inhabited gas giant it gives only a +3 [[metertype METER_INDUSTRY]] bonus.
+'''This building can only be constructed at a [[PT_GASGIANT]] in an inhabited system and gives a +5 [[metertype METER_INDUSTRY]] bonus to planets with the Industry focus in the same system. If the [[BLD_GAS_GIANT_GEN]] is built on an inhabited gas giant it gives only a +3 [[metertype METER_INDUSTRY]] bonus.
 Multiple copies in the same system do not stack.
 
 A power generator designed to harvest the energy of a [[PT_GASGIANT]].'''


### PR DESCRIPTION
As their effect is limited to the system they are in, they don't do anything if there are no planets within the system

* Changes location specification so that there must be an inhabited planet in the same system

* Encyclopedia entry text updated

Signed-off-by: Rob Gill <rrobgill@protonmail.com>