### PR TITLE
Move outpost troop effect into tech/construction/OUTPOST.focs.txt

### DIFF
--- a/default/scripting/species/common/troops.macros
+++ b/default/scripting/species/common/troops.macros
@@ -65,16 +65,7 @@ BASIC_DEFENSE_TROOPS
 '''
 
 AFTER_SPECIES_MULTIPLICATOR_TROOPS
-'''        EffectsGroup
-            scope = And [
-                Planet
-                OwnedBy empire = Source.Owner
-                Population high = 0
-            ]
-            stackinggroup = "OUTPOST_TROOPS_STACK"
-            priority = [[VERY_LATE_PRIORITY]]
-            effects = SetMaxTroops value = Value * .5
-            accountinglabel = "OUTPOST_TROOP_LABEL"
+'''        // VERY_LATE_PRIORITY halving troops on outposts can be found in techs/construction/OUTPOST.focs.txt
 
 [[PROTECTION_FOCUS_TROOPS]]
 '''

--- a/default/scripting/techs/construction/OUTPOST.focs.txt
+++ b/default/scripting/techs/construction/OUTPOST.focs.txt
@@ -9,8 +9,21 @@ Tech
 
     // Effects for outposts
     effectsgroups = [
+        // Outposts only have 50% of troops
+        EffectsGroup
+            scope = And [
+                Planet
+                OwnedBy empire = Source.Owner
+                Population high = 0
+            ]
+            stackinggroup = "OUTPOST_TROOPS_STACK"
+            priority = [[VERY_LATE_PRIORITY]]
+            effects = SetMaxTroops value = Value * .5
+            accountinglabel = "OUTPOST_TROOP_LABEL"
+
+        // Ensure construction minimum value of one, as this is necessary for being attacked
         // For colonies see STANDARD_CONSTRUCTION in default/scripting/species/common/general.macros
-        EffectsGroup    // always ensure minimum value of one, as this is necessary for being attacked
+        EffectsGroup
             scope = And [
                 Planet
                 OwnedBy empire = Source.Owner
@@ -22,6 +35,7 @@ Tech
                 SetTargetConstruction value = max(Value, 1)
                 SetConstruction value = max(Value, 1)
             ]
+
     ]
 
 #include "/scripting/common/priorities.macros"


### PR DESCRIPTION
Fix for #3059 - move outpost troop effect into outpost tech.

Untested. Should be cherry-picked for 0.4.10 (?)