### PR TITLE
Delay Experimentor outpost 50 turns, spawn monsters on pairs

### DIFF
--- a/default/scripting/buildings/EXPERIMENTOR_OUTPOST.focs.txt
+++ b/default/scripting/buildings/EXPERIMENTOR_OUTPOST.focs.txt
@@ -83,7 +83,7 @@ BuildingType
             effects = [
                 CreateShip designname = "SM_BLACK_KRAKEN" empire = Source.Owner
                 CreateShip designname = "SM_BLACK_KRAKEN" empire = Source.Owner
-                CreateShip designname = "SM_BLACK_KRAKEN" empire = Source.Owner
+                //CreateShip designname = "SM_BLACK_KRAKEN" empire = Source.Owner
                 GenerateSitRepMessage
                     message = "EFFECT_EXPERIMENT_MONSTERS_LAUNCH"
                     label = "EFFECT_EXPERIMENT_MONSTERS_LAUNCH_LABEL"
@@ -128,7 +128,7 @@ BuildingType
             effects = [
                 CreateShip designname = "SM_BLOATED_JUGGERNAUT" empire = Source.Owner
                 CreateShip designname = "SM_BLOATED_JUGGERNAUT" empire = Source.Owner
-                CreateShip designname = "SM_BLOATED_JUGGERNAUT" empire = Source.Owner
+                //CreateShip designname = "SM_BLOATED_JUGGERNAUT" empire = Source.Owner
                 GenerateSitRepMessage
                     message = "EFFECT_EXPERIMENT_MONSTERS_LAUNCH"
                     label = "EFFECT_EXPERIMENT_MONSTERS_LAUNCH_LABEL"
@@ -173,7 +173,7 @@ BuildingType
             effects = [
                 CreateShip designname = "SM_PSIONIC_SNOWFLAKE" empire = Source.Owner
                 CreateShip designname = "SM_PSIONIC_SNOWFLAKE" empire = Source.Owner
-                CreateShip designname = "SM_PSIONIC_SNOWFLAKE" empire = Source.Owner
+                //CreateShip designname = "SM_PSIONIC_SNOWFLAKE" empire = Source.Owner
                 GenerateSitRepMessage
                     message = "EFFECT_EXPERIMENT_MONSTERS_LAUNCH"
                     label = "EFFECT_EXPERIMENT_MONSTERS_LAUNCH_LABEL"
@@ -237,7 +237,7 @@ EXPERIMENTOR_MONSTER_FREQ_FACTOR
 '''((1 + GalaxyMaxAIAggression) / 5.0)'''
 
 EXPERIMENTOR_SPAWN_BASE_TURN
-'''200'''
+'''250'''
 
 EXPERIMENTOR_SPAWN_AI_AGGRESSION_CHECK
 '''(Statistic If condition = (GalaxyMaxAIAggression <= 2))'''


### PR DESCRIPTION
Reduces Experimentors difficulty to the nerfed resource output.

Cherry-pick for v0.4.10