### PR TITLE
Fix Sly refueling

### DIFF
--- a/default/scripting/species/SP_SLY.focs.txt
+++ b/default/scripting/species/SP_SLY.focs.txt
@@ -46,8 +46,7 @@ Species
                 Ship
                 Stationary
                 ContainedBy And [
-                    Object id = RootCandidate.SystemID
-                    System
+                    Object id = Source.SystemID
                     Contains condition = And [
                         Planet type = GasGiant
                         Not OwnedBy affiliation = EnemyOf empire = RootCandidate.Owner


### PR DESCRIPTION
Correct detection of systems containing gas giants for sly
refueling bonus.

Fixes #3086

Signed-off-by: Rob Gill <rrobgill@protonmail.com>