### PR TITLE
Use non-intrusive serialization for combat related classes

### DIFF
--- a/combat/CombatEvent.cpp
+++ b/combat/CombatEvent.cpp
@@ -1,10 +1,5 @@
 #include "CombatEvent.h"
 
-#include <boost/serialization/serialization.hpp>
-#include <boost/serialization/version.hpp>
-
-#include "../util/Serialize.ipp"
-#include "../util/Serialize.h"
 #include "../util/Logger.h"
 
 #include <sstream>
@@ -16,20 +11,3 @@ boost::optional<int> CombatEvent::PrincipalFaction(int viewing_empire_id) const 
                   << this->DebugString();
     return boost::optional<int>();
 }
-
-template<typename Archive>
-void CombatEvent::serialize(Archive& ar, const unsigned int version) {}
-
-BOOST_CLASS_EXPORT_IMPLEMENT(CombatEvent)
-
-template
-void CombatEvent::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-
-template
-void CombatEvent::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-
-template
-void CombatEvent::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
-
-template
-void CombatEvent::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);

--- a/combat/CombatEvent.h
+++ b/combat/CombatEvent.h
@@ -72,13 +72,7 @@ struct FO_COMMON_API CombatEvent {
         It is from the perspective of the \p viewing_empire_id. Some events
         like BoutBegin are not associated with any faction.*/
     virtual boost::optional<int> PrincipalFaction(int viewing_empire_id) const;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
-BOOST_CLASS_EXPORT_KEY(CombatEvent)
 
 #endif // COMBATEVENT_H

--- a/combat/CombatEvents.cpp
+++ b/combat/CombatEvents.cpp
@@ -1,9 +1,5 @@
 #include "CombatEvents.h"
-#include <boost/serialization/serialization.hpp>
-#include <boost/serialization/version.hpp>
 
-#include "../util/Serialize.ipp"
-#include "../util/Serialize.h"
 #include "../universe/Universe.h"
 #include "../universe/Enums.h"
 
@@ -124,9 +120,11 @@ namespace {
     }
 }
 
+
 //////////////////////////////////////////
 ///////// BoutBeginEvent//////////////////
 //////////////////////////////////////////
+
 BoutBeginEvent::BoutBeginEvent() :
     bout(-1)
 {}
@@ -144,30 +142,11 @@ std::string BoutBeginEvent::DebugString() const {
 std::string BoutBeginEvent::CombatLogDescription(int viewing_empire_id) const
 { return str(FlexibleFormat(UserString("ENC_ROUND_BEGIN")) % bout); }
 
-template <typename Archive>
-void BoutBeginEvent::serialize(Archive& ar, const unsigned int version) {
-    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
-    ar & BOOST_SERIALIZATION_NVP(bout);
-}
-
-BOOST_CLASS_EXPORT(BoutBeginEvent)
-
-template
-void BoutBeginEvent::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-
-template
-void BoutBeginEvent::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-
-template
-void BoutBeginEvent::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-
-template
-void BoutBeginEvent::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
-
 
 //////////////////////////////////////////
 ///////// BoutEvent /////////////
 //////////////////////////////////////////
+
 BoutEvent::BoutEvent():
     bout(-1)
 {}
@@ -195,28 +174,6 @@ std::vector<ConstCombatEventPtr> BoutEvent::SubEvents(int viewing_empire_id) con
         all_events.push_back(event);
     return all_events;
 }
-
-template <typename Archive>
-void BoutEvent::serialize(Archive& ar, const unsigned int version) {
-    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
-    ar & BOOST_SERIALIZATION_NVP(bout)
-       & BOOST_SERIALIZATION_NVP(events);
-}
-
-BOOST_CLASS_VERSION(BoutEvent, 4)
-BOOST_CLASS_EXPORT(BoutEvent)
-
-template
-void BoutEvent::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-
-template
-void BoutEvent::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-
-template
-void BoutEvent::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-
-template
-void BoutEvent::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
 
 
 //////////////////////////////////////////
@@ -274,28 +231,6 @@ std::vector<ConstCombatEventPtr> SimultaneousEvents::SubEvents(int viewing_empir
 
     return ordered_events;
 }
-
-
-template <typename Archive>
-void SimultaneousEvents::serialize(Archive& ar, const unsigned int version) {
-    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
-    ar & BOOST_SERIALIZATION_NVP(events);
-}
-
-BOOST_CLASS_VERSION(SimultaneousEvents, 4)
-BOOST_CLASS_EXPORT(SimultaneousEvents)
-
-template
-void SimultaneousEvents::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-
-template
-void SimultaneousEvents::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-
-template
-void SimultaneousEvents::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-
-template
-void SimultaneousEvents::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
 
 
 //////////////////////////////////////////
@@ -363,27 +298,6 @@ std::string InitialStealthEvent::CombatLogDescription(int viewing_empire_id) con
 
     return desc;
 }
-
-template <typename Archive>
-void InitialStealthEvent::serialize(Archive& ar, const unsigned int version) {
-    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
-    ar & BOOST_SERIALIZATION_NVP(empire_to_object_visibility);
-}
-
-BOOST_CLASS_VERSION(InitialStealthEvent, 4)
-BOOST_CLASS_EXPORT(InitialStealthEvent)
-
-template
-void InitialStealthEvent::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-
-template
-void InitialStealthEvent::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-
-template
-void InitialStealthEvent::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-
-template
-void InitialStealthEvent::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
 
 
 //////////////////////////////////////////
@@ -496,55 +410,11 @@ std::vector<ConstCombatEventPtr> StealthChangeEvent::SubEvents(int viewing_empir
     return all_events;
 }
 
-template <typename Archive>
-void StealthChangeEvent::serialize(Archive& ar, const unsigned int version) {
-    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
-    ar & BOOST_SERIALIZATION_NVP(bout)
-       & BOOST_SERIALIZATION_NVP(events);
-}
-
-BOOST_CLASS_VERSION(StealthChangeEvent, 4)
-BOOST_CLASS_EXPORT(StealthChangeEvent)
-
-template
-void StealthChangeEvent::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-
-template
-void StealthChangeEvent::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-
-template
-void StealthChangeEvent::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-
-template
-void StealthChangeEvent::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
-
-template <typename Archive>
-void StealthChangeEvent::StealthChangeEventDetail::serialize(Archive& ar, const unsigned int version) {
-    ar  & BOOST_SERIALIZATION_NVP(attacker_id)
-        & BOOST_SERIALIZATION_NVP(target_id)
-        & BOOST_SERIALIZATION_NVP(attacker_empire_id)
-        & BOOST_SERIALIZATION_NVP(target_empire_id)
-        & BOOST_SERIALIZATION_NVP(visibility);
-}
-
-BOOST_CLASS_VERSION(StealthChangeEvent::StealthChangeEventDetail, 4)
-BOOST_CLASS_EXPORT(StealthChangeEvent::StealthChangeEventDetail)
-
-template
-void StealthChangeEvent::StealthChangeEventDetail::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-
-template
-void StealthChangeEvent::StealthChangeEventDetail::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-
-template
-void StealthChangeEvent::StealthChangeEventDetail::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-
-template
-void StealthChangeEvent::StealthChangeEventDetail::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
 
 //////////////////////////////////////////
 ///////// Attack Event////////////////////
 //////////////////////////////////////////
+
 WeaponFireEvent::WeaponFireEvent() :
     bout(-1),
     round(-1),
@@ -615,53 +485,10 @@ boost::optional<int> WeaponFireEvent::PrincipalFaction(int viewing_empire_id) co
 }
 
 
-template <typename Archive>
-void WeaponFireEvent::serialize(Archive& ar, const unsigned int version) {
-    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
-
-    if (version < 5) {
-        ar & BOOST_SERIALIZATION_NVP(bout)
-           & BOOST_SERIALIZATION_NVP(round)
-           & BOOST_SERIALIZATION_NVP(attacker_id)
-           & BOOST_SERIALIZATION_NVP(target_id)
-           & BOOST_SERIALIZATION_NVP(weapon_name)
-           & BOOST_SERIALIZATION_NVP(power)
-           & BOOST_SERIALIZATION_NVP(shield)
-           & BOOST_SERIALIZATION_NVP(damage)
-           & BOOST_SERIALIZATION_NVP(target_owner_id)
-           & BOOST_SERIALIZATION_NVP(attacker_owner_id);
-    } else {
-        ar & boost::serialization::make_nvp("b", bout)
-           & boost::serialization::make_nvp("r", round)
-           & boost::serialization::make_nvp("a", attacker_id)
-           & boost::serialization::make_nvp("t", target_id)
-           & boost::serialization::make_nvp("w", weapon_name)
-           & boost::serialization::make_nvp("p", power)
-           & boost::serialization::make_nvp("s", shield)
-           & boost::serialization::make_nvp("d", damage)
-           & boost::serialization::make_nvp("to", target_owner_id)
-           & boost::serialization::make_nvp("ao", attacker_owner_id);
-    }
-}
-
-BOOST_CLASS_VERSION(WeaponFireEvent, 5)
-BOOST_CLASS_EXPORT(WeaponFireEvent)
-
-template
-void WeaponFireEvent::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-
-template
-void WeaponFireEvent::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-
-template
-void WeaponFireEvent::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-
-template
-void WeaponFireEvent::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
-
 //////////////////////////////////////////
 ///////// IncapacitationEvent/////////////
 //////////////////////////////////////////
+
 IncapacitationEvent::IncapacitationEvent() :
     bout(-1),
     object_id(INVALID_OBJECT_ID),
@@ -714,36 +541,6 @@ std::string IncapacitationEvent::CombatLogDescription(int viewing_empire_id) con
 
 boost::optional<int> IncapacitationEvent::PrincipalFaction(int viewing_empire_id) const
 { return object_owner_id; }
-
-
-template <typename Archive>
-void IncapacitationEvent::serialize (Archive& ar, const unsigned int version) {
-    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
-    if (version < 2) {
-        ar & BOOST_SERIALIZATION_NVP(bout)
-           & BOOST_SERIALIZATION_NVP(object_id)
-           & BOOST_SERIALIZATION_NVP(object_owner_id);
-    } else {
-        ar & boost::serialization::make_nvp("b", bout)
-           & boost::serialization::make_nvp("i", object_id)
-           & boost::serialization::make_nvp("o", object_owner_id);
-    }
-}
-
-BOOST_CLASS_VERSION(IncapacitationEvent, 2)
-BOOST_CLASS_EXPORT(IncapacitationEvent)
-
-template
-void IncapacitationEvent::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-
-template
-void IncapacitationEvent::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-
-template
-void IncapacitationEvent::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-
-template
-void IncapacitationEvent::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
 
 
 //////////////////////////////////////////
@@ -821,33 +618,10 @@ std::string FightersAttackFightersEvent::CombatLogDescription(int viewing_empire
 }
 
 
-template <typename Archive>
-void FightersAttackFightersEvent::serialize(Archive& ar, const unsigned int version) {
-    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
-    ar & BOOST_SERIALIZATION_NVP(bout)
-       & BOOST_SERIALIZATION_NVP(events);
-}
-
-BOOST_CLASS_VERSION(FightersAttackFightersEvent, 4)
-BOOST_CLASS_EXPORT(FightersAttackFightersEvent)
-
-template
-void FightersAttackFightersEvent::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-
-template
-void FightersAttackFightersEvent::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-
-template
-void FightersAttackFightersEvent::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-
-template
-void FightersAttackFightersEvent::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
-
-
-
 //////////////////////////////////////////
 /////////// FighterLaunchEvent ///////////
 //////////////////////////////////////////
+
 FighterLaunchEvent::FighterLaunchEvent() :
     bout(-1),
     fighter_owner_empire_id(ALL_EMPIRES),
@@ -888,30 +662,6 @@ std::string FighterLaunchEvent::CombatLogDescription(int viewing_empire_id) cons
 
 boost::optional<int> FighterLaunchEvent::PrincipalFaction(int viewing_empire_id) const
 { return fighter_owner_empire_id; }
-
-template <typename Archive>
-void FighterLaunchEvent::serialize (Archive& ar, const unsigned int version) {
-    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
-    ar & BOOST_SERIALIZATION_NVP(bout)
-       & BOOST_SERIALIZATION_NVP(fighter_owner_empire_id)
-       & BOOST_SERIALIZATION_NVP(launched_from_id)
-       & BOOST_SERIALIZATION_NVP(number_launched);
-}
-
-BOOST_CLASS_EXPORT(FighterLaunchEvent)
-
-template
-void FighterLaunchEvent::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-
-template
-void FighterLaunchEvent::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-
-template
-void FighterLaunchEvent::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-
-template
-void FighterLaunchEvent::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
-
 
 
 //////////////////////////////////////////
@@ -991,30 +741,6 @@ std::string FightersDestroyedEvent::CombatLogDescription(int viewing_empire_id) 
 
     return ss.str();
 }
-
-
-template <typename Archive>
-void FightersDestroyedEvent::serialize(Archive& ar, const unsigned int version) {
-    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
-    ar & BOOST_SERIALIZATION_NVP(bout)
-       & BOOST_SERIALIZATION_NVP(events);
-}
-
-BOOST_CLASS_VERSION(FightersDestroyedEvent, 4)
-BOOST_CLASS_EXPORT(FightersDestroyedEvent)
-
-template
-void FightersDestroyedEvent::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-
-template
-void FightersDestroyedEvent::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-
-template
-void FightersDestroyedEvent::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-
-template
-void FightersDestroyedEvent::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
-
 
 
 //////////////////////////////////////////
@@ -1117,27 +843,3 @@ std::vector<ConstCombatEventPtr> WeaponsPlatformEvent::SubEvents(int viewing_emp
 
 boost::optional<int> WeaponsPlatformEvent::PrincipalFaction(int viewing_empire_id) const
 { return attacker_owner_id; }
-
-template <typename Archive>
-void WeaponsPlatformEvent::serialize(Archive& ar, const unsigned int version) {
-    ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
-    ar & BOOST_SERIALIZATION_NVP(bout)
-       & BOOST_SERIALIZATION_NVP(attacker_id)
-       & BOOST_SERIALIZATION_NVP(attacker_owner_id)
-       & BOOST_SERIALIZATION_NVP(events);
-}
-
-BOOST_CLASS_VERSION(WeaponsPlatformEvent, 4)
-BOOST_CLASS_EXPORT(WeaponsPlatformEvent)
-
-template
-void WeaponsPlatformEvent::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-
-template
-void WeaponsPlatformEvent::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-
-template
-void WeaponsPlatformEvent::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-
-template
-void WeaponsPlatformEvent::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);

--- a/combat/CombatEvents.h
+++ b/combat/CombatEvents.h
@@ -7,8 +7,6 @@
 #include <set>
 
 #include <tuple>
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/export.hpp>
 
 #include "../util/Export.h"
 #include "../universe/EnumsFwd.h"
@@ -31,11 +29,6 @@ struct FO_COMMON_API BoutBeginEvent : public CombatEvent {
     std::string CombatLogDescription(int viewing_empire_id) const override;
 
     int bout = 0;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** BoutEvent describes all the events that happen in one bout of combat.
@@ -66,9 +59,8 @@ private:
 
     std::vector<CombatEventPtr> events;
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, BoutEvent&, unsigned int const);
 };
 
 /** SimultaneousEvents describes a set of simultaneous events in one bout of combat.
@@ -94,9 +86,8 @@ struct FO_COMMON_API SimultaneousEvents : public CombatEvent {
 protected:
     std::vector<CombatEventPtr> events;
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, SimultaneousEvents&, unsigned int const);
 };
 
 
@@ -125,9 +116,8 @@ struct FO_COMMON_API InitialStealthEvent : public CombatEvent {
 private:
     EmpireToObjectVisibilityMap empire_to_object_visibility;// filled by AutoresolveInfo::ReportInvisibleObjects
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, InitialStealthEvent&, unsigned int const);
 };
 
 /**StealthChangeEvent describes changes in the visibility of objects during combat.
@@ -159,19 +149,14 @@ struct FO_COMMON_API StealthChangeEvent : public CombatEvent {
         int attacker_empire_id = ALL_EMPIRES;
         int target_empire_id = ALL_EMPIRES;
         Visibility visibility;
-
-        friend class boost::serialization::access;
-        template <typename Archive>
-        void serialize(Archive& ar, const unsigned int version);
     };
 
 private:
     int bout = 0;
     std::map<int, std::vector<StealthChangeEventDetailPtr>> events;
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, StealthChangeEvent&, unsigned int const);
 };
 
 /// An event that describes a single attack by one object or fighter against
@@ -210,11 +195,6 @@ struct FO_COMMON_API WeaponFireEvent : public CombatEvent {
     float damage = 0.0f;
     int attacker_owner_id = ALL_EMPIRES;
     int target_owner_id = ALL_EMPIRES;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /// Created when an object becomes unable to fight anymore,
@@ -229,11 +209,6 @@ struct FO_COMMON_API IncapacitationEvent : public CombatEvent {
     int bout = 0;
     int object_id = INVALID_OBJECT_ID;
     int object_owner_id = ALL_EMPIRES;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 
@@ -251,9 +226,8 @@ private:
     // Store the number of each of the identical fighter combat events.
     std::map<std::pair<int, int>, unsigned int> events;
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, FightersAttackFightersEvent&, unsigned int const);
 };
 
 /// Created when an fighter is launched
@@ -270,11 +244,6 @@ struct FO_COMMON_API FighterLaunchEvent : public CombatEvent {
     int fighter_owner_empire_id = ALL_EMPIRES;
     int launched_from_id = INVALID_OBJECT_ID;
     int number_launched = 0;
-
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** FightersDestroyedEvent aggregates all the fighters destroyed during one combat bout.*/
@@ -291,9 +260,8 @@ private:
     // Store the number of each of the identical fighter combat events.
     std::map<int, unsigned int> events;
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, FightersDestroyedEvent&, unsigned int const);
 };
 
 /** WeaponsPlatformEvent describes a ship or planet with zero or more weapons firing its weapons in combat.
@@ -321,9 +289,9 @@ struct FO_COMMON_API WeaponsPlatformEvent : public CombatEvent {
 private:
     std::map<int, std::vector<WeaponFireEvent::WeaponFireEventPtr>> events;
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, WeaponsPlatformEvent&, unsigned int const);
 };
+
 
 #endif // COMBATEVENT_H

--- a/combat/CombatLogManager.cpp
+++ b/combat/CombatLogManager.cpp
@@ -2,8 +2,6 @@
 #include "../universe/Meter.h"
 #include "../universe/UniverseObject.h"
 #include "../universe/Enums.h"
-#include "../util/Serialize.h"
-#include "../util/Serialize.ipp"
 #include "../util/Logger.h"
 #include "CombatEvents.h"
 
@@ -88,55 +86,6 @@ CombatLog::CombatLog(const CombatInfo& combat_info) :
         participant_states[obj->ID()] = CombatParticipantState(*obj);
     }
 }
-
-template <typename Archive>
-void CombatParticipantState::serialize(Archive& ar, const unsigned int version)
-{
-    ar & BOOST_SERIALIZATION_NVP(current_health)
-       & BOOST_SERIALIZATION_NVP(max_health);
-}
-
-template <typename Archive>
-void CombatLog::serialize(Archive& ar, const unsigned int version)
-{
-    // CombatEvents are serialized only through
-    // pointers to their base class.
-    // Therefore we need to manually register their types
-    // in the archive.
-    ar.template register_type<WeaponFireEvent>();
-    ar.template register_type<IncapacitationEvent>();
-    ar.template register_type<BoutBeginEvent>();
-    ar.template register_type<InitialStealthEvent>();
-    ar.template register_type<StealthChangeEvent>();
-    ar.template register_type<WeaponsPlatformEvent>();
-
-    ar  & BOOST_SERIALIZATION_NVP(turn)
-        & BOOST_SERIALIZATION_NVP(system_id)
-        & BOOST_SERIALIZATION_NVP(empire_ids)
-        & BOOST_SERIALIZATION_NVP(object_ids)
-        & BOOST_SERIALIZATION_NVP(damaged_object_ids)
-        & BOOST_SERIALIZATION_NVP(destroyed_object_ids);
-
-    if (combat_events.size() > 1)
-        TraceLogger() << "CombatLog::serialize turn " << turn << "  combat at " << system_id << "  combat events size: " << combat_events.size();
-    try {
-        ar  & BOOST_SERIALIZATION_NVP(combat_events);
-    } catch (const std::exception& e) {
-        ErrorLogger() << "combat events serializing failed!: caught exception: " << e.what();
-    }
-
-    ar & BOOST_SERIALIZATION_NVP(participant_states);
-}
-
-template
-void CombatLog::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-template
-void CombatLog::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-template
-void CombatLog::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
-template
-void CombatLog::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-
 
 
 ////////////////////////////////////////////////

--- a/combat/CombatLogManager.cpp
+++ b/combat/CombatLogManager.cpp
@@ -144,9 +144,6 @@ void CombatLog::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, co
 ////////////////////////////////////////////////
 CombatLogManager::CombatLogManager() = default;
 
-// Require here because CombatLogManagerImpl is defined in this file.
-CombatLogManager::~CombatLogManager() {}
-
 boost::optional<const CombatLog&> CombatLogManager::GetLog(int log_id) const
 {
     auto it = m_logs.find(log_id);
@@ -208,63 +205,6 @@ CombatLogManager& CombatLogManager::GetCombatLogManager() {
     return manager;
 }
 
-template <typename Archive>
-void CombatLogManager::SerializeIncompleteLogs(Archive& ar, const unsigned int version)
-{
-    int old_latest_log_id = m_latest_log_id;
-    ar & BOOST_SERIALIZATION_NVP(m_latest_log_id);
-
-    // If the new m_latest_log_id is greater than the old one then add all
-    // of the new ids to the incomplete log set.
-    if (Archive::is_loading::value && m_latest_log_id > old_latest_log_id)
-        for (++old_latest_log_id; old_latest_log_id <= m_latest_log_id; ++old_latest_log_id)
-            m_incomplete_logs.insert(old_latest_log_id);
-}
-
-template <typename Archive>
-void CombatLogManager::serialize(Archive& ar, const unsigned int version)
-{
-    std::map<int, CombatLog> logs;
-
-    if (Archive::is_saving::value) {
-        // TODO: filter logs by who should have access to them
-        for (auto it = m_logs.begin(); it != m_logs.end(); ++it)
-            logs.insert({it->first, it->second});
-    }
-
-    ar  & BOOST_SERIALIZATION_NVP(logs)
-        & BOOST_SERIALIZATION_NVP(m_latest_log_id);
-
-    if (Archive::is_loading::value) {
-        // copy new logs, but don't erase old ones
-        for (auto& log : logs)
-            m_logs[log.first] = log.second;
-    }
-}
-
-template
-void CombatLogManager::SerializeIncompleteLogs<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-
-template
-void CombatLogManager::SerializeIncompleteLogs<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-
-template
-void CombatLogManager::SerializeIncompleteLogs<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-
-template
-void CombatLogManager::SerializeIncompleteLogs<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
-
-template
-void CombatLogManager::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-
-template
-void CombatLogManager::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-
-template
-void CombatLogManager::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-
-template
-void CombatLogManager::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
 
 ///////////////////////////////////////////////////////////
 // Free Functions                                        //

--- a/combat/CombatLogManager.h
+++ b/combat/CombatLogManager.h
@@ -64,17 +64,10 @@ public:
     void CompleteLog(int id, const CombatLog& log);
     void Clear();
 
-    /** Serialize log headers so that the receiving LogManager can then request
-        complete logs in the background.*/
-    template <typename Archive>
-    void SerializeIncompleteLogs(Archive& ar, const unsigned int version);
-    //@}
-
     static CombatLogManager& GetCombatLogManager();
 
 private:
     CombatLogManager();
-    ~CombatLogManager();
 
     std::unordered_map<int, CombatLog> m_logs;
     //! Set of logs ids that do not have bodies and need to be fetched from the server
@@ -82,20 +75,12 @@ private:
 
     int                                m_latest_log_id = -1;
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, CombatLogManager&, const unsigned int);
+
+    template <typename Archive>
+    friend void serializeIncompleteLogs(Archive&, CombatLogManager&, const unsigned int);
 };
-
-
-extern template
-FO_COMMON_API void CombatLogManager::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-extern template
-FO_COMMON_API void CombatLogManager::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-extern template
-FO_COMMON_API void CombatLogManager::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
-extern template
-FO_COMMON_API void CombatLogManager::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
 
 
 /** returns the singleton combat log manager */

--- a/combat/CombatLogManager.h
+++ b/combat/CombatLogManager.h
@@ -4,10 +4,8 @@
 #include "CombatSystem.h"
 
 #include "../util/Export.h"
-#include "../util/Serialize.h"
 
 #include <boost/optional/optional.hpp>
-#include <boost/serialization/nvp.hpp>
 
 #include <memory>
 
@@ -20,10 +18,6 @@ struct FO_COMMON_API CombatParticipantState {
 
     CombatParticipantState();
     CombatParticipantState(const UniverseObject& object);
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 struct FO_COMMON_API CombatLog {
@@ -38,13 +32,8 @@ struct FO_COMMON_API CombatLog {
     std::set<int>               destroyed_object_ids;
     std::vector<CombatEventPtr> combat_events;
     std::map<int, CombatParticipantState> participant_states;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
-BOOST_CLASS_VERSION(CombatLog, 1);
 
 /** Stores and retreives combat logs. */
 class FO_COMMON_API CombatLogManager {

--- a/msvc2017/Common/Common.vcxproj
+++ b/msvc2017/Common/Common.vcxproj
@@ -330,6 +330,7 @@
     <ClCompile Include="..\..\util\Order.cpp" />
     <ClCompile Include="..\..\util\OrderSet.cpp" />
     <ClCompile Include="..\..\util\Random.cpp" />
+    <ClCompile Include="..\..\util\SerializeCombat.cpp" />
     <ClCompile Include="..\..\util\SerializeEmpire.cpp" />
     <ClCompile Include="..\..\util\SerializeModeratorAction.cpp" />
     <ClCompile Include="..\..\util\SerializeMultiplayerCommon.cpp" />

--- a/msvc2017/Common/Common.vcxproj.filters
+++ b/msvc2017/Common/Common.vcxproj.filters
@@ -334,6 +334,9 @@
     <ClCompile Include="..\..\util\Random.cpp">
       <Filter>Source Files\util</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\util\SerializeCombat.cpp">
+      <Filter>Source Files\util</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\util\SerializeEmpire.cpp">
       <Filter>Source Files\util</Filter>
     </ClCompile>

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -192,7 +192,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
                << BOOST_SERIALIZATION_NVP(species);
-            combat_logs.SerializeIncompleteLogs(oa, 1);
+            serializeIncompleteLogs(oa, combat_logs, 1);
             oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = false;
@@ -208,7 +208,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
                << BOOST_SERIALIZATION_NVP(species);
-            combat_logs.SerializeIncompleteLogs(oa, 1);
+            serializeIncompleteLogs(oa, combat_logs, 1);
             oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = false;
@@ -240,7 +240,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
                << BOOST_SERIALIZATION_NVP(species);
-            combat_logs.SerializeIncompleteLogs(oa, 1);
+            serializeIncompleteLogs(oa, combat_logs, 1);
             oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = true;
@@ -263,7 +263,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
                << BOOST_SERIALIZATION_NVP(species);
-            combat_logs.SerializeIncompleteLogs(oa, 1);
+            serializeIncompleteLogs(oa, combat_logs, 1);
             oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = true;
@@ -309,7 +309,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
                << BOOST_SERIALIZATION_NVP(species);
-            combat_logs.SerializeIncompleteLogs(oa, 1);
+            serializeIncompleteLogs(oa, combat_logs, 1);
             oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = true;
@@ -332,7 +332,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
                << BOOST_SERIALIZATION_NVP(species);
-            combat_logs.SerializeIncompleteLogs(oa, 1);
+            serializeIncompleteLogs(oa, combat_logs, 1);
             oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = true;
@@ -453,7 +453,7 @@ Message TurnUpdateMessage(int empire_id, int current_turn,
             oa << BOOST_SERIALIZATION_NVP(current_turn);
             oa << BOOST_SERIALIZATION_NVP(empires);
             oa << BOOST_SERIALIZATION_NVP(species);
-            combat_logs.SerializeIncompleteLogs(oa, 1);
+            serializeIncompleteLogs(oa, combat_logs, 1);
             oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             oa << BOOST_SERIALIZATION_NVP(players);
@@ -463,7 +463,7 @@ Message TurnUpdateMessage(int empire_id, int current_turn,
             oa << BOOST_SERIALIZATION_NVP(current_turn)
                << BOOST_SERIALIZATION_NVP(empires)
                << BOOST_SERIALIZATION_NVP(species);
-            combat_logs.SerializeIncompleteLogs(oa, 1);
+            serializeIncompleteLogs(oa, combat_logs, 1);
             oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             oa << BOOST_SERIALIZATION_NVP(players);
@@ -853,7 +853,7 @@ void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, i
 
                 ia >> BOOST_SERIALIZATION_NVP(species);
                 combat_logs.Clear();    // only needed when loading new game, not when incrementally serializing logs on turn update
-                combat_logs.SerializeIncompleteLogs(ia, 1);
+                serializeIncompleteLogs(ia, combat_logs, 1);
                 ia >> BOOST_SERIALIZATION_NVP(supply);
 
                 deserialize_timer.restart();
@@ -899,7 +899,7 @@ void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, i
 
             ia >> BOOST_SERIALIZATION_NVP(species);
             combat_logs.Clear();    // only needed when loading new game, not when incrementally serializing logs on turn update
-            combat_logs.SerializeIncompleteLogs(ia, 1);
+            serializeIncompleteLogs(ia, combat_logs, 1);
             ia >> BOOST_SERIALIZATION_NVP(supply);
 
             deserialize_timer.restart();
@@ -1040,7 +1040,7 @@ void ExtractTurnUpdateMessageData(const Message& msg, int empire_id, int& curren
                 ia >> BOOST_SERIALIZATION_NVP(current_turn)
                    >> BOOST_SERIALIZATION_NVP(empires)
                    >> BOOST_SERIALIZATION_NVP(species);
-                combat_logs.SerializeIncompleteLogs(ia, 1);
+                serializeIncompleteLogs(ia, combat_logs, 1);
                 ia >> BOOST_SERIALIZATION_NVP(supply);
                 Deserialize(ia, universe);
                 ia >> BOOST_SERIALIZATION_NVP(players);
@@ -1058,7 +1058,7 @@ void ExtractTurnUpdateMessageData(const Message& msg, int empire_id, int& curren
             ia >> BOOST_SERIALIZATION_NVP(current_turn)
                >> BOOST_SERIALIZATION_NVP(empires)
                >> BOOST_SERIALIZATION_NVP(species);
-            combat_logs.SerializeIncompleteLogs(ia, 1);
+            serializeIncompleteLogs(ia, combat_logs, 1);
             ia >> BOOST_SERIALIZATION_NVP(supply);
             Deserialize(ia, universe);
             ia >> BOOST_SERIALIZATION_NVP(players);

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -45,6 +45,7 @@ target_sources(freeorioncommon
         ${CMAKE_CURRENT_LIST_DIR}/Random.cpp
         ${CMAKE_CURRENT_LIST_DIR}/SaveGamePreviewUtils.cpp
         ${CMAKE_CURRENT_LIST_DIR}/ScopedTimer.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/SerializeCombat.cpp
         ${CMAKE_CURRENT_LIST_DIR}/SerializeEmpire.cpp
         ${CMAKE_CURRENT_LIST_DIR}/SerializeModeratorAction.cpp
         ${CMAKE_CURRENT_LIST_DIR}/SerializeMultiplayerCommon.cpp

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -64,6 +64,18 @@ extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_b
 extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, ChatHistoryEntity&, unsigned int const);
 extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, ChatHistoryEntity&, unsigned int const);
 
+struct CombatLog;
+
+BOOST_CLASS_VERSION(CombatLog, 1);
+
+template <typename Archive>
+void serialize(Archive&, CombatLog&, const unsigned int);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, CombatLog&, const unsigned int);
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, CombatLog&, const unsigned int);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, CombatLog&, const unsigned int);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, CombatLog&, const unsigned int);
+
 
 class CombatLogManager;
 

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -65,6 +65,25 @@ extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_x
 extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, ChatHistoryEntity&, unsigned int const);
 
 
+class CombatLogManager;
+
+template <typename Archive>
+void serialize(Archive&, CombatLogManager&, const unsigned int);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, CombatLogManager&, const unsigned int);
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, CombatLogManager&, const unsigned int);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, CombatLogManager&, const unsigned int);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, CombatLogManager&, const unsigned int);
+
+template <typename Archive>
+void serializeIncompleteLogs(Archive&, CombatLogManager&, const unsigned int);
+
+extern template FO_COMMON_API void serializeIncompleteLogs<freeorion_bin_iarchive>(freeorion_bin_iarchive&, CombatLogManager&, const unsigned int);
+extern template FO_COMMON_API void serializeIncompleteLogs<freeorion_bin_oarchive>(freeorion_bin_oarchive&, CombatLogManager&, const unsigned int);
+extern template FO_COMMON_API void serializeIncompleteLogs<freeorion_xml_iarchive>(freeorion_xml_iarchive&, CombatLogManager&, const unsigned int);
+extern template FO_COMMON_API void serializeIncompleteLogs<freeorion_xml_oarchive>(freeorion_xml_oarchive&, CombatLogManager&, const unsigned int);
+
+
 struct GalaxySetupData;
 
 BOOST_CLASS_VERSION(GalaxySetupData, 3);

--- a/util/SerializeCombat.cpp
+++ b/util/SerializeCombat.cpp
@@ -5,6 +5,281 @@
 #include "../combat/CombatLogManager.h"
 
 
+template<typename Archive>
+void serialize(Archive&, CombatEvent&, unsigned int const)
+{}
+
+BOOST_CLASS_EXPORT(CombatEvent)
+
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, CombatEvent&, const unsigned int);
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, CombatEvent&, const unsigned int);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, CombatEvent&, const unsigned int);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, CombatEvent&, const unsigned int);
+
+
+template <typename Archive>
+void serialize(Archive& ar, BoutBeginEvent& obj, unsigned int const version)
+{
+    using namespace boost::serialization;
+
+    ar & make_nvp("CombatEvent", base_object<CombatEvent>(obj));
+    ar & make_nvp("bout", obj.bout);
+}
+
+BOOST_CLASS_EXPORT(BoutBeginEvent)
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, BoutBeginEvent&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, BoutBeginEvent&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, BoutBeginEvent&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, BoutBeginEvent&, unsigned int const);
+
+
+template <typename Archive>
+void serialize(Archive& ar, BoutEvent& obj, unsigned int const version)
+{
+    using namespace boost::serialization;
+
+    ar & make_nvp("CombatEvent", base_object<CombatEvent>(obj));
+    ar & make_nvp("bout", obj.bout)
+       & make_nvp("events", obj.events);
+}
+
+BOOST_CLASS_VERSION(BoutEvent, 4)
+BOOST_CLASS_EXPORT(BoutEvent)
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, BoutEvent&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, BoutEvent&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, BoutEvent&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, BoutEvent&, unsigned int const);
+
+
+template <typename Archive>
+void serialize(Archive& ar, SimultaneousEvents& obj, unsigned int const version)
+{
+    using namespace boost::serialization;
+
+    ar & make_nvp("CombatEvent", base_object<CombatEvent>(obj));
+    ar & make_nvp("events", obj.events);
+}
+
+BOOST_CLASS_VERSION(SimultaneousEvents, 4)
+BOOST_CLASS_EXPORT(SimultaneousEvents)
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, SimultaneousEvents&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, SimultaneousEvents&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, SimultaneousEvents&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, SimultaneousEvents&, unsigned int const);
+
+
+template <typename Archive>
+void serialize(Archive& ar, InitialStealthEvent& obj, unsigned int const version)
+{
+    using namespace boost::serialization;
+
+    ar & make_nvp("CombatEvent", base_object<CombatEvent>(obj));
+    ar & make_nvp("empire_to_object_visibility", obj.empire_to_object_visibility);
+}
+
+BOOST_CLASS_VERSION(InitialStealthEvent, 4)
+BOOST_CLASS_EXPORT(InitialStealthEvent)
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, InitialStealthEvent&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, InitialStealthEvent&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, InitialStealthEvent&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, InitialStealthEvent&, unsigned int const);
+
+
+template <typename Archive>
+void serialize(Archive& ar, StealthChangeEvent& obj, unsigned int const version)
+{
+    using namespace boost::serialization;
+
+    ar & make_nvp("CombatEvent", base_object<CombatEvent>(obj));
+    ar & make_nvp("bout", obj.bout)
+       & make_nvp("events", obj.events);
+}
+
+BOOST_CLASS_VERSION(StealthChangeEvent, 4)
+BOOST_CLASS_EXPORT(StealthChangeEvent)
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, StealthChangeEvent&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, StealthChangeEvent&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, StealthChangeEvent&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, StealthChangeEvent&, unsigned int const);
+
+
+template <typename Archive>
+void serialize(Archive& ar, StealthChangeEvent::StealthChangeEventDetail& obj, unsigned int const version)
+{
+    using namespace boost::serialization;
+
+    ar  & make_nvp("attacker_id", obj.attacker_id)
+        & make_nvp("target_id", obj.target_id)
+        & make_nvp("attacker_empire_id", obj.attacker_empire_id)
+        & make_nvp("target_empire_id", obj.target_empire_id)
+        & make_nvp("visibility", obj.visibility);
+}
+
+BOOST_CLASS_VERSION(StealthChangeEvent::StealthChangeEventDetail, 4)
+BOOST_CLASS_EXPORT(StealthChangeEvent::StealthChangeEventDetail)
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, StealthChangeEvent::StealthChangeEventDetail&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, StealthChangeEvent::StealthChangeEventDetail&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, StealthChangeEvent::StealthChangeEventDetail&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, StealthChangeEvent::StealthChangeEventDetail&, unsigned int const);
+
+
+template <typename Archive>
+void serialize(Archive& ar, WeaponFireEvent& obj, unsigned int const version)
+{
+    using namespace boost::serialization;
+
+    ar & make_nvp("CombatEvent", base_object<CombatEvent>(obj));
+
+    if (version < 5) {
+        ar & make_nvp("bout", obj.bout)
+           & make_nvp("round", obj.round)
+           & make_nvp("attacker_id", obj.attacker_id)
+           & make_nvp("target_id", obj.target_id)
+           & make_nvp("weapon_name", obj.weapon_name)
+           & make_nvp("power", obj.power)
+           & make_nvp("shield", obj.shield)
+           & make_nvp("damage", obj.damage)
+           & make_nvp("target_owner_id", obj.target_owner_id)
+           & make_nvp("attacker_owner_id", obj.attacker_owner_id);
+    } else {
+        ar & make_nvp("b", obj.bout)
+           & make_nvp("r", obj.round)
+           & make_nvp("a", obj.attacker_id)
+           & make_nvp("t", obj.target_id)
+           & make_nvp("w", obj.weapon_name)
+           & make_nvp("p", obj.power)
+           & make_nvp("s", obj.shield)
+           & make_nvp("d", obj.damage)
+           & make_nvp("to", obj.target_owner_id)
+           & make_nvp("ao", obj.attacker_owner_id);
+    }
+}
+
+BOOST_CLASS_VERSION(WeaponFireEvent, 5)
+BOOST_CLASS_EXPORT(WeaponFireEvent)
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, WeaponFireEvent&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, WeaponFireEvent&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, WeaponFireEvent&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, WeaponFireEvent&, unsigned int const);
+
+
+template <typename Archive>
+void serialize(Archive& ar, IncapacitationEvent& obj, unsigned int const version)
+{
+    using namespace boost::serialization;
+
+    ar & make_nvp("CombatEvent", base_object<CombatEvent>(obj));
+
+    if (version < 2) {
+        ar & make_nvp("bout", obj.bout)
+           & make_nvp("object_id", obj.object_id)
+           & make_nvp("object_owner_id", obj.object_owner_id);
+    } else {
+        ar & make_nvp("b", obj.bout)
+           & make_nvp("i", obj.object_id)
+           & make_nvp("o", obj.object_owner_id);
+    }
+}
+
+BOOST_CLASS_VERSION(IncapacitationEvent, 2)
+BOOST_CLASS_EXPORT(IncapacitationEvent)
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, IncapacitationEvent&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, IncapacitationEvent&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, IncapacitationEvent&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, IncapacitationEvent&, unsigned int const);
+
+
+template <typename Archive>
+void serialize(Archive& ar, FightersAttackFightersEvent& obj, unsigned int const)
+{
+    using namespace boost::serialization;
+
+    ar & make_nvp("CombatEvent", base_object<CombatEvent>(obj));
+
+    ar & make_nvp("bout", obj.bout)
+       & make_nvp("events", obj.events);
+}
+
+BOOST_CLASS_VERSION(FightersAttackFightersEvent, 4)
+BOOST_CLASS_EXPORT(FightersAttackFightersEvent)
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, FightersAttackFightersEvent&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, FightersAttackFightersEvent&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, FightersAttackFightersEvent&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, FightersAttackFightersEvent&, unsigned int const);
+
+
+template <typename Archive>
+void serialize (Archive& ar, FighterLaunchEvent& obj, unsigned int const version)
+{
+    using namespace boost::serialization;
+
+    ar & make_nvp("CombatEvent", base_object<CombatEvent>(obj));
+
+    ar & make_nvp("bout", obj.bout)
+       & make_nvp("fighter_owner_empire_id", obj.fighter_owner_empire_id)
+       & make_nvp("launched_from_id", obj.launched_from_id)
+       & make_nvp("number_launched", obj.number_launched);
+}
+
+BOOST_CLASS_EXPORT(FighterLaunchEvent)
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, FighterLaunchEvent&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, FighterLaunchEvent&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, FighterLaunchEvent&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, FighterLaunchEvent&, unsigned int const);
+
+
+template <typename Archive>
+void serialize(Archive& ar, FightersDestroyedEvent& obj, unsigned int const version)
+{
+    using namespace boost::serialization;
+
+    ar & make_nvp("CombatEvent", base_object<CombatEvent>(obj));
+
+    ar & make_nvp("bout", obj.bout)
+       & make_nvp("events", obj.events);
+}
+
+BOOST_CLASS_VERSION(FightersDestroyedEvent, 4)
+BOOST_CLASS_EXPORT(FightersDestroyedEvent)
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, FightersDestroyedEvent&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, FightersDestroyedEvent&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, FightersDestroyedEvent&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, FightersDestroyedEvent&, unsigned int const);
+
+
+template <typename Archive>
+void serialize(Archive& ar, WeaponsPlatformEvent& obj, unsigned int const version)
+{
+    using namespace boost::serialization;
+
+    ar & make_nvp("CombatEvent", base_object<CombatEvent>(obj));
+
+    ar & make_nvp("bout", obj.bout)
+       & make_nvp("attacker_id", obj.attacker_id)
+       & make_nvp("attacker_owner_id", obj.attacker_owner_id)
+       & make_nvp("events", obj.events);
+}
+
+BOOST_CLASS_VERSION(WeaponsPlatformEvent, 4)
+BOOST_CLASS_EXPORT(WeaponsPlatformEvent)
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, WeaponsPlatformEvent&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, WeaponsPlatformEvent&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, WeaponsPlatformEvent&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, WeaponsPlatformEvent&, unsigned int const);
+
+
 template <typename Archive>
 void serialize(Archive& ar, CombatParticipantState& obj, const unsigned int version)
 {

--- a/util/SerializeCombat.cpp
+++ b/util/SerializeCombat.cpp
@@ -1,0 +1,53 @@
+#include "Serialize.h"
+
+#include "Serialize.ipp"
+#include "../combat/CombatLogManager.h"
+
+template <typename Archive>
+void serialize(Archive& ar, CombatLogManager& obj, const unsigned int version)
+{
+    using namespace boost::serialization;
+
+    std::map<int, CombatLog> logs;
+
+    if (Archive::is_saving::value) {
+        // TODO: filter logs by who should have access to them
+        for (auto it = obj.m_logs.begin(); it != obj.m_logs.end(); ++it)
+            logs.insert({it->first, it->second});
+    }
+
+    ar  & make_nvp("logs", logs)
+        & make_nvp("m_latest_log_id", obj.m_latest_log_id);
+
+    if (Archive::is_loading::value) {
+        // copy new logs, but don't erase old ones
+        for (auto& log : logs)
+            obj.m_logs[log.first] = log.second;
+    }
+}
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, CombatLogManager&, const unsigned int);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, CombatLogManager&, const unsigned int);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, CombatLogManager&, const unsigned int);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, CombatLogManager&, const unsigned int);
+
+
+template <typename Archive>
+void serializeIncompleteLogs(Archive& ar, CombatLogManager& obj, const unsigned int version)
+{
+    using namespace boost::serialization;
+
+    int old_latest_log_id = obj.m_latest_log_id;
+    ar & make_nvp("m_latest_log_id", obj.m_latest_log_id);
+
+    // If the new m_latest_log_id is greater than the old one then add all
+    // of the new ids to the incomplete log set.
+    if (Archive::is_loading::value && obj.m_latest_log_id > old_latest_log_id)
+        for (++old_latest_log_id; old_latest_log_id <= obj.m_latest_log_id; ++old_latest_log_id)
+            obj.m_incomplete_logs.insert(old_latest_log_id);
+}
+
+template void serializeIncompleteLogs<freeorion_bin_oarchive>(freeorion_bin_oarchive&, CombatLogManager&, unsigned int const);
+template void serializeIncompleteLogs<freeorion_bin_iarchive>(freeorion_bin_iarchive&, CombatLogManager&, unsigned int const);
+template void serializeIncompleteLogs<freeorion_xml_oarchive>(freeorion_xml_oarchive&, CombatLogManager&, unsigned int const);
+template void serializeIncompleteLogs<freeorion_xml_iarchive>(freeorion_xml_iarchive&, CombatLogManager&, unsigned int const);


### PR DESCRIPTION
This PR removes the need for including any serialization related headers to `combat/CombatLogManager.h` by using the non-intrusive `boost::serialization` interface.