### PR TITLE
Nonintrusive serialization remove unused serialization features

### DIFF
--- a/universe/ShipHull.h
+++ b/universe/ShipHull.h
@@ -2,8 +2,6 @@
 #define _ShipHull_h_
 
 
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/nvp.hpp>
 #include "CommonParams.h"
 #include "../util/Pending.h"
 
@@ -173,35 +171,7 @@ private:
     std::vector<std::shared_ptr<Effect::EffectsGroup>>  m_effects;
     std::string                                         m_graphic;
     std::string                                         m_icon;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
-
-
-template <typename Archive>
-void ShipHull::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_description)
-        & BOOST_SERIALIZATION_NVP(m_speed)
-        & BOOST_SERIALIZATION_NVP(m_fuel)
-        & BOOST_SERIALIZATION_NVP(m_stealth)
-        & BOOST_SERIALIZATION_NVP(m_structure)
-        & BOOST_SERIALIZATION_NVP(m_production_cost)
-        & BOOST_SERIALIZATION_NVP(m_production_time)
-        & BOOST_SERIALIZATION_NVP(m_producible)
-        & BOOST_SERIALIZATION_NVP(m_slots)
-        & BOOST_SERIALIZATION_NVP(m_tags)
-        & BOOST_SERIALIZATION_NVP(m_production_meter_consumption)
-        & BOOST_SERIALIZATION_NVP(m_production_special_consumption)
-        & BOOST_SERIALIZATION_NVP(m_location)
-        & BOOST_SERIALIZATION_NVP(m_exclusions)
-        & BOOST_SERIALIZATION_NVP(m_effects)
-        & BOOST_SERIALIZATION_NVP(m_graphic)
-        & BOOST_SERIALIZATION_NVP(m_icon);
-}
 
 
 namespace CheckSums {

--- a/universe/ShipPart.h
+++ b/universe/ShipPart.h
@@ -2,7 +2,6 @@
 #define _ShipPart_h_
 
 
-#include <boost/serialization/nvp.hpp>
 #include <GG/Enum.h>
 #include "CommonParams.h"
 #include "../util/Pending.h"
@@ -154,35 +153,7 @@ private:
     std::string                                         m_icon;
     bool                                                m_add_standard_capacity_effect = false;
     std::unique_ptr<Condition::Condition>               m_combat_targets;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
-
-
-template <typename Archive>
-void ShipPart::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_description)
-        & BOOST_SERIALIZATION_NVP(m_class)
-        & BOOST_SERIALIZATION_NVP(m_capacity)
-        & BOOST_SERIALIZATION_NVP(m_secondary_stat)
-        & BOOST_SERIALIZATION_NVP(m_production_cost)
-        & BOOST_SERIALIZATION_NVP(m_production_time)
-        & BOOST_SERIALIZATION_NVP(m_producible)
-        & BOOST_SERIALIZATION_NVP(m_mountable_slot_types)
-        & BOOST_SERIALIZATION_NVP(m_tags)
-        & BOOST_SERIALIZATION_NVP(m_production_meter_consumption)
-        & BOOST_SERIALIZATION_NVP(m_production_special_consumption)
-        & BOOST_SERIALIZATION_NVP(m_location)
-        & BOOST_SERIALIZATION_NVP(m_exclusions)
-        & BOOST_SERIALIZATION_NVP(m_effects)
-        & BOOST_SERIALIZATION_NVP(m_icon)
-        & BOOST_SERIALIZATION_NVP(m_add_standard_capacity_effect)
-        & BOOST_SERIALIZATION_NVP(m_combat_targets);
-}
 
 
 //! Holds FreeOrion available ShipParts

--- a/universe/Special.h
+++ b/universe/Special.h
@@ -6,7 +6,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-#include <boost/serialization/nvp.hpp>
 #include <boost/optional/optional.hpp>
 #include "../util/Export.h"
 #include "../util/Pending.h"
@@ -81,10 +80,6 @@ private:
     std::unique_ptr<ValueRef::ValueRef<double>>         m_initial_capacity;
     std::unique_ptr<Condition::Condition>               m_location;
     std::string                                         m_graphic;
-
-    friend class boost::serialization::access;
-    template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Returns the Special object used to represent specials of type \a name.
@@ -94,20 +89,6 @@ FO_COMMON_API const Special* GetSpecial(const std::string& name);
 /** Returns names of all specials. */
 FO_COMMON_API std::vector<std::string> SpecialNames();
 
-// template implementations
-template <typename Archive>
-void Special::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_description)
-        & BOOST_SERIALIZATION_NVP(m_stealth)
-        & BOOST_SERIALIZATION_NVP(m_effects)
-        & BOOST_SERIALIZATION_NVP(m_spawn_rate)
-        & BOOST_SERIALIZATION_NVP(m_spawn_limit)
-        & BOOST_SERIALIZATION_NVP(m_initial_capacity)
-        & BOOST_SERIALIZATION_NVP(m_location)
-        & BOOST_SERIALIZATION_NVP(m_graphic);
-}
 
 /** Look up table for specials.*/
 class FO_COMMON_API SpecialsManager {


### PR DESCRIPTION
This PR removes dead code for the serialization of the following classes:

* Special
* ShipHull
* ShipPart