### PR TITLE
Nonintrusive serialization - hide Archive implementiation

### DIFF
--- a/Empire/EmpireManager.h
+++ b/Empire/EmpireManager.h
@@ -4,12 +4,10 @@
 #include "Diplomacy.h"
 #include "../universe/EnumsFwd.h"
 #include "../util/Export.h"
-#include "../util/Serialize.h"
 
 #include <GG/Clr.h>
 
 #include <boost/filesystem.hpp>
-#include <boost/serialization/access.hpp>
 #include <boost/signals2/signal.hpp>
 
 #include <map>
@@ -105,15 +103,9 @@ private:
     friend class ClientApp;
     friend class ServerApp;
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, EmpireManager&, unsigned int const);
 };
-
-extern template FO_COMMON_API void EmpireManager::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
-extern template FO_COMMON_API void EmpireManager::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);
-extern template FO_COMMON_API void EmpireManager::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
-extern template FO_COMMON_API void EmpireManager::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
 /** The colors that are available for use for empires in the game. */
 FO_COMMON_API const std::vector<GG::Clr>& EmpireColors();

--- a/universe/Species.h
+++ b/universe/Species.h
@@ -10,10 +10,8 @@
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/iterator/filter_iterator.hpp>
 #include <boost/optional/optional.hpp>
-#include <boost/serialization/nvp.hpp>
 #include "EnumsFwd.h"
 #include "../util/Export.h"
-#include "../util/Serialize.h"
 #include "../util/Pending.h"
 
 
@@ -308,19 +306,9 @@ private:
 
     static SpeciesManager* s_instance;
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, SpeciesManager&, unsigned int const);
 };
-
-extern template
-FO_COMMON_API void SpeciesManager::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-extern template
-FO_COMMON_API void SpeciesManager::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-extern template
-FO_COMMON_API void SpeciesManager::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-extern template
-FO_COMMON_API void SpeciesManager::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
 
 /** returns the singleton species manager */
 FO_COMMON_API SpeciesManager& GetSpeciesManager();

--- a/util/SaveGamePreviewUtils.cpp
+++ b/util/SaveGamePreviewUtils.cpp
@@ -8,7 +8,6 @@
 #include "Serialize.h"
 #include "Serialize.ipp"
 #include "ScopedTimer.h"
-#include "Version.h"
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -124,40 +123,6 @@ bool SaveGamePreviewData::Valid() const
 
 void SaveGamePreviewData::SetBinary(bool bin)
 { description = bin ? BIN_SAVE_FILE_DESCRIPTION : XML_SAVE_FILE_DESCRIPTION; }
-
-template <typename Archive>
-void SaveGamePreviewData::serialize(Archive& ar, unsigned int version)
-{
-    if (version >= 2) {
-        if (Archive::is_saving::value) {
-            freeorion_version = FreeOrionVersionString();
-        }
-        ar & BOOST_SERIALIZATION_NVP(description)
-           & BOOST_SERIALIZATION_NVP(freeorion_version);
-        if (version >= 3) {
-            ar & BOOST_SERIALIZATION_NVP(save_format_marker);
-            if (version >= 4) {
-                ar & BOOST_SERIALIZATION_NVP(uncompressed_text_size)
-                   & BOOST_SERIALIZATION_NVP(compressed_text_size);
-            }
-        }
-    }
-    ar & BOOST_SERIALIZATION_NVP(magic_number)
-       & BOOST_SERIALIZATION_NVP(main_player_name);
-    ar & BOOST_SERIALIZATION_NVP(main_player_empire_name)
-       & BOOST_SERIALIZATION_NVP(main_player_empire_colour)
-       & BOOST_SERIALIZATION_NVP(save_time)
-       & BOOST_SERIALIZATION_NVP(current_turn);
-    if (version > 0) {
-        ar & BOOST_SERIALIZATION_NVP(number_of_empires)
-           & BOOST_SERIALIZATION_NVP(number_of_human_players);
-    }
-}
-
-template void SaveGamePreviewData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, unsigned int);
-template void SaveGamePreviewData::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, unsigned int);
-template void SaveGamePreviewData::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, unsigned int);
-template void SaveGamePreviewData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, unsigned int);
 
 
 bool SaveFileWithValidHeader(const boost::filesystem::path& path) {

--- a/util/SaveGamePreviewUtils.cpp
+++ b/util/SaveGamePreviewUtils.cpp
@@ -174,20 +174,6 @@ template void FullPreview::serialize<freeorion_xml_oarchive>(freeorion_xml_oarch
 template void FullPreview::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, unsigned int);
 
 
-template<typename Archive>
-void PreviewInformation::serialize(Archive& ar, const unsigned int version)
-{
-    ar & BOOST_SERIALIZATION_NVP(subdirectories)
-       & BOOST_SERIALIZATION_NVP(folder)
-       & BOOST_SERIALIZATION_NVP(previews);
-}
-
-template void PreviewInformation::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
-template void PreviewInformation::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);
-template void PreviewInformation::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
-template void PreviewInformation::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
-
-
 bool SaveFileWithValidHeader(const boost::filesystem::path& path) {
     if (!fs::exists(path))
         return false;

--- a/util/SaveGamePreviewUtils.cpp
+++ b/util/SaveGamePreviewUtils.cpp
@@ -160,20 +160,6 @@ template void SaveGamePreviewData::serialize<freeorion_xml_oarchive>(freeorion_x
 template void SaveGamePreviewData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, unsigned int);
 
 
-template <typename Archive>
-void FullPreview::serialize(Archive& ar, unsigned int version)
-{
-    ar & BOOST_SERIALIZATION_NVP(filename)
-       & BOOST_SERIALIZATION_NVP(preview)
-       & BOOST_SERIALIZATION_NVP(galaxy);
-}
-
-template void FullPreview::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, unsigned int);
-template void FullPreview::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, unsigned int);
-template void FullPreview::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, unsigned int);
-template void FullPreview::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, unsigned int);
-
-
 bool SaveFileWithValidHeader(const boost::filesystem::path& path) {
     if (!fs::exists(path))
         return false;

--- a/util/SaveGamePreviewUtils.h
+++ b/util/SaveGamePreviewUtils.h
@@ -58,10 +58,6 @@ struct FO_COMMON_API FullPreview {
     std::string         filename;
     SaveGamePreviewData preview;
     GalaxySetupData     galaxy;
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** The preview information the server sends to the client. */

--- a/util/SaveGamePreviewUtils.h
+++ b/util/SaveGamePreviewUtils.h
@@ -7,14 +7,10 @@
 
 #include <vector>
 #include <string>
-
-#include <boost/serialization/version.hpp>
-
 #include <GG/Clr.h>
-
-#include "MultiplayerCommon.h"
 #include "Export.h"
-#include "Serialize.h"
+#include "MultiplayerCommon.h"
+
 
 /** Contains preview information about a savegame.
   * Stored the beginning of a savefile for quick access. */
@@ -41,17 +37,7 @@ struct FO_COMMON_API SaveGamePreviewData {
     std::string         save_format_marker = "";        /// What format was used for this save?
     unsigned int        uncompressed_text_size = 0;     /// How many bytes capacity does the uncompressed save text take up? (ie. the part that was / will be compressed with zlib for compressed xml format saves)
     unsigned int        compressed_text_size = 0;       /// How many bytes capacity does the compressed save text take up?
-
-    template <typename Archive>
-    void serialize(Archive& ar, unsigned int version);
 };
-
-BOOST_CLASS_VERSION(SaveGamePreviewData, 4);
-
-extern template FO_COMMON_API void SaveGamePreviewData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, unsigned int);
-extern template FO_COMMON_API void SaveGamePreviewData::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, unsigned int);
-extern template FO_COMMON_API void SaveGamePreviewData::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, unsigned int);
-extern template FO_COMMON_API void SaveGamePreviewData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, unsigned int);
 
 /** Stores all aggregated information about a save file */
 struct FO_COMMON_API FullPreview {

--- a/util/SaveGamePreviewUtils.h
+++ b/util/SaveGamePreviewUtils.h
@@ -69,10 +69,6 @@ struct FO_COMMON_API PreviewInformation {
     std::vector<std::string>    subdirectories; /// A list of all subfolders of the save game directory, in the format /name1/child1/grandchild
     std::string                 folder;         /// The directory whose previews are being listed now
     std::vector<FullPreview>    previews;       /// The previews of the saves in this folder
-private:
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /// Attempts to load headers of a save file.

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -168,6 +168,19 @@ extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_x
 extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PlayerSaveHeaderData&, unsigned int const);
 
 
+struct SaveGamePreviewData;
+
+template<typename Archive>
+void serialize(Archive&, SaveGamePreviewData&, unsigned int const);
+
+BOOST_CLASS_VERSION(SaveGamePreviewData, 4);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, SaveGamePreviewData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, SaveGamePreviewData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, SaveGamePreviewData&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, SaveGamePreviewData&, unsigned int const);
+
+
 struct PlayerSetupData;
 
 BOOST_CLASS_VERSION(PlayerSetupData, 2);

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -181,6 +181,17 @@ extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_x
 extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PlayerSetupData&, unsigned int const);
 
 
+class PreviewInformation;
+
+template<typename Archive>
+void serialize(Archive&, PreviewInformation&, unsigned int const);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, PreviewInformation&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, PreviewInformation&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, PreviewInformation&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PreviewInformation&, unsigned int const);
+
+
 struct SaveGameEmpireData;
 
 BOOST_CLASS_VERSION(SaveGameEmpireData, 2);

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -229,4 +229,15 @@ extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_b
 extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, SinglePlayerSetupData&, unsigned int const);
 
 
+class SpeciesManager;
+
+template <typename Archive>
+void serialize(Archive&, SpeciesManager&, unsigned int const);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, SpeciesManager&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, SpeciesManager&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, SpeciesManager&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, SpeciesManager&, unsigned int const);
+
+
 #endif // _Serialize_h_

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -96,6 +96,17 @@ extern template FO_COMMON_API void serializeIncompleteLogs<freeorion_xml_iarchiv
 extern template FO_COMMON_API void serializeIncompleteLogs<freeorion_xml_oarchive>(freeorion_xml_oarchive&, CombatLogManager&, const unsigned int);
 
 
+class EmpireManager;
+
+template <typename Archive>
+void serialize(Archive&, EmpireManager&, unsigned int const);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, EmpireManager&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, EmpireManager&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, EmpireManager&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, EmpireManager&, unsigned int const);
+
+
 struct GalaxySetupData;
 
 BOOST_CLASS_VERSION(GalaxySetupData, 3);

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -293,51 +293,54 @@ template void Empire::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&,
 template void Empire::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
 template void Empire::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
+
 namespace {
     std::pair<int, int> DiploKey(int id1, int ind2)
     { return std::make_pair(std::max(id1, ind2), std::min(id1, ind2)); }
 }
 
 template <typename Archive>
-void EmpireManager::serialize(Archive& ar, const unsigned int version)
+void serialize(Archive& ar, EmpireManager& em, unsigned int const version)
 {
+    using namespace boost::serialization;
+
     if (Archive::is_loading::value) {
-        Clear();    // clean up any existing dynamically allocated contents before replacing containers with deserialized data
+        em.Clear();    // clean up any existing dynamically allocated contents before replacing containers with deserialized data
     }
 
     std::map<std::pair<int, int>, DiplomaticMessage> messages;
     if (Archive::is_saving::value)
-        GetDiplomaticMessagesToSerialize(messages, GetUniverse().EncodingEmpire());
+        em.GetDiplomaticMessagesToSerialize(messages, GetUniverse().EncodingEmpire());
 
-    ar  & BOOST_SERIALIZATION_NVP(m_empire_map)
-        & BOOST_SERIALIZATION_NVP(m_empire_diplomatic_statuses)
+    ar  & make_nvp("m_empire_map", em.m_empire_map)
+        & make_nvp("m_empire_diplomatic_statuses", em.m_empire_diplomatic_statuses)
         & BOOST_SERIALIZATION_NVP(messages);
 
     if (Archive::is_loading::value) {
-        m_diplomatic_messages = std::move(messages);
+        em.m_diplomatic_messages = std::move(messages);
 
         // erase invalid empire diplomatic statuses
         std::vector<std::pair<int, int>> to_erase;
-        for (auto r : m_empire_diplomatic_statuses) {
+        for (auto r : em.m_empire_diplomatic_statuses) {
             auto e1 = r.first.first;
             auto e2 = r.first.second;
-            if (m_empire_map.count(e1) < 1 || m_empire_map.count(e2) < 1) {
+            if (em.m_empire_map.count(e1) < 1 || em.m_empire_map.count(e2) < 1) {
                 to_erase.push_back({e1, e2});
                 ErrorLogger() << "Erased invalid diplomatic status between empires " << e1 << " and " << e2;
             }
         }
         for (auto p : to_erase)
-            m_empire_diplomatic_statuses.erase(p);
+            em.m_empire_diplomatic_statuses.erase(p);
 
         // add missing empire diplomatic statuses
-        for (auto e1 : m_empire_map) {
-            for (auto e2 : m_empire_map) {
+        for (auto e1 : em.m_empire_map) {
+            for (auto e2 : em.m_empire_map) {
                 if (e1.first >= e2.first)
                     continue;
                 auto dk = DiploKey(e1.first, e2.first);
-                if (m_empire_diplomatic_statuses.count(dk) < 1)
+                if (em.m_empire_diplomatic_statuses.count(dk) < 1)
                 {
-                    m_empire_diplomatic_statuses[dk] = DIPLO_WAR;
+                    em.m_empire_diplomatic_statuses[dk] = DIPLO_WAR;
                     ErrorLogger() << "Added missing diplomatic status (default WAR) between empires " << e1.first << " and " << e2.first;
                 }
             }
@@ -345,10 +348,11 @@ void EmpireManager::serialize(Archive& ar, const unsigned int version)
     }
 }
 
-template void EmpireManager::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
-template void EmpireManager::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);
-template void EmpireManager::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
-template void EmpireManager::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, EmpireManager&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, EmpireManager&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, EmpireManager&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, EmpireManager&, unsigned int const);
+
 
 template <typename Archive>
 void DiplomaticMessage::serialize(Archive& ar, const unsigned int version)

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -4,6 +4,7 @@
 #include "OptionsDB.h"
 #include "OrderSet.h"
 #include "Order.h"
+#include "SaveGamePreviewUtils.h"
 #include "../universe/System.h"
 
 #include "Serialize.ipp"
@@ -226,6 +227,22 @@ template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, PlayerS
 template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, PlayerSaveGameData&, unsigned int const);
 template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, PlayerSaveGameData&, unsigned int const);
 template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PlayerSaveGameData&, unsigned int const);
+
+
+template<typename Archive>
+void serialize(Archive& ar, PreviewInformation& pi, unsigned int const version)
+{
+    using namespace boost::serialization;
+
+    ar & make_nvp("subdirectories", pi.subdirectories)
+       & make_nvp("folder", pi.folder)
+       & make_nvp("previews", pi.previews);
+}
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, PreviewInformation&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, PreviewInformation&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, PreviewInformation&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PreviewInformation&, unsigned int const);
 
 
 template <typename Archive>

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -15,6 +15,22 @@
 
 
 template <typename Archive>
+void serialize(Archive& ar, FullPreview& fp, unsigned int const version)
+{
+    using namespace boost::serialization;
+
+    ar & make_nvp("filename", fp.filename)
+       & make_nvp("preview", fp.preview)
+       & make_nvp("galaxy", fp.galaxy);
+}
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, FullPreview&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, FullPreview&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, FullPreview&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, FullPreview&, unsigned int const);
+
+
+template <typename Archive>
 void serialize(Archive& ar, GalaxySetupData& obj, unsigned int const version)
 {
     using namespace boost::serialization;

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -5,6 +5,7 @@
 #include "OrderSet.h"
 #include "Order.h"
 #include "SaveGamePreviewUtils.h"
+#include "Version.h"
 #include "../universe/System.h"
 
 #include "Serialize.ipp"
@@ -86,6 +87,43 @@ template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, SingleP
 template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, SinglePlayerSetupData&, unsigned int const);
 template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, SinglePlayerSetupData&, unsigned int const);
 template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, SinglePlayerSetupData&, unsigned int const);
+
+
+template <typename Archive>
+void serialize(Archive& ar, SaveGamePreviewData& obj, unsigned int const version)
+{
+    using namespace boost::serialization;
+
+    if (version >= 2) {
+        if (Archive::is_saving::value) {
+            obj.freeorion_version = FreeOrionVersionString();
+        }
+        ar & make_nvp("description", obj.description)
+           & make_nvp("freeorion_version", obj.freeorion_version);
+        if (version >= 3) {
+            ar & make_nvp("save_format_marker", obj.save_format_marker);
+            if (version >= 4) {
+                ar & make_nvp("uncompressed_text_size", obj.uncompressed_text_size)
+                   & make_nvp("compressed_text_size", obj.compressed_text_size);
+            }
+        }
+    }
+    ar & make_nvp("magic_number", obj.magic_number)
+       & make_nvp("main_player_name", obj.main_player_name);
+    ar & make_nvp("main_player_empire_name", obj.main_player_empire_name)
+       & make_nvp("main_player_empire_colour", obj.main_player_empire_colour)
+       & make_nvp("save_time", obj.save_time)
+       & make_nvp("current_turn", obj.current_turn);
+    if (version > 0) {
+        ar & make_nvp("number_of_empires", obj.number_of_empires)
+           & make_nvp("number_of_human_players", obj.number_of_human_players);
+    }
+}
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, SaveGamePreviewData&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, SaveGamePreviewData&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, SaveGamePreviewData&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, SaveGamePreviewData&, unsigned int const);
 
 
 template <typename Archive>

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -375,17 +375,8 @@ void ShipDesign::serialize(Archive& ar, const unsigned int version)
     }
 }
 
-template
-void SpeciesManager::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-template
-void SpeciesManager::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-template
-void SpeciesManager::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-template
-void SpeciesManager::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
-
 template <typename Archive>
-void SpeciesManager::serialize(Archive& ar, const unsigned int version)
+void serialize(Archive& ar, SpeciesManager& sm, unsigned int const version)
 {
     // Don't need to send all the data about species, as this is derived from
     // content data files in scripting/species that should be available to any
@@ -400,11 +391,11 @@ void SpeciesManager::serialize(Archive& ar, const unsigned int version)
     std::map<std::string, std::map<std::string, int>>   species_ships_destroyed;
 
     if (Archive::is_saving::value) {
-        species_homeworlds =        GetSpeciesHomeworldsMap(GetUniverse().EncodingEmpire());
-        empire_opinions =           GetSpeciesEmpireOpinionsMap(GetUniverse().EncodingEmpire());
-        other_species_opinions =    GetSpeciesSpeciesOpinionsMap(GetUniverse().EncodingEmpire());
-        species_object_populations =SpeciesObjectPopulations(GetUniverse().EncodingEmpire());
-        species_ships_destroyed =   SpeciesShipsDestroyed(GetUniverse().EncodingEmpire());
+        species_homeworlds = sm.GetSpeciesHomeworldsMap(GetUniverse().EncodingEmpire());
+        empire_opinions = sm.GetSpeciesEmpireOpinionsMap(GetUniverse().EncodingEmpire());
+        other_species_opinions = sm.GetSpeciesSpeciesOpinionsMap(GetUniverse().EncodingEmpire());
+        species_object_populations = sm.SpeciesObjectPopulations(GetUniverse().EncodingEmpire());
+        species_ships_destroyed = sm.SpeciesShipsDestroyed(GetUniverse().EncodingEmpire());
     }
 
     ar  & BOOST_SERIALIZATION_NVP(species_homeworlds)
@@ -414,13 +405,18 @@ void SpeciesManager::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(species_ships_destroyed);
 
     if (Archive::is_loading::value) {
-        SetSpeciesHomeworlds(species_homeworlds);
-        SetSpeciesEmpireOpinions(empire_opinions);
-        SetSpeciesSpeciesOpinions(other_species_opinions);
-        m_species_object_populations = std::move(species_object_populations);
-        m_species_species_ships_destroyed = std::move(species_ships_destroyed);
+        sm.SetSpeciesHomeworlds(species_homeworlds);
+        sm.SetSpeciesEmpireOpinions(empire_opinions);
+        sm.SetSpeciesSpeciesOpinions(other_species_opinions);
+        sm.m_species_object_populations = std::move(species_object_populations);
+        sm.m_species_species_ships_destroyed = std::move(species_ships_destroyed);
     }
 }
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, SpeciesManager&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, SpeciesManager&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, SpeciesManager&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, SpeciesManager&, unsigned int const);
 
 // explicit template initialization of System::serialize needed to avoid bug with GCC 4.5.2.
 template


### PR DESCRIPTION
This PR uses the nonintrusive interface of `boost::serialization` on the following classes and structs to reduce the visibility scope of the `boost/archive/*_archive.hpp` headers:

* EmpireManager
* SpeciesManager
* PreviewInformation
* FullPreview
* SaveGamePreviewData