### PR TITLE
Exclude data for universe generator from checksum

### DIFF
--- a/universe/Special.cpp
+++ b/universe/Special.cpp
@@ -167,8 +167,6 @@ unsigned int Special::GetCheckSum() const {
     CheckSums::CheckSumCombine(retval, m_description);
     CheckSums::CheckSumCombine(retval, m_stealth);
     CheckSums::CheckSumCombine(retval, m_effects);
-    CheckSums::CheckSumCombine(retval, m_spawn_rate);
-    CheckSums::CheckSumCombine(retval, m_spawn_limit);
     CheckSums::CheckSumCombine(retval, m_initial_capacity);
     CheckSums::CheckSumCombine(retval, m_location);
     CheckSums::CheckSumCombine(retval, m_graphic);


### PR DESCRIPTION
This allows to tune universe generator without desyncing checksum with client.