### PR TITLE
Remove unused ProductionQueue::Element constructors

### DIFF
--- a/Empire/ProductionQueue.cpp
+++ b/Empire/ProductionQueue.cpp
@@ -553,32 +553,14 @@ ProductionQueue::Element::Element(BuildType build_type, std::string name, int em
                                   boost::uuids::uuid uuid_, int ordered_,
                                   int remaining_, int blocksize_, int location_, bool paused_,
                                   bool allowed_imperial_stockpile_use_) :
-    item(build_type, name),
-    empire_id(empire_id_),
-    ordered(ordered_),
-    blocksize(blocksize_),
-    remaining(remaining_),
-    location(location_),
-    blocksize_memory(blocksize_),
-    paused(paused_),
-    allowed_imperial_stockpile_use(allowed_imperial_stockpile_use_),
-    uuid(uuid_)
+    Element(ProductionItem(build_type, name), empire_id_, uuid_, ordered_, remaining_, blocksize_, location_, paused_, allowed_imperial_stockpile_use_)
 {}
 
 ProductionQueue::Element::Element(BuildType build_type, int design_id, int empire_id_,
                                   boost::uuids::uuid uuid_, int ordered_,
                                   int remaining_, int blocksize_, int location_, bool paused_,
                                   bool allowed_imperial_stockpile_use_) :
-    item(build_type, design_id),
-    empire_id(empire_id_),
-    ordered(ordered_),
-    blocksize(blocksize_),
-    remaining(remaining_),
-    location(location_),
-    blocksize_memory(blocksize_),
-    paused(paused_),
-    allowed_imperial_stockpile_use(allowed_imperial_stockpile_use_),
-    uuid(uuid_)
+    Element(ProductionItem(build_type, design_id), empire_id_, uuid_, ordered_, remaining_, blocksize_, location_, paused_, allowed_imperial_stockpile_use_)
 {}
 
 std::string ProductionQueue::Element::Dump() const {

--- a/Empire/ProductionQueue.cpp
+++ b/Empire/ProductionQueue.cpp
@@ -549,20 +549,6 @@ ProductionQueue::Element::Element(ProductionItem item_, int empire_id_,
     uuid(uuid_)
 {}
 
-ProductionQueue::Element::Element(BuildType build_type, std::string name, int empire_id_,
-                                  boost::uuids::uuid uuid_, int ordered_,
-                                  int remaining_, int blocksize_, int location_, bool paused_,
-                                  bool allowed_imperial_stockpile_use_) :
-    Element(ProductionItem(build_type, name), empire_id_, uuid_, ordered_, remaining_, blocksize_, location_, paused_, allowed_imperial_stockpile_use_)
-{}
-
-ProductionQueue::Element::Element(BuildType build_type, int design_id, int empire_id_,
-                                  boost::uuids::uuid uuid_, int ordered_,
-                                  int remaining_, int blocksize_, int location_, bool paused_,
-                                  bool allowed_imperial_stockpile_use_) :
-    Element(ProductionItem(build_type, design_id), empire_id_, uuid_, ordered_, remaining_, blocksize_, location_, paused_, allowed_imperial_stockpile_use_)
-{}
-
 std::string ProductionQueue::Element::Dump() const {
     std::string retval = "ProductionQueue::Element (" + item.Dump() + ") (" +
         std::to_string(blocksize) + ") x" + std::to_string(ordered) + " ";

--- a/Empire/ProductionQueue.h
+++ b/Empire/ProductionQueue.h
@@ -59,18 +59,6 @@ struct FO_COMMON_API ProductionQueue {
                 int location_, bool paused_ = false,
                 bool allowed_imperial_stockpile_use_ = true);
 
-        Element(BuildType build_type, std::string name, int empire_id_,
-                boost::uuids::uuid uuid_,
-                int ordered_, int remaining_, int blocksize_,
-                int location_, bool paused_ = false,
-                bool allowed_imperial_stockpile_use_ = true);
-
-        Element(BuildType build_type, int design_id, int empire_id_,
-                boost::uuids::uuid uuid_,
-                int ordered_, int remaining_, int blocksize_,
-                int location_, bool paused_ = false,
-                bool allowed_imperial_stockpile_use_ = true);
-
         ProductionItem      item;
         int                 empire_id = ALL_EMPIRES;
         int                 ordered = 0;                ///< how many of item (blocks) to produce


### PR DESCRIPTION
Two of the three `ProductionQueue::Element` constructor variants are never used and can therefor be removed.

This is general clean up and a side product from working on the non-intrusive boost::serialization interface conversion.