### PR TITLE
Stop Duplicate Production UUID and Grooming

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -21,6 +21,7 @@
 #include "Supply.h"
 #include "Government.h"
 
+#include <boost/uuid/uuid_io.hpp>
 #include <unordered_set>
 
 
@@ -1517,7 +1518,7 @@ void Empire::SplitIncompleteProductionItem(int index, boost::uuids::uuid uuid) {
 }
 
 void Empire::DuplicateProductionItem(int index, boost::uuids::uuid uuid) {
-    DebugLogger() << "Empire::DuplicateProductionItem() called for index " << index << " with new UUID: " << uuid;
+    DebugLogger() << "Empire::DuplicateProductionItem() called for index " << index << " with new UUID: " << boost::uuids::to_string(uuid);
     if (index < 0 || static_cast<int>(m_production_queue.size()) <= index)
         throw std::runtime_error("Empire::DuplicateProductionItem() : Attempted to adjust the quantity of items to be built in a nonexistent production queue item.");
 

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1465,7 +1465,8 @@ void Empire::PlaceProductionOnQueue(const ProductionQueue::ProductionItem& item,
         throw std::invalid_argument("Empire::PlaceProductionOnQueue was passed a ProductionQueue::ProductionItem with an invalid BuildType");
     }
 
-    ProductionQueue::Element elem{item, m_id, uuid, number, number, blocksize, location, false, item.build_type != BT_STOCKPILE};
+    ProductionQueue::Element elem{item, m_id, uuid, number, number, blocksize,
+                                  location, false, item.build_type != BT_STOCKPILE};
     if (pos < 0 || static_cast<int>(m_production_queue.size()) <= pos)
         m_production_queue.push_back(elem);
     else

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1517,7 +1517,7 @@ void Empire::SplitIncompleteProductionItem(int index, boost::uuids::uuid uuid) {
 }
 
 void Empire::DuplicateProductionItem(int index, boost::uuids::uuid uuid) {
-    DebugLogger() << "Empire::DuplicateProductionItem() called for index " << index;
+    DebugLogger() << "Empire::DuplicateProductionItem() called for index " << index << " with new UUID: " << uuid;
     if (index < 0 || static_cast<int>(m_production_queue.size()) <= index)
         throw std::runtime_error("Empire::DuplicateProductionItem() : Attempted to adjust the quantity of items to be built in a nonexistent production queue item.");
 

--- a/Empire/ProductionQueue.cpp
+++ b/Empire/ProductionQueue.cpp
@@ -904,8 +904,7 @@ void ProductionQueue::Update() {
     ProductionQueueChangedSignal();
 }
 
-void ProductionQueue::push_back(const Element& element)
-{
+void ProductionQueue::push_back(const Element& element) {
     if (find(element.uuid) != end()) {
         ErrorLogger() << "Trying to push back repeated UUID " << element.uuid;
         throw std::invalid_argument("Repeated use of UUID");
@@ -913,8 +912,7 @@ void ProductionQueue::push_back(const Element& element)
     m_queue.push_back(element);
 }
 
-void ProductionQueue::insert(iterator it, const Element& element)
-{
+void ProductionQueue::insert(iterator it, const Element& element) {
     if (find(element.uuid) != end()) {
         ErrorLogger() << "Trying to insert repeated UUID " << element.uuid;
         throw std::invalid_argument("Repeated use of UUID");

--- a/Empire/ProductionQueue.cpp
+++ b/Empire/ProductionQueue.cpp
@@ -905,10 +905,22 @@ void ProductionQueue::Update() {
 }
 
 void ProductionQueue::push_back(const Element& element)
-{ m_queue.push_back(element); }
+{
+    if (find(element.uuid) != end()) {
+        ErrorLogger() << "Trying to push back repeated UUID " << element.uuid;
+        throw std::invalid_argument("Repeated use of UUID");
+    }
+    m_queue.push_back(element);
+}
 
 void ProductionQueue::insert(iterator it, const Element& element)
-{ m_queue.insert(it, element); }
+{
+    if (find(element.uuid) != end()) {
+        ErrorLogger() << "Trying to insert repeated UUID " << element.uuid;
+        throw std::invalid_argument("Repeated use of UUID");
+    }
+    m_queue.insert(it, element);
+}
 
 void ProductionQueue::erase(int i) {
     if (i < 0 || i >= static_cast<int>(m_queue.size()))

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -2630,7 +2630,7 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
         if (ship_menuitem_id > MENUITEM_SET_SHIP_BASE) {
             popup->AddMenuItem(std::move(ship_menu_item_top));
             popup->AddMenuItem(std::move(ship_menu_item));
-	}
+    }
 
         GG::MenuItem building_menu_item_top(UserString("MENUITEM_ENQUEUE_BUILDING_TO_TOP_OF_QUEUE"), false, false);
         GG::MenuItem building_menu_item(UserString("MENUITEM_ENQUEUE_BUILDING"), false, false);

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -756,7 +756,7 @@ namespace {
             }
 
             // pedia lookup
-            std::string item_name = "";
+            std::string item_name;
             switch (build_type) {
             case BT_BUILDING:
             case BT_STOCKPILE:
@@ -1253,10 +1253,12 @@ void ProductionWnd::DeleteQueueItem(GG::ListBox::iterator it) {
     auto idx = m_queue_wnd->GetQueueListBox()->IteraterIndex(it);
     auto queue_it = empire->GetProductionQueue().find(idx);
 
-    if (queue_it != empire->GetProductionQueue().end())
+    if (queue_it != empire->GetProductionQueue().end()) {
+        DebugLogger() << "DeleteQueueItem idx: " << idx << "  item: " << queue_it->Dump();
         HumanClientApp::GetApp()->Orders().IssueOrder(
             std::make_shared<ProductionQueueOrder>(ProductionQueueOrder::REMOVE_FROM_QUEUE,
                                                    client_empire_id, queue_it->uuid));
+    }
 
     empire->UpdateProductionQueue();
 }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -3209,8 +3209,7 @@ void ServerApp::PreCombatProcessTurns() {
             continue;
         }
         DebugLogger() << "<<= Executing Orders for empire " << empire_orders.first << " =>>";
-        for (const auto& id_and_order : *save_game_data->orders)
-            id_and_order.second->Execute();
+        save_game_data->orders->ApplyOrders();
     }
 
     // clean up orders, which are no longer needed

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -860,7 +860,7 @@ void ServerApp::LoadSPGameInit(const std::vector<PlayerSaveGameData>& player_sav
             // In a single player game, the host player is always the human player, so
             // this is just a matter of finding which entry in player_save_game_data was
             // a human player, and assigning that saved player data to the host player ID
-            player_id_to_save_game_data_index.push_back({m_networking.HostPlayerID(), i});
+            player_id_to_save_game_data_index.emplace_back(m_networking.HostPlayerID(), i);
 
         } else if (psgd.client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
             // All saved AI player data, as determined from their client type, is
@@ -873,7 +873,7 @@ void ServerApp::LoadSPGameInit(const std::vector<PlayerSaveGameData>& player_sav
                 // if player is an AI, assign it to this
                 if (player_connection->GetClientType() == Networking::CLIENT_TYPE_AI_PLAYER) {
                     int player_id = player_connection->PlayerID();
-                    player_id_to_save_game_data_index.push_back({player_id, i});
+                    player_id_to_save_game_data_index.emplace_back(player_id, i);
                     break;
                 }
             }
@@ -1991,7 +1991,7 @@ int ServerApp::EffectsProcessingThreads() const
 { return GetOptionsDB().Get<int>("effects.server.threads"); }
 
 void ServerApp::AddEmpireTurn(int empire_id, const PlayerSaveGameData& psgd)
-{ m_turn_sequence[empire_id] = std::make_unique<PlayerSaveGameData>(psgd); }
+{ m_turn_sequence.emplace(empire_id, std::make_unique<PlayerSaveGameData>(psgd)); }
 
 void ServerApp::RemoveEmpireTurn(int empire_id)
 { m_turn_sequence.erase(empire_id); }

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -1023,7 +1023,7 @@ void ProductionQueueOrder::ExecuteImpl() const {
             if (idx == -1) {
                 ErrorLogger() << "ProductionQueueOrder asked to remove invalid UUID: " << boost::uuids::to_string(m_uuid);
             } else {
-                DebugLogger() << "ProductionQueueOrder removing item";
+                DebugLogger() << "ProductionQueueOrder removing item at index: " << idx;
                 empire->RemoveProductionFromQueue(idx);
             }
             break;

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -1132,7 +1132,8 @@ void ProductionQueueOrder::ExecuteImpl() const {
             ErrorLogger() << "ProductionQueueOrder::ExecuteImpl got invalid action";
         }
     } catch (const std::exception& e) {
-        ErrorLogger() << "Build order execution threw exception: " << e.what();
+        ErrorLogger() << "Production order execution threw exception: " << e.what();
+        throw;
     }
 }
 
@@ -1277,7 +1278,6 @@ void ShipDesignOrder::ExecuteImpl() const {
                           << " that this empire hasn't seen";
             return;
         }
-
     }
 }
 

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -36,9 +36,9 @@ Empire* Order::GetValidatedEmpire() const {
 void Order::Execute() const {
     if (m_executed)
         return;
+    m_executed = true;
 
     ExecuteImpl();
-    m_executed = true;
 }
 
 bool Order::Undo() const {

--- a/util/OrderSet.cpp
+++ b/util/OrderSet.cpp
@@ -24,7 +24,11 @@ int OrderSet::IssueOrder(OrderPtr&& order) {
     // Insert the order into the m_orders map.  forward the rvalue to use the move constructor.
     auto inserted = m_orders.emplace(retval, std::forward<OrderPtr>(order));
     m_last_added_orders.emplace(retval);
-    inserted.first->second->Execute();
+    try {
+        inserted.first->second->Execute();
+    } catch (const std::exception& e) {
+        ErrorLogger() << "OrderSet::IssueOrder caught exception issuing order: " << e.what();
+    }
 
     TraceLogger() << "OrderSetIssueOrder m_orders size: " << m_orders.size();
 

--- a/util/OrderSet.cpp
+++ b/util/OrderSet.cpp
@@ -22,8 +22,8 @@ int OrderSet::IssueOrder(OrderPtr&& order) {
     int retval = ((m_orders.rbegin() != m_orders.rend()) ? m_orders.rbegin()->first + 1 : 0);
 
     // Insert the order into the m_orders map.  forward the rvalue to use the move constructor.
-    auto inserted = m_orders.insert({retval, std::forward<OrderPtr>(order)});
-    m_last_added_orders.insert(retval);
+    auto inserted = m_orders.emplace(retval, std::forward<OrderPtr>(order));
+    m_last_added_orders.emplace(retval);
     inserted.first->second->Execute();
 
     TraceLogger() << "OrderSetIssueOrder m_orders size: " << m_orders.size();
@@ -33,19 +33,32 @@ int OrderSet::IssueOrder(OrderPtr&& order) {
 
 void OrderSet::ApplyOrders() {
     DebugLogger() << "OrderSet::ApplyOrders() executing " << m_orders.size() << " orders";
-    try {
-        for (auto& order : m_orders)
-            order.second->Execute();
-    } catch (const std::exception& e) {
-        ErrorLogger() << "Caught exception executing orders: " << e.what();
+    unsigned int executed_count = 0, failed_count = 0, already_executed_count = 0;
+    for (auto& order : m_orders) {
+        if (order.second->Executed()) {
+            DebugLogger() << "Order " << order.first << " already executed";
+            ++already_executed_count;
+        } else {
+            try {
+                order.second->Execute();
+                ++executed_count;
+            } catch (const std::exception& e) {
+                ++failed_count;
+                ErrorLogger() << "Caught exception executing order " << order.first << ": " << e.what();
+            }
+        }
     }
+    DebugLogger() << "OrderSet::ApplyOrders() successfully executed " << executed_count
+                  << " orders, skipped " << already_executed_count
+                  << " already executed orders, and tried but failed to execute " << failed_count
+                  << " orders";
 }
 
 bool OrderSet::RescindOrder(int order) {
     auto it = m_orders.find(order);
     if (it != m_orders.end() && it->second->Undo()) {
-        m_last_deleted_orders.insert(it->first);
-        m_orders.erase(it);  // Invalidates `it`
+        m_last_deleted_orders.emplace(it->first);
+        m_orders.erase(it);  // Invalidates it
         return true;
     }
     return false;
@@ -62,9 +75,9 @@ std::pair<OrderSet, std::set<int>> OrderSet::ExtractChanges() {
     for(int added : m_last_added_orders) {
         auto it = m_orders.find(added);
         if (it != m_orders.end()) {
-            added_orders.m_orders.insert(*it);
+            added_orders.m_orders.emplace(*it);
         } else {
-            m_last_deleted_orders.insert(added);
+            m_last_deleted_orders.emplace(added);
         }
     }
     m_last_added_orders.clear();

--- a/util/OrderSet.h
+++ b/util/OrderSet.h
@@ -54,7 +54,7 @@ public:
     std::size_t     size() const            { return m_orders.size(); }
     bool            empty() const           { return m_orders.empty(); }
     iterator        find(const key_type& k) { return m_orders.find(k); }
-    std::pair<iterator,bool> insert (const value_type& val) { return m_orders.insert(val); } ///< direct insert without saving changes
+    std::pair<iterator, bool> insert(const value_type& val) { return m_orders.insert(val); } ///< direct insert without saving changes
     void            erase(const key_type& k){ m_orders.erase(k); } ///< direct erase without saving changes
     OrderPtr&       operator[](std::size_t i);
     key_compare     key_comp() const        { return m_orders.key_comp(); }

--- a/util/SerializeOrderSet.cpp
+++ b/util/SerializeOrderSet.cpp
@@ -169,7 +169,7 @@ void ProductionQueueOrder::serialize(Archive& ar, const unsigned int version)
     if (version < 2 && Archive::is_loading::value) {
         // would need to generate action and UUID from deserialized values. instead generate an invalid order. will break partial-turn saves.
         m_uuid = boost::uuids::nil_generator()();
-        m_uuid2 = m_uuid;
+        m_uuid2 = boost::uuids::nil_generator()();
         m_action = INVALID_PROD_QUEUE_ACTION;
 
     } else {
@@ -191,8 +191,11 @@ void ProductionQueueOrder::serialize(Archive& ar, const unsigned int version)
                 m_uuid = boost::lexical_cast<boost::uuids::uuid>(string_uuid);
                 m_uuid2 = boost::lexical_cast<boost::uuids::uuid>(string_uuid2);
             } catch (const boost::bad_lexical_cast&) {
+                ErrorLogger() << "Error casting to UUIDs from strings: " << string_uuid
+                              << " and " << string_uuid2 << ".  ProductionOrder will be invalid";
                 m_uuid = boost::uuids::nil_generator()();
-                m_uuid2 = m_uuid;
+                m_uuid2 = boost::uuids::nil_generator()();
+                m_action = INVALID_PROD_QUEUE_ACTION;
             }
         }
     }

--- a/util/SerializeOrderSet.cpp
+++ b/util/SerializeOrderSet.cpp
@@ -7,6 +7,7 @@
 #include <boost/serialization/version.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/nil_generator.hpp>
+#include "Logger.h"
 
 
 BOOST_CLASS_EXPORT(Order)


### PR DESCRIPTION
Logging and localized try-catch wrapping of order execution to hopefully mitigate #3042

Includes commit from https://github.com/freeorion/freeorion/pull/3080 from @o01eg