### PR TITLE
Serialization cleanup

### DIFF
--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -12,7 +12,6 @@
 #include "../util/Directories.h"
 #include "../util/i18n.h"
 #include "../util/OptionsDB.h"
-#include "../util/Serialize.h"
 #include "../util/Version.h"
 #include "../util/XMLDoc.h"
 

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -6,7 +6,6 @@
 
 #include "../util/i18n.h"
 #include "../util/Logger.h"
-#include "../util/Serialize.h"
 #include "../network/Message.h"
 #include "../client/ClientNetworking.h"
 #include "../client/human/HumanClientApp.h"

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -6,7 +6,6 @@
 #include "../../util/LoggerWithOptionsDB.h"
 #include "../../util/OptionsDB.h"
 #include "../../util/Directories.h"
-#include "../../util/Serialize.h"
 #include "../../util/i18n.h"
 #include "../util/AppInterface.h"
 #include "../../network/Message.h"

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -1,7 +1,6 @@
 #include "ClientApp.h"
 
 #include "../util/Logger.h"
-#include "../util/Serialize.h"
 #include "../universe/UniverseObject.h"
 #include "../universe/System.h"
 #include "../Empire/Empire.h"

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -24,7 +24,6 @@
 #include "../../util/OptionsDB.h"
 #include "../../util/Process.h"
 #include "../../util/SaveGamePreviewUtils.h"
-#include "../../util/Serialize.h"
 #include "../../util/SitRepEntry.h"
 #include "../../util/Directories.h"
 #include "../../util/Version.h"
@@ -48,7 +47,6 @@
 #include <boost/filesystem/fstream.hpp>
 #include <boost/format.hpp>
 #include <boost/optional/optional.hpp>
-#include <boost/serialization/vector.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/nil_generator.hpp>

--- a/msvc2017/FreeOrion/FreeOrion.vcxproj
+++ b/msvc2017/FreeOrion/FreeOrion.vcxproj
@@ -278,7 +278,6 @@
     <ClInclude Include="..\..\util\OrderSet.h" />
     <ClInclude Include="..\..\util\Process.h" />
     <ClInclude Include="..\..\util\Random.h" />
-    <ClInclude Include="..\..\util\Serialize.h" />
     <ClInclude Include="..\..\util\SitRepEntry.h" />
     <ClInclude Include="..\..\util\VarText.h" />
     <ClInclude Include="..\..\util\Version.h" />

--- a/msvc2017/FreeOrion/FreeOrion.vcxproj.filters
+++ b/msvc2017/FreeOrion/FreeOrion.vcxproj.filters
@@ -258,9 +258,6 @@
     <ClInclude Include="..\..\util\Random.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\util\Serialize.h">
-      <Filter>Header Files\util</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\util\SitRepEntry.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>

--- a/msvc2017/FreeOrionCA/FreeOrionCA.vcxproj
+++ b/msvc2017/FreeOrionCA/FreeOrionCA.vcxproj
@@ -212,7 +212,6 @@
     <ClInclude Include="..\..\util\OrderSet.h" />
     <ClInclude Include="..\..\util\Process.h" />
     <ClInclude Include="..\..\util\Random.h" />
-    <ClInclude Include="..\..\util\Serialize.h" />
     <ClInclude Include="..\..\util\SitRepEntry.h" />
     <ClInclude Include="..\..\util\VarText.h" />
     <ClInclude Include="..\..\util\Version.h" />

--- a/msvc2017/FreeOrionCA/FreeOrionCA.vcxproj.filters
+++ b/msvc2017/FreeOrionCA/FreeOrionCA.vcxproj.filters
@@ -134,9 +134,6 @@
     <ClInclude Include="..\..\util\Random.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\util\Serialize.h">
-      <Filter>Header Files\util</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\util\SitRepEntry.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>

--- a/msvc2017/FreeOrionD/FreeOrionD.vcxproj
+++ b/msvc2017/FreeOrionD/FreeOrionD.vcxproj
@@ -212,7 +212,6 @@
     <ClInclude Include="..\..\util\OrderSet.h" />
     <ClInclude Include="..\..\util\Process.h" />
     <ClInclude Include="..\..\util\Random.h" />
-    <ClInclude Include="..\..\util\Serialize.h" />
     <ClInclude Include="..\..\util\SitRepEntry.h" />
     <ClInclude Include="..\..\util\VarText.h" />
     <ClInclude Include="..\..\util\Version.h" />

--- a/msvc2017/FreeOrionD/FreeOrionD.vcxproj.filters
+++ b/msvc2017/FreeOrionD/FreeOrionD.vcxproj.filters
@@ -194,9 +194,6 @@
     <ClInclude Include="..\..\util\Random.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\util\Serialize.h">
-      <Filter>Header Files\util</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\util\SitRepEntry.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>


### PR DESCRIPTION
This PR:

- removes serialization related headers where serialization is not used.
- removes references to `util/Serialize.h` headers from MSVC server, human and ai client projects.