### PR TITLE
Require shipyard (built or enqueued) in system to build asteroid processor

### DIFF
--- a/default/scripting/buildings/shipyards/ASTEROID.focs.txt
+++ b/default/scripting/buildings/shipyards/ASTEROID.focs.txt
@@ -8,6 +8,17 @@ BuildingType
         Not Contains Building name = "BLD_SHIPYARD_AST"
         Planet type = Asteroids
         OwnedBy empire = Source.Owner
+        ContainedBy And [
+            System
+            Contains And [
+                Planet
+                OwnedBy empire = Source.Owner
+                Or [
+                    Contains Building name = "BLD_SHIPYARD_BASE"
+                    Enqueued type = Building name = "BLD_SHIPYARD_BASE"
+                ]
+            ]
+        ]
     ]
     EnqueueLocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
     effectsgroups = [

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -12995,7 +12995,7 @@ BLD_SHIPYARD_AST
 Asteroid Processor
 
 BLD_SHIPYARD_AST_DESC
-'''This building is required for the production of all asteroid hulls and all further asteroid processor upgrades. This building can only be built on an asteroid belt, which also can be an [[encyclopedia OUTPOSTS_TITLE]].
+'''This building is required for the production of all asteroid hulls and all further asteroid processor upgrades. This building can only be built on an asteroid belt of a system with a [[buildingtype BLD_SHIPYARD_BASE]], and can be built at an [[encyclopedia OUTPOSTS_TITLE]].
 
 A massive processing plant dedicated to the purpose of hollowing out asteroids and preparing them to be used as ships' hulls. Asteroids thus prepared are sent to a [[buildingtype BLD_SHIPYARD_BASE]] in the same system, where they are turned into the final hull.'''
 


### PR DESCRIPTION
As their effect is limited to the system they are in, they don't do anything if there are no shipyards within the system

* Changes location specification to that there must be a shipyard
  (either built or enqueued) within the same system

* Encyclopedia entry text updated

Signed-off-by: Rob Gill <rrobgill@protonmail.com>