### PR TITLE
Public struct attribute names

### DIFF
--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -1126,17 +1126,17 @@ namespace {
             const GalaxySetupData& gsd = ClientApp::GetApp()->GetGalaxySetupData();
 
             detailed_description += str(FlexibleFormat(UserString("ENC_GALAXY_SETUP_SETTINGS"))
-                % gsd.m_seed
-                % std::to_string(gsd.m_size)
-                % TextForGalaxyShape(gsd.m_shape)
-                % TextForGalaxySetupSetting(gsd.m_age)
-                % TextForGalaxySetupSetting(gsd.m_starlane_freq)
-                % TextForGalaxySetupSetting(gsd.m_planet_density)
-                % TextForGalaxySetupSetting(gsd.m_specials_freq)
-                % TextForGalaxySetupSetting(gsd.m_monster_freq)
-                % TextForGalaxySetupSetting(gsd.m_native_freq)
-                % TextForAIAggression(gsd.m_ai_aggr)
-                % gsd.m_game_uid);
+                % gsd.seed
+                % std::to_string(gsd.size)
+                % TextForGalaxyShape(gsd.shape)
+                % TextForGalaxySetupSetting(gsd.age)
+                % TextForGalaxySetupSetting(gsd.starlane_freq)
+                % TextForGalaxySetupSetting(gsd.planet_density)
+                % TextForGalaxySetupSetting(gsd.specials_freq)
+                % TextForGalaxySetupSetting(gsd.monster_freq)
+                % TextForGalaxySetupSetting(gsd.native_freq)
+                % TextForAIAggression(gsd.ai_aggr)
+                % gsd.game_uid);
 
             return;
         }

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -916,30 +916,30 @@ void GalaxySetupPanel::Disable(bool b/* = true*/) {
 }
 
 void GalaxySetupPanel::SetFromSetupData(const GalaxySetupData& setup_data) {
-    SetSeed(setup_data.m_seed, true);
-    m_stars_spin->SetValue(setup_data.m_size);
-    m_galaxy_shapes_list->Select(setup_data.m_shape);
+    SetSeed(setup_data.seed, true);
+    m_stars_spin->SetValue(setup_data.size);
+    m_galaxy_shapes_list->Select(setup_data.shape);
     ShapeChanged(m_galaxy_shapes_list->CurrentItem());
-    m_galaxy_ages_list->Select(setup_data.m_age - 1);
-    m_starlane_freq_list->Select(setup_data.m_starlane_freq - 1);
-    m_planet_density_list->Select(setup_data.m_planet_density - 1);
-    m_specials_freq_list->Select(setup_data.m_specials_freq);
-    m_monster_freq_list->Select(setup_data.m_monster_freq);
-    m_native_freq_list->Select(setup_data.m_native_freq);
-    m_ai_aggression_list->Select(setup_data.m_ai_aggr);
+    m_galaxy_ages_list->Select(setup_data.age - 1);
+    m_starlane_freq_list->Select(setup_data.starlane_freq - 1);
+    m_planet_density_list->Select(setup_data.planet_density - 1);
+    m_specials_freq_list->Select(setup_data.specials_freq);
+    m_monster_freq_list->Select(setup_data.monster_freq);
+    m_native_freq_list->Select(setup_data.native_freq);
+    m_ai_aggression_list->Select(setup_data.ai_aggr);
 }
 
 void GalaxySetupPanel::GetSetupData(GalaxySetupData& setup_data) const {
     setup_data.SetSeed(GetSeed());
-    setup_data.m_size =             Systems();
-    setup_data.m_shape =            GetShape();
-    setup_data.m_age =              GetAge();
-    setup_data.m_starlane_freq =    GetStarlaneFrequency();
-    setup_data.m_planet_density =   GetPlanetDensity();
-    setup_data.m_specials_freq =    GetSpecialsFrequency();
-    setup_data.m_monster_freq =     GetMonsterFrequency();
-    setup_data.m_native_freq =      GetNativeFrequency();
-    setup_data.m_ai_aggr =          GetAIAggression();
+    setup_data.size =             Systems();
+    setup_data.shape =            GetShape();
+    setup_data.age =              GetAge();
+    setup_data.starlane_freq =    GetStarlaneFrequency();
+    setup_data.planet_density =   GetPlanetDensity();
+    setup_data.specials_freq =    GetSpecialsFrequency();
+    setup_data.monster_freq =     GetMonsterFrequency();
+    setup_data.native_freq =      GetNativeFrequency();
+    setup_data.ai_aggr =          GetAIAggression();
 }
 
 void GalaxySetupPanel::SettingChanged() {

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -400,11 +400,11 @@ namespace {
                  it != m_save_game_empire_data.end(); ++it)
             {
                 // don't allow to select eliminated empire
-                if (it->second.m_eliminated)
+                if (it->second.eliminated)
                     continue;
 
                 // insert row into droplist of empires for this player row
-                m_empire_list->Insert(GG::Wnd::Create<CUISimpleDropDownListRow>(it->second.m_empire_name));
+                m_empire_list->Insert(GG::Wnd::Create<CUISimpleDropDownListRow>(it->second.empire_name));
 
                 // attempt to choose a default empire to be selected in this
                 // player row. If this empire row matches this player data's
@@ -413,13 +413,13 @@ namespace {
                 // select the row
                 if ((it->first == m_player_data.save_game_empire_id) ||
                         (m_player_data.save_game_empire_id == ALL_EMPIRES &&
-                         it->second.m_player_name == m_player_data.player_name &&
+                         it->second.player_name == m_player_data.player_name &&
                          !m_in_game))
                 {
                     m_empire_list->Select(--m_empire_list->end());
-                    m_player_data.empire_name =           it->second.m_empire_name;
-                    m_player_data.empire_color =          it->second.m_color;
-                    m_player_data.save_game_empire_id =   it->second.m_empire_id;
+                    m_player_data.empire_name =           it->second.empire_name;
+                    m_player_data.empire_color =          it->second.color;
+                    m_player_data.save_game_empire_id =   it->second.empire_id;
                     save_game_empire_it = it;
                 }
             }
@@ -431,7 +431,7 @@ namespace {
             push_back(m_color_selector);
 
             // original empire player name from saved game
-            push_back(GG::Wnd::Create<CUILabel>(save_game_empire_it != m_save_game_empire_data.end() ? save_game_empire_it->second.m_player_name : ""));
+            push_back(GG::Wnd::Create<CUILabel>(save_game_empire_it != m_save_game_empire_data.end() ? save_game_empire_it->second.player_name : ""));
 
             m_color_selector->Disable();
 
@@ -477,14 +477,14 @@ namespace {
             }
             auto it = m_save_game_empire_data.begin();
             std::advance(it, m_empire_list->IteratorToIndex(selected_it));
-            m_player_data.empire_name =           it->second.m_empire_name;
-            m_player_data.empire_color =          it->second.m_color;
-            m_player_data.save_game_empire_id =   it->second.m_empire_id;
+            m_player_data.empire_name =           it->second.empire_name;
+            m_player_data.empire_color =          it->second.color;
+            m_player_data.save_game_empire_id =   it->second.empire_id;
             m_color_selector->SelectColor(m_player_data.empire_color);
 
             // set previous player name indication
             if (size() >= 5)
-                boost::polymorphic_downcast<GG::Label*>(at(4))->SetText(it->second.m_player_name);
+                boost::polymorphic_downcast<GG::Label*>(at(4))->SetText(it->second.player_name);
 
             DataChangedSignal();
         }
@@ -515,14 +515,14 @@ namespace {
             // player name text
             push_back(GG::Wnd::Create<CUILabel>(""));
             // empire name
-            push_back(GG::Wnd::Create<CUILabel>(m_save_game_empire_data.m_empire_name));
+            push_back(GG::Wnd::Create<CUILabel>(m_save_game_empire_data.empire_name));
             // empire colour selector (disabled, so acts as colour indicator)
             m_color_selector = GG::Wnd::Create<EmpireColorSelector>(PlayerFontHeight() + PlayerRowMargin());
-            m_color_selector->SelectColor(m_save_game_empire_data.m_color);
+            m_color_selector->SelectColor(m_save_game_empire_data.color);
             m_color_selector->Disable();
             push_back(m_color_selector);
             // original empire player name from saved game
-            push_back(GG::Wnd::Create<CUILabel>(m_save_game_empire_data.m_player_name));
+            push_back(GG::Wnd::Create<CUILabel>(m_save_game_empire_data.player_name));
             // ready state
             push_back(GG::Wnd::Create<CUILabel>(""));
             // host
@@ -531,9 +531,9 @@ namespace {
     private:
         void PlayerTypeChanged(Networking::ClientType type) {
             m_player_data.client_type = type;
-            m_player_data.empire_name =         m_save_game_empire_data.m_empire_name;
-            m_player_data.empire_color =        m_save_game_empire_data.m_color;
-            m_player_data.save_game_empire_id = m_save_game_empire_data.m_empire_id;
+            m_player_data.empire_name =         m_save_game_empire_data.empire_name;
+            m_player_data.empire_color =        m_save_game_empire_data.color;
+            m_player_data.save_game_empire_id = m_save_game_empire_data.empire_id;
             DataChangedSignal();
         }
 
@@ -1050,7 +1050,7 @@ bool MultiPlayerLobbyWnd::PopulatePlayerList() {
         for (const auto& save_game_empire_data : m_lobby_data.save_game_empire_data) {
             bool is_assigned = false;
             for (const auto& player : m_lobby_data.players) {
-                if (player.second.save_game_empire_id == save_game_empire_data.second.m_empire_id) {
+                if (player.second.save_game_empire_id == save_game_empire_data.second.empire_id) {
                     is_assigned = true;
                     break;
                 }

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -253,7 +253,7 @@ namespace {
 
             // human / AI / observer indicator / selector
             auto type_drop = GG::Wnd::Create<TypeSelector>(
-                GG::X(90), PlayerRowHeight(), m_player_data.m_client_type, m_initial_disabled);
+                GG::X(90), PlayerRowHeight(), m_player_data.client_type, m_initial_disabled);
             push_back(type_drop);
             if (m_initial_disabled)
                 type_drop->Disable();
@@ -262,20 +262,20 @@ namespace {
                     boost::bind(&NewGamePlayerRow::PlayerTypeChanged, this, _1));
 
             // player name text
-            push_back(GG::Wnd::Create<CUILabel>(m_player_data.m_player_name));
+            push_back(GG::Wnd::Create<CUILabel>(m_player_data.player_name));
 
-            if (m_player_data.m_client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
-                m_player_data.m_client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR) {
+            if (m_player_data.client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
+                m_player_data.client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR) {
                 // observers don't need to pick an empire or species
                 push_back(GG::Wnd::Create<CUILabel>(""));
                 push_back(GG::Wnd::Create<CUILabel>(""));
                 push_back(GG::Wnd::Create<CUILabel>(""));
-                push_back(GG::Wnd::Create<GG::StaticGraphic>(GetReadyTexture(m_player_data.m_player_ready),
+                push_back(GG::Wnd::Create<GG::StaticGraphic>(GetReadyTexture(m_player_data.player_ready),
                                                              GG::GRAPHIC_CENTER | GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE, GG::INTERACTIVE));
                 at(5)->SetMinSize(GG::Pt(GG::X(ClientUI::Pts()), PlayerFontHeight()));
                 at(5)->SetBrowseModeTime(GetOptionsDB().Get<int>("ui.tooltip.delay"));
                 at(5)->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
-                    m_player_data.m_player_ready ? UserString("READY_BN") : UserString("NOT_READY_BN"),
+                    m_player_data.player_ready ? UserString("READY_BN") : UserString("NOT_READY_BN"),
                     "", PlayerReadyBrowseWidth()));
                 if (HumanClientApp::GetApp()->Networking().PlayerIsHost(m_player_id)) {
                     push_back(GG::Wnd::Create<GG::StaticGraphic>(GetHostTexture(),
@@ -289,7 +289,7 @@ namespace {
             }
 
             // empire name editable text
-            auto edit = GG::Wnd::Create<CUIEdit>(m_player_data.m_empire_name);
+            auto edit = GG::Wnd::Create<CUIEdit>(m_player_data.empire_name);
             edit->SetColor(GG::CLR_ZERO);
             edit->SetInteriorColor(GG::CLR_ZERO);
             edit->Resize(GG::Pt(EMPIRE_NAME_WIDTH, edit->MinUsableSize().y));
@@ -302,7 +302,7 @@ namespace {
 
             // empire colour selector
             auto color_selector = GG::Wnd::Create<EmpireColorSelector>(PlayerFontHeight() + PlayerRowMargin());
-            color_selector->SelectColor(m_player_data.m_empire_color);
+            color_selector->SelectColor(m_player_data.empire_color);
             push_back(color_selector);
             if (m_initial_disabled)
                 color_selector->Disable();
@@ -311,7 +311,7 @@ namespace {
                     boost::bind(&NewGamePlayerRow::ColorChanged, this, _1));
 
             // species selector
-            auto species_selector = GG::Wnd::Create<SpeciesSelector>(m_player_data.m_starting_species_name, EMPIRE_NAME_WIDTH, PlayerRowHeight());
+            auto species_selector = GG::Wnd::Create<SpeciesSelector>(m_player_data.starting_species_name, EMPIRE_NAME_WIDTH, PlayerRowHeight());
             push_back(species_selector);
             if (m_initial_disabled)
                 species_selector->Disable();
@@ -320,16 +320,16 @@ namespace {
                     boost::bind(&NewGamePlayerRow::SpeciesChanged, this, _1));
 
             // ready state
-            if (m_player_data.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
+            if (m_player_data.client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
                 push_back(GG::Wnd::Create<CUILabel>(""));
                 at(5)->SetMinSize(GG::Pt(GG::X(ClientUI::Pts()), PlayerFontHeight()));
             } else {
-                push_back(GG::Wnd::Create<GG::StaticGraphic>(GetReadyTexture(m_player_data.m_player_ready),
+                push_back(GG::Wnd::Create<GG::StaticGraphic>(GetReadyTexture(m_player_data.player_ready),
                                                              GG::GRAPHIC_CENTER | GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE, GG::INTERACTIVE));
                 at(5)->SetMinSize(GG::Pt(GG::X(ClientUI::Pts()), PlayerFontHeight()));
                 at(5)->SetBrowseModeTime(GetOptionsDB().Get<int>("ui.tooltip.delay"));
                 at(5)->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
-                    m_player_data.m_player_ready ? UserString("READY_BN") : UserString("NOT_READY_BN"),
+                    m_player_data.player_ready ? UserString("READY_BN") : UserString("NOT_READY_BN"),
                     "", PlayerReadyBrowseWidth()));
             }
 
@@ -346,19 +346,19 @@ namespace {
 
     private:
         void PlayerTypeChanged(Networking::ClientType type) {
-            m_player_data.m_client_type = type;
+            m_player_data.client_type = type;
             DataChangedSignal();
         }
         void EmpireNameChanged(const std::string& str) {
-            m_player_data.m_empire_name = str;
+            m_player_data.empire_name = str;
             DataChangedSignal();
         }
         void ColorChanged(const GG::Clr& clr) {
-            m_player_data.m_empire_color = clr;
+            m_player_data.empire_color = clr;
             DataChangedSignal();
         }
         void SpeciesChanged(const std::string& str) {
-            m_player_data.m_starting_species_name = str;
+            m_player_data.starting_species_name = str;
             DataChangedSignal();
         }
 
@@ -380,7 +380,7 @@ namespace {
             using boost::placeholders::_1;
 
             // human / AI / observer indicator / selector
-            auto type_drop = GG::Wnd::Create<TypeSelector>(GG::X(90), PlayerRowHeight(), m_player_data.m_client_type, m_initial_disabled);
+            auto type_drop = GG::Wnd::Create<TypeSelector>(GG::X(90), PlayerRowHeight(), m_player_data.client_type, m_initial_disabled);
             push_back(type_drop);
             if (m_initial_disabled)
                 type_drop->Disable();
@@ -389,7 +389,7 @@ namespace {
                     boost::bind(&LoadGamePlayerRow::PlayerTypeChanged, this, _1));
 
             // player name text
-            push_back(GG::Wnd::Create<CUILabel>(m_player_data.m_player_name));
+            push_back(GG::Wnd::Create<CUILabel>(m_player_data.player_name));
 
             // droplist to select empire
             m_empire_list = GG::Wnd::Create<CUIDropDownList>(6);
@@ -411,15 +411,15 @@ namespace {
                 // save game empire id, or if this empire row's player name
                 // matches this player data's player name in loading game,
                 // select the row
-                if ((it->first == m_player_data.m_save_game_empire_id) ||
-                        (m_player_data.m_save_game_empire_id == ALL_EMPIRES &&
-                         it->second.m_player_name == m_player_data.m_player_name &&
+                if ((it->first == m_player_data.save_game_empire_id) ||
+                        (m_player_data.save_game_empire_id == ALL_EMPIRES &&
+                         it->second.m_player_name == m_player_data.player_name &&
                          !m_in_game))
                 {
                     m_empire_list->Select(--m_empire_list->end());
-                    m_player_data.m_empire_name =           it->second.m_empire_name;
-                    m_player_data.m_empire_color =          it->second.m_color;
-                    m_player_data.m_save_game_empire_id =   it->second.m_empire_id;
+                    m_player_data.empire_name =           it->second.m_empire_name;
+                    m_player_data.empire_color =          it->second.m_color;
+                    m_player_data.save_game_empire_id =   it->second.m_empire_id;
                     save_game_empire_it = it;
                 }
             }
@@ -427,7 +427,7 @@ namespace {
 
             // empire colour selector (disabled, so acts as colour indicator)
             m_color_selector = GG::Wnd::Create<EmpireColorSelector>(PlayerFontHeight() + PlayerRowMargin());
-            m_color_selector->SelectColor(m_player_data.m_empire_color);
+            m_color_selector->SelectColor(m_player_data.empire_color);
             push_back(m_color_selector);
 
             // original empire player name from saved game
@@ -442,15 +442,15 @@ namespace {
                     boost::bind(&LoadGamePlayerRow::EmpireChanged, this, _1));
 
             // ready state
-            if (m_player_data.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
+            if (m_player_data.client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
                 push_back(GG::Wnd::Create<CUILabel>(""));
                 at(5)->SetMinSize(GG::Pt(GG::X(ClientUI::Pts()), PlayerFontHeight()));
             } else {
-                push_back(GG::Wnd::Create<GG::StaticGraphic>(GetReadyTexture(m_player_data.m_player_ready),
+                push_back(GG::Wnd::Create<GG::StaticGraphic>(GetReadyTexture(m_player_data.player_ready),
                                                              GG::GRAPHIC_CENTER | GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE, GG::INTERACTIVE));
                 at(5)->SetBrowseModeTime(GetOptionsDB().Get<int>("ui.tooltip.delay"));
                 at(5)->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
-                    m_player_data.m_player_ready ? UserString("READY_BN") : UserString("NOT_READY_BN"),
+                    m_player_data.player_ready ? UserString("READY_BN") : UserString("NOT_READY_BN"),
                     "", PlayerReadyBrowseWidth()));
                 at(5)->SetMinSize(GG::Pt(GG::X(ClientUI::Pts()), PlayerFontHeight()));
             }
@@ -467,7 +467,7 @@ namespace {
 
     private:
         void PlayerTypeChanged(Networking::ClientType type) {
-            m_player_data.m_client_type = type;
+            m_player_data.client_type = type;
             DataChangedSignal();
         }
         void EmpireChanged(GG::DropDownList::iterator selected_it) {
@@ -477,10 +477,10 @@ namespace {
             }
             auto it = m_save_game_empire_data.begin();
             std::advance(it, m_empire_list->IteratorToIndex(selected_it));
-            m_player_data.m_empire_name =           it->second.m_empire_name;
-            m_player_data.m_empire_color =          it->second.m_color;
-            m_player_data.m_save_game_empire_id =   it->second.m_empire_id;
-            m_color_selector->SelectColor(m_player_data.m_empire_color);
+            m_player_data.empire_name =           it->second.m_empire_name;
+            m_player_data.empire_color =          it->second.m_color;
+            m_player_data.save_game_empire_id =   it->second.m_empire_id;
+            m_color_selector->SelectColor(m_player_data.empire_color);
 
             // set previous player name indication
             if (size() >= 5)
@@ -530,10 +530,10 @@ namespace {
         }
     private:
         void PlayerTypeChanged(Networking::ClientType type) {
-            m_player_data.m_client_type = type;
-            m_player_data.m_empire_name =         m_save_game_empire_data.m_empire_name;
-            m_player_data.m_empire_color =        m_save_game_empire_data.m_color;
-            m_player_data.m_save_game_empire_id = m_save_game_empire_data.m_empire_id;
+            m_player_data.client_type = type;
+            m_player_data.empire_name =         m_save_game_empire_data.m_empire_name;
+            m_player_data.empire_color =        m_save_game_empire_data.m_color;
+            m_player_data.save_game_empire_id = m_save_game_empire_data.m_empire_id;
             DataChangedSignal();
         }
 
@@ -566,7 +566,7 @@ namespace {
         }
     private:
         void PlayerTypeChanged(Networking::ClientType type) {
-            m_player_data.m_client_type = type;
+            m_player_data.client_type = type;
             DataChangedSignal();
         }
     };
@@ -789,8 +789,8 @@ void MultiPlayerLobbyWnd::ChatMessage(int player_id, const boost::posix_time::pt
         for (auto& entry : m_lobby_data.m_players) {
             if (entry.first != player_id || entry.first == Networking::INVALID_PLAYER_ID)
                 continue;
-            player_name = entry.second.m_player_name;
-            text_color = entry.second.m_empire_color;
+            player_name = entry.second.player_name;
+            text_color = entry.second.empire_color;
         }
     } else {
         // It's a server message. Don't set player name.
@@ -817,10 +817,10 @@ namespace {
         DebugLogger() << "PlayerSetupData:";
         for (const std::pair<int, PlayerSetupData>& entry : psd)
             DebugLogger() << std::to_string(entry.first) << " : "
-                                   << entry.second.m_player_name << ", "
-                                   << entry.second.m_client_type << ", "
-                                   << entry.second.m_starting_species_name
-                                   << (entry.second.m_player_ready ? ", Ready" : "");
+                                   << entry.second.player_name << ", "
+                                   << entry.second.client_type << ", "
+                                   << entry.second.starting_species_name
+                                   << (entry.second.player_ready ? ", Ready" : "");
     }
 }
 
@@ -974,13 +974,13 @@ void MultiPlayerLobbyWnd::PlayerDataChangedLocally() {
         const PlayerRow* player_row = dynamic_cast<const PlayerRow*>(row.get());
         if (const EmptyPlayerRow* empty_row = dynamic_cast<const EmptyPlayerRow*>(player_row)) {
             // empty rows that have been changed to Add AI need to be sent so the server knows to add an AI player.
-            if (empty_row->m_player_data.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER)
+            if (empty_row->m_player_data.client_type == Networking::CLIENT_TYPE_AI_PLAYER)
                 m_lobby_data.m_players.push_back({Networking::INVALID_PLAYER_ID, player_row->m_player_data});
 
             // empty rows that are still showing no player don't need to be sent to the server.
 
         } else if (const LoadGameEmpireRow* empire_row = dynamic_cast<const LoadGameEmpireRow*>(player_row)) {
-            if (empire_row->m_player_data.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER)
+            if (empire_row->m_player_data.client_type == Networking::CLIENT_TYPE_AI_PLAYER)
                 m_lobby_data.m_players.push_back({Networking::INVALID_PLAYER_ID, empire_row->m_player_data});
         } else {
             // all other row types pass along data directly
@@ -1012,14 +1012,14 @@ bool MultiPlayerLobbyWnd::PopulatePlayerList() {
         PlayerSetupData& psd = entry.second;
 
         if (m_lobby_data.m_new_game) {
-            bool immutable_row = !HasAuthRole(Networking::ROLE_HOST) && (data_player_id != HumanClientApp::GetApp()->PlayerID()) && !(psd.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER && HasAuthRole(Networking::ROLE_GALAXY_SETUP));   // host can modify any player's row.  non-hosts can only modify their own row.  As of SVN 4026 this is not enforced on the server, but should be.
+            bool immutable_row = !HasAuthRole(Networking::ROLE_HOST) && (data_player_id != HumanClientApp::GetApp()->PlayerID()) && !(psd.client_type == Networking::CLIENT_TYPE_AI_PLAYER && HasAuthRole(Networking::ROLE_GALAXY_SETUP));   // host can modify any player's row.  non-hosts can only modify their own row.  As of SVN 4026 this is not enforced on the server, but should be.
             auto row = GG::Wnd::Create<NewGamePlayerRow>(psd, data_player_id, immutable_row);
             m_players_lb->Insert(row);
             row->DataChangedSignal.connect(
                 boost::bind(&MultiPlayerLobbyWnd::PlayerDataChangedLocally, this));
 
         } else {
-            bool immutable_row = (!HasAuthRole(Networking::ROLE_HOST) && (data_player_id != HumanClientApp::GetApp()->PlayerID()) && !(psd.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER && HasAuthRole(Networking::ROLE_GALAXY_SETUP))) || m_lobby_data.m_save_game_empire_data.empty();
+            bool immutable_row = (!HasAuthRole(Networking::ROLE_HOST) && (data_player_id != HumanClientApp::GetApp()->PlayerID()) && !(psd.client_type == Networking::CLIENT_TYPE_AI_PLAYER && HasAuthRole(Networking::ROLE_GALAXY_SETUP))) || m_lobby_data.m_save_game_empire_data.empty();
             auto row = GG::Wnd::Create<LoadGamePlayerRow>(psd, data_player_id, m_lobby_data.m_save_game_empire_data, immutable_row, m_lobby_data.m_in_game);
             m_players_lb->Insert(row);
             row->DataChangedSignal.connect(
@@ -1030,7 +1030,7 @@ bool MultiPlayerLobbyWnd::PopulatePlayerList() {
             // happened because the LoadGamePlayerRow constructor selects an
             // empire row for the droplist in the player row) then the change
             // needs to be sent to other players
-            if (row->m_player_data.m_save_game_empire_id != psd.m_save_game_empire_id) {
+            if (row->m_player_data.save_game_empire_id != psd.save_game_empire_id) {
                 psd = row->m_player_data;
                 send_update_back_retval = true;
             }
@@ -1038,11 +1038,11 @@ bool MultiPlayerLobbyWnd::PopulatePlayerList() {
 
         // checks for ready button
         if (data_player_id == HumanClientApp::GetApp()->PlayerID())
-            is_client_ready = psd.m_player_ready;
-        else if (psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER ||
-            psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
-            psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
-        { is_other_ready = is_other_ready && psd.m_player_ready; }
+            is_client_ready = psd.player_ready;
+        else if (psd.client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER ||
+            psd.client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
+            psd.client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
+        { is_other_ready = is_other_ready && psd.player_ready; }
     }
 
     // add rows for unassigned empires and adds "Add AI" to assign AI to empire
@@ -1050,7 +1050,7 @@ bool MultiPlayerLobbyWnd::PopulatePlayerList() {
         for (const auto& save_game_empire_data : m_lobby_data.m_save_game_empire_data) {
             bool is_assigned = false;
             for (const auto& player : m_lobby_data.m_players) {
-                if (player.second.m_save_game_empire_id == save_game_empire_data.second.m_empire_id) {
+                if (player.second.save_game_empire_id == save_game_empire_data.second.m_empire_id) {
                     is_assigned = true;
                     break;
                 }
@@ -1128,26 +1128,26 @@ bool MultiPlayerLobbyWnd::PlayerDataAcceptable() const {
 
     for (auto& row : *m_players_lb) {
         const PlayerRow& prow = dynamic_cast<const PlayerRow&>(*row);
-        if (prow.m_player_data.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER ||
-            prow.m_player_data.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER)
+        if (prow.m_player_data.client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER ||
+            prow.m_player_data.client_type == Networking::CLIENT_TYPE_AI_PLAYER)
         {
             num_players_excluding_observers++;
 
             // all non-observers must have unique non-blank names and colours
 
-            if (prow.m_player_data.m_empire_name.empty())
+            if (prow.m_player_data.empire_name.empty())
                 return false;
 
-            empire_names.insert(prow.m_player_data.m_empire_name);
+            empire_names.insert(prow.m_player_data.empire_name);
 
             unsigned int color_as_uint =
-                prow.m_player_data.m_empire_color.r << 24 |
-                prow.m_player_data.m_empire_color.g << 16 |
-                prow.m_player_data.m_empire_color.b << 8 |
-                prow.m_player_data.m_empire_color.a;
+                prow.m_player_data.empire_color.r << 24 |
+                prow.m_player_data.empire_color.g << 16 |
+                prow.m_player_data.empire_color.b << 8 |
+                prow.m_player_data.empire_color.a;
             empire_colors.insert(color_as_uint);
-        } else if (prow.m_player_data.m_client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
-                   prow.m_player_data.m_client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
+        } else if (prow.m_player_data.client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
+                   prow.m_player_data.client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
         {
             // do nothing special for this player
         } else {
@@ -1175,7 +1175,7 @@ bool MultiPlayerLobbyWnd::HasAuthRole(Networking::RoleType role) const
 void MultiPlayerLobbyWnd::ReadyClicked() {
     for (std::pair<int, PlayerSetupData>& entry : m_lobby_data.m_players) {
         if (entry.first == HumanClientApp::GetApp()->PlayerID()) {
-            entry.second.m_player_ready = (! entry.second.m_player_ready);
+            entry.second.player_ready = (! entry.second.player_ready);
         }
     }
 

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -286,7 +286,7 @@ void AIClientApp::HandleMessage(const Message& msg) {
             //Max 4         :  0   0   8  17  75   0
             //Max 5         :  0   0   0   8  17  75
 
-            const std::string g_seed = GetGalaxySetupData().m_seed;
+            const std::string g_seed = GetGalaxySetupData().seed;
             const std::string emp_name = GetEmpire(m_empire_id)->Name();
             unsigned int my_seed = 0;
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -548,16 +548,16 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
 
     // GalaxySetupData
     setup_data.SetSeed(GetOptionsDB().Get<std::string>("setup.seed"));
-    setup_data.m_size =             GetOptionsDB().Get<int>("setup.star.count");
-    setup_data.m_shape =            GetOptionsDB().Get<Shape>("setup.galaxy.shape");
-    setup_data.m_age =              GetOptionsDB().Get<GalaxySetupOption>("setup.galaxy.age");
-    setup_data.m_starlane_freq =    GetOptionsDB().Get<GalaxySetupOption>("setup.starlane.frequency");
-    setup_data.m_planet_density =   GetOptionsDB().Get<GalaxySetupOption>("setup.planet.density");
-    setup_data.m_specials_freq =    GetOptionsDB().Get<GalaxySetupOption>("setup.specials.frequency");
-    setup_data.m_monster_freq =     GetOptionsDB().Get<GalaxySetupOption>("setup.monster.frequency");
-    setup_data.m_native_freq =      GetOptionsDB().Get<GalaxySetupOption>("setup.native.frequency");
-    setup_data.m_ai_aggr =          GetOptionsDB().Get<Aggression>("setup.ai.aggression");
-    setup_data.m_game_rules =       game_rules;
+    setup_data.size =             GetOptionsDB().Get<int>("setup.star.count");
+    setup_data.shape =            GetOptionsDB().Get<Shape>("setup.galaxy.shape");
+    setup_data.age =              GetOptionsDB().Get<GalaxySetupOption>("setup.galaxy.age");
+    setup_data.starlane_freq =    GetOptionsDB().Get<GalaxySetupOption>("setup.starlane.frequency");
+    setup_data.planet_density =   GetOptionsDB().Get<GalaxySetupOption>("setup.planet.density");
+    setup_data.specials_freq =    GetOptionsDB().Get<GalaxySetupOption>("setup.specials.frequency");
+    setup_data.monster_freq =     GetOptionsDB().Get<GalaxySetupOption>("setup.monster.frequency");
+    setup_data.native_freq =      GetOptionsDB().Get<GalaxySetupOption>("setup.native.frequency");
+    setup_data.ai_aggr =          GetOptionsDB().Get<Aggression>("setup.ai.aggression");
+    setup_data.game_rules =       game_rules;
 
 
     // SinglePlayerSetupData contains a map of PlayerSetupData, for

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -540,8 +540,8 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
     }
 
     SinglePlayerSetupData setup_data;
-    setup_data.m_new_game = true;
-    setup_data.m_filename.clear();  // not used for new game
+    setup_data.new_game = true;
+    setup_data.filename.clear();  // not used for new game
 
     // get values stored in options from previous time game was run or
     // from just having run GalaxySetupWnd
@@ -596,7 +596,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
     human_player_setup_data.client_type = Networking::CLIENT_TYPE_HUMAN_PLAYER;
 
     // add to setup data players
-    setup_data.m_players.push_back(human_player_setup_data);
+    setup_data.players.push_back(human_player_setup_data);
 
 
     // AI player setup data.  One entry for each requested AI
@@ -611,7 +611,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
         ai_setup_data.save_game_empire_id = ALL_EMPIRES;  // not used for new games
         ai_setup_data.client_type = Networking::CLIENT_TYPE_AI_PLAYER;
 
-        setup_data.m_players.push_back(ai_setup_data);
+        setup_data.players.push_back(ai_setup_data);
     }
 
 
@@ -795,8 +795,8 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
 
     SinglePlayerSetupData setup_data;
     // leving GalaxySetupData information default / blank : not used when loading a game
-    setup_data.m_new_game = false;
-    setup_data.m_filename = filename;
+    setup_data.new_game = false;
+    setup_data.filename = filename;
     // leving setup_data.m_players empty : not specified when loading a game, as server will generate from save file
 
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -566,34 +566,34 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
 
     // Human player setup data
     PlayerSetupData human_player_setup_data;
-    human_player_setup_data.m_player_name = GetOptionsDB().Get<std::string>("setup.player.name");
-    human_player_setup_data.m_empire_name = GetOptionsDB().Get<std::string>("setup.empire.name");
+    human_player_setup_data.player_name = GetOptionsDB().Get<std::string>("setup.player.name");
+    human_player_setup_data.empire_name = GetOptionsDB().Get<std::string>("setup.empire.name");
 
     // DB stores index into array of available colours, so need to get that array to look up value of index.
     // if stored value is invalid, use a default colour
     const std::vector<GG::Clr>& empire_colours = EmpireColors();
     int colour_index = GetOptionsDB().Get<int>("setup.empire.color.index");
     if (colour_index >= 0 && colour_index < static_cast<int>(empire_colours.size()))
-        human_player_setup_data.m_empire_color = empire_colours[colour_index];
+        human_player_setup_data.empire_color = empire_colours[colour_index];
     else
-        human_player_setup_data.m_empire_color = GG::CLR_GREEN;
+        human_player_setup_data.empire_color = GG::CLR_GREEN;
 
-    human_player_setup_data.m_starting_species_name = GetOptionsDB().Get<std::string>("setup.initial.species");
-    if (human_player_setup_data.m_starting_species_name == "1")
-        human_player_setup_data.m_starting_species_name = "SP_HUMAN";   // kludge / bug workaround for bug with options storage and retreival.  Empty-string options are stored, but read in as "true" boolean, and converted to string equal to "1"
+    human_player_setup_data.starting_species_name = GetOptionsDB().Get<std::string>("setup.initial.species");
+    if (human_player_setup_data.starting_species_name == "1")
+        human_player_setup_data.starting_species_name = "SP_HUMAN";   // kludge / bug workaround for bug with options storage and retreival.  Empty-string options are stored, but read in as "true" boolean, and converted to string equal to "1"
 
-    if (human_player_setup_data.m_starting_species_name != "RANDOM" &&
-        !GetSpecies(human_player_setup_data.m_starting_species_name))
+    if (human_player_setup_data.starting_species_name != "RANDOM" &&
+        !GetSpecies(human_player_setup_data.starting_species_name))
     {
         const SpeciesManager& sm = GetSpeciesManager();
         if (sm.NumPlayableSpecies() < 1)
-            human_player_setup_data.m_starting_species_name.clear();
+            human_player_setup_data.starting_species_name.clear();
         else
-            human_player_setup_data.m_starting_species_name = sm.playable_begin()->first;
+            human_player_setup_data.starting_species_name = sm.playable_begin()->first;
     }
 
-    human_player_setup_data.m_save_game_empire_id = ALL_EMPIRES; // not used for new games
-    human_player_setup_data.m_client_type = Networking::CLIENT_TYPE_HUMAN_PLAYER;
+    human_player_setup_data.save_game_empire_id = ALL_EMPIRES; // not used for new games
+    human_player_setup_data.client_type = Networking::CLIENT_TYPE_HUMAN_PLAYER;
 
     // add to setup data players
     setup_data.m_players.push_back(human_player_setup_data);
@@ -604,12 +604,12 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
     for (int ai_i = 1; ai_i <= num_AIs; ++ai_i) {
         PlayerSetupData ai_setup_data;
 
-        ai_setup_data.m_player_name = "AI_" + std::to_string(ai_i);
-        ai_setup_data.m_empire_name.clear();                // leave blank, to be set by server in Universe::GenerateEmpires
-        ai_setup_data.m_empire_color = GG::CLR_ZERO;        // to be set by server
-        ai_setup_data.m_starting_species_name.clear();      // leave blank, to be set by server
-        ai_setup_data.m_save_game_empire_id = ALL_EMPIRES;  // not used for new games
-        ai_setup_data.m_client_type = Networking::CLIENT_TYPE_AI_PLAYER;
+        ai_setup_data.player_name = "AI_" + std::to_string(ai_i);
+        ai_setup_data.empire_name.clear();                // leave blank, to be set by server in Universe::GenerateEmpires
+        ai_setup_data.empire_color = GG::CLR_ZERO;        // to be set by server
+        ai_setup_data.starting_species_name.clear();      // leave blank, to be set by server
+        ai_setup_data.save_game_empire_id = ALL_EMPIRES;  // not used for new games
+        ai_setup_data.client_type = Networking::CLIENT_TYPE_AI_PLAYER;
 
         setup_data.m_players.push_back(ai_setup_data);
     }

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -587,10 +587,10 @@ boost::statechart::result MPLobby::react(const ChatHistory& msg) {
 
     const auto& wnd = Client().GetClientUI().GetMultiPlayerLobbyWnd();
     for (const auto& elem : chat_history)
-        wnd->ChatMessage(elem.m_text,
-                         elem.m_player_name,
-                         elem.m_player_name.empty() ? Client().GetClientUI().TextColor() : elem.m_text_color,
-                         elem.m_timestamp);
+        wnd->ChatMessage(elem.text,
+                         elem.player_name,
+                         elem.player_name.empty() ? Client().GetClientUI().TextColor() : elem.text_color,
+                         elem.timestamp);
 
     return discard_event();
 }

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -198,7 +198,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             bool loaded_game_data = false;
             oa << BOOST_SERIALIZATION_NVP(players)
                << BOOST_SERIALIZATION_NVP(loaded_game_data);
-            galaxy_setup_data.m_encoding_empire = empire_id;
+            galaxy_setup_data.encoding_empire = empire_id;
             oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         } else {
             freeorion_xml_oarchive oa(os);
@@ -214,7 +214,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             bool loaded_game_data = false;
             oa << BOOST_SERIALIZATION_NVP(players)
                << BOOST_SERIALIZATION_NVP(loaded_game_data);
-            galaxy_setup_data.m_encoding_empire = empire_id;
+            galaxy_setup_data.encoding_empire = empire_id;
             oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         }
     }
@@ -253,7 +253,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
                 oa << boost::serialization::make_nvp("ui_data", *ui_data);
             bool save_state_string_available = false;
             oa << BOOST_SERIALIZATION_NVP(save_state_string_available);
-            galaxy_setup_data.m_encoding_empire = empire_id;
+            galaxy_setup_data.encoding_empire = empire_id;
             oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         } else {
             freeorion_xml_oarchive oa(os);
@@ -283,7 +283,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             }
             bool save_state_string_available = false;
             oa << BOOST_SERIALIZATION_NVP(save_state_string_available);
-            galaxy_setup_data.m_encoding_empire = empire_id;
+            galaxy_setup_data.encoding_empire = empire_id;
             oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         }
     }
@@ -322,7 +322,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             oa << BOOST_SERIALIZATION_NVP(save_state_string_available);
             if (save_state_string_available)
                 oa << boost::serialization::make_nvp("save_state_string", *save_state_string);
-            galaxy_setup_data.m_encoding_empire = empire_id;
+            galaxy_setup_data.encoding_empire = empire_id;
             oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         } else {
             freeorion_xml_oarchive oa(os);
@@ -352,7 +352,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
                     oa << boost::serialization::make_nvp("save_state_string", temp_sss);
                 }
             }
-            galaxy_setup_data.m_encoding_empire = empire_id;
+            galaxy_setup_data.encoding_empire = empire_id;
             oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         }
     }

--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -166,7 +166,7 @@ int SaveGame(const std::string& filename, const ServerSaveGameData& server_save_
         pos_before_writing = ofs.tellp();
 
         bool save_completed_as_xml = false;
-        galaxy_setup_data.m_encoding_empire = ALL_EMPIRES;
+        galaxy_setup_data.encoding_empire = ALL_EMPIRES;
 
         if (!use_binary) {
             if (use_zlib_for_zml) {
@@ -621,18 +621,18 @@ void LoadEmpireSaveGameData(const std::string& filename,
         ErrorLogger() << UserString("UNABLE_TO_READ_SAVE_FILE") << " LoadEmpireSaveGameData exception: " << ": " << e.what();
         throw e;
     }
-    galaxy_setup_data.m_seed = saved_galaxy_setup_data.m_seed;
-    galaxy_setup_data.m_size = saved_galaxy_setup_data.m_size;
-    galaxy_setup_data.m_shape = saved_galaxy_setup_data.m_shape;
-    galaxy_setup_data.m_age = saved_galaxy_setup_data.m_age;
-    galaxy_setup_data.m_starlane_freq = saved_galaxy_setup_data.m_starlane_freq;
-    galaxy_setup_data.m_planet_density = saved_galaxy_setup_data.m_planet_density;
-    galaxy_setup_data.m_specials_freq = saved_galaxy_setup_data.m_specials_freq;
-    galaxy_setup_data.m_monster_freq = saved_galaxy_setup_data.m_monster_freq;
-    galaxy_setup_data.m_native_freq = saved_galaxy_setup_data.m_native_freq;
-    galaxy_setup_data.m_ai_aggr = saved_galaxy_setup_data.m_ai_aggr;
-    galaxy_setup_data.m_game_rules = saved_galaxy_setup_data.m_game_rules;
-    galaxy_setup_data.m_game_uid = saved_galaxy_setup_data.m_game_uid;
+    galaxy_setup_data.seed = saved_galaxy_setup_data.seed;
+    galaxy_setup_data.size = saved_galaxy_setup_data.size;
+    galaxy_setup_data.shape = saved_galaxy_setup_data.shape;
+    galaxy_setup_data.age = saved_galaxy_setup_data.age;
+    galaxy_setup_data.starlane_freq = saved_galaxy_setup_data.starlane_freq;
+    galaxy_setup_data.planet_density = saved_galaxy_setup_data.planet_density;
+    galaxy_setup_data.specials_freq = saved_galaxy_setup_data.specials_freq;
+    galaxy_setup_data.monster_freq = saved_galaxy_setup_data.monster_freq;
+    galaxy_setup_data.native_freq = saved_galaxy_setup_data.native_freq;
+    galaxy_setup_data.ai_aggr = saved_galaxy_setup_data.ai_aggr;
+    galaxy_setup_data.game_rules = saved_galaxy_setup_data.game_rules;
+    galaxy_setup_data.game_uid = saved_galaxy_setup_data.game_uid;
 
     current_turn = saved_server_save_game_data.current_turn;
 }

--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -76,8 +76,8 @@ namespace {
             // Find the empire of the player, if it has one
             auto empire = empire_save_game_data.find(player->empire_id);
             if (empire != empire_save_game_data.end()) {
-                preview.main_player_empire_name = empire->second.m_empire_name;
-                preview.main_player_empire_colour = empire->second.m_color;
+                preview.main_player_empire_name = empire->second.empire_name;
+                preview.main_player_empire_colour = empire->second.color;
             }
         }
     }

--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -59,10 +59,10 @@ namespace {
             // If there are human players, the first of them should be the main player
             short humans = 0;
             for (const PlayerSaveGameData& psgd : player_save_game_data) {
-                if (psgd.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
-                    if (player->m_client_type != Networking::CLIENT_TYPE_HUMAN_PLAYER &&
-                       player->m_client_type != Networking::CLIENT_TYPE_HUMAN_OBSERVER &&
-                       player->m_client_type != Networking::CLIENT_TYPE_HUMAN_MODERATOR)
+                if (psgd.client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
+                    if (player->client_type != Networking::CLIENT_TYPE_HUMAN_PLAYER &&
+                       player->client_type != Networking::CLIENT_TYPE_HUMAN_OBSERVER &&
+                       player->client_type != Networking::CLIENT_TYPE_HUMAN_MODERATOR)
                     {
                         player = &psgd;
                     }
@@ -70,11 +70,11 @@ namespace {
                 }
             }
 
-            preview.main_player_name = player->m_name;
+            preview.main_player_name = player->name;
             preview.number_of_human_players = humans;
 
             // Find the empire of the player, if it has one
-            auto empire = empire_save_game_data.find(player->m_empire_id);
+            auto empire = empire_save_game_data.find(player->empire_id);
             if (empire != empire_save_game_data.end()) {
                 preview.main_player_empire_name = empire->second.m_empire_name;
                 preview.main_player_empire_colour = empire->second.m_color;

--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -42,7 +42,7 @@ namespace {
                                     SaveGamePreviewData& preview)
     {
         // First compile the non-player related data
-        preview.current_turn = server_save_game_data.m_current_turn;
+        preview.current_turn = server_save_game_data.current_turn;
         preview.number_of_empires = empire_save_game_data.size();
         preview.save_time = boost::posix_time::to_iso_extended_string(boost::posix_time::second_clock::local_time());
 
@@ -634,5 +634,5 @@ void LoadEmpireSaveGameData(const std::string& filename,
     galaxy_setup_data.m_game_rules = saved_galaxy_setup_data.m_game_rules;
     galaxy_setup_data.m_game_uid = saved_galaxy_setup_data.m_game_uid;
 
-    current_turn = saved_server_save_game_data.m_current_turn;
+    current_turn = saved_server_save_game_data.current_turn;
 }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -539,12 +539,12 @@ void ServerApp::NewSPGameInit(const SinglePlayerSetupData& single_player_setup_d
     // id == m_networking.HostPlayerID() should be the human player in
     // PlayerSetupData.  AI player connections are assigned one of the remaining
     // PlayerSetupData entries that is for an AI player.
-    const auto& player_setup_data = single_player_setup_data.m_players;
+    const auto& player_setup_data = single_player_setup_data.players;
     NewGameInitConcurrentWithJoiners(single_player_setup_data, player_setup_data);
 }
 
 bool ServerApp::VerifySPGameAIs(const SinglePlayerSetupData& single_player_setup_data) {
-    const auto& player_setup_data = single_player_setup_data.m_players;
+    const auto& player_setup_data = single_player_setup_data.players;
     return NewGameInitVerifyJoiners(player_setup_data);
 }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1297,7 +1297,7 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
 
 
     // restore server state info from save
-    m_current_turn = server_save_game_data->m_current_turn;
+    m_current_turn = server_save_game_data->current_turn;
 
     std::map<int, PlayerSaveGameData> player_id_save_game_data;
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -197,7 +197,7 @@ void ServerApp::CreateAIClients(const std::vector<PlayerSetupData>& player_setup
     // check if AI clients are needed for given setup data
     bool need_AIs = false;
     for (const PlayerSetupData& psd : player_setup_data) {
-        if (psd.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
+        if (psd.client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
             need_AIs = true;
             break;
         }
@@ -267,11 +267,11 @@ void ServerApp::CreateAIClients(const std::vector<PlayerSetupData>& player_setup
 
     // for each AI client player, create a new AI client process
     for (const PlayerSetupData& psd : player_setup_data) {
-        if (psd.m_client_type != Networking::CLIENT_TYPE_AI_PLAYER)
+        if (psd.client_type != Networking::CLIENT_TYPE_AI_PLAYER)
             continue;
 
         // check that AIs have a name, as they will be sorted later based on it
-        std::string player_name = psd.m_player_name;
+        std::string player_name = psd.player_name;
         if (player_name.empty()) {
             ErrorLogger() << "ServerApp::CreateAIClients can't create a player with no name.";
             return;
@@ -558,9 +558,9 @@ void ServerApp::NewMPGameInit(const MultiplayerLobbyData& multiplayer_lobby_data
 
     for (const auto& entry : player_setup_data) {
         const PlayerSetupData& psd = entry.second;
-        if (psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER ||
-            psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
-            psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
+        if (psd.client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER ||
+            psd.client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
+            psd.client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
         {
             // Human players have consistent IDs, so these can be easily
             // matched between established player connections and setup data.
@@ -575,7 +575,7 @@ void ServerApp::NewMPGameInit(const MultiplayerLobbyData& multiplayer_lobby_data
                 if (player_connection->PlayerID() == player_id)
                 {
                     PlayerSetupData new_psd = psd;
-                    new_psd.m_player_id = player_id;
+                    new_psd.player_id = player_id;
                     psds.emplace_back(std::move(new_psd));
                     found_matched_id_connection = true;
                     break;
@@ -583,7 +583,7 @@ void ServerApp::NewMPGameInit(const MultiplayerLobbyData& multiplayer_lobby_data
             }
             if (!found_matched_id_connection) {
                 if (player_id != Networking::INVALID_PLAYER_ID) {
-                    ErrorLogger() << "ServerApp::NewMPGameInit couldn't find player setup data for human player with id: " << player_id << " player name: " << psd.m_player_name;
+                    ErrorLogger() << "ServerApp::NewMPGameInit couldn't find player setup data for human player with id: " << player_id << " player name: " << psd.player_name;
                 } else {
                     // There is no player currently connected for the current setup data. A player
                     // may connect later, at which time they may be assigned to this data or the
@@ -592,13 +592,13 @@ void ServerApp::NewMPGameInit(const MultiplayerLobbyData& multiplayer_lobby_data
                 }
             }
 
-        } else if (psd.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
+        } else if (psd.client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
             // All AI player setup data, as determined from their client type, is
             // assigned to player IDs of established AI players with the appropriate names
 
             // find player connection with same name as this player setup data
             bool found_matched_name_connection = false;
-            const std::string& player_name = psd.m_player_name;
+            const std::string& player_name = psd.player_name;
             for (auto established_player_it = m_networking.established_begin();
                  established_player_it != m_networking.established_end(); ++established_player_it)
             {
@@ -609,7 +609,7 @@ void ServerApp::NewMPGameInit(const MultiplayerLobbyData& multiplayer_lobby_data
                     // assign name-matched AI client's player setup data to appropriate AI connection
                     int player_id = player_connection->PlayerID();
                     PlayerSetupData new_psd = psd;
-                    new_psd.m_player_id = player_id;
+                    new_psd.player_id = player_id;
                     psds.emplace_back(std::move(new_psd));
                     found_matched_name_connection = true;
                     break;
@@ -672,9 +672,9 @@ void ServerApp::NewGameInitConcurrentWithJoiners(
     std::map<int, PlayerSetupData> active_empire_id_setup_data;
     int next_empire_id = 1;
     for (const auto& psd : player_setup_data) {
-        if (!psd.m_player_name.empty()
-            && (psd.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER
-                || psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER))
+        if (!psd.player_name.empty()
+            && (psd.client_type == Networking::CLIENT_TYPE_AI_PLAYER
+                || psd.client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER))
         {
             active_empire_id_setup_data[next_empire_id++] = psd;
         }
@@ -718,14 +718,14 @@ void ServerApp::NewGameInitConcurrentWithJoiners(
     // moderators are not included.
     for (const auto& player_id_and_setup : active_empire_id_setup_data) {
         int empire_id = player_id_and_setup.first;
-        if (player_id_and_setup.second.m_player_id != Networking::INVALID_PLAYER_ID)
-            m_player_empire_ids[player_id_and_setup.second.m_player_id] = empire_id;
+        if (player_id_and_setup.second.player_id != Networking::INVALID_PLAYER_ID)
+            m_player_empire_ids[player_id_and_setup.second.player_id] = empire_id;
 
         // add empires to turn processing
         if (auto *empire = GetEmpire(empire_id)) {
-            AddEmpireTurn(empire_id, PlayerSaveGameData(player_id_and_setup.second.m_player_name, empire_id,
+            AddEmpireTurn(empire_id, PlayerSaveGameData(player_id_and_setup.second.player_name, empire_id,
                                                         nullptr, nullptr, std::string(),
-                                                        player_id_and_setup.second.m_client_type));
+                                                        player_id_and_setup.second.client_type));
             empire->SetReady(false);
         }
     }
@@ -755,14 +755,14 @@ bool ServerApp::NewGameInitVerifyJoiners(const std::vector<PlayerSetupData>& pla
     bool host_in_player_id_setup_data = false;
 
     for (const auto& psd : player_setup_data) {
-        if (psd.m_client_type == Networking::INVALID_CLIENT_TYPE) {
-            ErrorLogger() << "Player with id " << psd.m_player_id << " has invalid client type";
+        if (psd.client_type == Networking::INVALID_CLIENT_TYPE) {
+            ErrorLogger() << "Player with id " << psd.player_id << " has invalid client type";
             continue;
         }
 
-        player_id_setup_data[psd.m_player_id] = psd;
+        player_id_setup_data[psd.player_id] = psd;
 
-        if (m_networking.HostPlayerID() == psd.m_player_id)
+        if (m_networking.HostPlayerID() == psd.player_id)
             host_in_player_id_setup_data = true;
     }
 
@@ -800,12 +800,12 @@ bool ServerApp::NewGameInitVerifyJoiners(const std::vector<PlayerSetupData>& pla
             return false;
         }
         const PlayerSetupData& psd = player_id_setup_data_it->second;
-        if (psd.m_client_type != client_type) {
-            ErrorLogger() << "ServerApp::NewGameInitVerifyJoiners found inconsistent client type between player connection (" << client_type << ") and player setup data (" << psd.m_client_type << ")";
+        if (psd.client_type != client_type) {
+            ErrorLogger() << "ServerApp::NewGameInitVerifyJoiners found inconsistent client type between player connection (" << client_type << ") and player setup data (" << psd.client_type << ")";
             return false;
         }
-        if (psd.m_player_name != player_connection->PlayerName()) {
-            ErrorLogger() << "ServerApp::NewGameInitVerifyJoiners found inconsistent player names: " << psd.m_player_name << " and " << player_connection->PlayerName();
+        if (psd.player_name != player_connection->PlayerName()) {
+            ErrorLogger() << "ServerApp::NewGameInitVerifyJoiners found inconsistent player names: " << psd.player_name << " and " << player_connection->PlayerName();
             return false;
         }
         if (player_connection->PlayerName().empty()) {
@@ -1118,7 +1118,7 @@ namespace {
                                             const ServerNetworking& sn)
     {
         // safety check: setup data has valid empire assigned
-        if (psd.m_save_game_empire_id == ALL_EMPIRES) {
+        if (psd.save_game_empire_id == ALL_EMPIRES) {
             ErrorLogger() << "ServerApp::LoadMPGameInit got player setup data for human player "
                                     << "with no empire assigned...";
             return;
@@ -1130,12 +1130,12 @@ namespace {
             return;   // error message logged in HumanPlayerWithIdConnected
 
         // determine and store save game data index for this player
-        int index = VectorIndexForPlayerSaveGameDataForEmpireID(player_save_game_data, psd.m_save_game_empire_id);
+        int index = VectorIndexForPlayerSaveGameDataForEmpireID(player_save_game_data, psd.save_game_empire_id);
         if (index != -1) {
             player_id_to_save_game_data_index.push_back({setup_data_player_id, index});
         } else {
             ErrorLogger() << "ServerApp::LoadMPGameInit couldn't find save game data for "
-                                   << "human player with assigned empire id: " << psd.m_save_game_empire_id;
+                                   << "human player with assigned empire id: " << psd.save_game_empire_id;
         }
     }
 
@@ -1175,30 +1175,30 @@ namespace {
         // as is listed in the player setup data for AI players.
 
         // safety check: setup data has valid empire assigned
-        if (psd.m_save_game_empire_id == ALL_EMPIRES) {
+        if (psd.save_game_empire_id == ALL_EMPIRES) {
             ErrorLogger() << "ServerApp::LoadMPGameInit got player setup data for AI player "
                                     << "with no empire assigned...";
             return;
         }
 
         // get ID of name-matched AI player
-        int player_id = AIPlayerIDWithName(sn, psd.m_player_name);
+        int player_id = AIPlayerIDWithName(sn, psd.player_name);
         if (player_id == Networking::INVALID_PLAYER_ID) {
-            ErrorLogger() << "ServerApp::LoadMPGameInit couldn't find expected AI player with name " << psd.m_player_name;
+            ErrorLogger() << "ServerApp::LoadMPGameInit couldn't find expected AI player with name " << psd.player_name;
             return;
         }
 
-        DebugLogger() << "ServerApp::LoadMPGameInit matched player named " << psd.m_player_name
+        DebugLogger() << "ServerApp::LoadMPGameInit matched player named " << psd.player_name
                                << " to setup data player id " << player_id
-                               << " with setup data empire id " << psd.m_save_game_empire_id;
+                               << " with setup data empire id " << psd.save_game_empire_id;
 
         // determine and store save game data index for this player
-        int index = VectorIndexForPlayerSaveGameDataForEmpireID(player_save_game_data, psd.m_save_game_empire_id);
+        int index = VectorIndexForPlayerSaveGameDataForEmpireID(player_save_game_data, psd.save_game_empire_id);
         if (index != -1) {
             player_id_to_save_game_data_index.push_back({player_id, index});
         } else {
             ErrorLogger() << "ServerApp::LoadMPGameInit couldn't find save game data for "
-                                   << "human player with assigned empire id: " << psd.m_save_game_empire_id;
+                                   << "human player with assigned empire id: " << psd.save_game_empire_id;
         }
     }
 }
@@ -1226,13 +1226,13 @@ void ServerApp::LoadMPGameInit(const MultiplayerLobbyData& lobby_data,
     for (const auto& entry : player_setup_data) {
         const PlayerSetupData& psd = entry.second;
 
-        if (psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
+        if (psd.client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
             int setup_data_player_id = entry.first;
             GetSaveGameDataIndexForHumanPlayer(player_id_to_save_game_data_index, psd,
                                                setup_data_player_id, player_save_game_data,
                                                m_networking);
 
-        } else if (psd.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
+        } else if (psd.client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
             // AI clients have no player id in setup data (even though humans do)
             GetSaveGameDataIndexForAIPlayer(player_id_to_save_game_data_index, psd,
                                             player_save_game_data, m_networking);

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -856,13 +856,13 @@ void ServerApp::LoadSPGameInit(const std::vector<PlayerSaveGameData>& player_sav
     // assign all saved game data to a player ID
     for (int i = 0; i < static_cast<int>(player_save_game_data.size()); ++i) {
         const PlayerSaveGameData& psgd = player_save_game_data[i];
-        if (psgd.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
+        if (psgd.client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
             // In a single player game, the host player is always the human player, so
             // this is just a matter of finding which entry in player_save_game_data was
             // a human player, and assigning that saved player data to the host player ID
             player_id_to_save_game_data_index.push_back({m_networking.HostPlayerID(), i});
 
-        } else if (psgd.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
+        } else if (psgd.client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
             // All saved AI player data, as determined from their client type, is
             // assigned to player IDs of established AI players
 
@@ -1105,7 +1105,7 @@ namespace {
         // find save game data vector index that has requested empire id
         for (int i = 0; i < static_cast<int>(player_save_game_data.size()); ++i) {
             const PlayerSaveGameData& psgd = player_save_game_data.at(i);
-            if (psgd.m_empire_id == empire_id)
+            if (psgd.empire_id == empire_id)
                 return i;
         }
         return -1;
@@ -1332,7 +1332,7 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
         int empire_id = ALL_EMPIRES;
         try {
             const PlayerSaveGameData& psgd = player_save_game_data.at(player_save_game_data_index);
-            empire_id = psgd.m_empire_id;               // can't use GetPlayerEmpireID here because m_player_empire_ids hasn't been set up yet.
+            empire_id = psgd.empire_id;               // can't use GetPlayerEmpireID here because m_player_empire_ids hasn't been set up yet.
             player_id_save_game_data[player_id] = psgd; // store by player ID for easier access later
         } catch (...) {
             ErrorLogger() << "ServerApp::LoadGameInit couldn't find save game data with index " << player_save_game_data_index;
@@ -1353,7 +1353,7 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
     }
 
     for (const auto& psgd : player_save_game_data) {
-        int empire_id = psgd.m_empire_id;
+        int empire_id = psgd.empire_id;
         // add empires to turn processing, and restore saved orders and UI data or save state data
         if (Empire* empire = GetEmpire(empire_id)) {
             if (!empire->Eliminated())
@@ -1394,7 +1394,7 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
 
         // get empire ID for player. safety check on it.
         int empire_id = PlayerEmpireID(player_id);
-        if (empire_id != psgd.m_empire_id) {
+        if (empire_id != psgd.empire_id) {
             ErrorLogger() << "LoadGameInit got inconsistent empire ids between player save game data and result of PlayerEmpireID";
         }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -553,7 +553,7 @@ void ServerApp::NewMPGameInit(const MultiplayerLobbyData& multiplayer_lobby_data
     // available (human) and names (for AI clients which didn't have an ID
     // before now because the lobby data was set up without connected/established
     // clients for the AIs.
-    const auto& player_setup_data = multiplayer_lobby_data.m_players;
+    const auto& player_setup_data = multiplayer_lobby_data.players;
     std::vector<PlayerSetupData> psds;
 
     for (const auto& entry : player_setup_data) {
@@ -1210,7 +1210,7 @@ void ServerApp::LoadMPGameInit(const MultiplayerLobbyData& lobby_data,
     // Need to determine which data in player_save_game_data should be assigned to which established player
     std::vector<std::pair<int, int>> player_id_to_save_game_data_index;
 
-    const auto& player_setup_data = lobby_data.m_players;
+    const auto& player_setup_data = lobby_data.players;
 
     // * Multiplayer lobby data has a map from player ID to PlayerSetupData.
     // * PlayerSetupData contains an empire ID that the player will be controlling.

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -99,17 +99,17 @@ ServerApp::ServerApp() :
     InfoLogger() << FreeOrionVersionString();
     LogDependencyVersions();
 
-    m_galaxy_setup_data.m_seed = GetOptionsDB().Get<std::string>("setup.seed");
-    m_galaxy_setup_data.m_size = GetOptionsDB().Get<int>("setup.star.count");
-    m_galaxy_setup_data.m_shape = GetOptionsDB().Get<Shape>("setup.galaxy.shape");
-    m_galaxy_setup_data.m_age = GetOptionsDB().Get<GalaxySetupOption>("setup.galaxy.age");
-    m_galaxy_setup_data.m_starlane_freq = GetOptionsDB().Get<GalaxySetupOption>("setup.starlane.frequency");
-    m_galaxy_setup_data.m_planet_density = GetOptionsDB().Get<GalaxySetupOption>("setup.planet.density");
-    m_galaxy_setup_data.m_specials_freq = GetOptionsDB().Get<GalaxySetupOption>("setup.specials.frequency");
-    m_galaxy_setup_data.m_monster_freq = GetOptionsDB().Get<GalaxySetupOption>("setup.monster.frequency");
-    m_galaxy_setup_data.m_native_freq = GetOptionsDB().Get<GalaxySetupOption>("setup.native.frequency");
-    m_galaxy_setup_data.m_ai_aggr = GetOptionsDB().Get<Aggression>("setup.ai.aggression");
-    m_galaxy_setup_data.m_game_uid = GetOptionsDB().Get<std::string>("setup.game.uid");
+    m_galaxy_setup_data.seed = GetOptionsDB().Get<std::string>("setup.seed");
+    m_galaxy_setup_data.size = GetOptionsDB().Get<int>("setup.star.count");
+    m_galaxy_setup_data.shape = GetOptionsDB().Get<Shape>("setup.galaxy.shape");
+    m_galaxy_setup_data.age = GetOptionsDB().Get<GalaxySetupOption>("setup.galaxy.age");
+    m_galaxy_setup_data.starlane_freq = GetOptionsDB().Get<GalaxySetupOption>("setup.starlane.frequency");
+    m_galaxy_setup_data.planet_density = GetOptionsDB().Get<GalaxySetupOption>("setup.planet.density");
+    m_galaxy_setup_data.specials_freq = GetOptionsDB().Get<GalaxySetupOption>("setup.specials.frequency");
+    m_galaxy_setup_data.monster_freq = GetOptionsDB().Get<GalaxySetupOption>("setup.monster.frequency");
+    m_galaxy_setup_data.native_freq = GetOptionsDB().Get<GalaxySetupOption>("setup.native.frequency");
+    m_galaxy_setup_data.ai_aggr = GetOptionsDB().Get<Aggression>("setup.ai.aggression");
+    m_galaxy_setup_data.game_uid = GetOptionsDB().Get<std::string>("setup.game.uid");
 
     // Start parsing content before FSM initialization
     // to have data initialized before autostart execution
@@ -1457,11 +1457,11 @@ void ServerApp::GenerateUniverse(std::map<int, PlayerSetupData>& player_setup_da
     // Initialize RNG with provided seed to get reproducible universes
     int seed = 0;
     try {
-        seed = boost::lexical_cast<unsigned int>(GetGalaxySetupData().m_seed);
+        seed = boost::lexical_cast<unsigned int>(GetGalaxySetupData().seed);
     } catch (...) {
         try {
             boost::hash<std::string> string_hash;
-            std::size_t h = string_hash(GetGalaxySetupData().m_seed);
+            std::size_t h = string_hash(GetGalaxySetupData().seed);
             seed = static_cast<unsigned int>(h);
         } catch (...) {}
     }
@@ -3439,7 +3439,7 @@ void ServerApp::PostCombatProcessTurns() {
     // execute all effects and update meters prior to production, research, etc.
     if (GetGameRules().Get<bool>("RULE_RESEED_PRNG_SERVER")) {
         static boost::hash<std::string> pcpt_string_hash;
-        Seed(static_cast<unsigned int>(CurrentTurn()) + pcpt_string_hash(m_galaxy_setup_data.m_seed));
+        Seed(static_cast<unsigned int>(CurrentTurn()) + pcpt_string_hash(m_galaxy_setup_data.seed));
     }
     m_universe.ApplyAllEffectsAndUpdateMeters(false);
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -208,7 +208,7 @@ namespace {
 
             if (colour_is_new) {
                 for (const auto& entry : sged) {
-                    const GG::Clr& player_colour = entry.second.m_color;
+                    const GG::Clr& player_colour = entry.second.color;
                     if (player_colour == possible_colour) {
                         colour_is_new = false;
                         break;
@@ -940,7 +940,7 @@ void MPLobby::ValidateClientLimits() {
     int non_eliminated_empires_count = 0;
     if (!m_lobby_data->new_game) {
         for (const auto& empire_data : m_lobby_data->save_game_empire_data) {
-            if (!empire_data.second.m_eliminated)
+            if (!empire_data.second.eliminated)
                 non_eliminated_empires_count ++;
         }
 
@@ -1492,13 +1492,13 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
                         if (plr.second.save_game_empire_id != ALL_EMPIRES) {
                             const auto empire_it = m_lobby_data->save_game_empire_data.find(plr.second.save_game_empire_id);
                             if (empire_it != m_lobby_data->save_game_empire_data.end()) {
-                                if (empire_it->second.m_eliminated) {
-                                    WarnLogger(FSM) << "Trying to take over eliminated empire \"" << empire_it->second.m_empire_name << "\"";
+                                if (empire_it->second.eliminated) {
+                                    WarnLogger(FSM) << "Trying to take over eliminated empire \"" << empire_it->second.empire_name << "\"";
                                     incorrect_empire = true;
-                                } else if (empire_it->second.m_authenticated) {
-                                    if (empire_it->second.m_player_name != sender->PlayerName()) {
-                                        WarnLogger(FSM) << "Unauthorized access to protected empire \"" << empire_it->second.m_empire_name << "\"."
-                                                        << " Expected player \"" << empire_it->second.m_player_name << "\""
+                                } else if (empire_it->second.authenticated) {
+                                    if (empire_it->second.player_name != sender->PlayerName()) {
+                                        WarnLogger(FSM) << "Unauthorized access to protected empire \"" << empire_it->second.empire_name << "\"."
+                                                        << " Expected player \"" << empire_it->second.player_name << "\""
                                                         << " got \"" << sender->PlayerName() << "\"";
                                         incorrect_empire = true;
                                     }
@@ -1636,13 +1636,13 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
                     if (j_player.second.save_game_empire_id != ALL_EMPIRES) {
                         const auto empire_it = m_lobby_data->save_game_empire_data.find(j_player.second.save_game_empire_id);
                         if (empire_it != m_lobby_data->save_game_empire_data.end()) {
-                            if (empire_it->second.m_eliminated) {
-                                WarnLogger(FSM) << "Trying to take over eliminated empire \"" << empire_it->second.m_empire_name << "\"";
+                            if (empire_it->second.eliminated) {
+                                WarnLogger(FSM) << "Trying to take over eliminated empire \"" << empire_it->second.empire_name << "\"";
                                 incorrect_empire = true;
-                            } else if (empire_it->second.m_authenticated) {
-                                if (empire_it->second.m_player_name != sender->PlayerName()) {
-                                    WarnLogger(FSM) << "Unauthorized access to protected empire \"" << empire_it->second.m_empire_name << "\"."
-                                                    << " Expected player \"" << empire_it->second.m_player_name << "\""
+                            } else if (empire_it->second.authenticated) {
+                                if (empire_it->second.player_name != sender->PlayerName()) {
+                                    WarnLogger(FSM) << "Unauthorized access to protected empire \"" << empire_it->second.empire_name << "\"."
+                                                    << " Expected player \"" << empire_it->second.player_name << "\""
                                                     << " got \"" << sender->PlayerName() << "\"";
                                     incorrect_empire = true;
                                 }
@@ -1725,8 +1725,8 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
                 player_setup_data.player_name =   UserString("AI_PLAYER") + "_" + std::to_string(m_ai_next_index++);
                 player_setup_data.client_type =   Networking::CLIENT_TYPE_AI_PLAYER;
                 player_setup_data.save_game_empire_id = pshd.empire_id;
-                player_setup_data.empire_name =   empire_data_it->second.m_empire_name;
-                player_setup_data.empire_color =  empire_data_it->second.m_color;
+                player_setup_data.empire_name =   empire_data_it->second.empire_name;
+                player_setup_data.empire_color =  empire_data_it->second.color;
                 if (m_lobby_data->m_seed != "")
                     player_setup_data.starting_species_name = GetSpeciesManager().RandomPlayableSpeciesName();
                 else

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -73,10 +73,10 @@ namespace {
     }
 
     std::string GetHostNameFromSinglePlayerSetupData(const SinglePlayerSetupData& single_player_setup_data) {
-        if (single_player_setup_data.m_new_game) {
+        if (single_player_setup_data.new_game) {
             // for new games, get host player's name from PlayerSetupData for the
             // (should be only) human player
-            for (const PlayerSetupData& psd : single_player_setup_data.m_players) {
+            for (const PlayerSetupData& psd : single_player_setup_data.players) {
                 // In a single player game, the host player is always the human player, so
                 // this is just a matter of finding which player setup data is for
                 // a human player, and assigning that setup data to the host player id
@@ -86,12 +86,12 @@ namespace {
 
         } else {
             // for loading saved games, get host / human player's name from save file
-            if (!single_player_setup_data.m_players.empty())
+            if (!single_player_setup_data.players.empty())
                 ErrorLogger(FSM) << "GetHostNameFromSinglePlayerSetupData got single player setup data to load a game, but also player setup data for a new game.  Ignoring player setup data";
 
 
             std::vector<PlayerSaveHeaderData> player_save_header_data;
-            LoadPlayerSaveHeaderData(single_player_setup_data.m_filename, player_save_header_data);
+            LoadPlayerSaveHeaderData(single_player_setup_data.filename, player_save_header_data);
 
             // find which player was the human (and thus the host) in the saved game
             for (const PlayerSaveHeaderData& psgd : player_save_header_data) {
@@ -1978,13 +1978,13 @@ WaitingForSPGameJoiners::WaitingForSPGameJoiners(my_context c) :
 
     context<ServerFSM>().m_single_player_setup_data.reset();
     ServerApp& server = Server();
-    std::vector<PlayerSetupData>& players = m_single_player_setup_data->m_players;
+    std::vector<PlayerSetupData>& players = m_single_player_setup_data->players;
 
     // Ensure all players have unique non-empty names   // TODO: the uniqueness part...
     unsigned int player_num = 1;
     int player_id = server.m_networking.NewPlayerID();
 
-    if (m_single_player_setup_data->m_new_game) {
+    if (m_single_player_setup_data->new_game) {
         // for new games, single player setup data contains full m_players
         // vector, so can just use the contents of that to create AI
         // clients
@@ -2020,7 +2020,7 @@ WaitingForSPGameJoiners::WaitingForSPGameJoiners(my_context c) :
 
         std::vector<PlayerSaveHeaderData> player_save_header_data;
         try {
-            LoadPlayerSaveHeaderData(m_single_player_setup_data->m_filename, player_save_header_data);
+            LoadPlayerSaveHeaderData(m_single_player_setup_data->filename, player_save_header_data);
         } catch (const std::exception& e) {
             SendMessageToHost(ErrorMessage(UserStringNop("UNABLE_TO_READ_SAVE_FILE"), true));
             post_event(LoadSaveFileFailed());
@@ -2066,7 +2066,7 @@ WaitingForSPGameJoiners::WaitingForSPGameJoiners(my_context c) :
     // Still check start conditions, which will abort the server after all
     // the expected players have joined if Python is (still) not initialized.
     if (server.m_python_server.IsPythonRunning()) {
-        if (m_single_player_setup_data->m_new_game) {
+        if (m_single_player_setup_data->new_game) {
             // For new SP game start inializaing while waiting for AI callbacks.
             DebugLogger(FSM) << "Initializing new SP game...";
             server.NewSPGameInit(*m_single_player_setup_data);
@@ -2160,15 +2160,15 @@ sc::result WaitingForSPGameJoiners::react(const CheckStartConditions& u) {
             return discard_event();
         }
 
-        if (m_single_player_setup_data->m_new_game) {
+        if (m_single_player_setup_data->new_game) {
             DebugLogger(FSM) << "Verify AIs SP game...";
             if (server.VerifySPGameAIs(*m_single_player_setup_data))
                 server.SendNewGameStartMessages();
 
         } else {
-            DebugLogger(FSM) << "Loading SP game save file: " << m_single_player_setup_data->m_filename;
+            DebugLogger(FSM) << "Loading SP game save file: " << m_single_player_setup_data->filename;
             try {
-                LoadGame(m_single_player_setup_data->m_filename,            *m_server_save_game_data,
+                LoadGame(m_single_player_setup_data->filename,              *m_server_save_game_data,
                          m_player_save_game_data,   GetUniverse(),          Empires(),
                          GetSpeciesManager(),       GetCombatLogManager(),  server.m_galaxy_setup_data);
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -95,8 +95,8 @@ namespace {
 
             // find which player was the human (and thus the host) in the saved game
             for (const PlayerSaveHeaderData& psgd : player_save_header_data) {
-                if (psgd.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER)
-                    return psgd.m_name;
+                if (psgd.client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER)
+                    return psgd.name;
             }
         }
         return "";
@@ -770,13 +770,13 @@ sc::result Idle::react(const Hostless&) {
             // fill lobby data with AI to start them with server
             int ai_next_index = 1;
             for (const auto& psgd : player_save_game_data) {
-                if (psgd.m_client_type != Networking::CLIENT_TYPE_AI_PLAYER)
+                if (psgd.client_type != Networking::CLIENT_TYPE_AI_PLAYER)
                     continue;
                 PlayerSetupData player_setup_data;
                 player_setup_data.player_id =     Networking::INVALID_PLAYER_ID;
                 player_setup_data.player_name =   UserString("AI_PLAYER") + "_" + std::to_string(ai_next_index++);
                 player_setup_data.client_type =   Networking::CLIENT_TYPE_AI_PLAYER;
-                player_setup_data.save_game_empire_id = psgd.m_empire_id;
+                player_setup_data.save_game_empire_id = psgd.empire_id;
                 lobby_data->players.push_back({Networking::INVALID_PLAYER_ID, player_setup_data});
             }
         } catch (const std::exception& e) {
@@ -1713,9 +1713,9 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
             // read all AI players from save game and add them into current lobby
             // with appropriate empire's data
             for (const auto& pshd : player_save_header_data) {
-                if (pshd.m_client_type != Networking::CLIENT_TYPE_AI_PLAYER)
+                if (pshd.client_type != Networking::CLIENT_TYPE_AI_PLAYER)
                     continue;
-                const auto& empire_data_it = m_lobby_data->save_game_empire_data.find(pshd.m_empire_id);
+                const auto& empire_data_it = m_lobby_data->save_game_empire_data.find(pshd.empire_id);
                 if (empire_data_it == m_lobby_data->save_game_empire_data.end())
                     continue;
 
@@ -1724,7 +1724,7 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
                 // don't use original names to prevent collision with manually added AIs
                 player_setup_data.player_name =   UserString("AI_PLAYER") + "_" + std::to_string(m_ai_next_index++);
                 player_setup_data.client_type =   Networking::CLIENT_TYPE_AI_PLAYER;
-                player_setup_data.save_game_empire_id = pshd.m_empire_id;
+                player_setup_data.save_game_empire_id = pshd.empire_id;
                 player_setup_data.empire_name =   empire_data_it->second.m_empire_name;
                 player_setup_data.empire_color =  empire_data_it->second.m_color;
                 if (m_lobby_data->m_seed != "")
@@ -2029,16 +2029,16 @@ WaitingForSPGameJoiners::WaitingForSPGameJoiners(my_context c) :
 
         // add player setup data for each player in saved gamed
         for (const PlayerSaveHeaderData& psgd : player_save_header_data) {
-            if (psgd.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER ||
-                psgd.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER)
+            if (psgd.client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER ||
+                psgd.client_type == Networking::CLIENT_TYPE_AI_PLAYER)
             {
                 PlayerSetupData psd;
-                psd.player_name =         psgd.m_name;
+                psd.player_name =         psgd.name;
                 //psd.empire_name // left default
                 //psd.empire_color // left default
                 //psd.starting_species_name // left default
-                psd.save_game_empire_id = psgd.m_empire_id;
-                psd.client_type =         psgd.m_client_type;
+                psd.save_game_empire_id = psgd.empire_id;
+                psd.client_type =         psgd.client_type;
 
                 if (psd.client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
                     psd.player_id = server.Networking().HostPlayerID();

--- a/server/ServerFramework.cpp
+++ b/server/ServerFramework.cpp
@@ -232,10 +232,10 @@ bool PythonServer::LoadChatHistory(boost::circular_buffer<ChatHistoryEntity>& ch
         boost::python::stl_input_iterator<boost::python::tuple> entity_begin(py_history), entity_end;
         for (auto& it = entity_begin; it != entity_end; ++ it) {
             ChatHistoryEntity e;
-            e.m_timestamp = boost::posix_time::from_time_t(boost::python::extract<time_t>((*it)[0]));;
-            e.m_player_name = boost::python::extract<std::string>((*it)[1]);
-            e.m_text = boost::python::extract<std::string>((*it)[2]);
-            e.m_text_color = boost::python::extract<GG::Clr>((*it)[3]);
+            e.timestamp = boost::posix_time::from_time_t(boost::python::extract<time_t>((*it)[0]));;
+            e.player_name = boost::python::extract<std::string>((*it)[1]);
+            e.text = boost::python::extract<std::string>((*it)[2]);
+            e.text_color = boost::python::extract<GG::Clr>((*it)[3]);
             chat_history.push_back(e);
         }
     }
@@ -255,10 +255,10 @@ bool PythonServer::PutChatHistoryEntity(const ChatHistoryEntity& chat_history_en
         return false;
     }
 
-    return f(boost::python::long_(to_time_t(chat_history_entity.m_timestamp)),
-             chat_history_entity.m_player_name,
-             chat_history_entity.m_text,
-             chat_history_entity.m_text_color);
+    return f(boost::python::long_(to_time_t(chat_history_entity.timestamp)),
+             chat_history_entity.player_name,
+             chat_history_entity.text,
+             chat_history_entity.text_color);
 }
 
 bool PythonServer::CreateUniverse(std::map<int, PlayerSetupData>& player_setup_data) {

--- a/server/ServerWrapper.cpp
+++ b/server/ServerWrapper.cpp
@@ -1276,11 +1276,11 @@ namespace {
 namespace FreeOrionPython {
     void WrapServer() {
         class_<PlayerSetupData>("PlayerSetupData")
-            .def_readwrite("player_name",        &PlayerSetupData::m_player_name)
-            .def_readwrite("empire_name",        &PlayerSetupData::m_empire_name)
-            .def_readonly("empire_color",        &PlayerSetupData::m_empire_color)
-            .def_readwrite("starting_species",   &PlayerSetupData::m_starting_species_name)
-            .def_readwrite("starting_team",      &PlayerSetupData::m_starting_team);
+            .def_readwrite("player_name",        &PlayerSetupData::player_name)
+            .def_readwrite("empire_name",        &PlayerSetupData::empire_name)
+            .def_readonly("empire_color",        &PlayerSetupData::empire_color)
+            .def_readwrite("starting_species",   &PlayerSetupData::starting_species_name)
+            .def_readwrite("starting_team",      &PlayerSetupData::starting_team);
 
         class_<FleetPlanWrapper>("FleetPlan", init<const std::string&, const list&>())
             .def("name",                        &FleetPlanWrapper::Name)

--- a/server/UniverseGenerator.cpp
+++ b/server/UniverseGenerator.cpp
@@ -864,9 +864,9 @@ void InitEmpires(const std::map<int, PlayerSetupData>& player_setup_data) {
         if (empire_id == ALL_EMPIRES)
             ErrorLogger() << "InitEmpires empire id (" << empire_id << ") is invalid";
 
-        std::string player_name =   entry.second.m_player_name;
-        GG::Clr     empire_colour = entry.second.m_empire_color;
-        bool        authenticated = entry.second.m_authenticated;
+        std::string player_name =   entry.second.player_name;
+        GG::Clr     empire_colour = entry.second.empire_color;
+        bool        authenticated = entry.second.authenticated;
 
         // validate or generate empire colour
         // ensure no other empire gets auto-assigned this colour automatically
@@ -891,7 +891,7 @@ void InitEmpires(const std::map<int, PlayerSetupData>& player_setup_data) {
         std::string empire_name = UserString("EMPIRE") + std::to_string(empire_id);
 
         DebugLogger() << "Universe::InitEmpires creating new empire" << " with ID: " << empire_id
-                      << " for player: " << player_name << " in team: " << entry.second.m_starting_team;
+                      << " for player: " << player_name << " in team: " << entry.second.starting_team;
 
         // create new Empire object through empire manager
         Empires().CreateEmpire(empire_id, empire_name, player_name, empire_colour, authenticated);
@@ -900,14 +900,14 @@ void InitEmpires(const std::map<int, PlayerSetupData>& player_setup_data) {
     Empires().ResetDiplomacy();
 
     for (const auto& entry : player_setup_data) {
-        if (entry.second.m_starting_team < 0)
+        if (entry.second.starting_team < 0)
             continue;
 
         for (const auto& other_entry : player_setup_data) {
             if (entry.first == other_entry.first)
                 continue;
 
-            if (entry.second.m_starting_team != other_entry.second.m_starting_team)
+            if (entry.second.starting_team != other_entry.second.starting_team)
                 continue;
 
             Empires().SetDiplomaticStatus(entry.first, other_entry.first, DIPLO_ALLIED);

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -50,8 +50,8 @@ void ClientAppFixture::HostSPGame(unsigned int num_AIs) {
     auto game_rules = GetGameRules().GetRulesAsStrings();
 
     SinglePlayerSetupData setup_data;
-    setup_data.m_new_game = true;
-    setup_data.m_filename.clear();  // not used for new game
+    setup_data.new_game = true;
+    setup_data.filename.clear();  // not used for new game
 
     // GalaxySetupData
     setup_data.SetSeed("TestSeed1");
@@ -81,7 +81,7 @@ void ClientAppFixture::HostSPGame(unsigned int num_AIs) {
     human_player_setup_data.client_type = Networking::CLIENT_TYPE_HUMAN_PLAYER;
 
     // add to setup data players
-    setup_data.m_players.push_back(human_player_setup_data);
+    setup_data.players.push_back(human_player_setup_data);
 
     // AI player setup data.  One entry for each requested AI
 
@@ -95,7 +95,7 @@ void ClientAppFixture::HostSPGame(unsigned int num_AIs) {
         ai_setup_data.save_game_empire_id = ALL_EMPIRES;  // not used for new games
         ai_setup_data.client_type = Networking::CLIENT_TYPE_AI_PLAYER;
 
-        setup_data.m_players.push_back(ai_setup_data);
+        setup_data.players.push_back(ai_setup_data);
     }
 
     m_networking->SendMessage(HostSPGameMessage(setup_data));

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -55,16 +55,16 @@ void ClientAppFixture::HostSPGame(unsigned int num_AIs) {
 
     // GalaxySetupData
     setup_data.SetSeed("TestSeed1");
-    setup_data.m_size =             100;
-    setup_data.m_shape =            Shape::SPIRAL_4;
-    setup_data.m_age =              GalaxySetupOption::GALAXY_SETUP_MEDIUM;
-    setup_data.m_starlane_freq =    GalaxySetupOption::GALAXY_SETUP_MEDIUM;
-    setup_data.m_planet_density =   GalaxySetupOption::GALAXY_SETUP_MEDIUM;
-    setup_data.m_specials_freq =    GalaxySetupOption::GALAXY_SETUP_MEDIUM;
-    setup_data.m_monster_freq =     GalaxySetupOption::GALAXY_SETUP_MEDIUM;
-    setup_data.m_native_freq =      GalaxySetupOption::GALAXY_SETUP_MEDIUM;
-    setup_data.m_ai_aggr =          Aggression::MANIACAL;
-    setup_data.m_game_rules =       game_rules;
+    setup_data.size =             100;
+    setup_data.shape =            Shape::SPIRAL_4;
+    setup_data.age =              GalaxySetupOption::GALAXY_SETUP_MEDIUM;
+    setup_data.starlane_freq =    GalaxySetupOption::GALAXY_SETUP_MEDIUM;
+    setup_data.planet_density =   GalaxySetupOption::GALAXY_SETUP_MEDIUM;
+    setup_data.specials_freq =    GalaxySetupOption::GALAXY_SETUP_MEDIUM;
+    setup_data.monster_freq =     GalaxySetupOption::GALAXY_SETUP_MEDIUM;
+    setup_data.native_freq =      GalaxySetupOption::GALAXY_SETUP_MEDIUM;
+    setup_data.ai_aggr =          Aggression::MANIACAL;
+    setup_data.game_rules =       game_rules;
 
     // SinglePlayerSetupData contains a map of PlayerSetupData, for
     // the human and AI players.  Need to compile this information

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -72,13 +72,13 @@ void ClientAppFixture::HostSPGame(unsigned int num_AIs) {
 
     // Human player setup data
     PlayerSetupData human_player_setup_data;
-    human_player_setup_data.m_player_name = "TestPlayer";
-    human_player_setup_data.m_empire_name = "TestEmpire";
-    human_player_setup_data.m_empire_color = GG::CLR_GREEN;
+    human_player_setup_data.player_name = "TestPlayer";
+    human_player_setup_data.empire_name = "TestEmpire";
+    human_player_setup_data.empire_color = GG::CLR_GREEN;
 
-    human_player_setup_data.m_starting_species_name = "SP_HUMAN";
-    human_player_setup_data.m_save_game_empire_id = ALL_EMPIRES; // not used for new games
-    human_player_setup_data.m_client_type = Networking::CLIENT_TYPE_HUMAN_PLAYER;
+    human_player_setup_data.starting_species_name = "SP_HUMAN";
+    human_player_setup_data.save_game_empire_id = ALL_EMPIRES; // not used for new games
+    human_player_setup_data.client_type = Networking::CLIENT_TYPE_HUMAN_PLAYER;
 
     // add to setup data players
     setup_data.m_players.push_back(human_player_setup_data);
@@ -88,12 +88,12 @@ void ClientAppFixture::HostSPGame(unsigned int num_AIs) {
     for (unsigned int ai_i = 1; ai_i <= num_AIs; ++ai_i) {
         PlayerSetupData ai_setup_data;
 
-        ai_setup_data.m_player_name = "AI_" + std::to_string(ai_i);
-        ai_setup_data.m_empire_name.clear();                // leave blank, to be set by server in Universe::GenerateEmpires
-        ai_setup_data.m_empire_color = GG::CLR_ZERO;        // to be set by server
-        ai_setup_data.m_starting_species_name.clear();      // leave blank, to be set by server
-        ai_setup_data.m_save_game_empire_id = ALL_EMPIRES;  // not used for new games
-        ai_setup_data.m_client_type = Networking::CLIENT_TYPE_AI_PLAYER;
+        ai_setup_data.player_name = "AI_" + std::to_string(ai_i);
+        ai_setup_data.empire_name.clear();                // leave blank, to be set by server in Universe::GenerateEmpires
+        ai_setup_data.empire_color = GG::CLR_ZERO;        // to be set by server
+        ai_setup_data.starting_species_name.clear();      // leave blank, to be set by server
+        ai_setup_data.save_game_empire_id = ALL_EMPIRES;  // not used for new games
+        ai_setup_data.client_type = Networking::CLIENT_TYPE_AI_PLAYER;
 
         setup_data.m_players.push_back(ai_setup_data);
     }
@@ -277,7 +277,7 @@ void ClientAppFixture::UpdateLobby() {
 unsigned int ClientAppFixture::GetLobbyAICount() const {
     unsigned int res = 0;
     for (const auto& plr: m_lobby_data.m_players) {
-        if (plr.second.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER)
+        if (plr.second.client_type == Networking::CLIENT_TYPE_AI_PLAYER)
             ++ res;
     }
     return res;

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -276,7 +276,7 @@ void ClientAppFixture::UpdateLobby() {
 
 unsigned int ClientAppFixture::GetLobbyAICount() const {
     unsigned int res = 0;
-    for (const auto& plr: m_lobby_data.m_players) {
+    for (const auto& plr: m_lobby_data.players) {
         if (plr.second.client_type == Networking::CLIENT_TYPE_AI_PLAYER)
             ++ res;
     }

--- a/test/system/SmokeTestHostless.cpp
+++ b/test/system/SmokeTestHostless.cpp
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(hostless_server) {
             for (unsigned int ai_i = 1; ai_i <= num_AIs; ++ai_i) {
                 PlayerSetupData ai_plr;
                 ai_plr.client_type = Networking::CLIENT_TYPE_AI_PLAYER;
-                m_lobby_data.m_players.push_back({Networking::INVALID_PLAYER_ID, ai_plr});
+                m_lobby_data.players.push_back({Networking::INVALID_PLAYER_ID, ai_plr});
                 // publish changes
                 UpdateLobby();
                 start_time = boost::posix_time::microsec_clock::local_time();
@@ -171,7 +171,7 @@ BOOST_AUTO_TEST_CASE(hostless_server) {
         BOOST_REQUIRE_EQUAL(GetLobbyAICount(), num_AIs);
 
         // get ready
-        for (auto& plr : m_lobby_data.m_players) {
+        for (auto& plr : m_lobby_data.players) {
             if (plr.first == PlayerID())
                 plr.second.player_ready = true;
         }

--- a/test/system/SmokeTestHostless.cpp
+++ b/test/system/SmokeTestHostless.cpp
@@ -156,7 +156,7 @@ BOOST_AUTO_TEST_CASE(hostless_server) {
             // fill lobby with AIs
             for (unsigned int ai_i = 1; ai_i <= num_AIs; ++ai_i) {
                 PlayerSetupData ai_plr;
-                ai_plr.m_client_type = Networking::CLIENT_TYPE_AI_PLAYER;
+                ai_plr.client_type = Networking::CLIENT_TYPE_AI_PLAYER;
                 m_lobby_data.m_players.push_back({Networking::INVALID_PLAYER_ID, ai_plr});
                 // publish changes
                 UpdateLobby();
@@ -173,7 +173,7 @@ BOOST_AUTO_TEST_CASE(hostless_server) {
         // get ready
         for (auto& plr : m_lobby_data.m_players) {
             if (plr.first == PlayerID())
-                plr.second.m_player_ready = true;
+                plr.second.player_ready = true;
         }
         UpdateLobby();
 

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -211,14 +211,14 @@ void GalaxySetupData::SetGameUID(const std::string& game_uid)
 // PlayerSetupData
 /////////////////////////////////////////////////////
 bool operator==(const PlayerSetupData& lhs, const PlayerSetupData& rhs) {
-    return  lhs.m_client_type == rhs.m_client_type &&
-            lhs.m_empire_color == rhs.m_empire_color &&
-            lhs.m_empire_name == rhs.m_empire_name &&
-            lhs.m_player_name == rhs.m_player_name &&
-            lhs.m_save_game_empire_id == rhs.m_save_game_empire_id &&
-            lhs.m_starting_species_name == rhs.m_starting_species_name &&
-            lhs.m_player_ready == rhs.m_player_ready &&
-            lhs.m_starting_team == rhs.m_starting_team;
+    return  lhs.client_type == rhs.client_type &&
+            lhs.empire_color == rhs.empire_color &&
+            lhs.empire_name == rhs.empire_name &&
+            lhs.player_name == rhs.player_name &&
+            lhs.save_game_empire_id == rhs.save_game_empire_id &&
+            lhs.starting_species_name == rhs.starting_species_name &&
+            lhs.player_ready == rhs.player_ready &&
+            lhs.starting_team == rhs.starting_team;
 }
 
 bool operator!=(const PlayerSetupData& lhs, const PlayerSetupData& rhs)
@@ -231,18 +231,18 @@ bool operator!=(const PlayerSetupData& lhs, const PlayerSetupData& rhs)
 std::string MultiplayerLobbyData::Dump() const {
     std::stringstream stream;
     for (const std::pair<int, PlayerSetupData>& psd : m_players) {
-        stream << psd.first << ": " << (psd.second.m_player_name.empty() ? "NO NAME" : psd.second.m_player_name) << "  ";
-        if (psd.second.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER)
+        stream << psd.first << ": " << (psd.second.player_name.empty() ? "NO NAME" : psd.second.player_name) << "  ";
+        if (psd.second.client_type == Networking::CLIENT_TYPE_AI_PLAYER)
             stream << "AI PLAYER";
-        else if (psd.second.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER)
+        else if (psd.second.client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER)
             stream << "HUMAN PLAYER";
-        else if (psd.second.m_client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER)
+        else if (psd.second.client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER)
             stream << "HUMAN OBSERVER";
-        else if (psd.second.m_client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
+        else if (psd.second.client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
             stream << "HUMAN MODERATOR";
         else
             stream << "UNKNOWN CLIENT TPYE";
-        stream << "  " << (psd.second.m_empire_name.empty() ? "NO EMPIRE NAME" : psd.second.m_empire_name) << std::endl;
+        stream << "  " << (psd.second.empire_name.empty() ? "NO EMPIRE NAME" : psd.second.empire_name) << std::endl;
     }
     return stream.str();
 }

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -106,94 +106,94 @@ namespace {
 }
 
 GalaxySetupData::GalaxySetupData() :
-    m_size(100),
-    m_shape(SPIRAL_2),
-    m_age(GALAXY_SETUP_MEDIUM),
-    m_starlane_freq(GALAXY_SETUP_MEDIUM),
-    m_planet_density(GALAXY_SETUP_MEDIUM),
-    m_specials_freq(GALAXY_SETUP_MEDIUM),
-    m_monster_freq(GALAXY_SETUP_MEDIUM),
-    m_native_freq(GALAXY_SETUP_MEDIUM),
-    m_ai_aggr(MANIACAL),
-    m_encoding_empire(ALL_EMPIRES)
+    size(100),
+    shape(SPIRAL_2),
+    age(GALAXY_SETUP_MEDIUM),
+    starlane_freq(GALAXY_SETUP_MEDIUM),
+    planet_density(GALAXY_SETUP_MEDIUM),
+    specials_freq(GALAXY_SETUP_MEDIUM),
+    monster_freq(GALAXY_SETUP_MEDIUM),
+    native_freq(GALAXY_SETUP_MEDIUM),
+    ai_aggr(MANIACAL),
+    encoding_empire(ALL_EMPIRES)
 {}
 
 GalaxySetupData::GalaxySetupData(GalaxySetupData&& base) :
-    m_seed(std::move(base.m_seed)),
-    m_size(base.m_size),
-    m_shape(base.m_shape),
-    m_age(base.m_age),
-    m_starlane_freq(base.m_starlane_freq),
-    m_planet_density(base.m_planet_density),
-    m_specials_freq(base.m_specials_freq),
-    m_monster_freq(base.m_monster_freq),
-    m_native_freq(base.m_native_freq),
-    m_ai_aggr(base.m_ai_aggr),
-    m_game_rules(std::move(base.m_game_rules)),
-    m_game_uid(std::move(base.m_game_uid)),
-    m_encoding_empire(base.m_encoding_empire)
-{ SetSeed(m_seed); }
+    seed(std::move(base.seed)),
+    size(base.size),
+    shape(base.shape),
+    age(base.age),
+    starlane_freq(base.starlane_freq),
+    planet_density(base.planet_density),
+    specials_freq(base.specials_freq),
+    monster_freq(base.monster_freq),
+    native_freq(base.native_freq),
+    ai_aggr(base.ai_aggr),
+    game_rules(std::move(base.game_rules)),
+    game_uid(std::move(base.game_uid)),
+    encoding_empire(base.encoding_empire)
+{ SetSeed(seed); }
 
 const std::string& GalaxySetupData::GetSeed() const
-{ return m_seed; }
+{ return seed; }
 
 int GalaxySetupData::GetSize() const
-{ return m_size; }
+{ return size; }
 
 Shape GalaxySetupData::GetShape() const {
-    if (m_shape != RANDOM)
-        return m_shape;
+    if (shape != RANDOM)
+        return shape;
     size_t num_shapes = static_cast<size_t>(GALAXY_SHAPES) - 1; // -1 so that RANDOM isn't counted
-    return static_cast<Shape>(GetIdx(num_shapes, m_seed + "shape"));
+    return static_cast<Shape>(GetIdx(num_shapes, seed + "shape"));
 }
 
 GalaxySetupOption GalaxySetupData::GetAge() const {
-    if (m_age != GALAXY_SETUP_RANDOM)
-        return m_age;
-    return static_cast<GalaxySetupOption>(GetIdx(3, m_seed + "age") + 1);       // need range 1-3 for age
+    if (age != GALAXY_SETUP_RANDOM)
+        return age;
+    return static_cast<GalaxySetupOption>(GetIdx(3, seed + "age") + 1);       // need range 1-3 for age
 }
 
 GalaxySetupOption GalaxySetupData::GetStarlaneFreq() const {
-    if (m_starlane_freq != GALAXY_SETUP_RANDOM)
-        return m_starlane_freq;
-    return static_cast<GalaxySetupOption>(GetIdx(3, m_seed + "lanes") + 1);     // need range 1-3 for starlane freq
+    if (starlane_freq != GALAXY_SETUP_RANDOM)
+        return starlane_freq;
+    return static_cast<GalaxySetupOption>(GetIdx(3, seed + "lanes") + 1);     // need range 1-3 for starlane freq
 }
 
 GalaxySetupOption GalaxySetupData::GetPlanetDensity() const {
-    if (m_planet_density != GALAXY_SETUP_RANDOM)
-        return m_planet_density;
-    return static_cast<GalaxySetupOption>(GetIdx(3, m_seed + "planets") + 1);   // need range 1-3 for planet density
+    if (planet_density != GALAXY_SETUP_RANDOM)
+        return planet_density;
+    return static_cast<GalaxySetupOption>(GetIdx(3, seed + "planets") + 1);   // need range 1-3 for planet density
 }
 
 GalaxySetupOption GalaxySetupData::GetSpecialsFreq() const {
-    if (m_specials_freq != GALAXY_SETUP_RANDOM)
-        return m_specials_freq;
-    return static_cast<GalaxySetupOption>(GetIdx(4, m_seed + "specials"));      // need range 0-3 for planet density
+    if (specials_freq != GALAXY_SETUP_RANDOM)
+        return specials_freq;
+    return static_cast<GalaxySetupOption>(GetIdx(4, seed + "specials"));      // need range 0-3 for planet density
 }
 
 GalaxySetupOption GalaxySetupData::GetMonsterFreq() const {
-    if (m_monster_freq != GALAXY_SETUP_RANDOM)
-        return m_monster_freq;
-    return static_cast<GalaxySetupOption>(GetIdx(4, m_seed + "monsters"));      // need range 0-3 for monster frequency
+    if (monster_freq != GALAXY_SETUP_RANDOM)
+        return monster_freq;
+    return static_cast<GalaxySetupOption>(GetIdx(4, seed + "monsters"));      // need range 0-3 for monster frequency
 }
 
 GalaxySetupOption GalaxySetupData::GetNativeFreq() const {
-    if (m_native_freq != GALAXY_SETUP_RANDOM)
-        return m_native_freq;
-    return static_cast<GalaxySetupOption>(GetIdx(4, m_seed + "natives"));       // need range 0-3 for native frequency
+    if (native_freq != GALAXY_SETUP_RANDOM)
+        return native_freq;
+    return static_cast<GalaxySetupOption>(GetIdx(4, seed + "natives"));       // need range 0-3 for native frequency
 }
 
 Aggression GalaxySetupData::GetAggression() const
-{ return m_ai_aggr; }
+{ return ai_aggr; }
 
 const std::map<std::string, std::string>& GalaxySetupData::GetGameRules() const
-{ return m_game_rules; }
+{ return game_rules; }
 
 const std::string& GalaxySetupData::GetGameUID() const
-{ return m_game_uid; }
+{ return game_uid; }
 
-void GalaxySetupData::SetSeed(const std::string& seed) {
-    std::string new_seed = seed;
+void GalaxySetupData::SetSeed(const std::string& seed_) {
+    std::string new_seed = seed_;
     if (new_seed.empty() || new_seed == "RANDOM") {
         ClockSeed();
         new_seed.clear();
@@ -201,11 +201,11 @@ void GalaxySetupData::SetSeed(const std::string& seed) {
             new_seed += alphanum[RandInt(0, (sizeof(alphanum) - 2))];
         DebugLogger() << "Set empty or requested random seed to " << new_seed;
     }
-    m_seed = std::move(new_seed);
+    seed = std::move(new_seed);
 }
 
-void GalaxySetupData::SetGameUID(const std::string& game_uid)
-{ m_game_uid = game_uid; }
+void GalaxySetupData::SetGameUID(const std::string& game_uid_)
+{ game_uid = game_uid_; }
 
 /////////////////////////////////////////////////////
 // PlayerSetupData

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -230,7 +230,7 @@ bool operator!=(const PlayerSetupData& lhs, const PlayerSetupData& rhs)
 /////////////////////////////////////////////////////
 std::string MultiplayerLobbyData::Dump() const {
     std::stringstream stream;
-    for (const std::pair<int, PlayerSetupData>& psd : m_players) {
+    for (const std::pair<int, PlayerSetupData>& psd : players) {
         stream << psd.first << ": " << (psd.second.player_name.empty() ? "NO NAME" : psd.second.player_name) << "  ";
         if (psd.second.client_type == Networking::CLIENT_TYPE_AI_PLAYER)
             stream << "AI PLAYER";

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -115,26 +115,23 @@ struct FO_COMMON_API PlayerSaveHeaderData {
 /** Contains data that must be saved for a single player. */
 struct FO_COMMON_API PlayerSaveGameData : public PlayerSaveHeaderData {
     PlayerSaveGameData() :
-        PlayerSaveHeaderData(),
-        m_orders(),
-        m_ui_data(),
-        m_save_state_string()
+        PlayerSaveHeaderData()
     {}
 
     PlayerSaveGameData(const std::string& name, int empire_id,
-                       const std::shared_ptr<OrderSet>& orders,
-                       const std::shared_ptr<SaveGameUIData>& ui_data,
-                       const std::string& save_state_string,
+                       const std::shared_ptr<OrderSet>& orders_,
+                       const std::shared_ptr<SaveGameUIData>& ui_data_,
+                       const std::string& save_state_string_,
                        Networking::ClientType client_type) :
         PlayerSaveHeaderData{name, empire_id, client_type},
-        m_orders(orders),
-        m_ui_data(ui_data),
-        m_save_state_string(save_state_string)
+        orders(orders_),
+        ui_data(ui_data_),
+        save_state_string(save_state_string_)
     {}
 
-    std::shared_ptr<OrderSet>       m_orders;
-    std::shared_ptr<SaveGameUIData> m_ui_data;
-    std::string                     m_save_state_string;
+    std::shared_ptr<OrderSet>       orders;
+    std::shared_ptr<SaveGameUIData> ui_data;
+    std::string                     save_state_string;
 };
 
 /** Data that must be retained by the server when saving and loading a

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -184,56 +184,56 @@ struct SinglePlayerSetupData : public GalaxySetupData {
 struct FO_COMMON_API MultiplayerLobbyData : public GalaxySetupData {
     /** \name Structors */ //@{
     MultiplayerLobbyData() :
-        m_any_can_edit(false),
-        m_new_game(true),
-        m_start_locked(false),
-        m_players(),
-        m_save_game(),
-        m_save_game_empire_data(),
-        m_save_game_current_turn(0),
-        m_in_game(false)
+        any_can_edit(false),
+        new_game(true),
+        start_locked(false),
+        players(),
+        save_game(),
+        save_game_empire_data(),
+        save_game_current_turn(0),
+        in_game(false)
     {}
 
     MultiplayerLobbyData(const GalaxySetupData& base) :
         GalaxySetupData(base),
-        m_any_can_edit(false),
-        m_new_game(true),
-        m_start_locked(false),
-        m_players(),
-        m_save_game(),
-        m_save_game_empire_data(),
-        m_save_game_current_turn(0),
-        m_in_game(false)
+        any_can_edit(false),
+        new_game(true),
+        start_locked(false),
+        players(),
+        save_game(),
+        save_game_empire_data(),
+        save_game_current_turn(0),
+        in_game(false)
     {}
 
     MultiplayerLobbyData(GalaxySetupData&& base) :
         GalaxySetupData(std::move(base)),
-        m_any_can_edit(false),
-        m_new_game(true),
-        m_start_locked(false),
-        m_players(),
-        m_save_game(),
-        m_save_game_empire_data(),
-        m_save_game_current_turn(0),
-        m_in_game(false)
+        any_can_edit(false),
+        new_game(true),
+        start_locked(false),
+        players(),
+        save_game(),
+        save_game_empire_data(),
+        save_game_current_turn(0),
+        in_game(false)
     {}
     //@}
 
     std::string Dump() const;
 
-    bool                                        m_any_can_edit;
-    bool                                        m_new_game;
-    bool                                        m_start_locked;
+    bool                                        any_can_edit;
+    bool                                        new_game;
+    bool                                        start_locked;
     // TODO: Change from a list<(player_id, PlayerSetupData)> where
     // PlayerSetupData contain player_id to a vector of PlayerSetupData
-    std::list<std::pair<int, PlayerSetupData>>  m_players;              // <player_id, PlayerSetupData>
+    std::list<std::pair<int, PlayerSetupData>>  players;              // <player_id, PlayerSetupData>
 
-    std::string                                 m_save_game;            //< File name of a save file
-    std::map<int, SaveGameEmpireData>           m_save_game_empire_data;// indexed by empire_id
-    int                                         m_save_game_current_turn;
+    std::string                                 save_game;            //< File name of a save file
+    std::map<int, SaveGameEmpireData>           save_game_empire_data;// indexed by empire_id
+    int                                         save_game_current_turn;
 
-    std::string                                 m_start_lock_cause;
-    bool                                        m_in_game; ///< In-game lobby
+    std::string                                 start_lock_cause;
+    bool                                        in_game; ///< In-game lobby
 };
 
 /** The data structure stores information about latest chat massages. */

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -169,15 +169,15 @@ bool operator!=(const PlayerSetupData& lhs, const PlayerSetupData& rhs);
 struct SinglePlayerSetupData : public GalaxySetupData {
     /** \name Structors */ //@{
     SinglePlayerSetupData():
-        m_new_game(true),
-        m_filename(),
-        m_players()
+        new_game(true),
+        filename(),
+        players()
     {}
     //@}
 
-    bool                            m_new_game;
-    std::string                     m_filename;
-    std::vector<PlayerSetupData>    m_players;
+    bool                            new_game;
+    std::string                     filename;
+    std::vector<PlayerSetupData>    players;
 };
 
 /** The data structure that represents the state of the multiplayer lobby. */

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -55,26 +55,26 @@ struct FO_COMMON_API GalaxySetupData {
 
     GalaxySetupData& operator=(const GalaxySetupData&) = default;
 
-    std::string         m_seed;
-    int                 m_size;
-    Shape               m_shape;
-    GalaxySetupOption   m_age;
-    GalaxySetupOption   m_starlane_freq;
-    GalaxySetupOption   m_planet_density;
-    GalaxySetupOption   m_specials_freq;
-    GalaxySetupOption   m_monster_freq;
-    GalaxySetupOption   m_native_freq;
-    Aggression          m_ai_aggr;
+    std::string         seed;
+    int                 size;
+    Shape               shape;
+    GalaxySetupOption   age;
+    GalaxySetupOption   starlane_freq;
+    GalaxySetupOption   planet_density;
+    GalaxySetupOption   specials_freq;
+    GalaxySetupOption   monster_freq;
+    GalaxySetupOption   native_freq;
+    Aggression          ai_aggr;
     std::map<std::string, std::string>
-                        m_game_rules;
-    std::string         m_game_uid;
+                        game_rules;
+    std::string         game_uid;
 
     /** HACK! This must be set to the encoding empire's id when serializing a
       * GalaxySetupData, so that only the relevant parts of the galaxy data are
       * serialized.  The use of this local field is done just so I don't
       * have to rewrite any custom boost::serialization classes that implement
       * empire-dependent visibility. */
-    int                 m_encoding_empire; ///< used during serialization to globally set what empire knowledge to use
+    int                 encoding_empire; ///< used during serialization to globally set what empire knowledge to use
 };
 
 

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -96,13 +96,13 @@ struct FO_COMMON_API SaveGameUIData {
 
 /** The data for one empire necessary for game-setup during multiplayer loading. */
 struct FO_COMMON_API SaveGameEmpireData {
-    int         m_empire_id = ALL_EMPIRES;
-    std::string m_empire_name;
-    std::string m_player_name;
-    GG::Clr     m_color;
-    bool        m_authenticated = false;
-    bool        m_eliminated = false;
-    bool        m_won = false;
+    int         empire_id = ALL_EMPIRES;
+    std::string empire_name;
+    std::string player_name;
+    GG::Clr     color;
+    bool        authenticated = false;
+    bool        eliminated = false;
+    bool        won = false;
 };
 
 /** Contains basic data about a player in a game. */

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -107,9 +107,9 @@ struct FO_COMMON_API SaveGameEmpireData {
 
 /** Contains basic data about a player in a game. */
 struct FO_COMMON_API PlayerSaveHeaderData {
-    std::string             m_name;
-    int                     m_empire_id = ALL_EMPIRES;
-    Networking::ClientType  m_client_type = Networking::INVALID_CLIENT_TYPE;
+    std::string             name;
+    int                     empire_id = ALL_EMPIRES;
+    Networking::ClientType  client_type = Networking::INVALID_CLIENT_TYPE;
 };
 
 /** Contains data that must be saved for a single player. */

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -140,7 +140,7 @@ struct FO_COMMON_API PlayerSaveGameData : public PlayerSaveHeaderData {
 /** Data that must be retained by the server when saving and loading a
   * game that isn't player data or the universe */
 struct FO_COMMON_API ServerSaveGameData {
-    int m_current_turn = INVALID_GAME_TURN;
+    int current_turn = INVALID_GAME_TURN;
 };
 
 /** The data structure used to represent a single player's setup options for a

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -146,17 +146,17 @@ struct FO_COMMON_API ServerSaveGameData {
 /** The data structure used to represent a single player's setup options for a
   * multiplayer game (in the multiplayer lobby screen). */
 struct PlayerSetupData {
-    std::string             m_player_name;
-    int                     m_player_id = Networking::INVALID_PLAYER_ID;
-    std::string             m_empire_name;
-    GG::Clr                 m_empire_color = GG::CLR_ZERO;
-    std::string             m_starting_species_name;
+    std::string             player_name;
+    int                     player_id = Networking::INVALID_PLAYER_ID;
+    std::string             empire_name;
+    GG::Clr                 empire_color = GG::CLR_ZERO;
+    std::string             starting_species_name;
     //! When loading a game, the ID of the empire that this player will control
-    int                     m_save_game_empire_id = ALL_EMPIRES;
-    Networking::ClientType  m_client_type = Networking::INVALID_CLIENT_TYPE;
-    bool                    m_player_ready = false;
-    bool                    m_authenticated = false;
-    int                     m_starting_team = Networking::NO_TEAM_ID;
+    int                     save_game_empire_id = ALL_EMPIRES;
+    Networking::ClientType  client_type = Networking::INVALID_CLIENT_TYPE;
+    bool                    player_ready = false;
+    bool                    authenticated = false;
+    int                     starting_team = Networking::NO_TEAM_ID;
 };
 
 bool FO_COMMON_API operator==(const PlayerSetupData& lhs, const PlayerSetupData& rhs);

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -238,10 +238,10 @@ struct FO_COMMON_API MultiplayerLobbyData : public GalaxySetupData {
 
 /** The data structure stores information about latest chat massages. */
 struct FO_COMMON_API ChatHistoryEntity {
-    boost::posix_time::ptime    m_timestamp;
-    std::string                 m_player_name;
-    std::string                 m_text;
-    GG::Clr                     m_text_color;
+    boost::posix_time::ptime    timestamp;
+    std::string                 player_name;
+    std::string                 text;
+    GG::Clr                     text_color;
 };
 
 /** Information about one player that other players are informed of.  Assembled by server and sent to players. */

--- a/util/SaveGamePreviewUtils.cpp
+++ b/util/SaveGamePreviewUtils.cpp
@@ -260,25 +260,25 @@ std::string ColumnInPreview(const FullPreview& full, const std::string& name, bo
     } else if (name == "file") {
         return full.filename;
     } else if (name == "galaxy_size") {
-        return std::to_string(full.galaxy.m_size);
+        return std::to_string(full.galaxy.size);
     } else if (name == "seed") {
-        return full.galaxy.m_seed;
+        return full.galaxy.seed;
     } else if (name == "galaxy_age") {
-        return TextForGalaxySetupSetting(full.galaxy.m_age);
+        return TextForGalaxySetupSetting(full.galaxy.age);
     } else if (name == "monster_freq") {
-        return TextForGalaxySetupSetting(full.galaxy.m_monster_freq);
+        return TextForGalaxySetupSetting(full.galaxy.monster_freq);
     } else if (name == "native_freq") {
-        return TextForGalaxySetupSetting(full.galaxy.m_native_freq);
+        return TextForGalaxySetupSetting(full.galaxy.native_freq);
     } else if (name == "planet_freq") {
-        return TextForGalaxySetupSetting(full.galaxy.m_planet_density);
+        return TextForGalaxySetupSetting(full.galaxy.planet_density);
     } else if (name == "specials_freq") {
-        return TextForGalaxySetupSetting(full.galaxy.m_specials_freq);
+        return TextForGalaxySetupSetting(full.galaxy.specials_freq);
     } else if (name == "starlane_freq") {
-        return TextForGalaxySetupSetting(full.galaxy.m_starlane_freq);
+        return TextForGalaxySetupSetting(full.galaxy.starlane_freq);
     } else if (name == "galaxy_shape") {
-        return TextForGalaxyShape(full.galaxy.m_shape);
+        return TextForGalaxyShape(full.galaxy.shape);
     } else if (name == "ai_aggression") {
-        return TextForAIAggression(full.galaxy.m_ai_aggr);
+        return TextForAIAggression(full.galaxy.ai_aggr);
     } else if (name == "number_of_empires") {
         return std::to_string(full.preview.number_of_empires);
     } else if (name == "number_of_humans") {

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -60,9 +60,9 @@ void serialize(Archive& ar, SinglePlayerSetupData& obj, unsigned int const versi
     using namespace boost::serialization;
 
     ar  & make_nvp("GalaxySetupData", base_object<GalaxySetupData>(obj))
-        & make_nvp("m_new_game", obj.m_new_game)
-        & make_nvp("m_filename", obj.m_filename)
-        & make_nvp("m_players", obj.m_players);
+        & make_nvp("m_new_game", obj.new_game)
+        & make_nvp("m_filename", obj.filename)
+        & make_nvp("m_players", obj.players);
 }
 
 template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, SinglePlayerSetupData&, unsigned int const);

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -245,19 +245,19 @@ void serialize(Archive& ar, PlayerSetupData& obj, unsigned int const version)
 {
     using namespace boost::serialization;
 
-    ar  & make_nvp("m_player_name", obj.m_player_name)
-        & make_nvp("m_player_id", obj.m_player_id)
-        & make_nvp("m_empire_name", obj.m_empire_name)
-        & make_nvp("m_empire_color", obj.m_empire_color)
-        & make_nvp("m_starting_species_name", obj.m_starting_species_name)
-        & make_nvp("m_save_game_empire_id", obj.m_save_game_empire_id)
-        & make_nvp("m_client_type", obj.m_client_type)
-        & make_nvp("m_player_ready", obj.m_player_ready);
+    ar  & make_nvp("m_player_name", obj.player_name)
+        & make_nvp("m_player_id", obj.player_id)
+        & make_nvp("m_empire_name", obj.empire_name)
+        & make_nvp("m_empire_color", obj.empire_color)
+        & make_nvp("m_starting_species_name", obj.starting_species_name)
+        & make_nvp("m_save_game_empire_id", obj.save_game_empire_id)
+        & make_nvp("m_client_type", obj.client_type)
+        & make_nvp("m_player_ready", obj.player_ready);
     if (version >= 1) {
-        ar & make_nvp("m_authenticated", obj.m_authenticated);
+        ar & make_nvp("m_authenticated", obj.authenticated);
     }
     if (version >= 2) {
-        ar & make_nvp("m_starting_team", obj.m_starting_team);
+        ar & make_nvp("m_starting_team", obj.starting_team);
     }
 }
 

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -18,32 +18,32 @@ void serialize(Archive& ar, GalaxySetupData& obj, unsigned int const version)
 {
     using namespace boost::serialization;
 
-    if (Archive::is_saving::value && obj.m_encoding_empire != ALL_EMPIRES && (!GetOptionsDB().Get<bool>("network.server.publish-seed"))) {
+    if (Archive::is_saving::value && obj.encoding_empire != ALL_EMPIRES && (!GetOptionsDB().Get<bool>("network.server.publish-seed"))) {
         std::string dummy = "";
         ar  & make_nvp("m_seed", dummy);
     } else {
-        ar  & make_nvp("m_seed", obj.m_seed);
+        ar  & make_nvp("m_seed", obj.seed);
     }
 
-    ar  & make_nvp("m_size", obj.m_size)
-        & make_nvp("m_shape", obj.m_shape)
-        & make_nvp("m_age", obj.m_age)
-        & make_nvp("m_starlane_freq", obj.m_starlane_freq)
-        & make_nvp("m_planet_density", obj.m_planet_density)
-        & make_nvp("m_specials_freq", obj.m_specials_freq)
-        & make_nvp("m_monster_freq", obj.m_monster_freq)
-        & make_nvp("m_native_freq", obj.m_native_freq)
-        & make_nvp("m_ai_aggr", obj.m_ai_aggr);
+    ar  & make_nvp("m_size", obj.size)
+        & make_nvp("m_shape", obj.shape)
+        & make_nvp("m_age", obj.age)
+        & make_nvp("m_starlane_freq", obj.starlane_freq)
+        & make_nvp("m_planet_density", obj.planet_density)
+        & make_nvp("m_specials_freq", obj.specials_freq)
+        & make_nvp("m_monster_freq", obj.monster_freq)
+        & make_nvp("m_native_freq", obj.native_freq)
+        & make_nvp("m_ai_aggr", obj.ai_aggr);
 
     if (version >= 1) {
-        ar & make_nvp("m_game_rules", obj.m_game_rules);
+        ar & make_nvp("m_game_rules", obj.game_rules);
     }
 
     if (version >= 2) {
-        ar & make_nvp("m_game_uid", obj.m_game_uid);
+        ar & make_nvp("m_game_uid", obj.game_uid);
     } else {
         if (Archive::is_loading::value) {
-            obj.m_game_uid = boost::uuids::to_string(boost::uuids::random_generator()());
+            obj.game_uid = boost::uuids::to_string(boost::uuids::random_generator()());
         }
     }
 }

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -300,14 +300,14 @@ void serialize(Archive& ar, ChatHistoryEntity& obj, unsigned int const version)
     using namespace boost::serialization;
 
     if (version < 1) {
-        ar  & make_nvp("m_timestamp", obj.m_timestamp)
-            & make_nvp("m_player_name", obj.m_player_name)
-            & make_nvp("m_text", obj.m_text);
+        ar  & make_nvp("m_timestamp", obj.timestamp)
+            & make_nvp("m_player_name", obj.player_name)
+            & make_nvp("m_text", obj.text);
     } else {
-        ar  & make_nvp("m_text", obj.m_text)
-            & make_nvp("m_player_name", obj.m_player_name)
-            & make_nvp("m_text_color", obj.m_text_color)
-            & make_nvp("m_timestamp", obj.m_timestamp);
+        ar  & make_nvp("m_text", obj.text)
+            & make_nvp("m_player_name", obj.player_name)
+            & make_nvp("m_text_color", obj.text_color)
+            & make_nvp("m_timestamp", obj.timestamp);
     }
 }
 

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -210,12 +210,12 @@ void serialize(Archive& ar, PlayerSaveGameData& obj, unsigned int const version)
 {
     using namespace boost::serialization;
 
-    ar  & make_nvp("m_name", obj.m_name)
-        & make_nvp("m_empire_id", obj.m_empire_id)
-        & make_nvp("m_orders", obj.m_orders)
-        & make_nvp("m_ui_data", obj.m_ui_data)
-        & make_nvp("m_save_state_string", obj.m_save_state_string)
-        & make_nvp("m_client_type", obj.m_client_type);
+    ar  & make_nvp("m_name", obj.name)
+        & make_nvp("m_empire_id", obj.empire_id)
+        & make_nvp("m_orders", obj.orders)
+        & make_nvp("m_ui_data", obj.ui_data)
+        & make_nvp("m_save_state_string", obj.save_state_string)
+        & make_nvp("m_client_type", obj.client_type);
     if (version == 1) {
         bool ready{false};
         ar & make_nvp("m_ready", ready);

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -170,16 +170,16 @@ void serialize(Archive& ar, SaveGameEmpireData& obj, unsigned int const version)
 {
     using namespace boost::serialization;
 
-    ar  & make_nvp("m_empire_id", obj.m_empire_id)
-        & make_nvp("m_empire_name", obj.m_empire_name)
-        & make_nvp("m_player_name", obj.m_player_name)
-        & make_nvp("m_color", obj.m_color);
+    ar  & make_nvp("m_empire_id", obj.empire_id)
+        & make_nvp("m_empire_name", obj.empire_name)
+        & make_nvp("m_player_name", obj.player_name)
+        & make_nvp("m_color", obj.color);
     if (version >= 1) {
-        ar & make_nvp("m_authenticated", obj.m_authenticated);
+        ar & make_nvp("m_authenticated", obj.authenticated);
     }
     if (version >= 2) {
-        ar & make_nvp("m_eliminated", obj.m_eliminated);
-        ar & make_nvp("m_won", obj.m_won);
+        ar & make_nvp("m_eliminated", obj.eliminated);
+        ar & make_nvp("m_won", obj.won);
     }
 }
 

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -231,7 +231,7 @@ template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PlayerS
 template <typename Archive>
 void serialize(Archive& ar, ServerSaveGameData& obj, unsigned int const version)
 {
-    ar  & boost::serialization::make_nvp("m_current_turn", obj.m_current_turn);
+    ar  & boost::serialization::make_nvp("m_current_turn", obj.current_turn);
 }
 
 template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, ServerSaveGameData&, unsigned int const);

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -194,9 +194,9 @@ void serialize(Archive& ar, PlayerSaveHeaderData& obj, unsigned int const versio
 {
     using namespace boost::serialization;
 
-    ar  & make_nvp("m_name", obj.m_name)
-        & make_nvp("m_empire_id", obj.m_empire_id)
-        & make_nvp("m_client_type", obj.m_client_type);
+    ar  & make_nvp("m_name", obj.name)
+        & make_nvp("m_empire_id", obj.empire_id)
+        & make_nvp("m_client_type", obj.client_type);
 }
 
 template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, PlayerSaveHeaderData&, unsigned int const);

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -273,18 +273,18 @@ void serialize(Archive& ar, MultiplayerLobbyData& obj, unsigned int const versio
     using namespace boost::serialization;
 
     ar  & make_nvp("GalaxySetupData", base_object<GalaxySetupData>(obj))
-        & make_nvp("m_new_game", obj.m_new_game)
-        & make_nvp("m_players", obj.m_players)
-        & make_nvp("m_save_game", obj.m_save_game)
-        & make_nvp("m_save_game_empire_data", obj.m_save_game_empire_data)
-        & make_nvp("m_any_can_edit", obj.m_any_can_edit)
-        & make_nvp("m_start_locked", obj.m_start_locked)
-        & make_nvp("m_start_lock_cause", obj.m_start_lock_cause);
+        & make_nvp("m_new_game", obj.new_game)
+        & make_nvp("m_players", obj.players)
+        & make_nvp("m_save_game", obj.save_game)
+        & make_nvp("m_save_game_empire_data", obj.save_game_empire_data)
+        & make_nvp("m_any_can_edit", obj.any_can_edit)
+        & make_nvp("m_start_locked", obj.start_locked)
+        & make_nvp("m_start_lock_cause", obj.start_lock_cause);
     if (version >= 1) {
-        ar & make_nvp("m_save_game_current_turn", obj.m_save_game_current_turn);
+        ar & make_nvp("m_save_game_current_turn", obj.save_game_current_turn);
     }
     if (version >= 2) {
-        ar & make_nvp("m_in_game", obj.m_in_game);
+        ar & make_nvp("m_in_game", obj.in_game);
     }
 }
 


### PR DESCRIPTION
This PR removes the `m_` prefix from the struct attributes declared in `util/MultiplayerCommon.h`.