### PR TITLE
Use python namespace alias consistent

### DIFF
--- a/client/AI/AIFramework.cpp
+++ b/client/AI/AIFramework.cpp
@@ -25,31 +25,13 @@
 #include <boost/python/scope.hpp>
 #include <boost/filesystem.hpp>
 
-using boost::python::class_;
-using boost::python::def;
-using boost::python::return_value_policy;
-using boost::python::copy_const_reference;
-using boost::python::reference_existing_object;
-using boost::python::return_by_value;
-using boost::python::return_internal_reference;
-
-using boost::python::vector_indexing_suite;
-using boost::python::map_indexing_suite;
-
-using boost::python::object;
-using boost::python::import;
-using boost::python::error_already_set;
-using boost::python::exec;
-using boost::python::dict;
-using boost::python::list;
-using boost::python::extract;
-
 namespace fs = boost::filesystem;
+namespace py = boost::python;
 
 
 BOOST_PYTHON_MODULE(freeOrionAIInterface)
 {
-    boost::python::docstring_options doc_options(true, true, false);
+    py::docstring_options doc_options(true, true, false);
 
     ///////////////////
     //  Game client  //
@@ -80,15 +62,15 @@ BOOST_PYTHON_MODULE(freeOrionAIInterface)
     ////////////////////
     // STL Containers //
     ////////////////////
-    class_<std::vector<int>>("IntVec")
-        .def(vector_indexing_suite<std::vector<int>>())
+    py::class_<std::vector<int>>("IntVec")
+        .def(py::vector_indexing_suite<std::vector<int>>())
     ;
-    class_<std::vector<std::string>>("StringVec")
-        .def(vector_indexing_suite<std::vector<std::string>>())
+    py::class_<std::vector<std::string>>("StringVec")
+        .def(py::vector_indexing_suite<std::vector<std::string>>())
     ;
 
-    class_<std::map<int, bool>>("IntBoolMap")
-        .def(map_indexing_suite<std::map<int, bool>>())
+    py::class_<std::map<int, bool>>("IntBoolMap")
+        .def(py::map_indexing_suite<std::map<int, bool>>())
     ;
 
     FreeOrionPython::SetWrapper<int>::Wrap("IntSet");
@@ -128,7 +110,7 @@ bool PythonAI::InitModules() {
     AddToSysPath(ai_path);
 
     // import universe generator script file
-    m_python_module_ai = import("FreeOrionAI");
+    m_python_module_ai = py::import("FreeOrionAI");
 
     DebugLogger() << "AI Python modules successfully initialized!";
     return true;
@@ -141,10 +123,10 @@ void PythonAI::GenerateOrders() {
     try {
         // call Python function that generates orders for current turn
         //DebugLogger() << "PythonAI::GenerateOrders : getting generate orders object";
-        object generateOrdersPythonFunction = m_python_module_ai.attr("generateOrders");
+        py::object generateOrdersPythonFunction = m_python_module_ai.attr("generateOrders");
         //DebugLogger() << "PythonAI::GenerateOrders : generating orders";
         generateOrdersPythonFunction();
-    } catch (const error_already_set& err) {
+    } catch (const py::error_already_set& err) {
         HandleErrorAlreadySet();
         if (!IsPythonRunning() || GetOptionsDB().Get<bool>("testing"))
             throw;
@@ -161,26 +143,26 @@ void PythonAI::GenerateOrders() {
 
 void PythonAI::HandleChatMessage(int sender_id, const std::string& msg) {
     // call Python function that responds or ignores a chat message
-    object handleChatMessagePythonFunction = m_python_module_ai.attr("handleChatMessage");
+    py::object handleChatMessagePythonFunction = m_python_module_ai.attr("handleChatMessage");
     handleChatMessagePythonFunction(sender_id, msg);
 }
 
 void PythonAI::HandleDiplomaticMessage(const DiplomaticMessage& msg) {
     // call Python function to inform of diplomatic message change
-    object handleDiplomaticMessagePythonFunction = m_python_module_ai.attr("handleDiplomaticMessage");
+    py::object handleDiplomaticMessagePythonFunction = m_python_module_ai.attr("handleDiplomaticMessage");
     handleDiplomaticMessagePythonFunction(msg);
 }
 
 void PythonAI::HandleDiplomaticStatusUpdate(const DiplomaticStatusUpdateInfo& u) {
     // call Python function to inform of diplomatic status update
-    object handleDiplomaticStatusUpdatePythonFunction = m_python_module_ai.attr("handleDiplomaticStatusUpdate");
+    py::object handleDiplomaticStatusUpdatePythonFunction = m_python_module_ai.attr("handleDiplomaticStatusUpdate");
     handleDiplomaticStatusUpdatePythonFunction(u);
 }
 
 void PythonAI::StartNewGame() {
     FreeOrionPython::ClearStaticSaveStateString();
     // call Python function that sets up the AI to be able to generate orders for a new game
-    object startNewGamePythonFunction = m_python_module_ai.attr("startNewGame");
+    py::object startNewGamePythonFunction = m_python_module_ai.attr("startNewGame");
     startNewGamePythonFunction(m_aggression);
 }
 
@@ -188,14 +170,14 @@ void PythonAI::ResumeLoadedGame(const std::string& save_state_string) {
     //DebugLogger() << "PythonAI::ResumeLoadedGame(" << save_state_string << ")";
     FreeOrionPython::SetStaticSaveStateString(save_state_string);
     // call Python function that deals with the new state string sent by the server
-    object resumeLoadedGamePythonFunction = m_python_module_ai.attr("resumeLoadedGame");
+    py::object resumeLoadedGamePythonFunction = m_python_module_ai.attr("resumeLoadedGame");
     resumeLoadedGamePythonFunction(FreeOrionPython::GetStaticSaveStateString());
 }
 
 const std::string& PythonAI::GetSaveStateString() const {
     // call Python function that serializes AI state for storage in save file and sets s_save_state_string
     // to contain that string
-    object prepareForSavePythonFunction = m_python_module_ai.attr("prepareForSave");
+    py::object prepareForSavePythonFunction = m_python_module_ai.attr("prepareForSave");
     prepareForSavePythonFunction();
     //DebugLogger() << "PythonAI::GetSaveStateString() returning: " << s_save_state_string;
     return FreeOrionPython::GetStaticSaveStateString();

--- a/client/AI/AIWrapper.cpp
+++ b/client/AI/AIWrapper.cpp
@@ -30,25 +30,7 @@
 #include <boost/python/scope.hpp>
 #include <boost/uuid/random_generator.hpp>
 
-using boost::python::class_;
-using boost::python::def;
-using boost::python::no_init;
-using boost::noncopyable;
-using boost::python::return_value_policy;
-using boost::python::copy_const_reference;
-using boost::python::reference_existing_object;
-using boost::python::return_by_value;
-using boost::python::return_internal_reference;
-
-using boost::python::vector_indexing_suite;
-using boost::python::map_indexing_suite;
-
-using boost::python::object;
-using boost::python::import;
-using boost::python::exec;
-using boost::python::dict;
-using boost::python::list;
-using boost::python::extract;
+namespace py = boost::python;
 
 
 ////////////////////////
@@ -253,8 +235,8 @@ namespace {
         empire->UpdateProductionQueue();
     }
 
-    boost::python::list GetUserStringList(const std::string& list_key) {
-        boost::python::list ret_list;
+    py::list GetUserStringList(const std::string& list_key) {
+        py::list ret_list;
         for (const std::string& string : UserStringList(list_key))
             ret_list.append(string);
         return ret_list;
@@ -578,7 +560,7 @@ namespace {
     }
 
     int IssueCreateShipDesignOrder(const std::string& name, const std::string& description,
-                                   const std::string& hull, const boost::python::list parts_list,
+                                   const std::string& hull, const py::list parts_list,
                                    const std::string& icon, const std::string& model,
                                    bool name_desc_in_stringtable)
     {
@@ -588,9 +570,9 @@ namespace {
         }
 
         std::vector<std::string> parts;
-        int const num_parts = boost::python::len(parts_list);
+        int const num_parts = py::len(parts_list);
         for (int i = 0; i < num_parts; i++)
-            parts.push_back(boost::python::extract<std::string>(parts_list[i]));
+            parts.push_back(py::extract<std::string>(parts_list[i]));
 
         int empire_id = AIClientApp::GetApp()->EmpireID();
         int current_turn = CurrentTurn();
@@ -677,84 +659,84 @@ namespace FreeOrionPython {
      */
     void WrapAI()
     {
-        def("playerName",               PlayerName,                     return_value_policy<copy_const_reference>(), "Returns the name (string) of this AI player.");
-        def("playerName",               PlayerNameByID,                 return_value_policy<copy_const_reference>(), "Returns the name (string) of the player with the indicated playerID (int).");
+        py::def("playerName",               PlayerName,                     py::return_value_policy<py::copy_const_reference>(), "Returns the name (string) of this AI player.");
+        py::def("playerName",               PlayerNameByID,                 py::return_value_policy<py::copy_const_reference>(), "Returns the name (string) of the player with the indicated playerID (int).");
 
-        def("playerID",                 PlayerID,                       "Returns the integer id of this AI player.");
-        def("empirePlayerID",           EmpirePlayerID,                 "Returns the player ID (int) of the player who is controlling the empire with the indicated empireID (int).");
-        def("allPlayerIDs",             AllPlayerIDs,                   return_value_policy<return_by_value>(), "Returns an object (intVec) that contains the player IDs of all players in the game.");
+        py::def("playerID",                 PlayerID,                       "Returns the integer id of this AI player.");
+        py::def("empirePlayerID",           EmpirePlayerID,                 "Returns the player ID (int) of the player who is controlling the empire with the indicated empireID (int).");
+        py::def("allPlayerIDs",             AllPlayerIDs,                   py::return_value_policy<py::return_by_value>(), "Returns an object (intVec) that contains the player IDs of all players in the game.");
 
-        def("playerIsAI",               PlayerIsAI,                     "Returns True (boolean) if the player with the indicated playerID (int) is controlled by an AI and false (boolean) otherwise.");
-        def("playerIsHost",             PlayerIsHost,                   "Returns True (boolean) if the player with the indicated playerID (int) is the host player for the game and false (boolean) otherwise.");
+        py::def("playerIsAI",               PlayerIsAI,                     "Returns True (boolean) if the player with the indicated playerID (int) is controlled by an AI and false (boolean) otherwise.");
+        py::def("playerIsHost",             PlayerIsHost,                   "Returns True (boolean) if the player with the indicated playerID (int) is the host player for the game and false (boolean) otherwise.");
 
-        def("empireID",                 EmpireID,                       "Returns the empire ID (int) of this AI player's empire.");
-        def("playerEmpireID",           PlayerEmpireID,                 "Returns the empire ID (int) of the player with the specified player ID (int).");
-        def("allEmpireIDs",             AllEmpireIDs,                   return_value_policy<return_by_value>(), "Returns an object (intVec) that contains the empire IDs of all empires in the game.");
+        py::def("empireID",                 EmpireID,                       "Returns the empire ID (int) of this AI player's empire.");
+        py::def("playerEmpireID",           PlayerEmpireID,                 "Returns the empire ID (int) of the player with the specified player ID (int).");
+        py::def("allEmpireIDs",             AllEmpireIDs,                   py::return_value_policy<py::return_by_value>(), "Returns an object (intVec) that contains the empire IDs of all empires in the game.");
 
-        def("getEmpire",                PlayerEmpire,                   return_value_policy<reference_existing_object>(), "Returns the empire object (Empire) of this AI player");
-        def("getEmpire",                GetEmpireByID,                  return_value_policy<reference_existing_object>(), "Returns the empire object (Empire) with the specified empire ID (int)");
+        py::def("getEmpire",                PlayerEmpire,                   py::return_value_policy<py::reference_existing_object>(), "Returns the empire object (Empire) of this AI player");
+        py::def("getEmpire",                GetEmpireByID,                  py::return_value_policy<py::reference_existing_object>(), "Returns the empire object (Empire) with the specified empire ID (int)");
 
-        def("getUniverse",              GetUniverse,       return_value_policy<reference_existing_object>(), "Returns the universe object (Universe)");
+        py::def("getUniverse",              GetUniverse,       py::return_value_policy<py::reference_existing_object>(), "Returns the universe object (Universe)");
 
-        def("currentTurn",              CurrentTurn,       "Returns the current game turn (int).");
+        py::def("currentTurn",              CurrentTurn,       "Returns the current game turn (int).");
 
-        def("getAIDir",                 GetAIDir,                       return_value_policy<return_by_value>());
+        py::def("getAIDir",                 GetAIDir,                       py::return_value_policy<py::return_by_value>());
 
-        def("initMeterEstimatesDiscrepancies",      InitMeterEstimatesAndDiscrepancies);
-        def("updateMeterEstimates",                 UpdateMeterEstimates);
-        def("updateResourcePools",                  UpdateResourcePools);
-        def("updateResearchQueue",                  UpdateResearchQueue);
-        def("updateProductionQueue",                UpdateProductionQueue);
+        py::def("initMeterEstimatesDiscrepancies",      InitMeterEstimatesAndDiscrepancies);
+        py::def("updateMeterEstimates",                 UpdateMeterEstimates);
+        py::def("updateResourcePools",                  UpdateResourcePools);
+        py::def("updateResearchQueue",                  UpdateResearchQueue);
+        py::def("updateProductionQueue",                UpdateProductionQueue);
 
-        def("issueFleetMoveOrder",                  IssueFleetMoveOrder, "Orders the fleet with indicated fleetID (int) to move to the system with the indicated destinationID (int). Returns 1 (int) on success or 0 (int) on failure due to not finding the indicated fleet or system.");
-        def("appendFleetMoveOrder",                 AppendFleetMoveOrder, "Orders the fleet with indicated fleetID (int) to append the system with the indicated destinationID (int) to its possibly already enqueued route. Returns 1 (int) on success or 0 (int) on failure due to not finding the indicated fleet or system.");
-        def("issueRenameOrder",                     IssueRenameOrder, "Orders the renaming of the object with indicated objectID (int) to the new indicated name (string). Returns 1 (int) on success or 0 (int) on failure due to this AI player not being able to rename the indicated object (which this player must fully own, and which must be a fleet, ship or planet).");
-        def("issueScrapOrder",                      IssueScrapOrder, "Orders the ship or building with the indicated objectID (int) to be scrapped. Returns 1 (int) on success or 0 (int) on failure due to not finding a ship or building with the indicated ID, or if the indicated ship or building is not owned by this AI client's empire.");
-        def("issueNewFleetOrder",                   IssueNewFleetOrder, "Orders a new fleet to be created with the indicated name (string) and containing the indicated shipIDs (IntVec). The ships must be located in the same system and must all be owned by this player. Returns the new fleets id (int) on success or 0 (int) on failure due to one of the noted conditions not being met.");
-        def("issueFleetTransferOrder",              IssueFleetTransferOrder, "Orders the ship with ID shipID (int) to be transferred to the fleet with ID newFleetID. Returns 1 (int) on success, or 0 (int) on failure due to not finding the fleet or ship, or the client's empire not owning either, or the two not being in the same system (or either not being in a system) or the ship already being in the fleet.");
-        def("issueColonizeOrder",                   IssueColonizeOrder, "Orders the ship with ID shipID (int) to colonize the planet with ID planetID (int). Returns 1 (int) on success or 0 (int) on failure due to not finding the indicated ship or planet, this client's player not owning the indicated ship, the planet already being colonized, or the planet and ship not being in the same system.");
-        def("issueInvadeOrder",                     IssueInvadeOrder);
-        def("issueBombardOrder",                    IssueBombardOrder);
-        def("issueAggressionOrder",                 IssueAggressionOrder);
-        def("issueGiveObjectToEmpireOrder",         IssueGiveObjectToEmpireOrder);
-        def("issueChangeFocusOrder",                IssueChangeFocusOrder, "Orders the planet with ID planetID (int) to use focus setting focus (string). Returns 1 (int) on success or 0 (int) on failure if the planet can't be found or isn't owned by this player, or if the specified focus is not valid on the planet.");
-        def("issueEnqueueTechOrder",                IssueEnqueueTechOrder, "Orders the tech with name techName (string) to be added to the tech queue at position (int) on the queue. Returns 1 (int) on success or 0 (int) on failure if the indicated tech can't be found. Will return 1 (int) but do nothing if the indicated tech can't be enqueued by this player's empire.");
-        def("issueDequeueTechOrder",                IssueDequeueTechOrder, "Orders the tech with name techName (string) to be removed from the queue. Returns 1 (int) on success or 0 (int) on failure if the indicated tech can't be found. Will return 1 (int) but do nothing if the indicated tech isn't on this player's empire's tech queue.");
-        def("issueAdoptPolicyOrder",                IssueAdoptPolicyOrder, "Orders the policy with name policyName (string) to be adopted by the empire in the category categoryName (string) and slot slot (int). Returns 1 (int) on success or 0 (int) on failure if the indicated policy can't be found. Will return 1 (int) but do nothing if the indicated policy can't be enqueued by this player's empire in the requested category and slot.");
-        def("issueDeadoptPolicyOrder",              IssueDeadoptPolicyOrder, "Orders the policy with name policyName (string) to be de-adopted by the empire. Returns 1 (int) on success or 0 (int) on failure if the indicated policy was not already adopted.");
-        def("issueEnqueueBuildingProductionOrder",  IssueEnqueueBuildingProductionOrder, "Orders the building with name (string) to be added to the production queue at the location of the planet with id locationID. Returns 1 (int) on success or 0 (int) on failure if there is no such building or it is not available to this player's empire, or if the building can't be produced at the specified location.");
-        def("issueEnqueueShipProductionOrder",      IssueEnqueueShipProductionOrder, "Orders the ship design with ID designID (int) to be added to the production queue at the location of the planet with id locationID (int). Returns 1 (int) on success or 0 (int) on failure there is no such ship design or it not available to this player's empire, or if the design can't be produced at the specified location.");
-        def("issueChangeProductionQuantityOrder",   IssueChangeProductionQuantityOrder);
-        def("issueRequeueProductionOrder",          IssueRequeueProductionOrder, "Orders the item on the production queue at index oldQueueIndex (int) to be moved to index newQueueIndex (int). Returns 1 (int) on success or 0 (int) on failure if the old and new queue indices are equal, if either queue index is less than 0 or greater than the largest indexed item on the queue.");
-        def("issueDequeueProductionOrder",          IssueDequeueProductionOrder, "Orders the item on the production queue at index queueIndex (int) to be removed form the production queue. Returns 1 (int) on success or 0 (int) on failure if the queue index is less than 0 or greater than the largest indexed item on the queue.");
-        def("issuePauseProductionOrder",            IssuePauseProductionOrder, "Orders the item on the production queue at index queueIndex (int) to be paused (or unpaused). Returns 1 (int) on success or 0 (int) on failure if the queue index is less than 0 or greater than the largest indexed item on the queue.");
-        def("issueAllowStockpileProductionOrder",   IssueAllowStockpileProductionOrder, "Orders the item on the production queue at index queueIndex (int) to be enabled (or disabled) to use the imperial stockpile. Returns 1 (int) on success or 0 (int) on failure if the queue index is less than 0 or greater than the largest indexed item on the queue.");
-        def("issueCreateShipDesignOrder",           IssueCreateShipDesignOrder, "Orders the creation of a new ship design with the name (string), description (string), hull (string), parts vector partsVec (StringVec), graphic (string) and model (string). model should be left as an empty string as of this writing. There is currently no easy way to find the id of the new design, though the client's empire should have the new design after this order is issued successfully. Returns 1 (int) on success or 0 (int) on failure if any of the name, description, hull or graphic are empty strings, if the design is invalid (due to not following number and type of slot requirements for the hull) or if creating the design fails for some reason.");
+        py::def("issueFleetMoveOrder",                  IssueFleetMoveOrder, "Orders the fleet with indicated fleetID (int) to move to the system with the indicated destinationID (int). Returns 1 (int) on success or 0 (int) on failure due to not finding the indicated fleet or system.");
+        py::def("appendFleetMoveOrder",                 AppendFleetMoveOrder, "Orders the fleet with indicated fleetID (int) to append the system with the indicated destinationID (int) to its possibly already enqueued route. Returns 1 (int) on success or 0 (int) on failure due to not finding the indicated fleet or system.");
+        py::def("issueRenameOrder",                     IssueRenameOrder, "Orders the renaming of the object with indicated objectID (int) to the new indicated name (string). Returns 1 (int) on success or 0 (int) on failure due to this AI player not being able to rename the indicated object (which this player must fully own, and which must be a fleet, ship or planet).");
+        py::def("issueScrapOrder",                      IssueScrapOrder, "Orders the ship or building with the indicated objectID (int) to be scrapped. Returns 1 (int) on success or 0 (int) on failure due to not finding a ship or building with the indicated ID, or if the indicated ship or building is not owned by this AI client's empire.");
+        py::def("issueNewFleetOrder",                   IssueNewFleetOrder, "Orders a new fleet to be created with the indicated name (string) and containing the indicated shipIDs (IntVec). The ships must be located in the same system and must all be owned by this player. Returns the new fleets id (int) on success or 0 (int) on failure due to one of the noted conditions not being met.");
+        py::def("issueFleetTransferOrder",              IssueFleetTransferOrder, "Orders the ship with ID shipID (int) to be transferred to the fleet with ID newFleetID. Returns 1 (int) on success, or 0 (int) on failure due to not finding the fleet or ship, or the client's empire not owning either, or the two not being in the same system (or either not being in a system) or the ship already being in the fleet.");
+        py::def("issueColonizeOrder",                   IssueColonizeOrder, "Orders the ship with ID shipID (int) to colonize the planet with ID planetID (int). Returns 1 (int) on success or 0 (int) on failure due to not finding the indicated ship or planet, this client's player not owning the indicated ship, the planet already being colonized, or the planet and ship not being in the same system.");
+        py::def("issueInvadeOrder",                     IssueInvadeOrder);
+        py::def("issueBombardOrder",                    IssueBombardOrder);
+        py::def("issueAggressionOrder",                 IssueAggressionOrder);
+        py::def("issueGiveObjectToEmpireOrder",         IssueGiveObjectToEmpireOrder);
+        py::def("issueChangeFocusOrder",                IssueChangeFocusOrder, "Orders the planet with ID planetID (int) to use focus setting focus (string). Returns 1 (int) on success or 0 (int) on failure if the planet can't be found or isn't owned by this player, or if the specified focus is not valid on the planet.");
+        py::def("issueEnqueueTechOrder",                IssueEnqueueTechOrder, "Orders the tech with name techName (string) to be added to the tech queue at position (int) on the queue. Returns 1 (int) on success or 0 (int) on failure if the indicated tech can't be found. Will return 1 (int) but do nothing if the indicated tech can't be enqueued by this player's empire.");
+        py::def("issueDequeueTechOrder",                IssueDequeueTechOrder, "Orders the tech with name techName (string) to be removed from the queue. Returns 1 (int) on success or 0 (int) on failure if the indicated tech can't be found. Will return 1 (int) but do nothing if the indicated tech isn't on this player's empire's tech queue.");
+        py::def("issueAdoptPolicyOrder",                IssueAdoptPolicyOrder, "Orders the policy with name policyName (string) to be adopted by the empire in the category categoryName (string) and slot slot (int). Returns 1 (int) on success or 0 (int) on failure if the indicated policy can't be found. Will return 1 (int) but do nothing if the indicated policy can't be enqueued by this player's empire in the requested category and slot.");
+        py::def("issueDeadoptPolicyOrder",              IssueDeadoptPolicyOrder, "Orders the policy with name policyName (string) to be de-adopted by the empire. Returns 1 (int) on success or 0 (int) on failure if the indicated policy was not already adopted.");
+        py::def("issueEnqueueBuildingProductionOrder",  IssueEnqueueBuildingProductionOrder, "Orders the building with name (string) to be added to the production queue at the location of the planet with id locationID. Returns 1 (int) on success or 0 (int) on failure if there is no such building or it is not available to this player's empire, or if the building can't be produced at the specified location.");
+        py::def("issueEnqueueShipProductionOrder",      IssueEnqueueShipProductionOrder, "Orders the ship design with ID designID (int) to be added to the production queue at the location of the planet with id locationID (int). Returns 1 (int) on success or 0 (int) on failure there is no such ship design or it not available to this player's empire, or if the design can't be produced at the specified location.");
+        py::def("issueChangeProductionQuantityOrder",   IssueChangeProductionQuantityOrder);
+        py::def("issueRequeueProductionOrder",          IssueRequeueProductionOrder, "Orders the item on the production queue at index oldQueueIndex (int) to be moved to index newQueueIndex (int). Returns 1 (int) on success or 0 (int) on failure if the old and new queue indices are equal, if either queue index is less than 0 or greater than the largest indexed item on the queue.");
+        py::def("issueDequeueProductionOrder",          IssueDequeueProductionOrder, "Orders the item on the production queue at index queueIndex (int) to be removed form the production queue. Returns 1 (int) on success or 0 (int) on failure if the queue index is less than 0 or greater than the largest indexed item on the queue.");
+        py::def("issuePauseProductionOrder",            IssuePauseProductionOrder, "Orders the item on the production queue at index queueIndex (int) to be paused (or unpaused). Returns 1 (int) on success or 0 (int) on failure if the queue index is less than 0 or greater than the largest indexed item on the queue.");
+        py::def("issueAllowStockpileProductionOrder",   IssueAllowStockpileProductionOrder, "Orders the item on the production queue at index queueIndex (int) to be enabled (or disabled) to use the imperial stockpile. Returns 1 (int) on success or 0 (int) on failure if the queue index is less than 0 or greater than the largest indexed item on the queue.");
+        py::def("issueCreateShipDesignOrder",           IssueCreateShipDesignOrder, "Orders the creation of a new ship design with the name (string), description (string), hull (string), parts vector partsVec (StringVec), graphic (string) and model (string). model should be left as an empty string as of this writing. There is currently no easy way to find the id of the new design, though the client's empire should have the new design after this order is issued successfully. Returns 1 (int) on success or 0 (int) on failure if any of the name, description, hull or graphic are empty strings, if the design is invalid (due to not following number and type of slot requirements for the hull) or if creating the design fails for some reason.");
 
-        class_<OrderSet, noncopyable>("OrderSet", no_init)
-            .def(map_indexing_suite<OrderSet>())
+        py::class_<OrderSet, boost::noncopyable>("OrderSet", py::no_init)
+            .def(py::map_indexing_suite<OrderSet>())
             .add_property("size",       &OrderSet::size)
         ;
 
-        class_<Order, boost::noncopyable>("Order", no_init)
+        py::class_<Order, boost::noncopyable>("Order", py::no_init)
             .add_property("empireID",   &Order::EmpireID)
             .add_property("executed",   &Order::Executed)
         ;
 
-        def("getOrders",                IssuedOrders,                   return_value_policy<reference_existing_object>(), "Returns the orders the client empire has issued (OrderSet).");
+        py::def("getOrders",                IssuedOrders,                   py::return_value_policy<py::reference_existing_object>(), "Returns the orders the client empire has issued (OrderSet).");
 
-        def("sendChatMessage",          SendPlayerChatMessage,          "Sends the indicated message (string) to the player with the indicated recipientID (int) or to all players if recipientID is -1.");
-        def("sendDiplomaticMessage",    SendDiplomaticMessage);
+        py::def("sendChatMessage",          SendPlayerChatMessage,          "Sends the indicated message (string) to the player with the indicated recipientID (int) or to all players if recipientID is -1.");
+        py::def("sendDiplomaticMessage",    SendDiplomaticMessage);
 
-        def("setSaveStateString",       SetStaticSaveStateString,       "Sets the save state string (string). This is a persistant storage space for the AI script to retain state information when the game is saved and reloaded. Any AI state information to be saved should be stored in a single string (likely using Python's pickle module) and stored using this function when the prepareForSave() Python function is called.");
-        def("getSaveStateString",       GetStaticSaveStateString,       return_value_policy<copy_const_reference>(), "Returns the previously-saved state string (string). Can be used to retrieve the last-set save state string at any time, although this string is also passed to the resumeLoadedGame(savedStateString) Python function when a game is loaded, so this function isn't necessary to use if resumeLoadedGame stores the passed string. ");
+        py::def("setSaveStateString",       SetStaticSaveStateString,       "Sets the save state string (string). This is a persistant storage space for the AI script to retain state information when the game is saved and reloaded. Any AI state information to be saved should be stored in a single string (likely using Python's pickle module) and stored using this function when the prepareForSave() Python function is called.");
+        py::def("getSaveStateString",       GetStaticSaveStateString,       py::return_value_policy<py::copy_const_reference>(), "Returns the previously-saved state string (string). Can be used to retrieve the last-set save state string at any time, although this string is also passed to the resumeLoadedGame(savedStateString) Python function when a game is loaded, so this function isn't necessary to use if resumeLoadedGame stores the passed string. ");
 
-        def("userString",               make_function(&UserString,      return_value_policy<copy_const_reference>()));
-        def("userStringExists",         make_function(&UserStringExists,return_value_policy<return_by_value>()));
-        def("userStringList",           &GetUserStringList);
+        py::def("userString",               make_function(&UserString,      py::return_value_policy<py::copy_const_reference>()));
+        py::def("userStringExists",         make_function(&UserStringExists,py::return_value_policy<py::return_by_value>()));
+        py::def("userStringList",           &GetUserStringList);
 
-        def("getGalaxySetupData",       PythonGalaxySetupData, return_value_policy<copy_const_reference>());
+        py::def("getGalaxySetupData",       PythonGalaxySetupData, py::return_value_policy<py::copy_const_reference>());
 
-        boost::python::scope().attr("INVALID_GAME_TURN") = INVALID_GAME_TURN;
+        py::scope().attr("INVALID_GAME_TURN") = INVALID_GAME_TURN;
     }
 }

--- a/python/CommonFramework.cpp
+++ b/python/CommonFramework.cpp
@@ -11,17 +11,8 @@
 #include <boost/python/extract.hpp>
 #include <boost/python/docstring_options.hpp>
 
-using boost::python::object;
-using boost::python::import;
-using boost::python::error_already_set;
-using boost::python::exec;
-using boost::python::dict;
-using boost::python::list;
-using boost::python::extract;
-using boost::python::handle;
-using boost::python::borrowed;
-
 namespace fs = boost::filesystem;
+namespace py = boost::python;
 
 // Python module for logging functions
 BOOST_PYTHON_MODULE(freeorion_logger) {
@@ -76,15 +67,15 @@ bool PythonBase::Initialize() {
     DebugLogger() << "Initializing C++ interfaces for Python";
 
     try {
-        m_system_exit = import("builtins").attr("SystemExit");
+        m_system_exit = py::import("builtins").attr("SystemExit");
         // get main namespace, needed to run other interpreted code
-        object py_main = import("__main__");
-        dict py_namespace = extract<dict>(py_main.attr("__dict__"));
+        py::object py_main = py::import("__main__");
+        py::dict py_namespace = py::extract<py::dict>(py_main.attr("__dict__"));
         m_namespace = py_namespace;
 
         // add the directory containing common Python modules used by all Python scripts to Python sys.path
         AddToSysPath(GetPythonCommonDir());
-    } catch (const error_already_set& err) {
+    } catch (const py::error_already_set& err) {
         HandleErrorAlreadySet();
         ErrorLogger() << "Unable to initialize FreeOrion Python namespace and set path";
         return false;
@@ -100,7 +91,7 @@ bool PythonBase::Initialize() {
             ErrorLogger() << "Unable to initialize FreeOrion Python modules";
             return false;
         }
-    } catch (const error_already_set& err) {
+    } catch (const py::error_already_set& err) {
         HandleErrorAlreadySet();
         ErrorLogger() << "Unable to initialize FreeOrion Python modules (exception caught)";
         return false;
@@ -138,14 +129,14 @@ void PythonBase::HandleErrorAlreadySet() {
         return;
     }
 
-    object o_extype(handle<>(borrowed(extype)));
-    object o_value(handle<>(borrowed(value)));
-    object o_traceback = traceback != nullptr ? object(handle<>(borrowed(traceback))) : object();
+    py::object o_extype(py::handle<>(py::borrowed(extype)));
+    py::object o_value(py::handle<>(py::borrowed(value)));
+    py::object o_traceback = traceback != nullptr ? py::object(py::handle<>(py::borrowed(traceback))) : py::object();
 
-    object mod_traceback = import("traceback");
-    object lines = mod_traceback.attr("format_exception")(o_extype, o_value, o_traceback);
+    py::object mod_traceback = py::import("traceback");
+    py::object lines = mod_traceback.attr("format_exception")(o_extype, o_value, o_traceback);
     for (int i = 0; i < len(lines); ++i) {
-        std::string line = extract<std::string>(lines[i])();
+        std::string line = py::extract<std::string>(lines[i])();
         boost::algorithm::trim_right(line);
         ErrorLogger() << line;
     }
@@ -156,10 +147,10 @@ void PythonBase::HandleErrorAlreadySet() {
 void PythonBase::Finalize() {
     if (Py_IsInitialized()) {
         // cleanup python objects before interpterer shutdown
-        m_system_exit = object();
+        m_system_exit = py::object();
         m_namespace = boost::none;
         if (m_python_module_error != nullptr) {
-            (*m_python_module_error) = object();
+            (*m_python_module_error) = py::object();
             m_python_module_error = nullptr;
         }
         try {
@@ -203,28 +194,28 @@ void PythonBase::AddToSysPath(const std::string dir) {
     exec(script.c_str(), *m_namespace, *m_namespace);
 }
 
-void PythonBase::SetErrorModule(object& module)
+void PythonBase::SetErrorModule(py::object& module)
 { m_python_module_error = &module; }
 
 std::vector<std::string> PythonBase::ErrorReport() {
     std::vector<std::string> err_list;
 
     if (m_python_module_error) {
-        object f = m_python_module_error->attr("error_report");
+        py::object f = m_python_module_error->attr("error_report");
         if (!f) {
             ErrorLogger() << "Unable to call Python function error_report ";
             return err_list;
         }
 
-        list py_err_list;
-        try { py_err_list = extract<list>(f()); }
-        catch (const error_already_set& err) {
+        py::list py_err_list;
+        try { py_err_list = py::extract<py::list>(f()); }
+        catch (const py::error_already_set& err) {
             HandleErrorAlreadySet();
             return err_list;
         }
 
         for (int i = 0; i < len(py_err_list); i++) {
-            err_list.push_back(extract<std::string>(py_err_list[i]));
+            err_list.push_back(py::extract<std::string>(py_err_list[i]));
         }
     }
 

--- a/python/ConfigWrapper.cpp
+++ b/python/ConfigWrapper.cpp
@@ -5,28 +5,27 @@
 
 #include <string>
 
-using boost::python::def;
-using boost::python::return_value_policy;
-using boost::python::return_by_value;
+namespace py = boost::python;
+
 
 namespace {
-    boost::python::object GetOptionsDBOptionStr(std::string const &option)
-    { return GetOptionsDB().OptionExists(option) ? boost::python::str(GetOptionsDB().Get<std::string>(option)) : boost::python::str(); }
+    py::object GetOptionsDBOptionStr(std::string const &option)
+    { return GetOptionsDB().OptionExists(option) ? py::str(GetOptionsDB().Get<std::string>(option)) : py::str(); }
 
-    boost::python::object GetOptionsDBOptionInt(std::string const &option)
-    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<int>(option)) : boost::python::object(); }
+    py::object GetOptionsDBOptionInt(std::string const &option)
+    { return GetOptionsDB().OptionExists(option) ? py::object(GetOptionsDB().Get<int>(option)) : py::object(); }
 
-    boost::python::object GetOptionsDBOptionBool(std::string const &option)
-    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<bool>(option)) : boost::python::object(); }
+    py::object GetOptionsDBOptionBool(std::string const &option)
+    { return GetOptionsDB().OptionExists(option) ? py::object(GetOptionsDB().Get<bool>(option)) : py::object(); }
 
-    boost::python::object GetOptionsDBOptionDouble(std::string const &option)
-    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<double>(option)) : boost::python::object(); }
+    py::object GetOptionsDBOptionDouble(std::string const &option)
+    { return GetOptionsDB().OptionExists(option) ? py::object(GetOptionsDB().Get<double>(option)) : py::object(); }
 
-    boost::python::str GetUserConfigDirWrapper()
-    { return boost::python::str(PathToString(GetUserConfigDir())); }
+    py::str GetUserConfigDirWrapper()
+    { return py::str(PathToString(GetUserConfigDir())); }
 
-    boost::python::str GetUserDataDirWrapper()
-    { return boost::python::str(PathToString(GetUserDataDir())); }
+    py::str GetUserDataDirWrapper()
+    { return py::str(PathToString(GetUserDataDir())); }
 }
 
 namespace FreeOrionPython {
@@ -35,24 +34,24 @@ namespace FreeOrionPython {
 #ifdef FREEORION_BUILD_AI
         // For the AI client provide function names in camelCase,
         // as that's still the preferred style there (for the time being)
-        def("getOptionsDBOptionStr",    GetOptionsDBOptionStr,     return_value_policy<return_by_value>(), "Returns the string value of option in OptionsDB or None if the option does not exist.");
-        def("getOptionsDBOptionInt",    GetOptionsDBOptionInt,     return_value_policy<return_by_value>(), "Returns the integer value of option in OptionsDB or None if the option does not exist.");
-        def("getOptionsDBOptionBool",   GetOptionsDBOptionBool,    return_value_policy<return_by_value>(), "Returns the bool value of option in OptionsDB or None if the option does not exist.");
-        def("getOptionsDBOptionDouble", GetOptionsDBOptionDouble,  return_value_policy<return_by_value>(), "Returns the double value of option in OptionsDB or None if the option does not exist.");
+        py::def("getOptionsDBOptionStr",    GetOptionsDBOptionStr,     py::return_value_policy<py::return_by_value>(), "Returns the string value of option in OptionsDB or None if the option does not exist.");
+        py::def("getOptionsDBOptionInt",    GetOptionsDBOptionInt,     py::return_value_policy<py::return_by_value>(), "Returns the integer value of option in OptionsDB or None if the option does not exist.");
+        py::def("getOptionsDBOptionBool",   GetOptionsDBOptionBool,    py::return_value_policy<py::return_by_value>(), "Returns the bool value of option in OptionsDB or None if the option does not exist.");
+        py::def("getOptionsDBOptionDouble", GetOptionsDBOptionDouble,  py::return_value_policy<py::return_by_value>(), "Returns the double value of option in OptionsDB or None if the option does not exist.");
 
-        def("getUserConfigDir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
-        def("getUserDataDir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
+        py::def("getUserConfigDir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
+        py::def("getUserDataDir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
 #endif
 
 #ifdef FREEORION_BUILD_SERVER
         // For the server, provide the function names already in snake_case
-        def("get_options_db_option_str",    GetOptionsDBOptionStr,     return_value_policy<return_by_value>(), "Returns the string value of option in OptionsDB or None if the option does not exist.");
-        def("get_options_db_option_int",    GetOptionsDBOptionInt,     return_value_policy<return_by_value>(), "Returns the integer value of option in OptionsDB or None if the option does not exist.");
-        def("get_options_db_option_bool",   GetOptionsDBOptionBool,    return_value_policy<return_by_value>(), "Returns the bool value of option in OptionsDB or None if the option does not exist.");
-        def("get_options_db_option_double", GetOptionsDBOptionDouble,  return_value_policy<return_by_value>(), "Returns the double value of option in OptionsDB or None if the option does not exist.");
+        py::def("get_options_db_option_str",    GetOptionsDBOptionStr,     py::return_value_policy<py::return_by_value>(), "Returns the string value of option in OptionsDB or None if the option does not exist.");
+        py::def("get_options_db_option_int",    GetOptionsDBOptionInt,     py::return_value_policy<py::return_by_value>(), "Returns the integer value of option in OptionsDB or None if the option does not exist.");
+        py::def("get_options_db_option_bool",   GetOptionsDBOptionBool,    py::return_value_policy<py::return_by_value>(), "Returns the bool value of option in OptionsDB or None if the option does not exist.");
+        py::def("get_options_db_option_double", GetOptionsDBOptionDouble,  py::return_value_policy<py::return_by_value>(), "Returns the double value of option in OptionsDB or None if the option does not exist.");
 
-        def("get_user_config_dir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
-        def("get_user_data_dir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
+        py::def("get_user_config_dir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
+        py::def("get_user_data_dir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
 #endif
     }
 }

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -26,6 +26,8 @@
 #include <iterator>
 #include <memory>
 
+namespace py = boost::python;
+
 
 namespace {
     // Queues test whether they contain items by name, but Python needs
@@ -93,7 +95,7 @@ namespace {
     template<typename T1, typename T2>
     struct PairToTupleConverter {
         static PyObject* convert(const std::pair<T1, T2>& pair) {
-            return boost::python::incref(boost::python::make_tuple(pair.first, pair.second).ptr());
+            return py::incref(py::make_tuple(pair.first, pair.second).ptr());
         }
     };
 
@@ -177,9 +179,9 @@ namespace {
     { return empire.ProductionCostAndTime(element); }
     auto ProductionCostAndTimeFunc = &ProductionCostAndTimeP;
 
-    //.def("availablePP",                     make_function(&ProductionQueue::AvailablePP,          return_value_policy<return_by_value>()))
-    //.add_property("allocatedPP",            make_function(&ProductionQueue::AllocatedPP,          return_internal_reference<>()))
-    //.def("objectsWithWastedPP",             make_function(&ProductionQueue::ObjectsWithWastedPP,  return_value_policy<return_by_value>()))
+    //.def("availablePP",                     make_function(&ProductionQueue::AvailablePP,          py::return_value_policy<py::return_by_value>()))
+    //.add_property("allocatedPP",            make_function(&ProductionQueue::AllocatedPP,          py::return_internal_reference<>()))
+    //.def("objectsWithWastedPP",             make_function(&ProductionQueue::ObjectsWithWastedPP,  py::return_value_policy<py::return_by_value>()))
 
     std::map<std::set<int>, float> PlanetsWithAvailablePP_P(const Empire& empire) {
         const auto& industry_pool = empire.GetResourcePool(RE_INDUSTRY);
@@ -245,17 +247,6 @@ namespace {
 }
 
 namespace FreeOrionPython {
-    using boost::python::class_;
-    using boost::python::iterator;
-    using boost::python::init;
-    using boost::python::no_init;
-    using boost::noncopyable;
-    using boost::python::return_value_policy;
-    using boost::python::copy_const_reference;
-    using boost::python::reference_existing_object;
-    using boost::python::return_by_value;
-    using boost::python::return_internal_reference;
-
     using boost::placeholders::_1;
     using boost::placeholders::_2;
 
@@ -277,113 +268,113 @@ namespace FreeOrionPython {
      *                                                  called
      */
     void WrapEmpire() {
-        class_<PairIntInt_IntMap>("PairIntInt_IntMap")
-            .def(boost::python::map_indexing_suite<PairIntInt_IntMap, true>())
+        py::class_<PairIntInt_IntMap>("PairIntInt_IntMap")
+            .def(py::map_indexing_suite<PairIntInt_IntMap, true>())
         ;
 
-        boost::python::to_python_converter<IntPair, myIntIntPairConverter>();
+        py::to_python_converter<IntPair, myIntIntPairConverter>();
 
-        class_<std::vector<IntPair>>("IntPairVec")
-            .def(boost::python::vector_indexing_suite<std::vector<IntPair>, true>())
+        py::class_<std::vector<IntPair>>("IntPairVec")
+            .def(py::vector_indexing_suite<std::vector<IntPair>, true>())
         ;
-        class_<std::vector<UnlockableItem>>("UnlockableItemVec")
-            .def(boost::python::vector_indexing_suite<std::vector<UnlockableItem>, true>())
+        py::class_<std::vector<UnlockableItem>>("UnlockableItemVec")
+            .def(py::vector_indexing_suite<std::vector<UnlockableItem>, true>())
         ;
-        boost::python::to_python_converter<FloatIntPair, FloatIntPairConverter>();
+        py::to_python_converter<FloatIntPair, FloatIntPairConverter>();
 
-        class_<ResourcePool, std::shared_ptr<ResourcePool>, boost::noncopyable>("resPool", boost::python::no_init);
+        py::class_<ResourcePool, std::shared_ptr<ResourcePool>, boost::noncopyable>("resPool", py::no_init);
 
         //FreeOrionPython::SetWrapper<int>::Wrap("IntSet");
         FreeOrionPython::SetWrapper<IntSet>::Wrap("IntSetSet");
 
-        class_<std::map<std::set<int>, float>>("resPoolMap")
-            .def(boost::python::map_indexing_suite<std::map<std::set<int>, float>, true>())
+        py::class_<std::map<std::set<int>, float>>("resPoolMap")
+            .def(py::map_indexing_suite<std::map<std::set<int>, float>, true>())
         ;
 
-        class_<std::map<std::string, int>>("StringIntMap")
-            .def(boost::python::map_indexing_suite<std::map<std::string, int>, true>())
+        py::class_<std::map<std::string, int>>("StringIntMap")
+            .def(py::map_indexing_suite<std::map<std::string, int>, true>())
         ;
 
-        class_<std::map<int, std::string>>("IntStringMap")
-            .def(boost::python::map_indexing_suite<std::map<int, std::string>, true>())
+        py::class_<std::map<int, std::string>>("IntStringMap")
+            .def(py::map_indexing_suite<std::map<int, std::string>, true>())
         ;
 
-        class_<std::map<std::string, std::map<int, std::string>>>("String_IntStringMap_Map")
-            .def(boost::python::map_indexing_suite<std::map<std::string, std::map<int, std::string>>, true>())
+        py::class_<std::map<std::string, std::map<int, std::string>>>("String_IntStringMap_Map")
+            .def(py::map_indexing_suite<std::map<std::string, std::map<int, std::string>>, true>())
         ;
 
         ///////////////////
         //     Empire    //
         ///////////////////
-        class_<Empire, noncopyable>("empire", no_init)
-            .add_property("name",                   make_function(&Empire::Name,                    return_value_policy<copy_const_reference>()))
-            .add_property("playerName",             make_function(&Empire::PlayerName,              return_value_policy<copy_const_reference>()))
+        py::class_<Empire, boost::noncopyable>("empire", py::no_init)
+            .add_property("name",                   make_function(&Empire::Name,                    py::return_value_policy<py::copy_const_reference>()))
+            .add_property("playerName",             make_function(&Empire::PlayerName,              py::return_value_policy<py::copy_const_reference>()))
 
             .add_property("empireID",               &Empire::EmpireID)
             .add_property("capitalID",              &Empire::CapitalID)
 
-            .add_property("colour",                 make_function(&Empire::Color,                   return_value_policy<copy_const_reference>()))
+            .add_property("colour",                 make_function(&Empire::Color,                   py::return_value_policy<py::copy_const_reference>()))
 
             .def("buildingTypeAvailable",           &Empire::BuildingTypeAvailable)
-            .add_property("availableBuildingTypes", make_function(&Empire::AvailableBuildingTypes,  return_internal_reference<>()))
+            .add_property("availableBuildingTypes", make_function(&Empire::AvailableBuildingTypes,  py::return_internal_reference<>()))
             .def("shipDesignAvailable",             (bool (Empire::*)(int) const)&Empire::ShipDesignAvailable)
-            .add_property("allShipDesigns",         make_function(&Empire::ShipDesigns,             return_value_policy<return_by_value>()))
-            .add_property("availableShipDesigns",   make_function(&Empire::AvailableShipDesigns,    return_value_policy<return_by_value>()))
-            .add_property("availableShipParts",     make_function(&Empire::AvailableShipParts,      return_value_policy<copy_const_reference>()))
-            .add_property("availableShipHulls",     make_function(&Empire::AvailableShipHulls,      return_value_policy<copy_const_reference>()))
-            .add_property("productionQueue",        make_function(&Empire::GetProductionQueue,      return_internal_reference<>()))
+            .add_property("allShipDesigns",         make_function(&Empire::ShipDesigns,             py::return_value_policy<py::return_by_value>()))
+            .add_property("availableShipDesigns",   make_function(&Empire::AvailableShipDesigns,    py::return_value_policy<py::return_by_value>()))
+            .add_property("availableShipParts",     make_function(&Empire::AvailableShipParts,      py::return_value_policy<py::copy_const_reference>()))
+            .add_property("availableShipHulls",     make_function(&Empire::AvailableShipHulls,      py::return_value_policy<py::copy_const_reference>()))
+            .add_property("productionQueue",        make_function(&Empire::GetProductionQueue,      py::return_internal_reference<>()))
             .def("productionCostAndTime",           make_function(
                                                         ProductionCostAndTimeFunc,
-                                                        return_value_policy<return_by_value>(),
+                                                        py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<FloatIntPair, const Empire&, const ProductionQueue::Element& >()
                                                     ))
             .add_property("planetsWithAvailablePP", make_function(
                                                         PlanetsWithAvailablePP_Func,
-                                                        return_value_policy<return_by_value>(),
+                                                        py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<std::map<std::set<int>, float>, const Empire& >()
                                                     ))
             .add_property("planetsWithAllocatedPP", make_function(
                                                         PlanetsWithAllocatedPP_Func,
-                                                        return_value_policy<return_by_value>(),
+                                                        py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<std::map<std::set<int>, float>, const Empire& >()
                                                     ))
             .add_property("planetsWithWastedPP",    make_function(
                                                         PlanetsWithWastedPP_Func,
-                                                        return_value_policy<return_by_value>(),
+                                                        py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<std::set<std::set<int>>, const Empire& >()
                                                     ))
 
             .def("techResearched",                  &Empire::TechResearched)
             .add_property("availableTechs",         make_function(
                                                         ResearchTechNamesFunc,
-                                                        return_value_policy<return_by_value>(),
+                                                        py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<const std::set<std::string>&, const Empire& >()
                                                     ))
             .def("getTechStatus",                   &Empire::GetTechStatus)
             .def("researchProgress",                &Empire::ResearchProgress)
-            .add_property("researchQueue",          make_function(&Empire::GetResearchQueue,        return_internal_reference<>()))
+            .add_property("researchQueue",          make_function(&Empire::GetResearchQueue,        py::return_internal_reference<>()))
 
             .def("policyAdopted",                   &Empire::PolicyAdopted)
             .def("turnPolicyAdopted",               &Empire::TurnPolicyAdopted)
             .def("slotPolicyAdoptedIn",             &Empire::SlotPolicyAdoptedIn)
-            .add_property("adoptedPolicies",        make_function(&Empire::AdoptedPolicies,                 return_value_policy<return_by_value>()))
-            .add_property("categoriesSlotPolicies", make_function(&Empire::CategoriesSlotsPoliciesAdopted,  return_value_policy<return_by_value>()))
-            .add_property("turnsPoliciesAdopted",   make_function(&Empire::TurnsPoliciesAdopted,            return_value_policy<return_by_value>()))
-            .add_property("availablePolicies",      make_function(&Empire::AvailablePolicies,               return_value_policy<copy_const_reference>()))
+            .add_property("adoptedPolicies",        make_function(&Empire::AdoptedPolicies,                 py::return_value_policy<py::return_by_value>()))
+            .add_property("categoriesSlotPolicies", make_function(&Empire::CategoriesSlotsPoliciesAdopted,  py::return_value_policy<py::return_by_value>()))
+            .add_property("turnsPoliciesAdopted",   make_function(&Empire::TurnsPoliciesAdopted,            py::return_value_policy<py::return_by_value>()))
+            .add_property("availablePolicies",      make_function(&Empire::AvailablePolicies,               py::return_value_policy<py::copy_const_reference>()))
             .def("policyAvailable",                 &Empire::PolicyAvailable)
-            .add_property("totalPolicySlots",       make_function(&Empire::TotalPolicySlots,                return_value_policy<return_by_value>()))
-            .add_property("emptyPolicySlots",       make_function(&Empire::EmptyPolicySlots,                return_value_policy<return_by_value>()))
+            .add_property("totalPolicySlots",       make_function(&Empire::TotalPolicySlots,                py::return_value_policy<py::return_by_value>()))
+            .add_property("emptyPolicySlots",       make_function(&Empire::EmptyPolicySlots,                py::return_value_policy<py::return_by_value>()))
 
             .def("canBuild",                        BuildableItemBuilding)
             .def("canBuild",                        BuildableItemShip)
 
             .def("hasExploredSystem",               &Empire::HasExploredSystem)
-            .add_property("exploredSystemIDs",      make_function(&Empire::ExploredSystems,         return_internal_reference<>()))
+            .add_property("exploredSystemIDs",      make_function(&Empire::ExploredSystems,         py::return_internal_reference<>()))
 
             .add_property("eliminated",             &Empire::Eliminated)
             .add_property("won",                    &Empire::Won)
 
-            .add_property("productionPoints",       make_function(&Empire::ProductionPoints,        return_value_policy<return_by_value>()))
+            .add_property("productionPoints",       make_function(&Empire::ProductionPoints,        py::return_value_policy<py::return_by_value>()))
             .def("resourceStockpile",               &Empire::ResourceStockpile)
             .def("resourceProduction",              &Empire::ResourceOutput)
             .def("resourceAvailable",               &Empire::ResourceAvailable)
@@ -394,52 +385,52 @@ namespace FreeOrionPython {
             .def("preservedLaneTravel",             &Empire::PreservedLaneTravel)
             .add_property("fleetSupplyableSystemIDs",   make_function(
                                                             empireFleetSupplyableSystemIDsFunc,
-                                                            return_value_policy<copy_const_reference>(),
+                                                            py::return_value_policy<py::copy_const_reference>(),
                                                             boost::mpl::vector<const std::set<int>&, const Empire& >()
                                                         ))
-            .add_property("supplyUnobstructedSystems",  make_function(&Empire::SupplyUnobstructedSystems,   return_internal_reference<>()))
-            .add_property("systemSupplyRanges",         make_function(&Empire::SystemSupplyRanges,          return_internal_reference<>()))
+            .add_property("supplyUnobstructedSystems",  make_function(&Empire::SupplyUnobstructedSystems,   py::return_internal_reference<>()))
+            .add_property("systemSupplyRanges",         make_function(&Empire::SystemSupplyRanges,          py::return_internal_reference<>()))
 
             .def("numSitReps",                      &Empire::NumSitRepEntries)
             .def("getSitRep",                       make_function(
                                                         GetEmpireSitRepFunc,
-                                                        return_internal_reference<>(),
+                                                        py::return_internal_reference<>(),
                                                         boost::mpl::vector<const SitRepEntry&, const Empire&, int>()
                                                     ))
-            //.add_property("obstructedStarlanes",  make_function(&Empire::SupplyObstructedStarlaneTraversals,   return_value_policy<return_by_value>()))
+            //.add_property("obstructedStarlanes",  make_function(&Empire::SupplyObstructedStarlaneTraversals,   py::return_value_policy<py::return_by_value>()))
             .def("obstructedStarlanes",             make_function(
                                                         obstructedStarlanesFunc,
-                                                        return_value_policy<return_by_value>(),
+                                                        py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<std::vector<IntPair>, const Empire&>()
                                                     ))
             .def("supplyProjections",               make_function(
                                                         jumpsToSuppliedSystemFunc,
-                                                        return_value_policy<return_by_value>(),
+                                                        py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<std::map<int, int>, const Empire&>()
                                                     ))
             .def("getMeter",                        make_function(
                                                         EmpireGetMeter,
-                                                        return_internal_reference<>()),
+                                                        py::return_internal_reference<>()),
                                                     "Returns the empire meter with the indicated name (string).")
         ;
 
         //////////////////////
         // Production Queue //
         //////////////////////
-        class_<ProductionQueue::Element>("productionQueueElement", no_init)
+        py::class_<ProductionQueue::Element>("productionQueueElement", py::no_init)
             .add_property("name",                   make_function(
                                                         boost::bind(NameFromProductionQueueElement, _1),
-                                                        return_value_policy<copy_const_reference>(),
+                                                        py::return_value_policy<py::copy_const_reference>(),
                                                         boost::mpl::vector<const std::string&, const ProductionQueue::Element&>()
                                                     ))
             .add_property("designID",               make_function(
                                                         boost::bind(DesignIDFromProductionQueueElement, _1),
-                                                        return_value_policy<return_by_value>(),
+                                                        py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<int, const ProductionQueue::Element&>()
                                                     ))
             .add_property("buildType",              make_function(
                                                         boost::bind(BuildTypeFromProductionQueueElement, _1),
-                                                        return_value_policy<return_by_value>(),
+                                                        py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<BuildType, const ProductionQueue::Element&>()
                                                     ))
             .add_property("locationID",             &ProductionQueue::Element::location)
@@ -451,37 +442,37 @@ namespace FreeOrionPython {
             .add_property("paused",                 &ProductionQueue::Element::paused)
             .add_property("allowedStockpile",       &ProductionQueue::Element::allowed_imperial_stockpile_use)
             ;
-        class_<ProductionQueue, noncopyable>("productionQueue", no_init)
-            .def("__iter__",                        iterator<ProductionQueue>())  // ProductionQueue provides STL container-like interface to contained queue
-            .def("__getitem__",                     ProductionQueueOperatorSquareBrackets,              return_internal_reference<>())
+        py::class_<ProductionQueue, boost::noncopyable>("productionQueue", py::no_init)
+            .def("__iter__",                        py::iterator<ProductionQueue>())  // ProductionQueue provides STL container-like interface to contained queue
+            .def("__getitem__",                     ProductionQueueOperatorSquareBrackets,              py::return_internal_reference<>())
             .def("__len__",                         &ProductionQueue::size)
             .add_property("size",                   &ProductionQueue::size)
             .add_property("empty",                  &ProductionQueue::empty)
             .add_property("totalSpent",             &ProductionQueue::TotalPPsSpent)
             .add_property("empireID",               &ProductionQueue::EmpireID)
-            .def("availablePP",                     make_function(&ProductionQueue::AvailablePP,        return_value_policy<return_by_value>()))
-            .add_property("allocatedPP",            make_function(&ProductionQueue::AllocatedPP,        return_internal_reference<>()))
-            .def("objectsWithWastedPP",             make_function(&ProductionQueue::ObjectsWithWastedPP,return_value_policy<return_by_value>()))
+            .def("availablePP",                     make_function(&ProductionQueue::AvailablePP,        py::return_value_policy<py::return_by_value>()))
+            .add_property("allocatedPP",            make_function(&ProductionQueue::AllocatedPP,        py::return_internal_reference<>()))
+            .def("objectsWithWastedPP",             make_function(&ProductionQueue::ObjectsWithWastedPP,py::return_value_policy<py::return_by_value>()))
             ;
 
         ////////////////////
         // Research Queue //
         ////////////////////
-        class_<ResearchQueue::Element>("researchQueueElement", no_init)
+        py::class_<ResearchQueue::Element>("researchQueueElement", py::no_init)
             .def_readonly("tech",                   &ResearchQueue::Element::name)
             .def_readonly("allocation",             &ResearchQueue::Element::allocated_rp)
             .def_readonly("turnsLeft",              &ResearchQueue::Element::turns_left)
         ;
-        class_<ResearchQueue, noncopyable>("researchQueue", no_init)
-            .def("__iter__",                        iterator<ResearchQueue>())  // ResearchQueue provides STL container-like interface to contained queue
-            .def("__getitem__",                     &ResearchQueue::operator[],                         return_internal_reference<>())
+        py::class_<ResearchQueue, boost::noncopyable>("researchQueue", py::no_init)
+            .def("__iter__",                        py::iterator<ResearchQueue>())  // ResearchQueue provides STL container-like interface to contained queue
+            .def("__getitem__",                     &ResearchQueue::operator[],                         py::return_internal_reference<>())
             .def("__len__",                         &ResearchQueue::size)
             .add_property("size",                   &ResearchQueue::size)
             .add_property("empty",                  &ResearchQueue::empty)
             .def("inQueue",                         &ResearchQueue::InQueue)
             .def("__contains__",                    make_function(
                                                         boost::bind(InQueueFromResearchQueueElementFunc, _1, _2),
-                                                        return_value_policy<return_by_value>(),
+                                                        py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<bool, const ResearchQueue*, const ResearchQueue::Element&>()
                                                     ))
             .add_property("totalSpent",             &ResearchQueue::TotalRPsSpent)
@@ -491,40 +482,40 @@ namespace FreeOrionPython {
         //////////////////
         //     Tech     //
         //////////////////
-        class_<Tech, noncopyable>("tech", no_init)
-            .add_property("name",                   make_function(&Tech::Name,              return_value_policy<copy_const_reference>()))
-            .add_property("description",            make_function(&Tech::Description,       return_value_policy<copy_const_reference>()))
-            .add_property("shortDescription",       make_function(&Tech::ShortDescription,  return_value_policy<copy_const_reference>()))
-            .add_property("category",               make_function(&Tech::Category,          return_value_policy<copy_const_reference>()))
+        py::class_<Tech, boost::noncopyable>("tech", py::no_init)
+            .add_property("name",                   make_function(&Tech::Name,              py::return_value_policy<py::copy_const_reference>()))
+            .add_property("description",            make_function(&Tech::Description,       py::return_value_policy<py::copy_const_reference>()))
+            .add_property("shortDescription",       make_function(&Tech::ShortDescription,  py::return_value_policy<py::copy_const_reference>()))
+            .add_property("category",               make_function(&Tech::Category,          py::return_value_policy<py::copy_const_reference>()))
             .def("researchCost",                    &Tech::ResearchCost)
             .def("perTurnCost",                     &Tech::PerTurnCost)
             .def("researchTime",                    &Tech::ResearchTime)
-            .add_property("prerequisites",          make_function(&Tech::Prerequisites,     return_internal_reference<>()))
-            .add_property("unlockedTechs",          make_function(&Tech::UnlockedTechs,     return_internal_reference<>()))
-            .add_property("unlockedItems",          make_function(&Tech::UnlockedItems,     return_internal_reference<>()))
+            .add_property("prerequisites",          make_function(&Tech::Prerequisites,     py::return_internal_reference<>()))
+            .add_property("unlockedTechs",          make_function(&Tech::UnlockedTechs,     py::return_internal_reference<>()))
+            .add_property("unlockedItems",          make_function(&Tech::UnlockedItems,     py::return_internal_reference<>()))
             .def("recursivePrerequisites",          make_function(
                                                         TechRecursivePrereqsFunc,
-                                                        return_value_policy<return_by_value>(),
+                                                        py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<std::vector<std::string>, const Tech&, int>()
                                                     ))
         ;
 
-        def("getTech",                              &GetTech,                               return_value_policy<reference_existing_object>(), "Returns the tech (Tech) with the indicated name (string).");
-        def("getTechCategories",                    &TechManager::CategoryNames,            return_value_policy<return_by_value>(), "Returns the names of all tech categories (StringVec).");
+        def("getTech",                              &GetTech,                               py::return_value_policy<py::reference_existing_object>(), "Returns the tech (Tech) with the indicated name (string).");
+        def("getTechCategories",                    &TechManager::CategoryNames,            py::return_value_policy<py::return_by_value>(), "Returns the names of all tech categories (StringVec).");
 
-        boost::python::object techsFunc = make_function(boost::bind(TechNamesMemberFunc, &(GetTechManager())),
-                                                        return_value_policy<boost::python::return_by_value>(),
+        py::object techsFunc = make_function(boost::bind(TechNamesMemberFunc, &(GetTechManager())),
+                                                        py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<std::vector<std::string>>());
-        boost::python::setattr(techsFunc, "__doc__", boost::python::str("Returns the names of all techs (StringVec)."));
+        py::setattr(techsFunc, "__doc__", py::str("Returns the names of all techs (StringVec)."));
         def("techs", techsFunc);
 
-        boost::python::object techsInCategoryFunc = make_function(boost::bind(TechNamesCategoryMemberFunc, &(GetTechManager()), _1),
-                                                                  return_value_policy<return_by_value>(),
+        py::object techsInCategoryFunc = make_function(boost::bind(TechNamesCategoryMemberFunc, &(GetTechManager()), _1),
+                                                                  py::return_value_policy<py::return_by_value>(),
                                                                   boost::mpl::vector<std::vector<std::string>, const std::string&>());
-        boost::python::setattr(techsInCategoryFunc, "__doc__", boost::python::str("Returns the names of all techs (StringVec) in the indicated tech category name (string)."));
+        py::setattr(techsInCategoryFunc, "__doc__", py::str("Returns the names of all techs (StringVec) in the indicated tech category name (string)."));
         def("techsInCategory", techsInCategoryFunc);
 
-        class_<UnlockableItem>("UnlockableItem", init<UnlockableItemType, const std::string&>())
+        py::class_<UnlockableItem>("UnlockableItem", py::init<UnlockableItemType, const std::string&>())
             .add_property("type",               &UnlockableItem::type)
             .add_property("name",               &UnlockableItem::name)
         ;
@@ -532,20 +523,20 @@ namespace FreeOrionPython {
         ///////////////////////
         //  Influence Queue  //
         ///////////////////////
-        class_<InfluenceQueue::Element>("influenceQueueElement", no_init)
+        py::class_<InfluenceQueue::Element>("influenceQueueElement", py::no_init)
             .def_readonly("name",                   &InfluenceQueue::Element::name)
             .def_readonly("allocation",             &InfluenceQueue::Element::allocated_ip)
         ;
-        class_<InfluenceQueue, noncopyable>("influenceQueue", no_init)
-            .def("__iter__",                        iterator<InfluenceQueue>())  // InfluenceQueue provides STL container-like interface to contained queue
-            .def("__getitem__",                     InfluenceQueueOperatorSquareBrackets,               return_internal_reference<>())
+        py::class_<InfluenceQueue, boost::noncopyable>("influenceQueue", py::no_init)
+            .def("__iter__",                        py::iterator<InfluenceQueue>())  // InfluenceQueue provides STL container-like interface to contained queue
+            .def("__getitem__",                     InfluenceQueueOperatorSquareBrackets,               py::return_internal_reference<>())
             .def("__len__",                         &InfluenceQueue::size)
             .add_property("size",                   &InfluenceQueue::size)
             .add_property("empty",                  &InfluenceQueue::empty)
             .def("inQueue",                         &InfluenceQueue::InQueue)
             .def("__contains__",                    make_function(
                                                         boost::bind(InQueueFromInfluenceQueueElementFunc, _1, _2),
-                                                        return_value_policy<return_by_value>(),
+                                                        py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<bool, const InfluenceQueue*, const InfluenceQueue::Element&>()
                                                     ))
             .add_property("totalSpent",             &InfluenceQueue::TotalIPsSpent)
@@ -558,45 +549,45 @@ namespace FreeOrionPython {
         //////////////////
         //    Policy    //
         //////////////////
-        class_<Policy, noncopyable>("policy", no_init)
-            .add_property("name",                   make_function(&Policy::Name,                return_value_policy<copy_const_reference>()))
-            .add_property("description",            make_function(&Policy::Description,         return_value_policy<copy_const_reference>()))
-            .add_property("shortDescription",       make_function(&Policy::ShortDescription,    return_value_policy<copy_const_reference>()))
-            .add_property("category",               make_function(&Policy::Category,            return_value_policy<copy_const_reference>()))
+        py::class_<Policy, boost::noncopyable>("policy", py::no_init)
+            .add_property("name",                   make_function(&Policy::Name,                py::return_value_policy<py::copy_const_reference>()))
+            .add_property("description",            make_function(&Policy::Description,         py::return_value_policy<py::copy_const_reference>()))
+            .add_property("shortDescription",       make_function(&Policy::ShortDescription,    py::return_value_policy<py::copy_const_reference>()))
+            .add_property("category",               make_function(&Policy::Category,            py::return_value_policy<py::copy_const_reference>()))
             .def("adoptionCost",                    &Policy::AdoptionCost)
         ;
 
-        def("getPolicy",                            &GetPolicy,                                 return_value_policy<reference_existing_object>(), "Returns the policy (Policy) with the indicated name (string).");
-        def("getPolicyCategories",                  &PolicyManager::PolicyCategories,           return_value_policy<return_by_value>(), "Returns the names of all policy categories (StringVec).");
+        def("getPolicy",                            &GetPolicy,                                 py::return_value_policy<py::reference_existing_object>(), "Returns the policy (Policy) with the indicated name (string).");
+        def("getPolicyCategories",                  &PolicyManager::PolicyCategories,           py::return_value_policy<py::return_by_value>(), "Returns the names of all policy categories (StringVec).");
 
-        boost::python::object policiesFunc = make_function(boost::bind(PolicyNamesMemberFunc, &(GetPolicyManager())),
-                                                           return_value_policy<boost::python::return_by_value>(),
+        py::object policiesFunc = make_function(boost::bind(PolicyNamesMemberFunc, &(GetPolicyManager())),
+                                                           py::return_value_policy<py::return_by_value>(),
                                                            boost::mpl::vector<std::vector<std::string>>());
-        boost::python::setattr(policiesFunc, "__doc__", boost::python::str("Returns the names of all policies (StringVec)."));
+        py::setattr(policiesFunc, "__doc__", py::str("Returns the names of all policies (StringVec)."));
         def("policies", policiesFunc);
 
-        boost::python::object policiesInCategoryFunc = make_function(boost::bind(PolicyNamesCategoryMemberFunc, &(GetPolicyManager()), _1),
-                                                                     return_value_policy<return_by_value>(),
+        py::object policiesInCategoryFunc = make_function(boost::bind(PolicyNamesCategoryMemberFunc, &(GetPolicyManager()), _1),
+                                                                     py::return_value_policy<py::return_by_value>(),
                                                                      boost::mpl::vector<std::vector<std::string>, const std::string&>());
-        boost::python::setattr(policiesInCategoryFunc, "__doc__", boost::python::str("Returns the names of all policies (StringVec) in the indicated policy category name (string)."));
+        py::setattr(policiesInCategoryFunc, "__doc__", py::str("Returns the names of all policies (StringVec) in the indicated policy category name (string)."));
         def("policiesInCategory", policiesInCategoryFunc);
 
         ///////////////////
         //  SitRepEntry  //
         ///////////////////
-        class_<SitRepEntry, noncopyable>("sitrep", no_init)
-            .add_property("typeString",         make_function(&SitRepEntry::GetTemplateString,  return_value_policy<copy_const_reference>()))
-            .def("getDataString",               make_function(&SitRepEntry::GetDataString,      return_value_policy<copy_const_reference>()))
+        py::class_<SitRepEntry, boost::noncopyable>("sitrep", py::no_init)
+            .add_property("typeString",         make_function(&SitRepEntry::GetTemplateString,  py::return_value_policy<py::copy_const_reference>()))
+            .def("getDataString",               make_function(&SitRepEntry::GetDataString,      py::return_value_policy<py::copy_const_reference>()))
             .def("getDataIDNumber",             &SitRepEntry::GetDataIDNumber)
-            .add_property("getTags",            make_function(&SitRepEntry::GetVariableTags,    return_value_policy<return_by_value>()))
+            .add_property("getTags",            make_function(&SitRepEntry::GetVariableTags,    py::return_value_policy<py::return_by_value>()))
             .add_property("getTurn",            &SitRepEntry::GetTurn)
         ;
 
         ///////////////////////
         // DiplomaticMessage //
         ///////////////////////
-        class_<DiplomaticMessage>("diplomaticMessage")
-            .def(init<int, int, DiplomaticMessage::Type>())
+        py::class_<DiplomaticMessage>("diplomaticMessage")
+            .def(py::init<int, int, DiplomaticMessage::Type>())
             .add_property("type",      &DiplomaticMessage::GetType)
             .add_property("recipient", &DiplomaticMessage::RecipientEmpireID)
             .add_property("sender",    &DiplomaticMessage::SenderEmpireID)
@@ -605,8 +596,8 @@ namespace FreeOrionPython {
         ////////////////////////////
         // DiplomaticStatusUpdate //
         ////////////////////////////
-        class_<DiplomaticStatusUpdateInfo>("diplomaticStatusUpdate")
-            .def(init<int, int, DiplomaticStatus>())
+        py::class_<DiplomaticStatusUpdateInfo>("diplomaticStatusUpdate")
+            .def(py::init<int, int, DiplomaticStatus>())
             .add_property("status",             &DiplomaticStatusUpdateInfo::diplo_status)
             .add_property("empire1",            &DiplomaticStatusUpdateInfo::empire1_id)
             .add_property("empire2",            &DiplomaticStatusUpdateInfo::empire2_id)
@@ -615,7 +606,7 @@ namespace FreeOrionPython {
         ///////////
         // Color //
         ///////////
-        class_<GG::Clr>("GGColor", init<unsigned char, unsigned char, unsigned char, unsigned char>())
+        py::class_<GG::Clr>("GGColor", py::init<unsigned char, unsigned char, unsigned char, unsigned char>())
             .add_property("r",                  &GG::Clr::r)
             .add_property("g",                  &GG::Clr::g)
             .add_property("b",                  &GG::Clr::b)

--- a/python/EnumWrapper.cpp
+++ b/python/EnumWrapper.cpp
@@ -8,9 +8,10 @@
 #include <boost/python.hpp>
 
 namespace FreeOrionPython {
-    using boost::python::enum_;
     void WrapGameStateEnums() {
-        enum_<StarType>("starType")
+        namespace py = boost::python;
+
+        py::enum_<StarType>("starType")
             .value("blue",      STAR_BLUE)
             .value("white",     STAR_WHITE)
             .value("yellow",    STAR_YELLOW)
@@ -21,14 +22,14 @@ namespace FreeOrionPython {
             .value("noStar",    STAR_NONE)
             .value("unknown",   INVALID_STAR_TYPE)
         ;
-        enum_<Visibility>("visibility")
+        py::enum_<Visibility>("visibility")
             .value("invalid",   INVALID_VISIBILITY)
             .value("none",      VIS_NO_VISIBILITY)
             .value("basic",     VIS_BASIC_VISIBILITY)
             .value("partial",   VIS_PARTIAL_VISIBILITY)
             .value("full",      VIS_FULL_VISIBILITY)
         ;
-        enum_<PlanetSize>("planetSize")
+        py::enum_<PlanetSize>("planetSize")
             .value("tiny",      SZ_TINY)
             .value("small",     SZ_SMALL)
             .value("medium",    SZ_MEDIUM)
@@ -39,7 +40,7 @@ namespace FreeOrionPython {
             .value("noWorld",   SZ_NOWORLD)
             .value("unknown",   INVALID_PLANET_SIZE)
         ;
-        enum_<PlanetType>("planetType")
+        py::enum_<PlanetType>("planetType")
             .value("swamp",     PT_SWAMP)
             .value("radiated",  PT_RADIATED)
             .value("toxic",     PT_TOXIC)
@@ -53,31 +54,31 @@ namespace FreeOrionPython {
             .value("gasGiant",  PT_GASGIANT)
             .value("unknown",   INVALID_PLANET_TYPE)
         ;
-        enum_<PlanetEnvironment>("planetEnvironment")
+        py::enum_<PlanetEnvironment>("planetEnvironment")
             .value("uninhabitable", PE_UNINHABITABLE)
             .value("hostile",       PE_HOSTILE)
             .value("poor",          PE_POOR)
             .value("adequate",      PE_ADEQUATE)
             .value("good",          PE_GOOD)
         ;
-        enum_<TechStatus>("techStatus")
+        py::enum_<TechStatus>("techStatus")
             .value("unresearchable",    TS_UNRESEARCHABLE)
             .value("partiallyUnlocked", TS_HAS_RESEARCHED_PREREQ)
             .value("researchable",      TS_RESEARCHABLE)
             .value("complete",          TS_COMPLETE)
         ;
-        enum_<BuildType>("buildType")
+        py::enum_<BuildType>("buildType")
             .value("building",          BT_BUILDING)
             .value("ship",              BT_SHIP)
             .value("stockpile",         BT_STOCKPILE)
         ;
-        enum_<ResourceType>("resourceType")
+        py::enum_<ResourceType>("resourceType")
             .value("industry",          RE_INDUSTRY)
             .value("influence",         RE_INFLUENCE)
             .value("research",          RE_RESEARCH)
             .value("stockpile",         RE_STOCKPILE)
         ;
-        enum_<MeterType>("meterType")
+        py::enum_<MeterType>("meterType")
             .value("targetPopulation",  METER_TARGET_POPULATION)
             .value("targetIndustry",    METER_TARGET_INDUSTRY)
             .value("targetResearch",    METER_TARGET_RESEARCH)
@@ -122,12 +123,12 @@ namespace FreeOrionPython {
             .value("detection",         METER_DETECTION)
             .value("speed",             METER_SPEED)
         ;
-        enum_<DiplomaticStatus>("diplomaticStatus")
+        py::enum_<DiplomaticStatus>("diplomaticStatus")
             .value("war",               DIPLO_WAR)
             .value("peace",             DIPLO_PEACE)
             .value("allied",            DIPLO_ALLIED)
         ;
-        enum_<DiplomaticMessage::Type>("diplomaticMessageType")
+        py::enum_<DiplomaticMessage::Type>("diplomaticMessageType")
             .value("noMessage",             DiplomaticMessage::Type::INVALID)
             .value("warDeclaration",        DiplomaticMessage::Type::WAR_DECLARATION)
             .value("peaceProposal",         DiplomaticMessage::Type::PEACE_PROPOSAL)
@@ -138,12 +139,12 @@ namespace FreeOrionPython {
             .value("cancelProposal",        DiplomaticMessage::Type::CANCEL_PROPOSAL)
             .value("rejectProposal",        DiplomaticMessage::Type::REJECT_PROPOSAL)
         ;
-        enum_<CaptureResult>("captureResult")
+        py::enum_<CaptureResult>("captureResult")
             .value("capture",       CR_CAPTURE)
             .value("destroy",       CR_DESTROY)
             .value("retain",        CR_RETAIN)
         ;
-        enum_<EffectsCauseType>("effectsCauseType")
+        py::enum_<EffectsCauseType>("effectsCauseType")
             .value("invalid",       INVALID_EFFECTS_GROUP_CAUSE_TYPE)
             .value("unknown",       ECT_UNKNOWN_CAUSE)
             .value("inherent",      ECT_INHERENT)
@@ -156,12 +157,12 @@ namespace FreeOrionPython {
             .value("shipHull",      ECT_SHIP_HULL)
             .value("policy",        ECT_POLICY)
         ;
-        enum_<ShipSlotType>("shipSlotType")
+        py::enum_<ShipSlotType>("shipSlotType")
             .value("external",      SL_EXTERNAL)
             .value("internal",      SL_INTERNAL)
             .value("core",          SL_CORE)
         ;
-        enum_<ShipPartClass>("shipPartClass")
+        py::enum_<ShipPartClass>("shipPartClass")
             .value("shortRange",        PC_DIRECT_WEAPON)
             .value("fighterBay",        PC_FIGHTER_BAY)
             .value("fighterHangar",     PC_FIGHTER_HANGAR)
@@ -180,7 +181,7 @@ namespace FreeOrionPython {
             .value("influence",         PC_INFLUENCE)
             .value("productionLocation",PC_PRODUCTION_LOCATION)
         ;
-        enum_<UnlockableItemType>("unlockableItemType")
+        py::enum_<UnlockableItemType>("unlockableItemType")
             .value("invalid",       INVALID_UNLOCKABLE_ITEM_TYPE)
             .value("building",      UIT_BUILDING)
             .value("shipPart",      UIT_SHIP_PART)
@@ -189,7 +190,7 @@ namespace FreeOrionPython {
             .value("tech",          UIT_TECH)
             .value("policy",        UIT_POLICY)
         ;
-        enum_<Aggression>("aggression")
+        py::enum_<Aggression>("aggression")
             .value("invalid",       INVALID_AGGRESSION)
             .value("beginner",      BEGINNER)
             .value("turtle",        TURTLE)
@@ -198,7 +199,7 @@ namespace FreeOrionPython {
             .value("aggressive",    AGGRESSIVE)
             .value("maniacal",      MANIACAL)
         ;
-        enum_<GalaxySetupOption>("galaxySetupOption")
+        py::enum_<GalaxySetupOption>("galaxySetupOption")
             .value("invalid",       INVALID_GALAXY_SETUP_OPTION)
             .value("none",          GALAXY_SETUP_NONE)
             .value("low",           GALAXY_SETUP_LOW)
@@ -206,7 +207,7 @@ namespace FreeOrionPython {
             .value("high",          GALAXY_SETUP_HIGH)
             .value("random",        GALAXY_SETUP_RANDOM)
         ;
-        enum_<Shape>("galaxyShape")
+        py::enum_<Shape>("galaxyShape")
             .value("invalid",       INVALID_SHAPE)
             .value("spiral2",       SPIRAL_2)
             .value("spiral3",       SPIRAL_3)
@@ -219,14 +220,14 @@ namespace FreeOrionPython {
             .value("ring",          RING)
             .value("random",        RANDOM)
         ;
-        enum_<GameRules::Type>("ruleType")
+        py::enum_<GameRules::Type>("ruleType")
             .value("invalid",       GameRules::Type::INVALID)
             .value("toggle",        GameRules::Type::TOGGLE)
             .value("int",           GameRules::Type::INT)
             .value("double",        GameRules::Type::DOUBLE)
             .value("string",        GameRules::Type::STRING)
         ;
-        enum_<Networking::RoleType>("roleType")
+        py::enum_<Networking::RoleType>("roleType")
             .value("host",                Networking::ROLE_HOST)
             .value("clientTypeModerator", Networking::ROLE_CLIENT_TYPE_MODERATOR)
             .value("clientTypePlayer",    Networking::ROLE_CLIENT_TYPE_PLAYER)

--- a/python/SetWrapper.h
+++ b/python/SetWrapper.h
@@ -8,11 +8,6 @@
 
 
 namespace FreeOrionPython {
-    using boost::python::class_;
-    using boost::python::no_init;
-    using boost::python::def;
-    using boost::python::iterator;
-
     /* SetWrapper class encapsulates functions that expose the STL std::set<>
      * class to Python in a limited, read-only fashion.  The set can be iterated
      * through in Python, and printed. */
@@ -32,13 +27,15 @@ namespace FreeOrionPython {
         static SetIterator  end(const Set& self) { return self.end(); }
 
         static void Wrap(const std::string& python_name) {
-            class_<Set>(python_name.c_str(), no_init)
+            namespace py = boost::python;
+
+            py::class_<Set>(python_name.c_str(), py::no_init)
                 .def("__len__",         &size)
                 .def("size",            &size)
                 .def("empty",           &empty)
                 .def("__contains__",    &contains)
                 .def("count",           &count)
-                .def("__iter__",        iterator<Set>())
+                .def("__iter__",        py::iterator<Set>())
             ;
         }
     };

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -30,6 +30,8 @@
 #include "../util/Logger.h"
 #include "../util/MultiplayerCommon.h"
 
+namespace py = boost::python;
+
 
 #if defined(_MSC_VER)
 #  if (_MSC_VER == 1900)
@@ -96,8 +98,8 @@ namespace {
         return retval;
     }
 
-    void UpdateMetersWrapper(const Universe& universe, const boost::python::object& objIter) {
-        boost::python::stl_input_iterator<int> begin(objIter), end;
+    void UpdateMetersWrapper(const Universe& universe, const py::object& objIter) {
+        py::stl_input_iterator<int> begin(objIter), end;
         std::vector<int> objvec(begin, end);
         GetUniverse().UpdateMeterEstimates(objvec);
     }
@@ -283,18 +285,6 @@ namespace {
 }
 
 namespace FreeOrionPython {
-    using boost::python::def;
-    using boost::python::class_;
-    using boost::python::bases;
-    using boost::python::no_init;
-    using boost::noncopyable;
-    using boost::python::return_value_policy;
-    using boost::python::copy_const_reference;
-    using boost::python::reference_existing_object;
-    using boost::python::return_by_value;
-    using boost::python::return_internal_reference;
-    using boost::python::enum_;
-
     /**
      * CallPolicies:
      *
@@ -316,124 +306,119 @@ namespace FreeOrionPython {
         ////////////////////////
         // Container Wrappers //
         ////////////////////////
-        class_<std::map<int, int>>("IntIntMap")
-            .def(boost::python::map_indexing_suite<std::map<int, int>, true>())
+        py::class_<std::map<int, int>>("IntIntMap")
+            .def(py::map_indexing_suite<std::map<int, int>, true>())
         ;
-        class_<std::map<int, double>>("IntDblMap")
-            .def(boost::python::map_indexing_suite<std::map<int, double>, true>())
+        py::class_<std::map<int, double>>("IntDblMap")
+            .def(py::map_indexing_suite<std::map<int, double>, true>())
         ;
-        class_<std::map<int, float>>("IntFltMap")
-            .def(boost::python::map_indexing_suite<std::map<int, float>, true>())
+        py::class_<std::map<int, float>>("IntFltMap")
+            .def(py::map_indexing_suite<std::map<int, float>, true>())
         ;
-        class_<std::map<Visibility, int>>("VisibilityIntMap")
-            .def(boost::python::map_indexing_suite<std::map<Visibility, int>, true>())
+        py::class_<std::map<Visibility, int>>("VisibilityIntMap")
+            .def(py::map_indexing_suite<std::map<Visibility, int>, true>())
         ;
-        class_<std::vector<ShipSlotType>>("ShipSlotVec")
-            .def(boost::python::vector_indexing_suite<std::vector<ShipSlotType>, true>())
+        py::class_<std::vector<ShipSlotType>>("ShipSlotVec")
+            .def(py::vector_indexing_suite<std::vector<ShipSlotType>, true>())
         ;
-        class_<std::map<std::string, std::string>>("StringsMap")
-            .def(boost::python::map_indexing_suite<std::map<std::string, std::string>, true>())
+        py::class_<std::map<std::string, std::string>>("StringsMap")
+            .def(py::map_indexing_suite<std::map<std::string, std::string>, true>())
         ;
 
-        class_<std::map<MeterType, Meter>>("MeterTypeMeterMap")
-            .def(boost::python::map_indexing_suite<std::map<MeterType, Meter>, true>())
+        py::class_<std::map<MeterType, Meter>>("MeterTypeMeterMap")
+            .def(py::map_indexing_suite<std::map<MeterType, Meter>, true>())
         ;
 
         // typedef std::map<std::pair<MeterType, std::string>, Meter> PartMeterMap;
-        class_<std::pair<MeterType, std::string>>("MeterTypeStringPair")
+        py::class_<std::pair<MeterType, std::string>>("MeterTypeStringPair")
             .add_property("meterType",  &std::pair<MeterType, std::string>::first)
             .add_property("string",     &std::pair<MeterType, std::string>::second)
         ;
-        class_<Ship::PartMeterMap>("ShipPartMeterMap")
-            .def(boost::python::map_indexing_suite<Ship::PartMeterMap>())
+        py::class_<Ship::PartMeterMap>("ShipPartMeterMap")
+            .def(py::map_indexing_suite<Ship::PartMeterMap>())
         ;
 
-        class_<std::map<std::string, std::map<int, std::map<int, double>>>>("StatRecordsMap")
-            .def(boost::python::map_indexing_suite<
-                 std::map<std::string, std::map<int, std::map<int, double>>>, true>())
+        py::class_<std::map<std::string, std::map<int, std::map<int, double>>>>("StatRecordsMap")
+            .def(py::map_indexing_suite<std::map<std::string, std::map<int, std::map<int, double>>>, true>())
         ;
-        class_<std::map<int, std::map<int, double>>>("IntIntDblMapMap")
-            .def(boost::python::map_indexing_suite<
-                 std::map<int, std::map<int, double>>, true>())
+        py::class_<std::map<int, std::map<int, double>>>("IntIntDblMapMap")
+            .def(py::map_indexing_suite<std::map<int, std::map<int, double>>, true>())
         ;
 
         ///////////////////////////
         //   Effect Accounting   //
         ///////////////////////////
-        class_<Effect::EffectCause>("EffectCause")
+        py::class_<Effect::EffectCause>("EffectCause")
             .add_property("causeType",          &Effect::AccountingInfo::cause_type)
             .def_readonly("specificCause",      &Effect::AccountingInfo::specific_cause)
             .def_readonly("customLabel",        &Effect::AccountingInfo::custom_label)
         ;
-        class_<Effect::AccountingInfo, bases<Effect::EffectCause>>("AccountingInfo")
+        py::class_<Effect::AccountingInfo, py::bases<Effect::EffectCause>>("AccountingInfo")
             .add_property("sourceID",           &Effect::AccountingInfo::source_id)
             .add_property("meterChange",        &Effect::AccountingInfo::meter_change)
             .add_property("meterRunningTotal",  &Effect::AccountingInfo::running_meter_total)
         ;
-        class_<std::vector<Effect::AccountingInfo>>("AccountingInfoVec")
-            .def(boost::python::vector_indexing_suite<
-                 std::vector<Effect::AccountingInfo>, true>())
+        py::class_<std::vector<Effect::AccountingInfo>>("AccountingInfoVec")
+            .def(py::vector_indexing_suite<std::vector<Effect::AccountingInfo>, true>())
         ;
-        class_<std::map<MeterType, std::vector<Effect::AccountingInfo>>>("MeterTypeAccountingInfoVecMap")
-            .def(boost::python::map_indexing_suite<
-                 std::map<MeterType, std::vector<Effect::AccountingInfo>>, true>())
+        py::class_<std::map<MeterType, std::vector<Effect::AccountingInfo>>>("MeterTypeAccountingInfoVecMap")
+            .def(py::map_indexing_suite<std::map<MeterType, std::vector<Effect::AccountingInfo>>, true>())
         ;
-        class_<Effect::AccountingMap>("TargetIDAccountingMapMap")
-            .def(boost::python::map_indexing_suite<
-                 Effect::AccountingMap, true>())
+        py::class_<Effect::AccountingMap>("TargetIDAccountingMapMap")
+            .def(py::map_indexing_suite<Effect::AccountingMap, true>())
         ;
 
         ///////////////
         //   Meter   //
         ///////////////
-        class_<Meter, noncopyable>("meter", no_init)
+        py::class_<Meter, boost::noncopyable>("meter", py::no_init)
             .add_property("current",            &Meter::Current)
             .add_property("initial",            &Meter::Initial)
-            .def("dump",                        &Meter::Dump,                       return_value_policy<return_by_value>(), "Returns string with debug information, use '0' as argument.")
+            .def("dump",                        &Meter::Dump,                       py::return_value_policy<py::return_by_value>(), "Returns string with debug information, use '0' as argument.")
         ;
 
         ////////////////////
         //    Universe    //
         ////////////////////
-        class_<Universe, noncopyable>("universe", no_init)
-            .def("getObject",                   make_function(GetUniverseObjectP,   return_value_policy<reference_existing_object>()))
-            .def("getFleet",                    make_function(GetFleetP,            return_value_policy<reference_existing_object>()))
-            .def("getShip",                     make_function(GetShipP,             return_value_policy<reference_existing_object>()))
-            .def("getPlanet",                   make_function(GetPlanetP,           return_value_policy<reference_existing_object>()))
-            .def("getSystem",                   make_function(GetSystemP,           return_value_policy<reference_existing_object>()))
-            .def("getField",                    make_function(GetFieldP,            return_value_policy<reference_existing_object>()))
-            .def("getBuilding",                 make_function(GetBuildingP,         return_value_policy<reference_existing_object>()))
-            .def("getGenericShipDesign",        &Universe::GetGenericShipDesign,    return_value_policy<reference_existing_object>(), "Returns the ship design (ShipDesign) with the indicated name (string).")
+        py::class_<Universe, boost::noncopyable>("universe", py::no_init)
+            .def("getObject",                   make_function(GetUniverseObjectP,   py::return_value_policy<py::reference_existing_object>()))
+            .def("getFleet",                    make_function(GetFleetP,            py::return_value_policy<py::reference_existing_object>()))
+            .def("getShip",                     make_function(GetShipP,             py::return_value_policy<py::reference_existing_object>()))
+            .def("getPlanet",                   make_function(GetPlanetP,           py::return_value_policy<py::reference_existing_object>()))
+            .def("getSystem",                   make_function(GetSystemP,           py::return_value_policy<py::reference_existing_object>()))
+            .def("getField",                    make_function(GetFieldP,            py::return_value_policy<py::reference_existing_object>()))
+            .def("getBuilding",                 make_function(GetBuildingP,         py::return_value_policy<py::reference_existing_object>()))
+            .def("getGenericShipDesign",        &Universe::GetGenericShipDesign,    py::return_value_policy<py::reference_existing_object>(), "Returns the ship design (ShipDesign) with the indicated name (string).")
 
-            .add_property("allObjectIDs",       make_function(ObjectIDs<UniverseObject>,return_value_policy<return_by_value>()))
-            .add_property("fleetIDs",           make_function(ObjectIDs<Fleet>,         return_value_policy<return_by_value>()))
-            .add_property("systemIDs",          make_function(ObjectIDs<System>,        return_value_policy<return_by_value>()))
-            .add_property("fieldIDs",           make_function(ObjectIDs<Field>,         return_value_policy<return_by_value>()))
-            .add_property("planetIDs",          make_function(ObjectIDs<Planet>,        return_value_policy<return_by_value>()))
-            .add_property("shipIDs",            make_function(ObjectIDs<Ship>,          return_value_policy<return_by_value>()))
-            .add_property("buildingIDs",        make_function(ObjectIDs<Building>,      return_value_policy<return_by_value>()))
+            .add_property("allObjectIDs",       make_function(ObjectIDs<UniverseObject>,py::return_value_policy<py::return_by_value>()))
+            .add_property("fleetIDs",           make_function(ObjectIDs<Fleet>,         py::return_value_policy<py::return_by_value>()))
+            .add_property("systemIDs",          make_function(ObjectIDs<System>,        py::return_value_policy<py::return_by_value>()))
+            .add_property("fieldIDs",           make_function(ObjectIDs<Field>,         py::return_value_policy<py::return_by_value>()))
+            .add_property("planetIDs",          make_function(ObjectIDs<Planet>,        py::return_value_policy<py::return_by_value>()))
+            .add_property("shipIDs",            make_function(ObjectIDs<Ship>,          py::return_value_policy<py::return_by_value>()))
+            .add_property("buildingIDs",        make_function(ObjectIDs<Building>,      py::return_value_policy<py::return_by_value>()))
             .def("destroyedObjectIDs",          make_function(&Universe::EmpireKnownDestroyedObjectIDs,
-                                                              return_value_policy<return_by_value>()))
+                                                              py::return_value_policy<py::return_by_value>()))
 
             .def("systemHasStarlane",           make_function(
                                                     SystemHasVisibleStarlanesFunc,
-                                                    return_value_policy<return_by_value>(),
+                                                    py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<bool, const Universe&, int, int>()
                                                 ))
 
             .def("updateMeterEstimates",        &UpdateMetersWrapper)
             .add_property("effectAccounting",   make_function(&Universe::GetEffectAccountingMap,
-                                                                                    return_value_policy<reference_existing_object>()))
+                                                                                    py::return_value_policy<py::reference_existing_object>()))
 
             .def("linearDistance",              make_function(
                                                     LinearDistanceFunc,
-                                                    return_value_policy<return_by_value>(),
+                                                    py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<double, const Universe&, int, int>()
                                                 ))
 
             .def("jumpDistance",                make_function(
                                                     JumpDistanceFunc,
-                                                    return_value_policy<return_by_value>(),
+                                                    py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<int, const Universe&, int, int>()
                                                 ),
                                                 "If two system ids are passed or both objects are within a system, "
@@ -445,13 +430,13 @@ namespace FreeOrionPython {
 
             .def("shortestPath",                make_function(
                                                     ShortestPathFunc,
-                                                    return_value_policy<return_by_value>(),
+                                                    py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<std::vector<int>, const Universe&, int, int, int>()
                                                 ))
 
             .def("shortestNonHostilePath",      make_function(
                                                     ShortestNonHostilePathFunc,
-                                                    return_value_policy<return_by_value>(),
+                                                    py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<std::vector<int>, const Universe&, int, int, int>()
                                                 ),
                                                 "Shortest sequence of System ids and distance from System (number1) to "
@@ -461,49 +446,49 @@ namespace FreeOrionPython {
 
             .def("shortestPathDistance",        make_function(
                                                     ShortestPathDistanceFunc,
-                                                    return_value_policy<return_by_value>(),
+                                                    py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<double, const Universe&, int, int>()
                                                 ))
 
             .def("leastJumpsPath",              make_function(
                                                     LeastJumpsFunc,
-                                                    return_value_policy<return_by_value>(),
+                                                    py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<std::vector<int>, const Universe&, int, int, int>()
                                                 ))
 
             .def("systemsConnected",            make_function(
                                                     SystemsConnectedFunc,
-                                                    return_value_policy<return_by_value>(),
+                                                    py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<bool, const Universe&, int, int, int>()
                                                 ))
 
             .def("getImmediateNeighbors",       make_function(
                                                     ImmediateNeighborsFunc,
-                                                    return_value_policy<return_by_value>(),
+                                                    py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<std::vector<int>, const Universe&, int, int>()
                                                 ))
 
             .def("getSystemNeighborsMap",       make_function(
                                                     SystemNeighborsMapFunc,
-                                                    return_value_policy<return_by_value>(),
+                                                    py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<std::map<int, double>, const Universe&, int, int>()
                                                 ))
 
             .def("getVisibilityTurnsMap",       make_function(
                                                     &Universe::GetObjectVisibilityTurnMapByEmpire,
-                                                    return_value_policy<return_by_value>()
+                                                    py::return_value_policy<py::return_by_value>()
                                                 ))
 
             .def("getVisibility",               make_function(
                                                     &Universe::GetObjectVisibilityByEmpire,
-                                                    return_value_policy<return_by_value>()
+                                                    py::return_value_policy<py::return_by_value>()
                                                 ))
 
             // Indexed by stat name (string), contains a map indexed by empire id,
             // contains a map from turn number (int) to stat value (double).
             .def("statRecords",                 make_function(
                                                     &Universe::GetStatRecords,
-                                                    return_value_policy<reference_existing_object>()),
+                                                    py::return_value_policy<py::reference_existing_object>()),
                                                 "Empire statistics recorded by the server each turn. Indexed first by "
                                                 "staistic name (string), then by empire id (int), then by turn "
                                                 "number (int), pointing to the statisic value (double)."
@@ -515,9 +500,9 @@ namespace FreeOrionPython {
         ////////////////////
         // UniverseObject //
         ////////////////////
-        class_<UniverseObject, noncopyable>("universeObject", no_init)
+        py::class_<UniverseObject, boost::noncopyable>("universeObject", py::no_init)
             .add_property("id",                 &UniverseObject::ID)
-            .add_property("name",               make_function(&UniverseObject::Name,        return_value_policy<copy_const_reference>()))
+            .add_property("name",               make_function(&UniverseObject::Name,        py::return_value_policy<py::copy_const_reference>()))
             .add_property("x",                  &UniverseObject::X)
             .add_property("y",                  &UniverseObject::Y)
             .add_property("systemID",           &UniverseObject::SystemID)
@@ -526,38 +511,38 @@ namespace FreeOrionPython {
             .def("ownedBy",                     &UniverseObject::OwnedBy)
             .add_property("creationTurn",       &UniverseObject::CreationTurn)
             .add_property("ageInTurns",         &UniverseObject::AgeInTurns)
-            .add_property("specials",           make_function(ObjectSpecials,               return_value_policy<return_by_value>()))
+            .add_property("specials",           make_function(ObjectSpecials,               py::return_value_policy<py::return_by_value>()))
             .def("hasSpecial",                  &UniverseObject::HasSpecial)
             .def("specialAddedOnTurn",          &UniverseObject::SpecialAddedOnTurn)
             .def("contains",                    &UniverseObject::Contains)
             .def("containedBy",                 &UniverseObject::ContainedBy)
-            .add_property("containedObjects",   make_function(&UniverseObject::ContainedObjectIDs,  return_value_policy<return_by_value>()))
+            .add_property("containedObjects",   make_function(&UniverseObject::ContainedObjectIDs,  py::return_value_policy<py::return_by_value>()))
             .add_property("containerObject",    &UniverseObject::ContainerObjectID)
             .def("currentMeterValue",           make_function(
                                                     ObjectCurrentMeterValueFunc,
-                                                    return_value_policy<return_by_value>(),
+                                                    py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<float, const UniverseObject&, MeterType>()
                                                 ))
             .def("initialMeterValue",           make_function(
                                                     ObjectInitialMeterValueFunc,
-                                                    return_value_policy<return_by_value>(),
+                                                    py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<float, const UniverseObject&, MeterType>()
                                                 ))
-            .add_property("tags",               make_function(&UniverseObject::Tags,        return_value_policy<return_by_value>()))
+            .add_property("tags",               make_function(&UniverseObject::Tags,        py::return_value_policy<py::return_by_value>()))
             .def("hasTag",                      &UniverseObject::HasTag)
             .add_property("meters",             make_function(
                                                     ObjectMetersFunc,
-                                                    return_value_policy<return_by_value>(),
+                                                    py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<std::map<MeterType, Meter>, const UniverseObject&>()
                                                 ))
-            .def("getMeter",                    make_function(ObjectGetMeter,               return_internal_reference<>()))
-            .def("dump",                        make_function(&ObjectDump,                  return_value_policy<return_by_value>()), "Returns string with debug information.")
+            .def("getMeter",                    make_function(ObjectGetMeter,               py::return_internal_reference<>()))
+            .def("dump",                        make_function(&ObjectDump,                  py::return_value_policy<py::return_by_value>()), "Returns string with debug information.")
         ;
 
         ///////////////////
         //     Fleet     //
         ///////////////////
-        class_<Fleet, bases<UniverseObject>, noncopyable>("fleet", no_init)
+        py::class_<Fleet, py::bases<UniverseObject>, boost::noncopyable>("fleet", py::no_init)
             .add_property("fuel",                       &Fleet::Fuel)
             .add_property("maxFuel",                    &Fleet::MaxFuel)
             .add_property("finalDestinationID",         &Fleet::FinalDestinationID)
@@ -574,14 +559,14 @@ namespace FreeOrionPython {
             .add_property("hasTroopShips",              &Fleet::HasTroopShips)
             .add_property("numShips",                   &Fleet::NumShips)
             .add_property("empty",                      &Fleet::Empty)
-            .add_property("shipIDs",                    make_function(&Fleet::ShipIDs,      return_internal_reference<>()))
+            .add_property("shipIDs",                    make_function(&Fleet::ShipIDs,      py::return_internal_reference<>()))
         ;
 
         //////////////////
         //     Ship     //
         //////////////////
-        class_<Ship, bases<UniverseObject>, noncopyable>("ship", no_init)
-            .add_property("design",                 make_function(&Ship::Design,            return_value_policy<reference_existing_object>()))
+        py::class_<Ship, py::bases<UniverseObject>, boost::noncopyable>("ship", py::no_init)
+            .add_property("design",                 make_function(&Ship::Design,            py::return_value_policy<py::reference_existing_object>()))
             .add_property("designID",               &Ship::DesignID)
             .add_property("fleetID",                &Ship::FleetID)
             .add_property("producedByEmpireID",     &Ship::ProducedByEmpireID)
@@ -594,7 +579,7 @@ namespace FreeOrionPython {
             .add_property("canColonize",            &Ship::CanColonize)
             .add_property("canInvade",              &Ship::HasTroops)
             .add_property("canBombard",             &Ship::CanBombard)
-            .add_property("speciesName",            make_function(&Ship::SpeciesName,       return_value_policy<copy_const_reference>()))
+            .add_property("speciesName",            make_function(&Ship::SpeciesName,       py::return_value_policy<py::copy_const_reference>()))
             .add_property("speed",                  &Ship::Speed)
             .add_property("colonyCapacity",         &Ship::ColonyCapacity)
             .add_property("troopCapacity",          &Ship::TroopCapacity)
@@ -603,77 +588,77 @@ namespace FreeOrionPython {
             .add_property("orderedInvadePlanet",    &Ship::OrderedInvadePlanet)
             .def("initialPartMeterValue",           &Ship::InitialPartMeterValue)
             .def("currentPartMeterValue",           &Ship::CurrentPartMeterValue)
-            .add_property("partMeters",             make_function(ShipPartMeters,           return_internal_reference<>()))
-            .def("getMeter",                        make_function(ShipGetPartMeter,         return_internal_reference<>()))
+            .add_property("partMeters",             make_function(ShipPartMeters,           py::return_internal_reference<>()))
+            .def("getMeter",                        make_function(ShipGetPartMeter,         py::return_internal_reference<>()))
         ;
 
         //////////////////
         //  ShipDesign  //
         //////////////////
-        class_<ShipDesign, noncopyable>("shipDesign", no_init)
-            .add_property("id",                 make_function(&ShipDesign::ID,              return_value_policy<return_by_value>()))
+        py::class_<ShipDesign, boost::noncopyable>("shipDesign", py::no_init)
+            .add_property("id",                 make_function(&ShipDesign::ID,              py::return_value_policy<py::return_by_value>()))
             .add_property("name",               make_function(
                                                     ShipDesignNameFunc,
-                                                    return_value_policy<copy_const_reference>(),
+                                                    py::return_value_policy<py::copy_const_reference>(),
                                                     boost::mpl::vector<const std::string&, const ShipDesign&>()
                                                 ))
             .add_property("description",        make_function(
                                                     ShipDesignDescriptionFunc,
-                                                    return_value_policy<copy_const_reference>(),
+                                                    py::return_value_policy<py::copy_const_reference>(),
                                                     boost::mpl::vector<const std::string&, const ShipDesign&>()
                                                 ))
-            .add_property("designedOnTurn",     make_function(&ShipDesign::DesignedOnTurn,  return_value_policy<return_by_value>()))
-            .add_property("speed",              make_function(&ShipDesign::Speed,           return_value_policy<return_by_value>()))
-            .add_property("structure",          make_function(&ShipDesign::Structure,       return_value_policy<return_by_value>()))
-            .add_property("shields",            make_function(&ShipDesign::Shields,         return_value_policy<return_by_value>()))
-            .add_property("fuel",               make_function(&ShipDesign::Fuel,            return_value_policy<return_by_value>()))
-            .add_property("detection",          make_function(&ShipDesign::Detection,       return_value_policy<return_by_value>()))
-            .add_property("colonyCapacity",     make_function(&ShipDesign::ColonyCapacity,  return_value_policy<return_by_value>()))
-            .add_property("troopCapacity",      make_function(&ShipDesign::TroopCapacity,   return_value_policy<return_by_value>()))
-            .add_property("stealth",            make_function(&ShipDesign::Stealth,         return_value_policy<return_by_value>()))
-            .add_property("industryGeneration", make_function(&ShipDesign::IndustryGeneration,  return_value_policy<return_by_value>()))
-            .add_property("researchGeneration", make_function(&ShipDesign::ResearchGeneration,  return_value_policy<return_by_value>()))
-            .add_property("influenceGeneration",make_function(&ShipDesign::InfluenceGeneration, return_value_policy<return_by_value>()))
-            .add_property("defense",            make_function(&ShipDesign::Defense,         return_value_policy<return_by_value>()))
-            .add_property("attack",             make_function(&ShipDesign::Attack,          return_value_policy<return_by_value>()))
-            .add_property("canColonize",        make_function(&ShipDesign::CanColonize,     return_value_policy<return_by_value>()))
-            .add_property("canInvade",          make_function(&ShipDesign::HasTroops,       return_value_policy<return_by_value>()))
-            .add_property("isArmed",            make_function(&ShipDesign::IsArmed,         return_value_policy<return_by_value>()))
-            .add_property("hasFighters",        make_function(&ShipDesign::HasFighters,     return_value_policy<return_by_value>()))
-            .add_property("hasDirectWeapons",   make_function(&ShipDesign::HasDirectWeapons,return_value_policy<return_by_value>()))
-            .add_property("isMonster",          make_function(&ShipDesign::IsMonster,       return_value_policy<return_by_value>()))
+            .add_property("designedOnTurn",     make_function(&ShipDesign::DesignedOnTurn,  py::return_value_policy<py::return_by_value>()))
+            .add_property("speed",              make_function(&ShipDesign::Speed,           py::return_value_policy<py::return_by_value>()))
+            .add_property("structure",          make_function(&ShipDesign::Structure,       py::return_value_policy<py::return_by_value>()))
+            .add_property("shields",            make_function(&ShipDesign::Shields,         py::return_value_policy<py::return_by_value>()))
+            .add_property("fuel",               make_function(&ShipDesign::Fuel,            py::return_value_policy<py::return_by_value>()))
+            .add_property("detection",          make_function(&ShipDesign::Detection,       py::return_value_policy<py::return_by_value>()))
+            .add_property("colonyCapacity",     make_function(&ShipDesign::ColonyCapacity,  py::return_value_policy<py::return_by_value>()))
+            .add_property("troopCapacity",      make_function(&ShipDesign::TroopCapacity,   py::return_value_policy<py::return_by_value>()))
+            .add_property("stealth",            make_function(&ShipDesign::Stealth,         py::return_value_policy<py::return_by_value>()))
+            .add_property("industryGeneration", make_function(&ShipDesign::IndustryGeneration,  py::return_value_policy<py::return_by_value>()))
+            .add_property("researchGeneration", make_function(&ShipDesign::ResearchGeneration,  py::return_value_policy<py::return_by_value>()))
+            .add_property("influenceGeneration",make_function(&ShipDesign::InfluenceGeneration, py::return_value_policy<py::return_by_value>()))
+            .add_property("defense",            make_function(&ShipDesign::Defense,         py::return_value_policy<py::return_by_value>()))
+            .add_property("attack",             make_function(&ShipDesign::Attack,          py::return_value_policy<py::return_by_value>()))
+            .add_property("canColonize",        make_function(&ShipDesign::CanColonize,     py::return_value_policy<py::return_by_value>()))
+            .add_property("canInvade",          make_function(&ShipDesign::HasTroops,       py::return_value_policy<py::return_by_value>()))
+            .add_property("isArmed",            make_function(&ShipDesign::IsArmed,         py::return_value_policy<py::return_by_value>()))
+            .add_property("hasFighters",        make_function(&ShipDesign::HasFighters,     py::return_value_policy<py::return_by_value>()))
+            .add_property("hasDirectWeapons",   make_function(&ShipDesign::HasDirectWeapons,py::return_value_policy<py::return_by_value>()))
+            .add_property("isMonster",          make_function(&ShipDesign::IsMonster,       py::return_value_policy<py::return_by_value>()))
             .def("productionCost",              &ShipDesign::ProductionCost)
             .def("productionTime",              &ShipDesign::ProductionTime)
             .def("perTurnCost",                 &ShipDesign::PerTurnCost)
             .add_property("costTimeLocationInvariant",
                                                 &ShipDesign::ProductionCostTimeLocationInvariant)
-            .add_property("hull",               make_function(&ShipDesign::Hull,            return_value_policy<return_by_value>()))
+            .add_property("hull",               make_function(&ShipDesign::Hull,            py::return_value_policy<py::return_by_value>()))
             .add_property("ship_hull",          make_function(
                                                     ShipDesignHullFunc,
-                                                    return_value_policy<reference_existing_object>(),
+                                                    py::return_value_policy<py::reference_existing_object>(),
                                                     boost::mpl::vector<const ShipHull*, const ShipDesign&>()
                                                 ))
-            .add_property("parts",              make_function(PartsVoid,                    return_internal_reference<>()))
+            .add_property("parts",              make_function(PartsVoid,                    py::return_internal_reference<>()))
             .add_property("attackStats",        make_function(
                                                     AttackStatsFunc,
-                                                    return_value_policy<return_by_value>(),
+                                                    py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<std::vector<int>, const ShipDesign&>()
                                                 ))
 
             .def("productionLocationForEmpire", &ShipDesign::ProductionLocation)
-            .def("dump",                        &ShipDesign::Dump,                          return_value_policy<return_by_value>(), "Returns string with debug information, use '0' as argument.")
+            .def("dump",                        &ShipDesign::Dump,                          py::return_value_policy<py::return_by_value>(), "Returns string with debug information, use '0' as argument.")
         ;
-        def("validShipDesign",                  ValidDesignHullAndParts, "Returns true (boolean) if the passed hull (string) and parts (StringVec) make up a valid ship design, and false (boolean) otherwise. Valid ship designs don't have any parts in slots that can't accept that type of part, and contain only hulls and parts that exist (and may also need to contain the correct number of parts - this needs to be verified).");
-        def("getShipDesign",                    &GetShipDesign,                             return_value_policy<reference_existing_object>(), "Returns the ship design (ShipDesign) with the indicated id number (int).");
-        def("getPredefinedShipDesign",          &GetPredefinedShipDesign,                   return_value_policy<reference_existing_object>(), "Returns the ship design (ShipDesign) with the indicated name (string).");
+        py::def("validShipDesign",                  ValidDesignHullAndParts, "Returns true (boolean) if the passed hull (string) and parts (StringVec) make up a valid ship design, and false (boolean) otherwise. Valid ship designs don't have any parts in slots that can't accept that type of part, and contain only hulls and parts that exist (and may also need to contain the correct number of parts - this needs to be verified).");
+        py::def("getShipDesign",                    &GetShipDesign,                             py::return_value_policy<py::reference_existing_object>(), "Returns the ship design (ShipDesign) with the indicated id number (int).");
+        py::def("getPredefinedShipDesign",          &GetPredefinedShipDesign,                   py::return_value_policy<py::reference_existing_object>(), "Returns the ship design (ShipDesign) with the indicated name (string).");
 
 
-        class_<ShipPart, noncopyable>("shipPart", no_init)
-            .add_property("name",               make_function(&ShipPart::Name,              return_value_policy<copy_const_reference>()))
+        py::class_<ShipPart, boost::noncopyable>("shipPart", py::no_init)
+            .add_property("name",               make_function(&ShipPart::Name,              py::return_value_policy<py::copy_const_reference>()))
             .add_property("partClass",          &ShipPart::Class)
             .add_property("capacity",           &ShipPart::Capacity)
             .add_property("secondaryStat",      &ShipPart::SecondaryStat)
-            .add_property("mountableSlotTypes", make_function(&ShipPart::MountableSlotTypes,return_value_policy<return_by_value>()))
+            .add_property("mountableSlotTypes", make_function(&ShipPart::MountableSlotTypes,py::return_value_policy<py::return_by_value>()))
             .def("productionCost",              &ShipPart::ProductionCost)
             .def("productionTime",              &ShipPart::ProductionTime)
             .def("canMountInSlotType",          &ShipPart::CanMountInSlotType)
@@ -681,11 +666,11 @@ namespace FreeOrionPython {
                                                 &ShipPart::ProductionCostTimeLocationInvariant)
             .def("productionLocation",          &ShipPartProductionLocation, "Returns the result of Location condition (bool) in passed location_id (int)")
         ;
-        def("getShipPart",                      &GetShipPart,                               return_value_policy<reference_existing_object>(), "Returns the ShipPart with the indicated name (string).");
+        py::def("getShipPart",                      &GetShipPart,                               py::return_value_policy<py::reference_existing_object>(), "Returns the ShipPart with the indicated name (string).");
 
-        class_<ShipHull, noncopyable>("shipHull", no_init)
-            .add_property("name",               make_function(&ShipHull::Name,              return_value_policy<copy_const_reference>()))
-            .add_property("numSlots",           make_function(NumSlotsTotal,                return_value_policy<return_by_value>()))
+        py::class_<ShipHull, boost::noncopyable>("shipHull", py::no_init)
+            .add_property("name",               make_function(&ShipHull::Name,              py::return_value_policy<py::copy_const_reference>()))
+            .add_property("numSlots",           make_function(NumSlotsTotal,                py::return_value_policy<py::return_by_value>()))
             .add_property("structure",          &ShipHull::Structure)
             .add_property("stealth",            &ShipHull::Stealth)
             .add_property("fuel",               &ShipHull::Fuel)
@@ -694,7 +679,7 @@ namespace FreeOrionPython {
             .def("numSlotsOfSlotType",          NumSlotsOfSlotType)
             .add_property("slots",              make_function(
                                                     HullSlotsFunc,
-                                                    return_value_policy<return_by_value>(),
+                                                    py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<std::vector<ShipSlotType>, const ShipHull&>()
                                                 ))
             .def("productionCost",              &ShipHull::ProductionCost)
@@ -704,14 +689,14 @@ namespace FreeOrionPython {
             .def("hasTag",                      &ShipHull::HasTag)
             .def("productionLocation",          &HullProductionLocation, "Returns the result of Location condition (bool) in passed location_id (int)")
         ;
-        def("getShipHull",                      &GetShipHull,                               return_value_policy<reference_existing_object>(), "Returns the ship hull with the indicated name (string).");
+        py::def("getShipHull",                      &GetShipHull,                               py::return_value_policy<py::reference_existing_object>(), "Returns the ship hull with the indicated name (string).");
 
         //////////////////
         //   Building   //
         //////////////////
-        class_<Building, bases<UniverseObject>, noncopyable>("building", no_init)
-            .add_property("buildingTypeName",   make_function(&Building::BuildingTypeName,  return_value_policy<copy_const_reference>()))
-            .add_property("planetID",           make_function(&Building::PlanetID,          return_value_policy<return_by_value>()))
+        py::class_<Building, py::bases<UniverseObject>, boost::noncopyable>("building", py::no_init)
+            .add_property("buildingTypeName",   make_function(&Building::BuildingTypeName,  py::return_value_policy<py::copy_const_reference>()))
+            .add_property("planetID",           make_function(&Building::PlanetID,          py::return_value_policy<py::return_by_value>()))
             .add_property("producedByEmpireID", &Building::ProducedByEmpireID)
             .add_property("orderedScrapped",    &Building::OrderedScrapped)
         ;
@@ -719,9 +704,9 @@ namespace FreeOrionPython {
         //////////////////
         // BuildingType //
         //////////////////
-        class_<BuildingType, noncopyable>("buildingType", no_init)
-            .add_property("name",               make_function(&BuildingType::Name,          return_value_policy<copy_const_reference>()))
-            .add_property("description",        make_function(&BuildingType::Description,   return_value_policy<copy_const_reference>()))
+        py::class_<BuildingType, boost::noncopyable>("buildingType", py::no_init)
+            .add_property("name",               make_function(&BuildingType::Name,          py::return_value_policy<py::copy_const_reference>()))
+            .add_property("description",        make_function(&BuildingType::Description,   py::return_value_policy<py::copy_const_reference>()))
             .def("productionCost",              &BuildingType::ProductionCost)
             .def("productionTime",              &BuildingType::ProductionTime)
             .def("perTurnCost",                 &BuildingType::PerTurnCost)
@@ -730,14 +715,14 @@ namespace FreeOrionPython {
             .def("canBeEnqueued",               &EnqueueLocationTest)  //(int empire_id, int location_id)
             .add_property("costTimeLocationInvariant",
                                                 &BuildingType::ProductionCostTimeLocationInvariant)
-            .def("dump",                        &BuildingType::Dump,                        return_value_policy<return_by_value>(), "Returns string with debug information, use '0' as argument.")
+            .def("dump",                        &BuildingType::Dump,                        py::return_value_policy<py::return_by_value>(), "Returns string with debug information, use '0' as argument.")
         ;
-        def("getBuildingType",                  &GetBuildingType,                           return_value_policy<reference_existing_object>(), "Returns the building type (BuildingType) with the indicated name (string).");
+        py::def("getBuildingType",                  &GetBuildingType,                           py::return_value_policy<py::reference_existing_object>(), "Returns the building type (BuildingType) with the indicated name (string).");
         ////////////////////
         // ResourceCenter //
         ////////////////////
-        class_<ResourceCenter, noncopyable>("resourceCenter", no_init)
-            .add_property("focus",                  make_function(&ResourceCenter::Focus,   return_value_policy<copy_const_reference>()))
+        py::class_<ResourceCenter, boost::noncopyable>("resourceCenter", py::no_init)
+            .add_property("focus",                  make_function(&ResourceCenter::Focus,   py::return_value_policy<py::copy_const_reference>()))
             .add_property("turnsSinceFocusChange" , &ResourceCenter::TurnsSinceFocusChange)
             .add_property("availableFoci",          &ResourceCenter::AvailableFoci)
         ;
@@ -745,14 +730,14 @@ namespace FreeOrionPython {
         ///////////////////
         //   PopCenter   //
         ///////////////////
-        class_<PopCenter, noncopyable>("popCenter", no_init)
-            .add_property("speciesName",        make_function(&PopCenter::SpeciesName,      return_value_policy<copy_const_reference>()))
+        py::class_<PopCenter, boost::noncopyable>("popCenter", py::no_init)
+            .add_property("speciesName",        make_function(&PopCenter::SpeciesName,      py::return_value_policy<py::copy_const_reference>()))
         ;
 
         //////////////////
         //    Planet    //
         //////////////////
-        class_<Planet, bases<UniverseObject, PopCenter, ResourceCenter>, noncopyable>("planet", no_init)
+        py::class_<Planet, py::bases<UniverseObject, PopCenter, ResourceCenter>, boost::noncopyable>("planet", py::no_init)
             .add_property("size",                           &Planet::Size)
             .add_property("type",                           &Planet::Type)
             .add_property("originalType",                   &Planet::OriginalType)
@@ -769,33 +754,33 @@ namespace FreeOrionPython {
             .add_property("RotationalPeriod",               &Planet::RotationalPeriod)
             .add_property("LastTurnAttackedByShip",         &Planet::LastTurnAttackedByShip)
             .add_property("LastTurnConquered",              &Planet::LastTurnConquered)
-            .add_property("buildingIDs",                    make_function(&Planet::BuildingIDs,     return_internal_reference<>()))
+            .add_property("buildingIDs",                    make_function(&Planet::BuildingIDs,     py::return_internal_reference<>()))
             .add_property("habitableSize",                  &Planet::HabitableSize)
         ;
 
         //////////////////
         //    System    //
         //////////////////
-        class_<System, bases<UniverseObject>, noncopyable>("system", no_init)
+        py::class_<System, py::bases<UniverseObject>, boost::noncopyable>("system", py::no_init)
             .add_property("starType",           &System::GetStarType)
             .add_property("numStarlanes",       &System::NumStarlanes)
             .add_property("numWormholes",       &System::NumWormholes, "Currently unused.")
             .def("HasStarlaneToSystemID",       &System::HasStarlaneTo)
             .def("HasWormholeToSystemID",       &System::HasWormholeTo, "Currently unused.")
-            .add_property("starlanesWormholes", make_function(&System::StarlanesWormholes,  return_value_policy<return_by_value>()), "Currently unused.")
-            .add_property("planetIDs",          make_function(&System::PlanetIDs,           return_value_policy<return_by_value>()))
-            .add_property("buildingIDs",        make_function(&System::BuildingIDs,         return_value_policy<return_by_value>()))
-            .add_property("fleetIDs",           make_function(&System::FleetIDs,            return_value_policy<return_by_value>()))
-            .add_property("shipIDs",            make_function(&System::ShipIDs,             return_value_policy<return_by_value>()))
-            .add_property("fieldIDs",           make_function(&System::FieldIDs,            return_value_policy<return_by_value>()))
+            .add_property("starlanesWormholes", make_function(&System::StarlanesWormholes,  py::return_value_policy<py::return_by_value>()), "Currently unused.")
+            .add_property("planetIDs",          make_function(&System::PlanetIDs,           py::return_value_policy<py::return_by_value>()))
+            .add_property("buildingIDs",        make_function(&System::BuildingIDs,         py::return_value_policy<py::return_by_value>()))
+            .add_property("fleetIDs",           make_function(&System::FleetIDs,            py::return_value_policy<py::return_by_value>()))
+            .add_property("shipIDs",            make_function(&System::ShipIDs,             py::return_value_policy<py::return_by_value>()))
+            .add_property("fieldIDs",           make_function(&System::FieldIDs,            py::return_value_policy<py::return_by_value>()))
             .add_property("lastTurnBattleHere", &System::LastTurnBattleHere)
         ;
 
         //////////////////
         //    Field     //
         //////////////////
-        class_<Field, bases<UniverseObject>, noncopyable>("field", no_init)
-            .add_property("fieldTypeName",      make_function(&Field::FieldTypeName,        return_value_policy<copy_const_reference>()))
+        py::class_<Field, py::bases<UniverseObject>, boost::noncopyable>("field", py::no_init)
+            .add_property("fieldTypeName",      make_function(&Field::FieldTypeName,        py::return_value_policy<py::copy_const_reference>()))
             .def("inField",                     &ObjectInField)
             .def("inField",                     LocationInField)
         ;
@@ -803,71 +788,71 @@ namespace FreeOrionPython {
         //////////////////
         //   FieldType  //
         //////////////////
-        class_<FieldType, noncopyable>("fieldType", no_init)
-            .add_property("name",               make_function(&FieldType::Name,             return_value_policy<copy_const_reference>()))
-            .add_property("description",        make_function(&FieldType::Description,      return_value_policy<copy_const_reference>()))
-            .def("dump",                        &FieldType::Dump,                           return_value_policy<return_by_value>(), "Returns string with debug information, use '0' as argument.")
+        py::class_<FieldType, boost::noncopyable>("fieldType", py::no_init)
+            .add_property("name",               make_function(&FieldType::Name,             py::return_value_policy<py::copy_const_reference>()))
+            .add_property("description",        make_function(&FieldType::Description,      py::return_value_policy<py::copy_const_reference>()))
+            .def("dump",                        &FieldType::Dump,                           py::return_value_policy<py::return_by_value>(), "Returns string with debug information, use '0' as argument.")
         ;
-        def("getFieldType",                     &GetFieldType,                           return_value_policy<reference_existing_object>());
+        py::def("getFieldType",                     &GetFieldType,                           py::return_value_policy<py::reference_existing_object>());
 
 
         /////////////////
         //   Special   //
         /////////////////
-        class_<Special, noncopyable>("special", no_init)
-            .add_property("name",               make_function(&Special::Name,           return_value_policy<copy_const_reference>()))
+        py::class_<Special, boost::noncopyable>("special", py::no_init)
+            .add_property("name",               make_function(&Special::Name,           py::return_value_policy<py::copy_const_reference>()))
             .add_property("description",        &Special::Description)
-            .add_property("spawnrate",          make_function(&Special::SpawnRate,      return_value_policy<return_by_value>()))
-            .add_property("spawnlimit",         make_function(&Special::SpawnLimit,     return_value_policy<return_by_value>()))
-            .def("dump",                        &Special::Dump,                         return_value_policy<return_by_value>(), "Returns string with debug information, use '0' as argument.")
+            .add_property("spawnrate",          make_function(&Special::SpawnRate,      py::return_value_policy<py::return_by_value>()))
+            .add_property("spawnlimit",         make_function(&Special::SpawnLimit,     py::return_value_policy<py::return_by_value>()))
+            .def("dump",                        &Special::Dump,                         py::return_value_policy<py::return_by_value>(), "Returns string with debug information, use '0' as argument.")
             .def("initialCapacity",             SpecialInitialCapacityOnObject)
         ;
-        def("getSpecial",                       &GetSpecial,                            return_value_policy<reference_existing_object>(), "Returns the special (Special) with the indicated name (string).");
+        py::def("getSpecial",                       &GetSpecial,                            py::return_value_policy<py::reference_existing_object>(), "Returns the special (Special) with the indicated name (string).");
 
         /////////////////
         //   Species   //
         /////////////////
-        class_<Species, noncopyable>("species", no_init)
-            .add_property("name",               make_function(&Species::Name,           return_value_policy<copy_const_reference>()))
-            .add_property("description",        make_function(&Species::Description,    return_value_policy<copy_const_reference>()))
-            .add_property("homeworlds",         make_function(&Species::Homeworlds,     return_value_policy<copy_const_reference>()))
+        py::class_<Species, boost::noncopyable>("species", py::no_init)
+            .add_property("name",               make_function(&Species::Name,           py::return_value_policy<py::copy_const_reference>()))
+            .add_property("description",        make_function(&Species::Description,    py::return_value_policy<py::copy_const_reference>()))
+            .add_property("homeworlds",         make_function(&Species::Homeworlds,     py::return_value_policy<py::copy_const_reference>()))
             .add_property("foci",               &SpeciesFoci)
-            .add_property("preferredFocus",     make_function(&Species::PreferredFocus, return_value_policy<copy_const_reference>()))
-            .add_property("canColonize",        make_function(&Species::CanColonize,    return_value_policy<return_by_value>()))
-            .add_property("canProduceShips",    make_function(&Species::CanProduceShips,return_value_policy<return_by_value>()))
-            .add_property("tags",               make_function(&Species::Tags,           return_value_policy<return_by_value>()))
+            .add_property("preferredFocus",     make_function(&Species::PreferredFocus, py::return_value_policy<py::copy_const_reference>()))
+            .add_property("canColonize",        make_function(&Species::CanColonize,    py::return_value_policy<py::return_by_value>()))
+            .add_property("canProduceShips",    make_function(&Species::CanProduceShips,py::return_value_policy<py::return_by_value>()))
+            .add_property("tags",               make_function(&Species::Tags,           py::return_value_policy<py::return_by_value>()))
             // TODO: const std::vector<FocusType>& Species::Foci()
             .def("getPlanetEnvironment",        &Species::GetPlanetEnvironment)
-            .def("dump",                        &Species::Dump,                         return_value_policy<return_by_value>(), "Returns string with debug information, use '0' as argument.")
+            .def("dump",                        &Species::Dump,                         py::return_value_policy<py::return_by_value>(), "Returns string with debug information, use '0' as argument.")
         ;
-        def("getSpecies",                       &GetSpecies,                            return_value_policy<reference_existing_object>(), "Returns the species (Species) with the indicated name (string).");
+        py::def("getSpecies",                       &GetSpecies,                            py::return_value_policy<py::reference_existing_object>(), "Returns the species (Species) with the indicated name (string).");
     }
 
     void WrapGalaxySetupData() {
-        class_<GalaxySetupData>("GalaxySetupData")
-            .add_property("seed",               make_function(&GalaxySetupData::GetSeed,            return_value_policy<return_by_value>()))
-            .add_property("size",               make_function(&GalaxySetupData::GetSize,            return_value_policy<return_by_value>()))
-            .add_property("shape",              make_function(&GalaxySetupData::GetShape,           return_value_policy<return_by_value>()))
-            .add_property("age",                make_function(&GalaxySetupData::GetAge,             return_value_policy<return_by_value>()))
-            .add_property("starlaneFrequency",  make_function(&GalaxySetupData::GetStarlaneFreq,    return_value_policy<return_by_value>()))
-            .add_property("planetDensity",      make_function(&GalaxySetupData::GetPlanetDensity,   return_value_policy<return_by_value>()))
-            .add_property("specialsFrequency",  make_function(&GalaxySetupData::GetSpecialsFreq,    return_value_policy<return_by_value>()))
-            .add_property("monsterFrequency",   make_function(&GalaxySetupData::GetMonsterFreq,     return_value_policy<return_by_value>()))
-            .add_property("nativeFrequency",    make_function(&GalaxySetupData::GetNativeFreq,      return_value_policy<return_by_value>()))
-            .add_property("maxAIAggression",    make_function(&GalaxySetupData::GetAggression,      return_value_policy<return_by_value>()))
-            .add_property("gameUID",            make_function(&GalaxySetupData::GetGameUID,         return_value_policy<return_by_value>()),
+        py::class_<GalaxySetupData>("GalaxySetupData")
+            .add_property("seed",               make_function(&GalaxySetupData::GetSeed,            py::return_value_policy<py::return_by_value>()))
+            .add_property("size",               make_function(&GalaxySetupData::GetSize,            py::return_value_policy<py::return_by_value>()))
+            .add_property("shape",              make_function(&GalaxySetupData::GetShape,           py::return_value_policy<py::return_by_value>()))
+            .add_property("age",                make_function(&GalaxySetupData::GetAge,             py::return_value_policy<py::return_by_value>()))
+            .add_property("starlaneFrequency",  make_function(&GalaxySetupData::GetStarlaneFreq,    py::return_value_policy<py::return_by_value>()))
+            .add_property("planetDensity",      make_function(&GalaxySetupData::GetPlanetDensity,   py::return_value_policy<py::return_by_value>()))
+            .add_property("specialsFrequency",  make_function(&GalaxySetupData::GetSpecialsFreq,    py::return_value_policy<py::return_by_value>()))
+            .add_property("monsterFrequency",   make_function(&GalaxySetupData::GetMonsterFreq,     py::return_value_policy<py::return_by_value>()))
+            .add_property("nativeFrequency",    make_function(&GalaxySetupData::GetNativeFreq,      py::return_value_policy<py::return_by_value>()))
+            .add_property("maxAIAggression",    make_function(&GalaxySetupData::GetAggression,      py::return_value_policy<py::return_by_value>()))
+            .add_property("gameUID",            make_function(&GalaxySetupData::GetGameUID,         py::return_value_policy<py::return_by_value>()),
                                                 &GalaxySetupData::SetGameUID);
 
-        class_<GameRules, noncopyable>("GameRules", no_init)
-            .add_property("empty",              make_function(&GameRules::Empty,                return_value_policy<return_by_value>()))
-            .def("getRulesAsStrings",           make_function(&GameRules::GetRulesAsStrings,    return_value_policy<return_by_value>()))
+        py::class_<GameRules, boost::noncopyable>("GameRules", py::no_init)
+            .add_property("empty",              make_function(&GameRules::Empty,                py::return_value_policy<py::return_by_value>()))
+            .def("getRulesAsStrings",           make_function(&GameRules::GetRulesAsStrings,    py::return_value_policy<py::return_by_value>()))
             .def("ruleExists",                  RuleExistsAnyType)
             .def("ruleExistsWithType",          RuleExistsWithType)
-            .def("getDescription",              make_function(&GameRules::GetDescription,       return_value_policy<copy_const_reference>()))
+            .def("getDescription",              make_function(&GameRules::GetDescription,       py::return_value_policy<py::copy_const_reference>()))
             .def("getToggle",                   &GameRules::Get<bool>)
             .def("getInt",                      &GameRules::Get<int>)
             .def("getDouble",                   &GameRules::Get<double>)
-            .def("getString",                   make_function(&GameRules::Get<std::string>,     return_value_policy<return_by_value>()));
-        def("getGameRules",                     &GetGameRules,                                  return_value_policy<reference_existing_object>(), "Returns the game rules manager, which can be used to look up the names (string) of rules are defined with what type (boolean / toggle, int, double, string), and what values the rules have in the current game.");
+            .def("getString",                   make_function(&GameRules::Get<std::string>,     py::return_value_policy<py::return_by_value>()));
+        py::def("getGameRules",                     &GetGameRules,                                  py::return_value_policy<py::reference_existing_object>(), "Returns the game rules manager, which can be used to look up the names (string) of rules are defined with what type (boolean / toggle, int, double, string), and what values the rules have in the current game.");
     }
 }


### PR DESCRIPTION
This PR introduces the `py` namepace alias for `boost::python` in favor to `using boost::python::*` statement and applies it consistently across the binding code.

This is a general cleanup task and a possible preparation to use pybind11 in the future.