### PR TITLE
Migrate Python related CI jobs onto GitHub actions CI

### DIFF
--- a/.github/workflows/test-AI.yml
+++ b/.github/workflows/test-AI.yml
@@ -15,6 +15,8 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Register flake8 annotation problem matcher
+        uses: rbialon/flake8-annotations@v1
       - name: Set up system dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/test-AI.yml
+++ b/.github/workflows/test-AI.yml
@@ -28,7 +28,7 @@ jobs:
           ninja-build
       - name: Set up python test dependencies
         run: |
-          python3 -m pip install flake8==3.7.9 pytest==5.4.1
+          python3 -m pip install flake8==3.7.9 pytest==5.4.1 pytest-github-actions-annotate-failures==0.0.5
       - name: Create build directory
         run: |
           mkdir build

--- a/.github/workflows/test-AI.yml
+++ b/.github/workflows/test-AI.yml
@@ -1,0 +1,45 @@
+name: Test AI with linting and unit tests
+on: push
+jobs:
+  test-AI:
+    name: AI source linting and testing
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        python-version:
+          - 3.6
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Set up system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install --assume-yes \
+          libboost1.62-all-dev \
+          libglew-dev \
+          libogg-dev \
+          libopenal-dev \
+          libsdl2-dev \
+          libvorbis-dev \
+          ninja-build
+      - name: Set up python test dependencies
+        run: |
+          python3 -m pip install flake8==3.7.9 pytest==5.4.1
+      - name: Create build directory
+        run: |
+          mkdir build
+          cd build
+          cmake -G Ninja ..
+      - name: Lint AI sources against PEP8
+        if: always()
+        working-directory: build
+        run: |
+          ninja check-pep8
+      - name: Unit test AI sources
+        if: always()
+        run: |
+          pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -43,25 +43,8 @@ _linux_setup_common: &_linux_setup_common
     - ccache --cleanup
     - ccache --show-stats
 
-_test_python_common: &_test_python_common
-  stage: test
-  os: linux
-  dist: bionic
-  language: python
-  install:
-    - pip install pytest==5.4.1
-  script:
-    - pytest
-
 jobs:
   include:
-    - name: Lint AI with Python 3.5
-      <<: *_linux_setup_common
-      stage: lint
-      script:
-        - cmake ..
-        - cmake --build . --target check-pep8
-
     - name: Lint string tables
       stage: lint
       os: linux
@@ -152,15 +135,3 @@ jobs:
       before_cache:
         - ccache --cleanup
         - ccache --show-stats
-
-    - name: Unittest AI with Python 3.5
-      <<: *_test_python_common
-      python: 3.5
-      before_install:
-        - alias pip=/usr/bin/pip3
-
-    - name: Unittest AI with Python 3.8
-      <<: *_test_python_common
-      python: 3.8
-      before_install:
-        - alias pip=/usr/bin/pip3

--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -16,11 +16,12 @@ endif()
 
 if(TARGET Flake8::flake8)
     add_custom_target(check-pep8
-        COMMAND "$<TARGET_FILE:Flake8::flake8>"
+        COMMAND "$<TARGET_FILE:Flake8::flake8>" "default/python"
         COMMENT "Check python code for PEP-8 style conformance"
         VERBATIM
         SOURCES "${PROJECT_SOURCE_DIR}/default/python/tox.ini"
-        WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/default/python"
+        WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}"
+        USES_TERMINAL
     )
 endif()
 

--- a/default/python/tox.ini
+++ b/default/python/tox.ini
@@ -20,6 +20,18 @@ per-file-ignores =
   universe_generation/universe_tables.py: E201,E122,E231
   stub_generator/__init__.py: F401
   tests/conftest.py: E402,F401
+  default/python/AI/FreeOrionAI.py:E402
+  default/python/AI/AIDependencies.py: E241
+  default/python/AI/savegame_codec/__init__.py: F401
+  default/python/AI/freeorion_tools/__init__.py: F401,F403
+  default/python/auth/auth.py: E402
+  default/python/chat/chat.py: E402
+  default/python/turn_events/turn_events.py: E402
+  default/python/universe_generation/teams.py: E402
+  default/python/universe_generation/universe_generator.py: E402
+  default/python/universe_generation/universe_tables.py: E201,E122,E231
+  default/python/stub_generator/__init__.py: F401
+  default/python/tests/conftest.py: E402,F401
 
 exclude =
   *_venv/


### PR DESCRIPTION
This PR migrates the existing Travis CI jobs related to Python

* Syntax check (compileall)
* PEP-8 conformance test
* Unit test

onto GitHub Actions CI infrastructure.

The PR contains some intentional bugs to show the integration of GitHub Check annotations, which display errors and warnings within the PR file diff for easier reviewing.

I'm not sure if the annotations are already created on this initial PR, so you can take a look into a PR in private repository: adrianbroher/freeorion#8.  Most relevant aspects are the `Checks` tab for looking into the CI run logs and the `Files` tab to see the in-place annotations for the provoked error messages.