### PR TITLE
Refactor credits rendering

### DIFF
--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -101,53 +101,49 @@ CreditsWnd::CreditsWnd(GG::X x, GG::Y y, GG::X w, GG::Y h, int cx, int cy, int c
 
     auto credits_node = doc.root_node.Child("CREDITS");
 
+    std::ostringstream credits;
+
+    auto group_format = boost::format("%1%\n\n");
+    auto nick_format = boost::format(" <rgba 153 153 153 255>(%1%)</rgba>");
+    auto task_format = boost::format(" - <rgba 204 204 204 255>%1%</rgba>");
+    auto resource_format = boost::format("%1% - <rgba 153 153 153 255>%2%</rgba>\n%3% %4%%5%\n");
+    auto source_format = boost::format(" - <rgba 153 153 153 255>%1%</rgba>");
+    auto note_format = boost::format("<rgba 204 204 204 255>(%1%)\n");
+
     for (const XMLElement& group : credits_node.children) {
         if (0 == group.Tag().compare("GROUP")) {
-            m_credits += group.attributes.at("name") + "\n\n";
+            credits << group_format % group.attributes.at("name");
             for (const XMLElement& item : group.children) {
-                if (0 == item.Tag().compare("PERSON")) {    
+                if (0 == item.Tag().compare("PERSON")) {
                     if (item.attributes.count("name"))
-                        m_credits += item.attributes.at("name");
-                    if (item.attributes.count("nick") && item.attributes.at("nick").length() > 0) {
-                        m_credits += " <rgba 153 153 153 255>(";
-                        m_credits += item.attributes.at("nick");
-                        m_credits += ")</rgba>";
-                    }
-                    if (item.attributes.count("task") && item.attributes.at("task").length() > 0) {
-                        m_credits += " - <rgba 204 204 204 255>";
-                        m_credits += item.attributes.at("task");
-                        m_credits += "</rgba>";
-                    }
+                        credits << item.attributes.at("name");
+                    if (item.attributes.count("nick") && item.attributes.at("nick").length() > 0)
+                        credits << nick_format % item.attributes.at("nick");
+                    if (item.attributes.count("task"))
+                        credits << task_format % item.attributes.at("task");
                 }
 
                 if (0 == item.Tag().compare("RESOURCE")) {
-                    if (item.attributes.count("author"))
-                        m_credits += item.attributes.at("author");
-                    if (item.attributes.count("title")) {
-                        m_credits += "<rgba 153 153 153 255> - ";
-                        m_credits += item.attributes.at("title");
-                        m_credits += "</rgba>\n";
-                    }
-                    if (item.attributes.count("license"))
-                        m_credits += UserString("INTRO_CREDITS_LICENSE") + " " + item.attributes.at("license");
-                    if (item.attributes.count("source")) {
-                        m_credits += "<rgba 153 153 153 255> - ";
-                        m_credits += item.attributes.at("source");
-                        m_credits += "</rgba>\n";
-                    }
-                    if (item.attributes.count("notes") && item.attributes.at("notes").length() > 0) {
-                        m_credits += "<rgba 204 204 204 255>(";
-                        m_credits += item.attributes.at("notes");
-                        m_credits += ")</rgba>";
-                    }
+                    credits << resource_format
+                        % item.attributes.at("author")
+                        % item.attributes.at("title")
+                        % UserString("INTRO_CREDITS_LICENSE")
+                        % item.attributes.at("license")
+                        % ((item.attributes.count("source"))
+                            ? boost::str(source_format % item.attributes.at("source"))
+                            : std::string{});
+                    if (item.attributes.count("notes"))
+                        credits << note_format % item.attributes.at("notes");
                 }
 
-                m_credits += "\n";
+                credits << "\n";
             }
 
-            m_credits += "\n\n";
+            credits << "\n\n";
         }
     }
+
+    m_credits = credits.str();
 }
 
 CreditsWnd::~CreditsWnd() {

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -128,9 +128,8 @@ void CreditsWnd::DrawCredits(GG::X x1, GG::Y y1, GG::X x2, GG::Y y2, int transpa
     std::string credit;
     for (const XMLElement& group : m_credits.children) {
         if (0 == group.Tag().compare("GROUP")) {
+            credit += group.attributes.at("name") + "\n\n";
             for (const XMLElement& item : group.children) {
-                credit = "";
-
                 if (0 == item.Tag().compare("PERSON")) {    
                     if (item.attributes.count("name"))
                         credit += item.attributes.at("name");
@@ -168,16 +167,19 @@ void CreditsWnd::DrawCredits(GG::X x1, GG::Y y1, GG::X x2, GG::Y y2, int transpa
                     }
                 }
 
-                std::vector<std::shared_ptr<GG::Font::TextElement>> text_elements =
-                    m_font->ExpensiveParseFromTextToTextElements(credit, format);
-                std::vector<GG::Font::LineData> lines =
-                    m_font->DetermineLines(credit, format, x2 - x1, text_elements);
-                m_font->RenderText(GG::Pt(x1, y1 + offset), GG::Pt(x2, y2), credit, format, lines);
-                offset += m_font->TextExtent(lines).y + 2;
+                credit += "\n";
             }
-            offset += m_font->Lineskip() + 2;
+
+            credit += "\n\n";
         }
     }
+
+    std::vector<std::shared_ptr<GG::Font::TextElement>> text_elements =
+        m_font->ExpensiveParseFromTextToTextElements(credit, format);
+    std::vector<GG::Font::LineData> lines =
+        m_font->DetermineLines(credit, format, x2 - x1, text_elements);
+    m_font->RenderText(GG::Pt(x1, y1 + offset), GG::Pt(x2, y2), credit, format, lines);
+    offset = m_font->TextExtent(lines).y;
     //store complete height for self destruction
     m_credits_height = Value(offset);
 }


### PR DESCRIPTION
This PR:

* Moves the credit.xml file loading into the `CreditsWnd` constructor.
* Shows the grouping title (Lead, Programming, Graphics, …) above each section (I assume this was a bug?).
* Generates the markup text within the `CreditsWnd` constructor instead of recreating it on each frame.  Calculation of the text extents still happens within the drawing function.
* Uses now hardcoded color markup instead of a never used variable.
* composes the markup text with a `std::ostringstream` and reusable `boost::format` formatters instead of continuous appending to a string.