### PR TITLE
Add CMake GiGi::header import target to simplify headless build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -354,16 +354,13 @@ target_compile_definitions(freeorioncommon
         -DFREEORION_PYTHON_VERSION=\"${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}\"
 )
 
-target_include_directories(freeorioncommon SYSTEM
-    PUBLIC
-        $<TARGET_PROPERTY:GiGi::GiGi,INCLUDE_DIRECTORIES>
-)
-
 target_link_libraries(freeorioncommon
-    INTERFACE
+    PUBLIC
+        GiGi::header
         Boost::boost
         Boost::disable_autolinking
         Boost::dynamic_linking
+    INTERFACE
         Boost::filesystem
         Boost::iostreams
         Boost::locale
@@ -394,26 +391,16 @@ add_library(freeorionparseobj OBJECT "")
 # dependencies via imported targets and target_link_libraries starting 3.12.
 # For now manually unpack the compiler definitions and include directories.
 target_compile_definitions(freeorionparseobj
-    INTERFACE
-        $<TARGET_PROPERTY:Boost::disable_autolinking,COMPILE_DEFINITIONS>
-        $<TARGET_PROPERTY:Boost::dynamic_linking,COMPILE_DEFINITIONS>
     PUBLIC
-        $<TARGET_PROPERTY:GiGi::GiGi,COMPILE_DEFINITIONS>
+        $<TARGET_PROPERTY:Boost::boost,INTERFACE_COMPILE_DEFINITIONS>
+        $<TARGET_PROPERTY:GiGi::header,INTERFACE_COMPILE_DEFINITIONS>
 )
 
 target_include_directories(freeorionparseobj
-    INTERFACE
-        $<TARGET_PROPERTY:Boost::boost,INCLUDE_DIRECTORIES>
     PUBLIC
-        $<TARGET_PROPERTY:GiGi::GiGi,INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:Boost::boost,INTERFACE_INCLUDE_DIRECTORIES>
+        $<TARGET_PROPERTY:GiGi::header,INTERFACE_INCLUDE_DIRECTORIES>
 )
-
-if(NOT BUILD_HEADLESS)
-    target_link_libraries(freeorioncommon
-        PUBLIC
-            GiGi::GiGi
-    )
-endif()
 
 set_property(TARGET freeorionparseobj
     PROPERTY
@@ -621,6 +608,7 @@ if(NOT BUILD_HEADLESS)
     target_link_libraries(freeorion
         freeorioncommon
         freeorionparse
+        GiGi::GiGi
         ${SDL_LIBRARIES}
         ${OPENGL_gl_LIBRARY}
         ${OPENAL_LIBRARY}

--- a/GG/CMakeLists.txt
+++ b/GG/CMakeLists.txt
@@ -89,7 +89,7 @@ if(NOT BUILD_HEADLESS)
     else()
         set(int_have_png 0)
     endif()
-    
+
     if(ENABLE_TIFF_TEXTURES)
         find_package(TIFF REQUIRED)
         set(int_have_tiff 1)
@@ -114,29 +114,32 @@ configure_file(
 ## Define main project targets.
 ##
 
-add_library(GiGi "")
+add_library(GiGiHeader INTERFACE)
+add_library(GiGi::header ALIAS GiGiHeader)
 
-add_library(GiGi::GiGi ALIAS GiGi)
-
-target_compile_definitions(GiGi
-    PRIVATE
-        -DFONS_USE_FREETYPE
-        # Starting with boost 1.68 boost::gil integrates support for
-        # grayscale-alpha png images, so prefer their implementation
-        # instead of our hacky gilext code.
-        $<$<VERSION_LESS:${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION},1.68>:GIGI_CONFIG_USE_OLD_IMPLEMENTATION_OF_GIL_PNG_IO>
-        $<$<VERSION_GREATER:${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION},1.67>:BOOST_GIL_IO_ENABLE_GRAY_ALPHA>
-        $<$<VERSION_GREATER:${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION},1.71>:BOOST_GIL_USES_MP11>
-)
-
-target_include_directories(GiGi
-    PUBLIC
+target_include_directories(GiGiHeader
+    INTERFACE
+        Boost::boost
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 
-set_target_properties(GiGi PROPERTIES LINKER_LANGUAGE CXX)
-
 if(NOT BUILD_HEADLESS)
+    add_library(GiGi "")
+    add_library(GiGi::GiGi ALIAS GiGi)
+
+    target_compile_definitions(GiGi
+        PUBLIC
+            GiGiHeader
+        PRIVATE
+            -DFONS_USE_FREETYPE
+            # Starting with boost 1.68 boost::gil integrates support for
+            # grayscale-alpha png images, so prefer their implementation
+            # instead of our hacky gilext code.
+            $<$<VERSION_LESS:${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION},1.68>:GIGI_CONFIG_USE_OLD_IMPLEMENTATION_OF_GIL_PNG_IO>
+            $<$<VERSION_GREATER:${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION},1.67>:BOOST_GIL_IO_ENABLE_GRAY_ALPHA>
+            $<$<VERSION_GREATER:${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION},1.71>:BOOST_GIL_USES_MP11>
+)
+
     target_include_directories(GiGi
         INTERFACE
             ${OPENGL_INCLUDE_DIR}
@@ -146,13 +149,13 @@ if(NOT BUILD_HEADLESS)
 
     target_link_libraries(GiGi
         PUBLIC
-            GLEW::GLEW
-            Boost::boost
+            GiGiHeader
             Boost::disable_autolinking
             Boost::dynamic_linking
-            Boost::filesystem
+            GLEW::GLEW
             ${OPENGL_gl_LIBRARY}
         PRIVATE
+            Boost::filesystem
             Boost::regex
             ${FREETYPE_LIBRARIES}
     )

--- a/GG/test/unit/CMakeLists.txt
+++ b/GG/test/unit/CMakeLists.txt
@@ -32,8 +32,7 @@ add_executable(gg_unittest
 target_link_libraries(gg_unittest
     GiGi
     Boost::boost
-    Boost::disable_autolinking
-    Boost::dynamic_linking
+    Boost::system
     Boost::unit_test_framework
 )
 

--- a/test/UI/CMakeLists.txt
+++ b/test/UI/CMakeLists.txt
@@ -23,7 +23,8 @@ add_library(fo_acceptance_runner STATIC
 
 target_link_libraries(fo_acceptance_runner
     PUBLIC
-        GiGi
+        Boost::system
+        GiGi::GiGi
         GLEW::GLEW
         ${SDL_LIBRARIES}
 )


### PR DESCRIPTION
This PR adds a CMake INTERFACE target to GG, called header.  This target contains all build settings and source references required to use common classes like `GG::Clr` or the `GG_ENUM` macro within the `freeorioncommon` targets without the need to depend on the GG library target itself.  This simplifies the `headless` build logic somewhat and is a prerequisite for Docker-less TravisCI builds.