### PR TITLE
Production Queue Safety

### DIFF
--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -671,21 +671,6 @@ namespace {
             }
         }
 
-        // scans this ListBox for the input iterator \a and returns its distance
-        // from begin(), or -1 if not present
-        int IteraterIndex(const ProdQueueListBox::const_iterator it) {
-            if (it == this->end())
-                return -1;
-
-            size_t dist = 0;
-            for (auto qit = this->begin(); qit != this->end(); ++qit) {
-                if (qit == it)
-                    return dist;
-                dist++;
-            }
-            return -1;
-        }
-
         boost::signals2::signal<void (GG::ListBox::iterator, int)>  QueueItemRalliedToSignal;
         boost::signals2::signal<void ()>                            ShowPediaSignal;
         boost::signals2::signal<void (GG::ListBox::iterator, bool)> QueueItemPausedSignal;

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -666,7 +666,7 @@ namespace {
             QueueListBox::EnableOrderIssuing(enable);
 
             for (auto it = this->begin(); it != this->end(); ++it) {
-                if (auto& queue_row = std::dynamic_pointer_cast<QueueRow>(*it))
+                if (auto queue_row = std::dynamic_pointer_cast<QueueRow>(*it))
                     queue_row->Disable(!enable);
             }
         }

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -154,6 +154,19 @@ void QueueListBox::DragDropLeave() {
     m_show_drop_point = false;
 }
 
+int QueueListBox::IteraterIndex(const const_iterator it) {
+    if (it == this->end())
+        return -1;
+
+    size_t dist = 0;
+    for (auto qit = this->begin(); qit != this->end(); ++qit) {
+        if (qit == it)
+            return dist;
+        dist++;
+    }
+    return -1;
+}
+
 void QueueListBox::EnableOrderIssuing(bool enable/* = true*/) {
     m_order_issuing_enabled = enable;
     AllowDrops(enable);

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -194,27 +194,36 @@ void QueueListBox::SetEmptyPromptText(const std::string prompt) {
 
 std::function<void()> QueueListBox::MoveToTopAction(GG::ListBox::iterator it) {
     return [it, this]() {
-        ListBox::Insert(*it, begin(), true);
+        if (OrderIssuingEnabled())
+            ListBox::Insert(*it, begin(), true);
     };
 }
 
 std::function<void()> QueueListBox::MoveToBottomAction(GG::ListBox::iterator it) {
     return [it, this]() {
-        ListBox::Insert(*it, end(), true);
+        if (OrderIssuingEnabled())
+            ListBox::Insert(*it, end(), true);
     };
 }
 
-std::function<void()> QueueListBox::DeleteAction(GG::ListBox::iterator it) const
-{ return [it, this]() { QueueItemDeletedSignal(it); }; }
+std::function<void()> QueueListBox::DeleteAction(GG::ListBox::iterator it) const {
+    return [it, this]() {
+        if (OrderIssuingEnabled())
+            QueueItemDeletedSignal(it);
+    };
+}
 
 void QueueListBox::ItemRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys)
 { this->ItemRightClickedImpl(it, pt, modkeys); }
 
 void QueueListBox::ItemRightClickedImpl(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys) {
     auto popup = GG::Wnd::Create<CUIPopupMenu>(pt.x, pt.y);
-    popup->AddMenuItem(GG::MenuItem(UserString("MOVE_UP_QUEUE_ITEM"),   false, false, MoveToTopAction(it)));
-    popup->AddMenuItem(GG::MenuItem(UserString("MOVE_DOWN_QUEUE_ITEM"), false, false, MoveToBottomAction(it)));
-    popup->AddMenuItem(GG::MenuItem(UserString("DELETE_QUEUE_ITEM"),    false, false, DeleteAction(it)));
+
+    bool disabled = !OrderIssuingEnabled();
+
+    popup->AddMenuItem(GG::MenuItem(UserString("MOVE_UP_QUEUE_ITEM"),   disabled, false, MoveToTopAction(it)));
+    popup->AddMenuItem(GG::MenuItem(UserString("MOVE_DOWN_QUEUE_ITEM"), disabled, false, MoveToBottomAction(it)));
+    popup->AddMenuItem(GG::MenuItem(UserString("DELETE_QUEUE_ITEM"),    disabled, false, DeleteAction(it)));
     popup->Run();
 }
 

--- a/UI/QueueListBox.h
+++ b/UI/QueueListBox.h
@@ -34,6 +34,10 @@ public:
 
     GG::X           RowWidth() const;
 
+    //! scans this ListBox for the input iterator \a and returns its distance
+    //! from begin(), or -1 if not present
+    int             IteraterIndex(const const_iterator it);
+
     virtual void    EnableOrderIssuing(bool enable = true);
     bool            OrderIssuingEnabled() const { return m_order_issuing_enabled; }
     bool            DisplayingValidQueueItems(); ///< whether or not this QueueListBox is displaying valid queue items, as opposed to, for example, a prompt for the user to enter an item


### PR DESCRIPTION
Hopefully fixes hangs if the right-click popups of the production or research queues are open during a turn cycle.