### PR TITLE
Fix Travis CI ccache setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,7 @@ _build_cpp_common: &_build_cpp_common
   language: cpp
   cache: ccache
   install:
-    - mkdir -p $HOME/.ccache;
-    - echo sloppiness = file_macro > $HOME/.ccache/ccache.conf
-    - echo max_size = 200M >> $HOME/.ccache/ccache.conf
+    - ccache --set-config=max_size=200M --set-config=sloppiness=file_macro
     - ccache --version
     - ccache --show-stats
   before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,7 @@ _build_cpp_common: &_build_cpp_common
   cache: ccache
   install:
     - ccache --set-config=max_size=200M --set-config=sloppiness=file_macro
-    - ccache --version
-    - ccache --show-stats
+    - ccache --zero-stats
   before_script:
     - mkdir build
     - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ _build_cpp_common: &_build_cpp_common
   after_success:
     - cmake --build . --config Release --target unittest
   before_cache:
-    - ccache --clean
+    - ccache --cleanup
     - ccache --show-stats
 
 _test_python_common: &_test_python_common

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,11 @@ _build_cpp_common: &_build_cpp_common
   language: cpp
   cache: ccache
   install:
-    - ccache --set-config=max_size=200M --set-config=sloppiness=file_macro
+    # The build cache for a full project build currently packs around 340M
+    # in combination wit a bug in ccache before 3.4.2 prematurely cleaned
+    # the cache if it was filled up to 80%.  Therefor raise the cache size
+    # to 500MB
+    - ccache --set-config=max_size=500M --set-config=sloppiness=file_macro
     - ccache --zero-stats
   before_script:
     - mkdir build

--- a/.travis.yml
+++ b/.travis.yml
@@ -111,6 +111,8 @@ jobs:
       <<: *_build_cpp_common
       os: linux
       dist: bionic
+      env:
+        - CACHE_NAME=linux-full
       services:
         - docker
       before_install:
@@ -129,6 +131,8 @@ jobs:
       <<: *_build_cpp_common
       os: linux
       dist: bionic
+      env:
+        - CACHE_NAME=linux-headless
       services:
         - docker
       before_install:
@@ -148,6 +152,8 @@ jobs:
       os: osx
       osx_image: xcode8.3
       compiler: clang
+      env:
+        - CACHE_NAME=macos-full
       before_install:
         - brew install ccache
         - export PATH="/usr/local/opt/ccache/libexec:$PATH"


### PR DESCRIPTION
This PR fixes some defects regarding build result caches currently present on the CI builds:

* Use the ccache `--set-config` parameter to set configuration instead of writing into the config file directly.
* Use the correct `--cleanup` parameter instead of `--clean`.
* Reset the ccache statistic counters to prevent old builds influencing the statistics regarding cache hits or misses.
* Separate the ccache caches between jobs to prevent cache thrashing/overwriting across jobs, slowing down builds unnecessarily.
* Raise the cache size to 500MB as the project currently uses around 340MB of cache, causing cache thrashing with the previous 200MB and resulting in slower builds.