### PR TITLE
Refactor Python bindings

### DIFF
--- a/client/AI/AIFramework.cpp
+++ b/client/AI/AIFramework.cpp
@@ -80,7 +80,8 @@ BOOST_PYTHON_MODULE(freeOrionAIInterface)
 //////////////////////
 //     PythonAI     //
 //////////////////////
-bool PythonAI::Initialize() {
+auto PythonAI::Initialize() -> bool
+{
     if (PythonBase::Initialize()) {
         BuildingTypeManager& temp = GetBuildingTypeManager();  // Ensure buildings are initialized
         (void)temp; // Hide unused variable warning
@@ -90,13 +91,15 @@ bool PythonAI::Initialize() {
         return false;
 }
 
-bool PythonAI::InitImports() {
+auto PythonAI::InitImports() -> bool
+{
     DebugLogger() << "Initializing AI Python imports";
     // allows the "freeOrionAIInterface" C++ module to be imported within Python code
     return PyImport_AppendInittab("freeOrionAIInterface", &PyInit_freeOrionAIInterface) != -1;
 }
 
-bool PythonAI::InitModules() {
+auto PythonAI::InitModules() -> bool
+{
     DebugLogger() << "Initializing AI Python modules";
 
     // Confirm existence of the directory containing the AI Python scripts
@@ -116,7 +119,8 @@ bool PythonAI::InitModules() {
     return true;
 }
 
-void PythonAI::GenerateOrders() {
+void PythonAI::GenerateOrders()
+{
     DebugLogger() << "PythonAI::GenerateOrders : initializing turn";
 
     ScopedTimer order_timer;
@@ -141,32 +145,37 @@ void PythonAI::GenerateOrders() {
     DebugLogger() << "PythonAI::GenerateOrders order generating time: " << order_timer.DurationString();
 }
 
-void PythonAI::HandleChatMessage(int sender_id, const std::string& msg) {
+void PythonAI::HandleChatMessage(int sender_id, const std::string& msg)
+{
     // call Python function that responds or ignores a chat message
     py::object handleChatMessagePythonFunction = m_python_module_ai.attr("handleChatMessage");
     handleChatMessagePythonFunction(sender_id, msg);
 }
 
-void PythonAI::HandleDiplomaticMessage(const DiplomaticMessage& msg) {
+void PythonAI::HandleDiplomaticMessage(const DiplomaticMessage& msg)
+{
     // call Python function to inform of diplomatic message change
     py::object handleDiplomaticMessagePythonFunction = m_python_module_ai.attr("handleDiplomaticMessage");
     handleDiplomaticMessagePythonFunction(msg);
 }
 
-void PythonAI::HandleDiplomaticStatusUpdate(const DiplomaticStatusUpdateInfo& u) {
+void PythonAI::HandleDiplomaticStatusUpdate(const DiplomaticStatusUpdateInfo& u)
+{
     // call Python function to inform of diplomatic status update
     py::object handleDiplomaticStatusUpdatePythonFunction = m_python_module_ai.attr("handleDiplomaticStatusUpdate");
     handleDiplomaticStatusUpdatePythonFunction(u);
 }
 
-void PythonAI::StartNewGame() {
+void PythonAI::StartNewGame()
+{
     FreeOrionPython::ClearStaticSaveStateString();
     // call Python function that sets up the AI to be able to generate orders for a new game
     py::object startNewGamePythonFunction = m_python_module_ai.attr("startNewGame");
     startNewGamePythonFunction(m_aggression);
 }
 
-void PythonAI::ResumeLoadedGame(const std::string& save_state_string) {
+void PythonAI::ResumeLoadedGame(const std::string& save_state_string)
+{
     //DebugLogger() << "PythonAI::ResumeLoadedGame(" << save_state_string << ")";
     FreeOrionPython::SetStaticSaveStateString(save_state_string);
     // call Python function that deals with the new state string sent by the server
@@ -174,7 +183,8 @@ void PythonAI::ResumeLoadedGame(const std::string& save_state_string) {
     resumeLoadedGamePythonFunction(FreeOrionPython::GetStaticSaveStateString());
 }
 
-const std::string& PythonAI::GetSaveStateString() const {
+auto PythonAI::GetSaveStateString() const -> const std::string&
+{
     // call Python function that serializes AI state for storage in save file and sets s_save_state_string
     // to contain that string
     py::object prepareForSavePythonFunction = m_python_module_ai.attr("prepareForSave");

--- a/client/AI/AIWrapper.cpp
+++ b/client/AI/AIWrapper.cpp
@@ -40,7 +40,7 @@ namespace {
     // static string to save AI state
     static std::string s_save_state_string("");
 
-    const std::string& PlayerName()
+    auto PlayerName() -> const std::string&
     { return AIClientApp::GetApp()->PlayerName(); }
 
     /** @brief Return the player name of the client identified by @a player_id
@@ -51,7 +51,8 @@ namespace {
      *      name of this client or an empty string the player is not known or
      *      does not exist.
      */
-    const std::string& PlayerNameByID(int player_id) {
+    auto PlayerNameByID(int player_id) -> const std::string&
+    {
         auto& players = AIClientApp::GetApp()->Players();
         auto it = players.find(player_id);
         if (it != players.end())
@@ -62,10 +63,11 @@ namespace {
         }
     }
 
-    int PlayerID()
+    auto PlayerID() -> int
     { return AIClientApp::GetApp()->PlayerID(); }
 
-    int EmpirePlayerID(int empire_id) {
+    auto EmpirePlayerID(int empire_id) -> int
+    {
         int player_id = AIClientApp::GetApp()->EmpirePlayerID(empire_id);
         if (Networking::INVALID_PLAYER_ID == player_id)
             DebugLogger() << "AIWrapper::EmpirePlayerID(" << empire_id << ") - passed an invalid empire_id";
@@ -76,7 +78,8 @@ namespace {
      *
      * @return A vector containing the identifiers of all players.
      */
-    std::vector<int> AllPlayerIDs() {
+    auto AllPlayerIDs() -> std::vector<int>
+    {
         std::vector<int> player_ids;
         for (auto& entry : AIClientApp::GetApp()->Players())
             player_ids.push_back(entry.first);
@@ -89,7 +92,7 @@ namespace {
      *
      * @return True if the player is an AI, false if not.
      */
-    bool PlayerIsAI(int player_id)
+    auto PlayerIsAI(int player_id) -> bool
     { return AIClientApp::GetApp()->GetPlayerClientType(player_id) == Networking::CLIENT_TYPE_AI_PLAYER; }
 
     /** @brief Return if the player identified by @a player_id is the game
@@ -99,7 +102,8 @@ namespace {
      *
      * @return True if the player is the game host, false if not.
      */
-    bool PlayerIsHost(int player_id) {
+    auto PlayerIsHost(int player_id) -> bool
+    {
         auto& players = AIClientApp::GetApp()->Players();
         auto it = players.find(player_id);
         if (it == players.end())
@@ -107,7 +111,7 @@ namespace {
         return it->second.host;
     }
 
-    int EmpireID()
+    auto EmpireID() -> int
     { return AIClientApp::GetApp()->EmpireID(); }
 
     /** @brief Return the empire identifier of the empire @a player_id controls
@@ -116,7 +120,8 @@ namespace {
      *
      * @return An empire identifier.
      */
-    int PlayerEmpireID(int player_id) {
+    auto PlayerEmpireID(int player_id) -> int
+    {
         for (auto& entry : AIClientApp::GetApp()->Players()) {
             if (entry.first == player_id)
                 return entry.second.empire_id;
@@ -128,7 +133,8 @@ namespace {
      *
      * @return A vector containing the identifiers of all empires.
      */
-    std::vector<int> AllEmpireIDs() {
+    auto AllEmpireIDs() -> std::vector<int>
+    {
         std::vector<int> empire_ids;
         for (auto& entry : AIClientApp::GetApp()->Players()) {
             auto empire_id = entry.second.empire_id;
@@ -143,13 +149,13 @@ namespace {
      * @return A pointer to the Empire instance this client has the control
      *      over.
      */
-    const Empire* PlayerEmpire()
+    auto PlayerEmpire() -> const Empire*
     { return AIClientApp::GetApp()->GetEmpire(AIClientApp::GetApp()->EmpireID()); }
 
-    const Empire* GetEmpireByID(int empire_id)
+    auto GetEmpireByID(int empire_id) -> const Empire*
     { return AIClientApp::GetApp()->GetEmpire(empire_id); }
 
-    const GalaxySetupData& PythonGalaxySetupData()
+    auto PythonGalaxySetupData() -> const GalaxySetupData&
     { return AIClientApp::GetApp()->GetGalaxySetupData(); }
 
     void InitMeterEstimatesAndDiscrepancies() {
@@ -235,7 +241,8 @@ namespace {
         empire->UpdateProductionQueue();
     }
 
-    py::list GetUserStringList(const std::string& list_key) {
+    auto GetUserStringList(const std::string& list_key) -> py::list
+    {
         py::list ret_list;
         for (const std::string& string : UserStringList(list_key))
             ret_list.append(string);
@@ -249,14 +256,15 @@ namespace {
     //! @return
     //! The canonical path pointing to the directory containing all python AI
     //! scripts.
-    std::string GetAIDir()
+    auto GetAIDir() -> std::string
     { return (GetResourceDir() / GetOptionsDB().Get<std::string>("ai-path")).string(); }
 
-    OrderSet& IssuedOrders()
+    auto IssuedOrders() -> OrderSet&
     { return AIClientApp::GetApp()->Orders(); }
 
     template<typename OrderType, typename... Args>
-    int Issue(Args &&... args) {
+    auto Issue(Args &&... args) -> int
+    {
         auto app = ClientApp::GetApp();
 
         if (!OrderType::Check(app->EmpireID(), std::forward<Args>(args)...))
@@ -267,7 +275,8 @@ namespace {
         return 1;
     }
 
-    int IssueNewFleetOrder(const std::string& fleet_name, int ship_id) {
+    auto IssueNewFleetOrder(const std::string& fleet_name, int ship_id) -> int
+    {
         std::vector<int> ship_ids{ship_id};
         auto app = ClientApp::GetApp();
         if (!NewFleetOrder::Check(app->EmpireID(), fleet_name, ship_ids, false))
@@ -279,21 +288,23 @@ namespace {
         return order->FleetID();
     }
 
-    int IssueFleetTransferOrder(int ship_id, int new_fleet_id) {
+    auto IssueFleetTransferOrder(int ship_id, int new_fleet_id) -> int
+    {
         std::vector<int> ship_ids{ship_id};
         return Issue<FleetTransferOrder>(new_fleet_id, ship_ids);
     }
 
-    int IssueRenameOrder(int object_id, const std::string& new_name)
+    auto IssueRenameOrder(int object_id, const std::string& new_name) -> int
     { return Issue<RenameOrder>(object_id, new_name); }
 
-    int IssueScrapOrder(int object_id)
+    auto IssueScrapOrder(int object_id) -> int
     { return Issue<ScrapOrder>(object_id); }
 
-    int IssueChangeFocusOrder(int planet_id, const std::string& focus)
+    auto IssueChangeFocusOrder(int planet_id, const std::string& focus) -> int
     { return Issue<ChangeFocusOrder>(planet_id, focus); }
 
-    int IssueEnqueueTechOrder(const std::string& tech_name, int position) {
+    auto IssueEnqueueTechOrder(const std::string& tech_name, int position) -> int
+    {
         const Tech* tech = GetTech(tech_name);
         if (!tech) {
             ErrorLogger() << "IssueEnqueueTechOrder : passed tech_name that is not the name of a tech.";
@@ -308,7 +319,8 @@ namespace {
         return 1;
     }
 
-    int IssueDequeueTechOrder(const std::string& tech_name) {
+    auto IssueDequeueTechOrder(const std::string& tech_name) -> int
+    {
         const Tech* tech = GetTech(tech_name);
         if (!tech) {
             ErrorLogger() << "IssueDequeueTechOrder : passed tech_name that is not the name of a tech.";
@@ -322,7 +334,8 @@ namespace {
         return 1;
     }
 
-    int IssueAdoptPolicyOrder(const std::string& policy_name, const std::string& category, int slot) {
+    auto IssueAdoptPolicyOrder(const std::string& policy_name, const std::string& category, int slot) -> int
+    {
         const Policy* policy = GetPolicy(policy_name);
         if (!policy) {
             ErrorLogger() << "IssueAdoptPolicyOrder : passed policy_name, " << policy_name << ", that is not the name of a policy.";
@@ -350,7 +363,8 @@ namespace {
         return 1;
     }
 
-    int IssueDeadoptPolicyOrder(const std::string& policy_name) {
+    auto IssueDeadoptPolicyOrder(const std::string& policy_name) -> int
+    {
         int empire_id = AIClientApp::GetApp()->EmpireID();
         Empire* empire = AIClientApp::GetApp()->GetEmpire(empire_id);
         if (!empire) {
@@ -368,7 +382,8 @@ namespace {
 
     }
 
-    int IssueEnqueueBuildingProductionOrder(const std::string& item_name, int location_id) {
+    auto IssueEnqueueBuildingProductionOrder(const std::string& item_name, int location_id) -> int
+    {
         int empire_id = AIClientApp::GetApp()->EmpireID();
         Empire* empire = AIClientApp::GetApp()->GetEmpire(empire_id);
         if (!empire) {
@@ -395,7 +410,8 @@ namespace {
         return 1;
     }
 
-    int IssueEnqueueShipProductionOrder(int design_id, int location_id) {
+    auto IssueEnqueueShipProductionOrder(int design_id, int location_id) -> int
+    {
         int empire_id = AIClientApp::GetApp()->EmpireID();
         Empire* empire = AIClientApp::GetApp()->GetEmpire(empire_id);
         if (!empire) {
@@ -417,7 +433,8 @@ namespace {
         return 1;
     }
 
-    int IssueChangeProductionQuantityOrder(int queue_index, int new_quantity, int new_blocksize) {
+    auto IssueChangeProductionQuantityOrder(int queue_index, int new_quantity, int new_blocksize) -> int
+    {
         int empire_id = AIClientApp::GetApp()->EmpireID();
         Empire* empire = AIClientApp::GetApp()->GetEmpire(empire_id);
         if (!empire) {
@@ -446,7 +463,8 @@ namespace {
         return 1;
     }
 
-    int IssueRequeueProductionOrder(int old_queue_index, int new_queue_index) {
+    auto IssueRequeueProductionOrder(int old_queue_index, int new_queue_index) -> int
+    {
         if (old_queue_index == new_queue_index) {
             ErrorLogger() << "IssueRequeueProductionOrder : passed same old and new indexes... nothing to do.";
             return 0;
@@ -487,7 +505,8 @@ namespace {
         return 1;
     }
 
-    int IssueDequeueProductionOrder(int queue_index) {
+    auto IssueDequeueProductionOrder(int queue_index) -> int
+    {
         int empire_id = AIClientApp::GetApp()->EmpireID();
         Empire* empire = AIClientApp::GetApp()->GetEmpire(empire_id);
         if (!empire) {
@@ -511,7 +530,8 @@ namespace {
         return 1;
     }
 
-    int IssuePauseProductionOrder(int queue_index, bool pause) {
+    auto IssuePauseProductionOrder(int queue_index, bool pause) -> int
+    {
         int empire_id = AIClientApp::GetApp()->EmpireID();
         Empire* empire = AIClientApp::GetApp()->GetEmpire(empire_id);
         if (!empire) {
@@ -535,7 +555,8 @@ namespace {
         return 1;
     }
 
-    int IssueAllowStockpileProductionOrder(int queue_index, bool use_stockpile) {
+    auto IssueAllowStockpileProductionOrder(int queue_index, bool use_stockpile) -> int
+    {
         int empire_id = AIClientApp::GetApp()->EmpireID();
         Empire* empire = AIClientApp::GetApp()->GetEmpire(empire_id);
         if (!empire) {
@@ -559,10 +580,10 @@ namespace {
         return 1;
     }
 
-    int IssueCreateShipDesignOrder(const std::string& name, const std::string& description,
-                                   const std::string& hull, const py::list parts_list,
-                                   const std::string& icon, const std::string& model,
-                                   bool name_desc_in_stringtable)
+    auto IssueCreateShipDesignOrder(const std::string& name, const std::string& description,
+                                    const std::string& hull, const py::list parts_list,
+                                    const std::string& icon, const std::string& model,
+                                    bool name_desc_in_stringtable) -> int
     {
         if (name.empty() || description.empty() || hull.empty()) {
             ErrorLogger() << "IssueCreateShipDesignOrderOrder : passed an empty name, description, or hull.";
@@ -597,25 +618,25 @@ namespace {
         return 1;
     }
 
-    int IssueFleetMoveOrder(int fleet_id, int destination_id)
+    auto IssueFleetMoveOrder(int fleet_id, int destination_id) -> int
     { return Issue<FleetMoveOrder>(fleet_id, destination_id); }
 
-    int AppendFleetMoveOrder(int fleet_id, int destination_id)
+    auto AppendFleetMoveOrder(int fleet_id, int destination_id) -> int
     { return Issue<FleetMoveOrder>(fleet_id, destination_id, true); }
 
-    int IssueColonizeOrder(int ship_id, int planet_id)
+    auto IssueColonizeOrder(int ship_id, int planet_id) -> int
     { return Issue<ColonizeOrder>(ship_id, planet_id); }
 
-    int IssueInvadeOrder(int ship_id, int planet_id)
+    auto IssueInvadeOrder(int ship_id, int planet_id) -> int
     { return Issue<InvadeOrder>(ship_id, planet_id); }
 
-    int IssueBombardOrder(int ship_id, int planet_id)
+    auto IssueBombardOrder(int ship_id, int planet_id) -> int
     { return Issue<BombardOrder>(ship_id, planet_id); }
 
-    int IssueAggressionOrder(int object_id, bool aggressive)
+    auto IssueAggressionOrder(int object_id, bool aggressive) -> int
     { return Issue<AggressiveOrder>(object_id, aggressive); }
 
-    int IssueGiveObjectToEmpireOrder(int object_id, int recipient_id)
+    auto IssueGiveObjectToEmpireOrder(int object_id, int recipient_id) -> int
     { return Issue<GiveObjectToEmpireOrder>(object_id, recipient_id); }
 
     void SendPlayerChatMessage(int recipient_player_id, const std::string& message_text)
@@ -636,7 +657,7 @@ namespace {
 }
 
 namespace FreeOrionPython {
-    const std::string& GetStaticSaveStateString()
+    auto GetStaticSaveStateString() -> const std::string&
     { return s_save_state_string; }
 
     void SetStaticSaveStateString(const std::string& new_state_string)

--- a/python/ConfigWrapper.cpp
+++ b/python/ConfigWrapper.cpp
@@ -9,22 +9,22 @@ namespace py = boost::python;
 
 
 namespace {
-    py::object GetOptionsDBOptionStr(std::string const &option)
+    auto GetOptionsDBOptionStr(std::string const &option) -> py::object
     { return GetOptionsDB().OptionExists(option) ? py::str(GetOptionsDB().Get<std::string>(option)) : py::str(); }
 
-    py::object GetOptionsDBOptionInt(std::string const &option)
+    auto GetOptionsDBOptionInt(std::string const &option) -> py::object
     { return GetOptionsDB().OptionExists(option) ? py::object(GetOptionsDB().Get<int>(option)) : py::object(); }
 
-    py::object GetOptionsDBOptionBool(std::string const &option)
+    auto GetOptionsDBOptionBool(std::string const &option) -> py::object
     { return GetOptionsDB().OptionExists(option) ? py::object(GetOptionsDB().Get<bool>(option)) : py::object(); }
 
-    py::object GetOptionsDBOptionDouble(std::string const &option)
+    auto GetOptionsDBOptionDouble(std::string const &option) -> py::object
     { return GetOptionsDB().OptionExists(option) ? py::object(GetOptionsDB().Get<double>(option)) : py::object(); }
 
-    py::str GetUserConfigDirWrapper()
+    auto GetUserConfigDirWrapper() -> py::str
     { return py::str(PathToString(GetUserConfigDir())); }
 
-    py::str GetUserDataDirWrapper()
+    auto GetUserDataDirWrapper() -> py::str
     { return py::str(PathToString(GetUserDataDir())); }
 }
 

--- a/python/ConfigWrapper.cpp
+++ b/python/ConfigWrapper.cpp
@@ -1,57 +1,92 @@
-#include "../util/Directories.h"
-#include "../util/OptionsDB.h"
-
-#include <boost/python.hpp>
+#include "CommonWrappers.h"
 
 #include <string>
+#include <boost/python.hpp>
+#include "../util/Directories.h"
+#include "../util/OptionsDB.h"
 
 namespace py = boost::python;
 
 
-namespace {
-    auto GetOptionsDBOptionStr(std::string const &option) -> py::object
-    { return GetOptionsDB().OptionExists(option) ? py::str(GetOptionsDB().Get<std::string>(option)) : py::str(); }
+void FreeOrionPython::WrapConfig()
+{
+    // For the AI client provide function names in camelCase,
+    // as that's still the preferred style there (for the time being)
+    // For the server, provide the function names already in snake_case
 
-    auto GetOptionsDBOptionInt(std::string const &option) -> py::object
-    { return GetOptionsDB().OptionExists(option) ? py::object(GetOptionsDB().Get<int>(option)) : py::object(); }
-
-    auto GetOptionsDBOptionBool(std::string const &option) -> py::object
-    { return GetOptionsDB().OptionExists(option) ? py::object(GetOptionsDB().Get<bool>(option)) : py::object(); }
-
-    auto GetOptionsDBOptionDouble(std::string const &option) -> py::object
-    { return GetOptionsDB().OptionExists(option) ? py::object(GetOptionsDB().Get<double>(option)) : py::object(); }
-
-    auto GetUserConfigDirWrapper() -> py::str
-    { return py::str(PathToString(GetUserConfigDir())); }
-
-    auto GetUserDataDirWrapper() -> py::str
-    { return py::str(PathToString(GetUserDataDir())); }
-}
-
-namespace FreeOrionPython {
-    void WrapConfig()
-    {
+    py::def(
 #ifdef FREEORION_BUILD_AI
-        // For the AI client provide function names in camelCase,
-        // as that's still the preferred style there (for the time being)
-        py::def("getOptionsDBOptionStr",    GetOptionsDBOptionStr,     py::return_value_policy<py::return_by_value>(), "Returns the string value of option in OptionsDB or None if the option does not exist.");
-        py::def("getOptionsDBOptionInt",    GetOptionsDBOptionInt,     py::return_value_policy<py::return_by_value>(), "Returns the integer value of option in OptionsDB or None if the option does not exist.");
-        py::def("getOptionsDBOptionBool",   GetOptionsDBOptionBool,    py::return_value_policy<py::return_by_value>(), "Returns the bool value of option in OptionsDB or None if the option does not exist.");
-        py::def("getOptionsDBOptionDouble", GetOptionsDBOptionDouble,  py::return_value_policy<py::return_by_value>(), "Returns the double value of option in OptionsDB or None if the option does not exist.");
-
-        py::def("getUserConfigDir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
-        py::def("getUserDataDir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
+            "getOptionsDBOptionStr"
 #endif
-
 #ifdef FREEORION_BUILD_SERVER
-        // For the server, provide the function names already in snake_case
-        py::def("get_options_db_option_str",    GetOptionsDBOptionStr,     py::return_value_policy<py::return_by_value>(), "Returns the string value of option in OptionsDB or None if the option does not exist.");
-        py::def("get_options_db_option_int",    GetOptionsDBOptionInt,     py::return_value_policy<py::return_by_value>(), "Returns the integer value of option in OptionsDB or None if the option does not exist.");
-        py::def("get_options_db_option_bool",   GetOptionsDBOptionBool,    py::return_value_policy<py::return_by_value>(), "Returns the bool value of option in OptionsDB or None if the option does not exist.");
-        py::def("get_options_db_option_double", GetOptionsDBOptionDouble,  py::return_value_policy<py::return_by_value>(), "Returns the double value of option in OptionsDB or None if the option does not exist.");
-
-        py::def("get_user_config_dir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
-        py::def("get_user_data_dir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
+            "get_options_db_option_str"
 #endif
-    }
+            ,
+            +[](std::string const &option) -> py::object { return GetOptionsDB().OptionExists(option) ? py::str(GetOptionsDB().Get<std::string>(option)) : py::str(); },
+            py::return_value_policy<py::return_by_value>(),
+            "Returns the string value of option in OptionsDB or None if the"
+            " option does not exist.");
+
+    py::def(
+#ifdef FREEORION_BUILD_AI
+            "getOptionsDBOptionInt"
+#endif
+#ifdef FREEORION_BUILD_SERVER
+            "get_options_db_option_int"
+#endif
+            ,
+            +[](std::string const &option) -> py::object { return GetOptionsDB().OptionExists(option) ? py::object(GetOptionsDB().Get<int>(option)) : py::object(); },
+            py::return_value_policy<py::return_by_value>(),
+            "Returns the integer value of option in OptionsDB or None if the"
+            " option does not exist.");
+
+    py::def(
+#ifdef FREEORION_BUILD_AI
+            "getOptionsDBOptionBool"
+#endif
+#ifdef FREEORION_BUILD_SERVER
+            "get_options_db_option_bool"
+#endif
+            ,
+            +[](std::string const &option) -> py::object { return GetOptionsDB().OptionExists(option) ? py::object(GetOptionsDB().Get<bool>(option)) : py::object(); },
+            py::return_value_policy<py::return_by_value>(),
+            "Returns the bool value of option in OptionsDB or None if the"
+            " option does not exist.");
+
+    py::def(
+#ifdef FREEORION_BUILD_AI
+            "getOptionsDBOptionDouble"
+#endif
+#ifdef FREEORION_BUILD_SERVER
+            "get_options_db_option_double"
+#endif
+            ,
+            +[](std::string const &option) -> py::object { return GetOptionsDB().OptionExists(option) ? py::object(GetOptionsDB().Get<double>(option)) : py::object(); },
+            py::return_value_policy<py::return_by_value>(),
+            "Returns the double value of option in OptionsDB or None if the"
+            " option does not exist.");
+
+    py::def(
+#ifdef FREEORION_BUILD_AI
+            "getUserConfigDir"
+#endif
+#ifdef FREEORION_BUILD_SERVER
+            "get_user_config_dir"
+#endif
+            ,
+            +[]() -> py::str { return py::str(PathToString(GetUserConfigDir())); },
+            "Returns path to directory where FreeOrion stores user specific"
+            " configuration.");
+
+    py::def(
+#ifdef FREEORION_BUILD_AI
+            "getUserDataDir"
+#endif
+#ifdef FREEORION_BUILD_SERVER
+            "get_user_data_dir"
+#endif
+            ,
+            +[]() -> py::str { return py::str(PathToString(GetUserDataDir())); },
+            "Returns path to directory where FreeOrion stores user specific"
+            " data (saves, etc.).");
 }

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -33,26 +33,21 @@ namespace {
     // Queues test whether they contain items by name, but Python needs
     // a __contains__ function that takes a *Queue::Element.  This helper
     // functions take an Element and returns the associated name string.
-    const std::string&  TechFromResearchQueueElement(const ResearchQueue::Element& element)
+    const std::string& TechFromResearchQueueElement(const ResearchQueue::Element& element)
     { return element.name; }
-    const std::string&  NameFromInfluenceQueueElement(const InfluenceQueue::Element& element)
+    const std::string& NameFromInfluenceQueueElement(const InfluenceQueue::Element& element)
     { return element.name; }
 
     std::vector<std::string> (TechManager::*TechNamesVoid)(void) const = &TechManager::TechNames;
-    auto TechNamesMemberFunc = TechNamesVoid;
 
     std::vector<std::string> (TechManager::*TechNamesCategory)(const std::string&) const = &TechManager::TechNames;
-    auto TechNamesCategoryMemberFunc = TechNamesCategory;
 
     std::vector<std::string> (PolicyManager::*PolicyNamesVoid)(void) const = &PolicyManager::PolicyNames;
-    auto PolicyNamesMemberFunc = PolicyNamesVoid;
 
     std::vector<std::string> (PolicyManager::*PolicyNamesCategory)(const std::string&) const = &PolicyManager::PolicyNames;
-    auto PolicyNamesCategoryMemberFunc = PolicyNamesCategory;
 
-    std::vector<std::string>    TechRecursivePrereqs(const Tech& tech, int empire_id)
+    std::vector<std::string> TechRecursivePrereqs(const Tech& tech, int empire_id)
     { return GetTechManager().RecursivePrereqs(tech.Name(), empire_id); }
-    auto TechRecursivePrereqsFunc = TechRecursivePrereqs;
 
     // Concatenate functions to create one that takes two parameters.  The first
     // parameter is a ResearchQueue*, which is passed directly to
@@ -88,7 +83,6 @@ namespace {
             return EMPTY_ENTRY;
         return *std::next(empire.SitRepBegin(), index);
     }
-    auto GetEmpireSitRepFunc = GetSitRep;
 
     const Meter* (Empire::*EmpireGetMeter)(const std::string&) const = &Empire::GetMeter;
 
@@ -107,7 +101,7 @@ namespace {
 
     typedef std::map<std::pair<int, int>,int > PairIntInt_IntMap;
 
-    std::vector<IntPair> obstructedStarlanesP(const Empire& empire) {
+    std::vector<IntPair> obstructedStarlanes(const Empire& empire) {
         const std::set<IntPair>& laneset = GetSupplyManager().SupplyObstructedStarlaneTraversals(empire.EmpireID());
         std::vector<IntPair> retval;
         try {
@@ -117,9 +111,8 @@ namespace {
         }
         return retval;
     }
-    auto obstructedStarlanesFunc = &obstructedStarlanesP;
 
-    std::map<int, int> jumpsToSuppliedSystemP(const Empire& empire) {
+    std::map<int, int> jumpsToSuppliedSystem(const Empire& empire) {
         std::map<int, int> retval;
         const std::map<int, std::set<int>>& empire_starlanes = empire.KnownStarlanes();
         std::list<int> propagating_list;
@@ -154,7 +147,7 @@ namespace {
         }
 
         //// DEBUG
-        //DebugLogger() << "jumpsToSuppliedSystemP results for empire, " << empire.Name() << " (" << empire.EmpireID() << ") :";
+        //DebugLogger() << "jumpsToSuppliedSystem results for empire, " << empire.Name() << " (" << empire.EmpireID() << ") :";
         //for (const auto& system_jumps : retval) {
         //    DebugLogger() << "sys " << system_jumps.first << "  range: " << system_jumps.second;
         //}
@@ -163,27 +156,17 @@ namespace {
         return retval;
     }
 
-    auto jumpsToSuppliedSystemFunc = &jumpsToSuppliedSystemP;
-
-    const std::set<int>& EmpireFleetSupplyableSystemIDsP(const Empire& empire)
+    const std::set<int>& EmpireFleetSupplyableSystemIDs(const Empire& empire)
     { return GetSupplyManager().FleetSupplyableSystemIDs(empire.EmpireID()); }
-    auto empireFleetSupplyableSystemIDsFunc = &EmpireFleetSupplyableSystemIDsP;
 
     typedef std::pair<float, int> FloatIntPair;
 
     typedef PairToTupleConverter<float, int> FloatIntPairConverter;
 
-    //boost::mpl::vector<FloatIntPair, const Empire&, const ProductionQueue::Element&>()
-    FloatIntPair ProductionCostAndTimeP(const Empire& empire,
-                                        const ProductionQueue::Element& element)
+    FloatIntPair ProductionCostAndTime(const Empire& empire, const ProductionQueue::Element& element)
     { return empire.ProductionCostAndTime(element); }
-    auto ProductionCostAndTimeFunc = &ProductionCostAndTimeP;
 
-    //.def("availablePP",                     make_function(&ProductionQueue::AvailablePP,          py::return_value_policy<py::return_by_value>()))
-    //.add_property("allocatedPP",            make_function(&ProductionQueue::AllocatedPP,          py::return_internal_reference<>()))
-    //.def("objectsWithWastedPP",             make_function(&ProductionQueue::ObjectsWithWastedPP,  py::return_value_policy<py::return_by_value>()))
-
-    std::map<std::set<int>, float> PlanetsWithAvailablePP_P(const Empire& empire) {
+    std::map<std::set<int>, float> PlanetsWithAvailablePP(const Empire& empire) {
         const auto& industry_pool = empire.GetResourcePool(RE_INDUSTRY);
         const ProductionQueue& prod_queue = empire.GetProductionQueue();
         std::map<std::set<int>, float> planets_with_available_pp;
@@ -199,9 +182,8 @@ namespace {
         }
         return planets_with_available_pp;
     }
-    auto PlanetsWithAvailablePP_Func = &PlanetsWithAvailablePP_P;
 
-    std::map<std::set<int>, float> PlanetsWithAllocatedPP_P(const Empire& empire) {
+    std::map<std::set<int>, float> PlanetsWithAllocatedPP(const Empire& empire) {
         const auto& prod_queue = empire.GetProductionQueue();
         std::map<std::set<int>, float> planets_with_allocated_pp;
         for (const auto& objects_pp : prod_queue.AllocatedPP()) {
@@ -216,9 +198,8 @@ namespace {
         }
         return planets_with_allocated_pp;
     }
-    auto PlanetsWithAllocatedPP_Func = &PlanetsWithAllocatedPP_P;
 
-    std::set<std::set<int>> PlanetsWithWastedPP_P(const Empire& empire) {
+    std::set<std::set<int>> PlanetsWithWastedPP(const Empire& empire) {
         const auto& industry_pool = empire.GetResourcePool(RE_INDUSTRY);
         const ProductionQueue& prod_queue = empire.GetProductionQueue();
         std::set<std::set<int>> planets_with_wasted_pp;
@@ -234,7 +215,6 @@ namespace {
              }
              return planets_with_wasted_pp;
     }
-    auto PlanetsWithWastedPP_Func = &PlanetsWithWastedPP_P;
 
     std::set<std::string> ResearchedTechNames(const Empire& empire) {
         std::set<std::string> retval;
@@ -242,8 +222,6 @@ namespace {
             retval.insert(entry.first);
         return retval;
     }
-    auto ResearchTechNamesFunc = &ResearchedTechNames;
-
 }
 
 namespace FreeOrionPython {
@@ -324,31 +302,31 @@ namespace FreeOrionPython {
             .add_property("availableShipHulls",     make_function(&Empire::AvailableShipHulls,      py::return_value_policy<py::copy_const_reference>()))
             .add_property("productionQueue",        make_function(&Empire::GetProductionQueue,      py::return_internal_reference<>()))
             .def("productionCostAndTime",           make_function(
-                                                        ProductionCostAndTimeFunc,
+                                                        ProductionCostAndTime,
                                                         py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<FloatIntPair, const Empire&, const ProductionQueue::Element& >()
                                                     ))
             .add_property("planetsWithAvailablePP", make_function(
-                                                        PlanetsWithAvailablePP_Func,
+                                                        PlanetsWithAvailablePP,
                                                         py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<std::map<std::set<int>, float>, const Empire& >()
                                                     ))
             .add_property("planetsWithAllocatedPP", make_function(
-                                                        PlanetsWithAllocatedPP_Func,
+                                                        PlanetsWithAllocatedPP,
                                                         py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<std::map<std::set<int>, float>, const Empire& >()
                                                     ))
             .add_property("planetsWithWastedPP",    make_function(
-                                                        PlanetsWithWastedPP_Func,
+                                                        PlanetsWithWastedPP,
                                                         py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<std::set<std::set<int>>, const Empire& >()
                                                     ))
 
             .def("techResearched",                  &Empire::TechResearched)
             .add_property("availableTechs",         make_function(
-                                                        ResearchTechNamesFunc,
+                                                        ResearchedTechNames,
                                                         py::return_value_policy<py::return_by_value>(),
-                                                        boost::mpl::vector<const std::set<std::string>&, const Empire& >()
+                                                        boost::mpl::vector<std::set<std::string>, const Empire& >()
                                                     ))
             .def("getTechStatus",                   &Empire::GetTechStatus)
             .def("researchProgress",                &Empire::ResearchProgress)
@@ -384,7 +362,7 @@ namespace FreeOrionPython {
 
             .def("preservedLaneTravel",             &Empire::PreservedLaneTravel)
             .add_property("fleetSupplyableSystemIDs",   make_function(
-                                                            empireFleetSupplyableSystemIDsFunc,
+                                                            EmpireFleetSupplyableSystemIDs,
                                                             py::return_value_policy<py::copy_const_reference>(),
                                                             boost::mpl::vector<const std::set<int>&, const Empire& >()
                                                         ))
@@ -393,18 +371,17 @@ namespace FreeOrionPython {
 
             .def("numSitReps",                      &Empire::NumSitRepEntries)
             .def("getSitRep",                       make_function(
-                                                        GetEmpireSitRepFunc,
+                                                        GetSitRep,
                                                         py::return_internal_reference<>(),
                                                         boost::mpl::vector<const SitRepEntry&, const Empire&, int>()
                                                     ))
-            //.add_property("obstructedStarlanes",  make_function(&Empire::SupplyObstructedStarlaneTraversals,   py::return_value_policy<py::return_by_value>()))
             .def("obstructedStarlanes",             make_function(
-                                                        obstructedStarlanesFunc,
+                                                        obstructedStarlanes,
                                                         py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<std::vector<IntPair>, const Empire&>()
                                                     ))
             .def("supplyProjections",               make_function(
-                                                        jumpsToSuppliedSystemFunc,
+                                                        jumpsToSuppliedSystem,
                                                         py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<std::map<int, int>, const Empire&>()
                                                     ))
@@ -494,7 +471,7 @@ namespace FreeOrionPython {
             .add_property("unlockedTechs",          make_function(&Tech::UnlockedTechs,     py::return_internal_reference<>()))
             .add_property("unlockedItems",          make_function(&Tech::UnlockedItems,     py::return_internal_reference<>()))
             .def("recursivePrerequisites",          make_function(
-                                                        TechRecursivePrereqsFunc,
+                                                        TechRecursivePrereqs,
                                                         py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<std::vector<std::string>, const Tech&, int>()
                                                     ))
@@ -503,13 +480,13 @@ namespace FreeOrionPython {
         def("getTech",                              &GetTech,                               py::return_value_policy<py::reference_existing_object>(), "Returns the tech (Tech) with the indicated name (string).");
         def("getTechCategories",                    &TechManager::CategoryNames,            py::return_value_policy<py::return_by_value>(), "Returns the names of all tech categories (StringVec).");
 
-        py::object techsFunc = make_function(boost::bind(TechNamesMemberFunc, &(GetTechManager())),
+        py::object techsFunc = make_function(boost::bind(TechNamesVoid, &(GetTechManager())),
                                                         py::return_value_policy<py::return_by_value>(),
                                                         boost::mpl::vector<std::vector<std::string>>());
         py::setattr(techsFunc, "__doc__", py::str("Returns the names of all techs (StringVec)."));
         def("techs", techsFunc);
 
-        py::object techsInCategoryFunc = make_function(boost::bind(TechNamesCategoryMemberFunc, &(GetTechManager()), _1),
+        py::object techsInCategoryFunc = make_function(boost::bind(TechNamesCategory, &(GetTechManager()), _1),
                                                                   py::return_value_policy<py::return_by_value>(),
                                                                   boost::mpl::vector<std::vector<std::string>, const std::string&>());
         py::setattr(techsInCategoryFunc, "__doc__", py::str("Returns the names of all techs (StringVec) in the indicated tech category name (string)."));
@@ -560,13 +537,13 @@ namespace FreeOrionPython {
         def("getPolicy",                            &GetPolicy,                                 py::return_value_policy<py::reference_existing_object>(), "Returns the policy (Policy) with the indicated name (string).");
         def("getPolicyCategories",                  &PolicyManager::PolicyCategories,           py::return_value_policy<py::return_by_value>(), "Returns the names of all policy categories (StringVec).");
 
-        py::object policiesFunc = make_function(boost::bind(PolicyNamesMemberFunc, &(GetPolicyManager())),
+        py::object policiesFunc = make_function(boost::bind(PolicyNamesVoid, &(GetPolicyManager())),
                                                            py::return_value_policy<py::return_by_value>(),
                                                            boost::mpl::vector<std::vector<std::string>>());
         py::setattr(policiesFunc, "__doc__", py::str("Returns the names of all policies (StringVec)."));
         def("policies", policiesFunc);
 
-        py::object policiesInCategoryFunc = make_function(boost::bind(PolicyNamesCategoryMemberFunc, &(GetPolicyManager()), _1),
+        py::object policiesInCategoryFunc = make_function(boost::bind(PolicyNamesCategory, &(GetPolicyManager()), _1),
                                                                      py::return_value_policy<py::return_by_value>(),
                                                                      boost::mpl::vector<std::vector<std::string>, const std::string&>());
         py::setattr(policiesInCategoryFunc, "__doc__", py::str("Returns the names of all policies (StringVec) in the indicated policy category name (string)."));

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -248,25 +248,21 @@ namespace FreeOrionPython {
                                                     py::return_value_policy<py::return_by_value>())
             .add_property("planetsWithAvailablePP", make_function(
                                                         PlanetsWithAvailablePP,
-                                                        py::return_value_policy<py::return_by_value>(),
-                                                        boost::mpl::vector<std::map<std::set<int>, float>, const Empire& >()
+                                                        py::return_value_policy<py::return_by_value>()
                                                     ))
             .add_property("planetsWithAllocatedPP", make_function(
                                                         PlanetsWithAllocatedPP,
-                                                        py::return_value_policy<py::return_by_value>(),
-                                                        boost::mpl::vector<std::map<std::set<int>, float>, const Empire& >()
+                                                        py::return_value_policy<py::return_by_value>()
                                                     ))
             .add_property("planetsWithWastedPP",    make_function(
                                                         PlanetsWithWastedPP,
-                                                        py::return_value_policy<py::return_by_value>(),
-                                                        boost::mpl::vector<std::set<std::set<int>>, const Empire& >()
+                                                        py::return_value_policy<py::return_by_value>()
                                                     ))
 
             .def("techResearched",                  &Empire::TechResearched)
             .add_property("availableTechs",         make_function(
                                                         ResearchedTechNames,
-                                                        py::return_value_policy<py::return_by_value>(),
-                                                        boost::mpl::vector<std::set<std::string>, const Empire& >()
+                                                        py::return_value_policy<py::return_by_value>()
                                                     ))
             .def("getTechStatus",                   &Empire::GetTechStatus)
             .def("researchProgress",                &Empire::ResearchProgress)
@@ -309,21 +305,12 @@ namespace FreeOrionPython {
             .add_property("systemSupplyRanges",         make_function(&Empire::SystemSupplyRanges,          py::return_internal_reference<>()))
 
             .def("numSitReps",                      &Empire::NumSitRepEntries)
-            .def("getSitRep",                       make_function(
-                                                        GetSitRep,
-                                                        py::return_internal_reference<>(),
-                                                        boost::mpl::vector<const SitRepEntry&, const Empire&, int>()
-                                                    ))
-            .def("obstructedStarlanes",             make_function(
-                                                        obstructedStarlanes,
-                                                        py::return_value_policy<py::return_by_value>(),
-                                                        boost::mpl::vector<std::vector<std::pair<int, int>>, const Empire&>()
-                                                    ))
-            .def("supplyProjections",               make_function(
-                                                        jumpsToSuppliedSystem,
-                                                        py::return_value_policy<py::return_by_value>(),
-                                                        boost::mpl::vector<std::map<int, int>, const Empire&>()
-                                                    ))
+            .def("getSitRep",                       GetSitRep,
+                                                    py::return_internal_reference<>())
+            .def("obstructedStarlanes",             obstructedStarlanes,
+                                                    py::return_value_policy<py::return_by_value>())
+            .def("supplyProjections",               jumpsToSuppliedSystem,
+                                                    py::return_value_policy<py::return_by_value>())
             .def("getMeter",                        +[](const Empire& empire, const std::string& name) -> const Meter* { return empire.GetMeter(name); },
                                                     py::return_internal_reference<>(),
                                                     "Returns the empire meter with the indicated name (string).")
@@ -364,9 +351,11 @@ namespace FreeOrionPython {
             .add_property("empty",                  &ProductionQueue::empty)
             .add_property("totalSpent",             &ProductionQueue::TotalPPsSpent)
             .add_property("empireID",               &ProductionQueue::EmpireID)
-            .def("availablePP",                     make_function(&ProductionQueue::AvailablePP,        py::return_value_policy<py::return_by_value>()))
+            .def("availablePP",                     &ProductionQueue::AvailablePP,
+                                                    py::return_value_policy<py::return_by_value>())
             .add_property("allocatedPP",            make_function(&ProductionQueue::AllocatedPP,        py::return_internal_reference<>()))
-            .def("objectsWithWastedPP",             make_function(&ProductionQueue::ObjectsWithWastedPP,py::return_value_policy<py::return_by_value>()))
+            .def("objectsWithWastedPP",             &ProductionQueue::ObjectsWithWastedPP,
+                                                    py::return_value_policy<py::return_by_value>())
             ;
 
         ////////////////////
@@ -482,7 +471,8 @@ namespace FreeOrionPython {
         ///////////////////
         py::class_<SitRepEntry, boost::noncopyable>("sitrep", py::no_init)
             .add_property("typeString",         make_function(&SitRepEntry::GetTemplateString,  py::return_value_policy<py::copy_const_reference>()))
-            .def("getDataString",               make_function(&SitRepEntry::GetDataString,      py::return_value_policy<py::copy_const_reference>()))
+            .def("getDataString",               &SitRepEntry::GetDataString,
+                                                py::return_value_policy<py::copy_const_reference>())
             .def("getDataIDNumber",             &SitRepEntry::GetDataIDNumber)
             .add_property("getTags",            make_function(&SitRepEntry::GetVariableTags,    py::return_value_policy<py::return_by_value>()))
             .add_property("getTurn",            &SitRepEntry::GetTurn)

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -36,22 +36,39 @@ namespace py = boost::python;
 #if defined(_MSC_VER)
 #  if (_MSC_VER == 1900)
 namespace boost {
-    template<>
-    const volatile UniverseObject*  get_pointer(const volatile UniverseObject* p) { return p; }
-    template<>
-    const volatile Fleet*           get_pointer(const volatile Fleet* p) { return p; }
-    template<>
-    const volatile Ship*            get_pointer(const volatile Ship* p) { return p; }
-    template<>
-    const volatile Planet*          get_pointer(const volatile Planet* p) { return p; }
-    template<>
-    const volatile System*          get_pointer(const volatile System* p) { return p; }
-    template<>
-    const volatile Field*           get_pointer(const volatile Field* p) { return p; }
-    template<>
-    const volatile Building*        get_pointer(const volatile Building* p) { return p; }
-    template<>
-    const volatile Universe*        get_pointer<const volatile Universe>(const volatile Universe* p) { return p; }
+
+template<>
+auto get_pointer(const volatile UniverseObject* p) -> const volatile UniverseObject*
+{ return p; }
+
+template<>
+auto get_pointer(const volatile Fleet* p) -> const volatile Fleet*
+{ return p; }
+
+template<>
+auto get_pointer(const volatile Ship* p) -> const volatile Ship*
+{ return p; }
+
+template<>
+auto get_pointer(const volatile Planet* p) -> const volatile Planet*
+{ return p; }
+
+template<>
+auto get_pointer(const volatile System* p) -> const volatile System*
+{ return p; }
+
+template<>
+auto get_pointer(const volatile Field* p) -> const volatile Field*
+{ return p; }
+
+template<>
+auto get_pointer(const volatile Building* p) -> const volatile Building*
+{ return p; }
+
+template<>
+auto get_pointer<const volatile Universe>(const volatile Universe* p) -> const volatile Universe*
+{ return p; }
+
 }
 #  endif
 #endif
@@ -66,23 +83,29 @@ namespace {
     // We're returning the result of operator-> here so that python doesn't
     // need to deal with std::shared_ptr class.
     // Please don't use this trick elsewhere to grab a raw UniverseObject*!
-    const UniverseObject*   GetUniverseObjectP(const Universe& universe, int id)
+    auto GetUniverseObjectP(const Universe& universe, int id) -> const UniverseObject*
     { return ::Objects().get<UniverseObject>(id).operator->(); }
-    const Ship*             GetShipP(const Universe& universe, int id)
+
+    auto GetShipP(const Universe& universe, int id) -> const Ship*
     { return ::Objects().get<Ship>(id).operator->(); }
-    const Fleet*            GetFleetP(const Universe& universe, int id)
+
+    auto GetFleetP(const Universe& universe, int id) -> const Fleet*
     { return ::Objects().get<Fleet>(id).operator->(); }
-    const Planet*           GetPlanetP(const Universe& universe, int id)
+
+    auto GetPlanetP(const Universe& universe, int id) -> const Planet*
     { return ::Objects().get<Planet>(id).operator->(); }
-    const System*           GetSystemP(const Universe& universe, int id)
+
+    auto GetSystemP(const Universe& universe, int id) -> const System*
     { return ::Objects().get<System>(id).operator->(); }
-    const Field*            GetFieldP(const Universe& universe, int id)
+
+    auto GetFieldP(const Universe& universe, int id) -> const Field*
     { return ::Objects().get<Field>(id).operator->();  }
-    const Building*         GetBuildingP(const Universe& universe, int id)
+
+    auto GetBuildingP(const Universe& universe, int id) -> const Building*
     { return ::Objects().get<Building>(id).operator->(); }
 
     template<typename T>
-    std::vector<int> ObjectIDs(const Universe& universe)
+    auto ObjectIDs(const Universe& universe) -> std::vector<int>
     {
         std::vector<int> result;
         result.reserve(universe.Objects().size<T>());
@@ -91,7 +114,8 @@ namespace {
         return result;
     }
 
-    std::vector<std::string>SpeciesFoci(const Species& species) {
+    auto SpeciesFoci(const Species& species) -> std::vector<std::string>
+    {
         std::vector<std::string> retval;
         retval.reserve(species.Foci().size());
         for (const FocusType& focus : species.Foci())
@@ -99,26 +123,29 @@ namespace {
         return retval;
     }
 
-    void UpdateMetersWrapper(const Universe& universe, const py::object& objIter) {
+    void UpdateMetersWrapper(const Universe& universe, const py::object& objIter)
+    {
         py::stl_input_iterator<int> begin(objIter), end;
         std::vector<int> objvec(begin, end);
         GetUniverse().UpdateMeterEstimates(objvec);
     }
 
-    double LinearDistance(const Universe& universe, int system1_id, int system2_id)
+    auto LinearDistance(const Universe& universe, int system1_id, int system2_id) -> double
     { return universe.GetPathfinder()->LinearDistance(system1_id, system2_id); }
 
-    int JumpDistanceBetweenObjects(const Universe& universe, int object1_id, int object2_id)
+    auto JumpDistanceBetweenObjects(const Universe& universe, int object1_id, int object2_id) -> int
     { return universe.GetPathfinder()->JumpDistanceBetweenObjects(object1_id, object2_id); }
 
-    std::vector<int> ShortestPath(const Universe& universe, int start_sys, int end_sys, int empire_id) {
+    auto ShortestPath(const Universe& universe, int start_sys, int end_sys, int empire_id) -> std::vector<int>
+    {
         std::vector<int> retval;
         std::pair<std::list<int>, int> path = universe.GetPathfinder()->ShortestPath(start_sys, end_sys, empire_id);
         std::copy(path.first.begin(), path.first.end(), std::back_inserter(retval));
         return retval;
     }
 
-    std::vector<int> ShortestNonHostilePath(const Universe& universe, int start_sys, int end_sys, int empire_id) {
+    auto ShortestNonHostilePath(const Universe& universe, int start_sys, int end_sys, int empire_id) -> std::vector<int>
+    {
         std::vector<int> retval;
         auto fleet_pred = std::make_shared<HostileVisitor>(empire_id);
         std::pair<std::list<int>, int> path = universe.GetPathfinder()->ShortestPath(start_sys, end_sys, empire_id, fleet_pred);
@@ -126,42 +153,47 @@ namespace {
         return retval;
     }
 
-    double ShortestPathDistance(const Universe& universe, int object1_id, int object2_id)
+    auto ShortestPathDistance(const Universe& universe, int object1_id, int object2_id) -> double
     { return universe.GetPathfinder()->ShortestPathDistance(object1_id, object2_id); }
 
-    std::vector<int> LeastJumpsPath(const Universe& universe, int start_sys, int end_sys, int empire_id) {
+    auto LeastJumpsPath(const Universe& universe, int start_sys, int end_sys, int empire_id) -> std::vector<int>
+    {
         std::vector<int> retval;
         std::pair<std::list<int>, int> path = universe.GetPathfinder()->LeastJumpsPath(start_sys, end_sys, empire_id);
         std::copy(path.first.begin(), path.first.end(), std::back_inserter(retval));
         return retval;
     }
 
-    bool SystemsConnected(const Universe& universe, int system1_id, int system2_id, int empire_id)
+    auto SystemsConnected(const Universe& universe, int system1_id, int system2_id, int empire_id) -> bool
     { return universe.GetPathfinder()->SystemsConnected(system1_id, system2_id, empire_id); }
 
-    bool SystemHasVisibleStarlanes(const Universe& universe, int system_id, int empire_id)
+    auto SystemHasVisibleStarlanes(const Universe& universe, int system_id, int empire_id) -> bool
     { return universe.GetPathfinder()->SystemHasVisibleStarlanes(system_id, empire_id); }
 
-    std::vector<int> ImmediateNeighbors(const Universe& universe, int system1_id, int empire_id) {
+    auto ImmediateNeighbors(const Universe& universe, int system1_id, int empire_id) -> std::vector<int>
+    {
         std::vector<int> retval;
         for (const auto& entry : universe.GetPathfinder()->ImmediateNeighbors(system1_id, empire_id))
         { retval.push_back(entry.second); }
         return retval;
     }
 
-    std::map<int, double> SystemNeighborsMap(const Universe& universe, int system1_id, int empire_id = ALL_EMPIRES) {
+    auto SystemNeighborsMap(const Universe& universe, int system1_id, int empire_id = ALL_EMPIRES) -> std::map<int, double>
+    {
         std::map<int, double> retval;
         for (const auto& entry : universe.GetPathfinder()->ImmediateNeighbors(system1_id, empire_id))
         { retval[entry.second] = entry.first; }
         return retval;
     }
 
-    const Meter*            (UniverseObject::*ObjectGetMeter)(MeterType) const =                &UniverseObject::GetMeter;
+    auto ObjectGetMeter(const UniverseObject& object, MeterType type) -> const Meter*
+    { return object.GetMeter(type); }
 
-    std::map<MeterType, Meter> ObjectMeters(const UniverseObject& object)
+    auto ObjectMeters(const UniverseObject& object) -> std::map<MeterType, Meter>
     { return std::map<MeterType, Meter>{object.Meters().begin(), object.Meters().end()}; }
 
-    std::vector<std::string> ObjectSpecials(const UniverseObject& object) {
+    auto ObjectSpecials(const UniverseObject& object) -> std::vector<std::string>
+    {
         std::vector<std::string> retval;
         retval.reserve(object.Specials().size());
         for (const auto& special : object.Specials())
@@ -169,36 +201,43 @@ namespace {
         return retval;
     }
 
-    const Meter*            (Ship::*ShipGetPartMeter)(MeterType, const std::string&) const =    &Ship::GetPartMeter;
-    const auto&             (Ship::*ShipPartMeters)(void) const =                               &Ship::PartMeters;
+    auto ShipGetPartMeter(const Ship& ship, MeterType type, const std::string& part_name) -> const Meter*
+    { return ship.GetPartMeter(type, part_name); }
 
-    float ObjectCurrentMeterValue(const UniverseObject& o, MeterType meter_type) {
+    auto ShipPartMeters(const Ship& ship) -> const Ship::PartMeterMap&
+    { return ship.PartMeters(); }
+
+    auto ObjectCurrentMeterValue(const UniverseObject& o, MeterType meter_type) -> float
+    {
         if (auto* m = o.GetMeter(meter_type))
             return m->Current();
         return 0.0f;
     }
 
-    float ObjectInitialMeterValue(const UniverseObject& o, MeterType meter_type) {
+    auto ObjectInitialMeterValue(const UniverseObject& o, MeterType meter_type) -> float
+    {
         if (auto* m = o.GetMeter(meter_type))
             return m->Initial();
         return 0.0f;
     }
 
-    const ShipHull* ShipDesignHull(const ShipDesign& design)
+    auto ShipDesignHull(const ShipDesign& design) -> const ShipHull*
     { return GetShipHull(design.Hull()); }
 
-    const std::string& ShipDesignName(const ShipDesign& ship_design)
+    auto ShipDesignName(const ShipDesign& ship_design) -> const std::string&
     { return ship_design.Name(false); }
 
-    const std::string& ShipDesignDescription(const ShipDesign& ship_design)
+    auto ShipDesignDescription(const ShipDesign& ship_design) -> const std::string&
     { return ship_design.Description(false); }
 
-    bool                    (*ValidDesignHullAndParts)(const std::string& hull,
-                                                       const std::vector<std::string>& parts) = &ShipDesign::ValidDesign;
+    auto ValidDesignHullAndParts(const ShipDesign& design, const std::string& hull, const std::vector<std::string>& parts) -> bool
+    { return design.ValidDesign(hull, parts); }
 
-    const std::vector<std::string>& (ShipDesign::*PartsVoid)(void) const =                      &ShipDesign::Parts;
+    auto PartsVoid(const ShipDesign& design) -> const std::vector<std::string>&
+    { return design.Parts(); }
 
-    std::vector<int> AttackStats(const ShipDesign& ship_design) {
+    auto AttackStats(const ShipDesign& ship_design) -> std::vector<int>
+    {
         std::vector<int> results;
         results.reserve(ship_design.Parts().size());
         for (const std::string& part_name : ship_design.Parts()) {
@@ -209,26 +248,34 @@ namespace {
         return results;
     }
 
-    std::vector<ShipSlotType> HullSlots(const ShipHull& hull) {
+    auto HullSlots(const ShipHull& hull) -> std::vector<ShipSlotType>
+    {
         std::vector<ShipSlotType> retval;
         for (const ShipHull::Slot& slot : hull.Slots())
             retval.push_back(slot.type);
         return retval;
     }
 
-    unsigned int            (ShipHull::*NumSlotsTotal)(void) const =                            &ShipHull::NumSlots;
-    unsigned int            (ShipHull::*NumSlotsOfSlotType)(ShipSlotType) const =               &ShipHull::NumSlots;
+    auto NumSlotsTotal(const ShipHull& hull) -> unsigned int
+    { return hull.NumSlots(); }
+
+    auto NumSlotsOfSlotType(const ShipHull& hull, ShipSlotType slot_type) -> unsigned int
+    { return hull.NumSlots(slot_type); }
 
     bool ObjectInField(const Field& field, const UniverseObject& obj)
     { return field.InField(obj.X(), obj.Y()); }
-    bool                    (Field::*LocationInField)(double x, double y) const =               &Field::InField;
 
-    float                   (Special::*SpecialInitialCapacityOnObject)(int) const =             &Special::InitialCapacity;
+    auto LocationInField(const Field& field, double x, double y) -> bool
+    { return field.InField(x, y); }
 
-    bool EnqueueLocationTest(const BuildingType& building_type, int empire_id, int loc_id)
+    auto SpecialInitialCapacityOnObject(const Special& special, int obj_id) -> float
+    { return special.InitialCapacity(obj_id); }
+
+    auto EnqueueLocationTest(const BuildingType& building_type, int empire_id, int loc_id) -> bool
     { return building_type.EnqueueLocation(empire_id, loc_id);}
 
-    bool HullProductionLocation(const ShipHull& hull, int location_id) {
+    auto HullProductionLocation(const ShipHull& hull, int location_id) -> bool
+    {
         auto location = Objects().get(location_id);
         if (!location) {
             ErrorLogger() << "UniverseWrapper::HullProductionLocation Could not find location with id " << location_id;
@@ -238,7 +285,8 @@ namespace {
         return hull.Location()->Eval(location_as_source_context, location);
     }
 
-    bool ShipPartProductionLocation(const ShipPart& part_type, int location_id) {
+    auto ShipPartProductionLocation(const ShipPart& part_type, int location_id) -> bool
+    {
         auto location = Objects().get(location_id);
         if (!location) {
             ErrorLogger() << "UniverseWrapper::PartTypeProductionLocation Could not find location with id " << location_id;
@@ -248,9 +296,10 @@ namespace {
         return part_type.Location()->Eval(location_as_source_context, location);
     }
 
-    bool RuleExistsAnyType(const GameRules& rules, const std::string& name)
+    auto RuleExistsAnyType(const GameRules& rules, const std::string& name) -> bool
     { return rules.RuleExists(name); }
-    bool RuleExistsWithType(const GameRules& rules, const std::string& name, GameRules::Type type)
+
+    auto RuleExistsWithType(const GameRules& rules, const std::string& name, GameRules::Type type) -> bool
     { return rules.RuleExists(name, type); }
 }
 

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -133,7 +133,7 @@ namespace {
         return retval;
     }
 
-    auto SystemNeighborsMap(const Universe& universe, int system1_id, int empire_id = ALL_EMPIRES) -> std::map<int, double>
+    auto SystemNeighborsMap(const Universe& universe, int system1_id, int empire_id) -> std::map<int, double>
     {
         std::map<int, double> retval;
         for (const auto& entry : universe.GetPathfinder()->ImmediateNeighbors(system1_id, empire_id))
@@ -318,7 +318,9 @@ namespace FreeOrionPython {
                                                 py::return_value_policy<py::reference_existing_object>())
             .def("getBuilding",                 +[](const Universe&, int id) -> const Building* { return ::Objects().get<Building>(id).operator->(); },
                                                 py::return_value_policy<py::reference_existing_object>())
-            .def("getGenericShipDesign",        &Universe::GetGenericShipDesign,    py::return_value_policy<py::reference_existing_object>(), "Returns the ship design (ShipDesign) with the indicated name (string).")
+            .def("getGenericShipDesign",        &Universe::GetGenericShipDesign,
+                                                py::return_value_policy<py::reference_existing_object>(),
+                                                "Returns the ship design (ShipDesign) with the indicated name (string).")
 
             .add_property("allObjectIDs",       make_function(ObjectIDs<UniverseObject>,py::return_value_policy<py::return_by_value>()))
             .add_property("fleetIDs",           make_function(ObjectIDs<Fleet>,         py::return_value_policy<py::return_by_value>()))
@@ -327,97 +329,64 @@ namespace FreeOrionPython {
             .add_property("planetIDs",          make_function(ObjectIDs<Planet>,        py::return_value_policy<py::return_by_value>()))
             .add_property("shipIDs",            make_function(ObjectIDs<Ship>,          py::return_value_policy<py::return_by_value>()))
             .add_property("buildingIDs",        make_function(ObjectIDs<Building>,      py::return_value_policy<py::return_by_value>()))
-            .def("destroyedObjectIDs",          make_function(&Universe::EmpireKnownDestroyedObjectIDs,
-                                                              py::return_value_policy<py::return_by_value>()))
+            .def("destroyedObjectIDs",          &Universe::EmpireKnownDestroyedObjectIDs,
+                                                py::return_value_policy<py::return_by_value>())
 
-            .def("systemHasStarlane",           make_function(
-                                                    +[](const Universe& universe, int system_id, int empire_id) -> bool { return universe.GetPathfinder()->SystemHasVisibleStarlanes(system_id, empire_id); },
-                                                    py::return_value_policy<py::return_by_value>()
-                                                ))
+            .def("systemHasStarlane",           +[](const Universe& universe, int system_id, int empire_id) -> bool { return universe.GetPathfinder()->SystemHasVisibleStarlanes(system_id, empire_id); },
+                                                py::return_value_policy<py::return_by_value>())
 
             .def("updateMeterEstimates",        &UpdateMetersWrapper)
             .add_property("effectAccounting",   make_function(&Universe::GetEffectAccountingMap,
                                                                                     py::return_value_policy<py::reference_existing_object>()))
 
-            .def("linearDistance",              make_function(
-                                                    +[](const Universe& universe, int system1_id, int system2_id) -> double { return universe.GetPathfinder()->LinearDistance(system1_id, system2_id); },
-                                                    py::return_value_policy<py::return_by_value>()
-                                                ))
+            .def("linearDistance",              +[](const Universe& universe, int system1_id, int system2_id) -> double { return universe.GetPathfinder()->LinearDistance(system1_id, system2_id); },
+                                                py::return_value_policy<py::return_by_value>())
 
-            .def("jumpDistance",                make_function(
-                                                    +[](const Universe& universe, int object1_id, int object2_id) -> int { return universe.GetPathfinder()->JumpDistanceBetweenObjects(object1_id, object2_id); },
-                                                    py::return_value_policy<py::return_by_value>()
-                                                ),
+            .def("jumpDistance",                +[](const Universe& universe, int object1_id, int object2_id) -> int { return universe.GetPathfinder()->JumpDistanceBetweenObjects(object1_id, object2_id); },
+                                                py::return_value_policy<py::return_by_value>(),
                                                 "If two system ids are passed or both objects are within a system, "
                                                 "return the jump distance between the two systems. If one object "
                                                 "(e.g. a fleet) is on a starlane, then calculate the jump distance "
                                                 "from both ends of the starlane to the target system and "
-                                                "return the smaller one."
-                                                )
+                                                "return the smaller one.")
 
-            .def("shortestPath",                make_function(
-                                                    ShortestPath,
-                                                    py::return_value_policy<py::return_by_value>(),
-                                                    boost::mpl::vector<std::vector<int>, const Universe&, int, int, int>()
-                                                ))
+            .def("shortestPath",                ShortestPath,
+                                                py::return_value_policy<py::return_by_value>())
 
-            .def("shortestNonHostilePath",      make_function(
-                                                    ShortestNonHostilePath,
-                                                    py::return_value_policy<py::return_by_value>(),
-                                                    boost::mpl::vector<std::vector<int>, const Universe&, int, int, int>()
-                                                ),
+            .def("shortestNonHostilePath",      ShortestNonHostilePath,
+                                                py::return_value_policy<py::return_by_value>(),
                                                 "Shortest sequence of System ids and distance from System (number1) to "
                                                 "System (number2) with no hostile Fleets as determined by visibility "
-                                                "of Empire (number3).  (number3) must be a valid empire."
-                                                )
+                                                "of Empire (number3).  (number3) must be a valid empire.")
 
-            .def("shortestPathDistance",        make_function(
-                                                    +[](const Universe& universe, int object1_id, int object2_id) -> double { return universe.GetPathfinder()->ShortestPathDistance(object1_id, object2_id); },
-                                                    py::return_value_policy<py::return_by_value>()
-                                                ))
+            .def("shortestPathDistance",        +[](const Universe& universe, int object1_id, int object2_id) -> double { return universe.GetPathfinder()->ShortestPathDistance(object1_id, object2_id); },
+                                                py::return_value_policy<py::return_by_value>())
 
-            .def("leastJumpsPath",              make_function(
-                                                    LeastJumpsPath,
-                                                    py::return_value_policy<py::return_by_value>(),
-                                                    boost::mpl::vector<std::vector<int>, const Universe&, int, int, int>()
-                                                ))
+            .def("leastJumpsPath",              LeastJumpsPath,
+                                                py::return_value_policy<py::return_by_value>())
 
-            .def("systemsConnected",            make_function(
-                                                    +[](const Universe& universe, int system1_id, int system2_id, int empire_id) -> bool { return universe.GetPathfinder()->SystemsConnected(system1_id, system2_id, empire_id); },
-                                                    py::return_value_policy<py::return_by_value>()
-                                                ))
+            .def("systemsConnected",            +[](const Universe& universe, int system1_id, int system2_id, int empire_id) -> bool { return universe.GetPathfinder()->SystemsConnected(system1_id, system2_id, empire_id); },
+                                                py::return_value_policy<py::return_by_value>())
 
-            .def("getImmediateNeighbors",       make_function(
-                                                    ImmediateNeighbors,
-                                                    py::return_value_policy<py::return_by_value>(),
-                                                    boost::mpl::vector<std::vector<int>, const Universe&, int, int>()
-                                                ))
+            .def("getImmediateNeighbors",       ImmediateNeighbors,
+                                                py::return_value_policy<py::return_by_value>())
 
-            .def("getSystemNeighborsMap",       make_function(
-                                                    SystemNeighborsMap,
-                                                    py::return_value_policy<py::return_by_value>(),
-                                                    boost::mpl::vector<std::map<int, double>, const Universe&, int, int>()
-                                                ))
+            .def("getSystemNeighborsMap",       SystemNeighborsMap,
+                                                py::return_value_policy<py::return_by_value>())
 
-            .def("getVisibilityTurnsMap",       make_function(
-                                                    &Universe::GetObjectVisibilityTurnMapByEmpire,
-                                                    py::return_value_policy<py::return_by_value>()
-                                                ))
+            .def("getVisibilityTurnsMap",       &Universe::GetObjectVisibilityTurnMapByEmpire,
+                                                py::return_value_policy<py::return_by_value>())
 
-            .def("getVisibility",               make_function(
-                                                    &Universe::GetObjectVisibilityByEmpire,
-                                                    py::return_value_policy<py::return_by_value>()
-                                                ))
+            .def("getVisibility",               &Universe::GetObjectVisibilityByEmpire,
+                                                py::return_value_policy<py::return_by_value>())
 
             // Indexed by stat name (string), contains a map indexed by empire id,
             // contains a map from turn number (int) to stat value (double).
-            .def("statRecords",                 make_function(
-                                                    &Universe::GetStatRecords,
-                                                    py::return_value_policy<py::reference_existing_object>()),
+            .def("statRecords",                 &Universe::GetStatRecords,
+                                                py::return_value_policy<py::reference_existing_object>(),
                                                 "Empire statistics recorded by the server each turn. Indexed first by "
                                                 "staistic name (string), then by empire id (int), then by turn "
-                                                "number (int), pointing to the statisic value (double)."
-                                                )
+                                                "number (int), pointing to the statisic value (double).")
 
             .def("dump",                        +[](const Universe& universe) { DebugLogger() << universe.Objects().Dump(); })
         ;
@@ -443,16 +412,10 @@ namespace FreeOrionPython {
             .def("containedBy",                 &UniverseObject::ContainedBy)
             .add_property("containedObjects",   make_function(&UniverseObject::ContainedObjectIDs,  py::return_value_policy<py::return_by_value>()))
             .add_property("containerObject",    &UniverseObject::ContainerObjectID)
-            .def("currentMeterValue",           make_function(
-                                                    ObjectCurrentMeterValue,
-                                                    py::return_value_policy<py::return_by_value>(),
-                                                    boost::mpl::vector<float, const UniverseObject&, MeterType>()
-                                                ))
-            .def("initialMeterValue",           make_function(
-                                                    ObjectInitialMeterValue,
-                                                    py::return_value_policy<py::return_by_value>(),
-                                                    boost::mpl::vector<float, const UniverseObject&, MeterType>()
-                                                ))
+            .def("currentMeterValue",           ObjectCurrentMeterValue,
+                                                py::return_value_policy<py::return_by_value>())
+            .def("initialMeterValue",           ObjectInitialMeterValue,
+                                                py::return_value_policy<py::return_by_value>())
             .add_property("tags",               make_function(&UniverseObject::Tags,        py::return_value_policy<py::return_by_value>()))
             .def("hasTag",                      &UniverseObject::HasTag)
             .add_property("meters",             make_function(
@@ -572,8 +535,7 @@ namespace FreeOrionPython {
                                                 ))
             .add_property("attackStats",        make_function(
                                                     AttackStats,
-                                                    py::return_value_policy<py::return_by_value>(),
-                                                    boost::mpl::vector<std::vector<int>, const ShipDesign&>()
+                                                    py::return_value_policy<py::return_by_value>()
                                                 ))
 
             .def("productionLocationForEmpire", &ShipDesign::ProductionLocation)
@@ -620,8 +582,7 @@ namespace FreeOrionPython {
             .def("numSlotsOfSlotType",          +[](const ShipHull& hull, ShipSlotType slot_type) -> unsigned int { return hull.NumSlots(slot_type); })
             .add_property("slots",              make_function(
                                                     HullSlots,
-                                                    py::return_value_policy<py::return_by_value>(),
-                                                    boost::mpl::vector<std::vector<ShipSlotType>, const ShipHull&>()
+                                                    py::return_value_policy<py::return_by_value>()
                                                 ))
             .def("productionCost",              &ShipHull::ProductionCost)
             .def("productionTime",              &ShipHull::ProductionTime)
@@ -786,14 +747,24 @@ namespace FreeOrionPython {
 
         py::class_<GameRules, boost::noncopyable>("GameRules", py::no_init)
             .add_property("empty",              make_function(&GameRules::Empty,                py::return_value_policy<py::return_by_value>()))
-            .def("getRulesAsStrings",           make_function(&GameRules::GetRulesAsStrings,    py::return_value_policy<py::return_by_value>()))
+            .def("getRulesAsStrings",           &GameRules::GetRulesAsStrings,
+                                                py::return_value_policy<py::return_by_value>())
             .def("ruleExists",                  +[](const GameRules& rules, const std::string& name) -> bool { return rules.RuleExists(name); })
             .def("ruleExistsWithType",          +[](const GameRules& rules, const std::string& name, GameRules::Type type) -> bool { return rules.RuleExists(name, type); })
-            .def("getDescription",              make_function(&GameRules::GetDescription,       py::return_value_policy<py::copy_const_reference>()))
+            .def("getDescription",              &GameRules::GetDescription,
+                                                py::return_value_policy<py::copy_const_reference>())
             .def("getToggle",                   &GameRules::Get<bool>)
             .def("getInt",                      &GameRules::Get<int>)
             .def("getDouble",                   &GameRules::Get<double>)
-            .def("getString",                   make_function(&GameRules::Get<std::string>,     py::return_value_policy<py::return_by_value>()));
-        py::def("getGameRules",                     &GetGameRules,                                  py::return_value_policy<py::reference_existing_object>(), "Returns the game rules manager, which can be used to look up the names (string) of rules are defined with what type (boolean / toggle, int, double, string), and what values the rules have in the current game.");
+            .def("getString",                   &GameRules::Get<std::string>,
+                                                py::return_value_policy<py::return_by_value>());
+
+        py::def("getGameRules",
+                &GetGameRules,
+                py::return_value_policy<py::reference_existing_object>(),
+                "Returns the game rules manager, which can be used to look up"
+                " the names (string) of rules are defined with what type"
+                " (boolean / toggle, int, double, string), and what values the"
+                " rules have in the current game.");
     }
 }

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -57,9 +57,10 @@ namespace boost {
 #endif
 
 namespace {
-    void                    DumpObjects(const Universe& universe)
+    void DumpObjects(const Universe& universe)
     { DebugLogger() << universe.Objects().Dump(); }
-    std::string             ObjectDump(const UniverseObject& obj)
+
+    auto ObjectDump(const UniverseObject& obj) -> std::string
     { return obj.Dump(0); }
 
     // We're returning the result of operator-> here so that python doesn't
@@ -104,18 +105,11 @@ namespace {
         GetUniverse().UpdateMeterEstimates(objvec);
     }
 
-    //void (Universe::*UpdateMeterEstimatesVoidFunc)(void) = &Universe::UpdateMeterEstimates;
+    double LinearDistance(const Universe& universe, int system1_id, int system2_id)
+    { return universe.GetPathfinder()->LinearDistance(system1_id, system2_id); }
 
-    double LinearDistance(const Universe& universe, int system1_id, int system2_id) {
-        double retval = universe.GetPathfinder()->LinearDistance(system1_id, system2_id);
-        return retval;
-    }
-    std::function<double (const Universe&, int, int)> LinearDistanceFunc = &LinearDistance;
-
-    int JumpDistanceBetweenObjects(const Universe& universe, int object1_id, int object2_id) {
-        return universe.GetPathfinder()->JumpDistanceBetweenObjects(object1_id, object2_id);
-    }
-    std::function<int (const Universe&, int, int)> JumpDistanceFunc = &JumpDistanceBetweenObjects;
+    int JumpDistanceBetweenObjects(const Universe& universe, int object1_id, int object2_id)
+    { return universe.GetPathfinder()->JumpDistanceBetweenObjects(object1_id, object2_id); }
 
     std::vector<int> ShortestPath(const Universe& universe, int start_sys, int end_sys, int empire_id) {
         std::vector<int> retval;
@@ -123,7 +117,6 @@ namespace {
         std::copy(path.first.begin(), path.first.end(), std::back_inserter(retval));
         return retval;
     }
-    std::function<std::vector<int> (const Universe&, int, int, int)> ShortestPathFunc = &ShortestPath;
 
     std::vector<int> ShortestNonHostilePath(const Universe& universe, int start_sys, int end_sys, int empire_id) {
         std::vector<int> retval;
@@ -132,12 +125,9 @@ namespace {
         std::copy(path.first.begin(), path.first.end(), std::back_inserter(retval));
         return retval;
     }
-    std::function<std::vector<int> (const Universe&, int, int, int)> ShortestNonHostilePathFunc = &ShortestNonHostilePath;
 
-    double ShortestPathDistance(const Universe& universe, int object1_id, int object2_id) {
-        return universe.GetPathfinder()->ShortestPathDistance(object1_id, object2_id);
-    }
-    std::function<double (const Universe&, int, int)> ShortestPathDistanceFunc = &ShortestPathDistance;
+    double ShortestPathDistance(const Universe& universe, int object1_id, int object2_id)
+    { return universe.GetPathfinder()->ShortestPathDistance(object1_id, object2_id); }
 
     std::vector<int> LeastJumpsPath(const Universe& universe, int start_sys, int end_sys, int empire_id) {
         std::vector<int> retval;
@@ -145,42 +135,31 @@ namespace {
         std::copy(path.first.begin(), path.first.end(), std::back_inserter(retval));
         return retval;
     }
-    std::function<std::vector<int> (const Universe&, int, int, int)> LeastJumpsFunc = &LeastJumpsPath;
 
-    bool SystemsConnectedP(const Universe& universe, int system1_id, int system2_id, int empire_id=ALL_EMPIRES) {
-        //DebugLogger() << "SystemsConnected!(" << system1_id << ", " << system2_id << ")";
-        bool retval = universe.GetPathfinder()->SystemsConnected(system1_id, system2_id, empire_id);
-        //DebugLogger() << "SystemsConnected! retval: " << retval;
-        return retval;
-    }
-    std::function<bool (const Universe&, int, int, int)> SystemsConnectedFunc = &SystemsConnectedP;
+    bool SystemsConnected(const Universe& universe, int system1_id, int system2_id, int empire_id)
+    { return universe.GetPathfinder()->SystemsConnected(system1_id, system2_id, empire_id); }
 
-    bool SystemHasVisibleStarlanesP(const Universe& universe, int system_id, int empire_id = ALL_EMPIRES) {
-        return universe.GetPathfinder()->SystemHasVisibleStarlanes(system_id, empire_id);
-    }
-    std::function<bool (const Universe&, int, int)> SystemHasVisibleStarlanesFunc = &SystemHasVisibleStarlanesP;
+    bool SystemHasVisibleStarlanes(const Universe& universe, int system_id, int empire_id)
+    { return universe.GetPathfinder()->SystemHasVisibleStarlanes(system_id, empire_id); }
 
-    std::vector<int> ImmediateNeighborsP(const Universe& universe, int system1_id, int empire_id = ALL_EMPIRES) {
+    std::vector<int> ImmediateNeighbors(const Universe& universe, int system1_id, int empire_id) {
         std::vector<int> retval;
         for (const auto& entry : universe.GetPathfinder()->ImmediateNeighbors(system1_id, empire_id))
         { retval.push_back(entry.second); }
         return retval;
     }
-    std::function<std::vector<int> (const Universe&, int, int)> ImmediateNeighborsFunc = &ImmediateNeighborsP;
 
-    std::map<int, double> SystemNeighborsMapP(const Universe& universe, int system1_id, int empire_id = ALL_EMPIRES) {
+    std::map<int, double> SystemNeighborsMap(const Universe& universe, int system1_id, int empire_id = ALL_EMPIRES) {
         std::map<int, double> retval;
         for (const auto& entry : universe.GetPathfinder()->ImmediateNeighbors(system1_id, empire_id))
         { retval[entry.second] = entry.first; }
         return retval;
     }
-    std::function<std::map<int, double> (const Universe&, int, int)> SystemNeighborsMapFunc = &SystemNeighborsMapP;
 
     const Meter*            (UniverseObject::*ObjectGetMeter)(MeterType) const =                &UniverseObject::GetMeter;
 
-    std::map<MeterType, Meter> ObjectMetersP(const UniverseObject& object)
+    std::map<MeterType, Meter> ObjectMeters(const UniverseObject& object)
     { return std::map<MeterType, Meter>{object.Meters().begin(), object.Meters().end()}; }
-    std::function<std::map<MeterType, Meter> (const UniverseObject&)> ObjectMetersFunc = &ObjectMetersP;
 
     std::vector<std::string> ObjectSpecials(const UniverseObject& object) {
         std::vector<std::string> retval;
@@ -193,40 +172,33 @@ namespace {
     const Meter*            (Ship::*ShipGetPartMeter)(MeterType, const std::string&) const =    &Ship::GetPartMeter;
     const auto&             (Ship::*ShipPartMeters)(void) const =                               &Ship::PartMeters;
 
-    float ObjectCurrentMeterValueP(const UniverseObject& o, MeterType meter_type) {
+    float ObjectCurrentMeterValue(const UniverseObject& o, MeterType meter_type) {
         if (auto* m = o.GetMeter(meter_type))
             return m->Current();
         return 0.0f;
     }
-    std::function<float(const UniverseObject&, MeterType)> ObjectCurrentMeterValueFunc = &ObjectCurrentMeterValueP;
 
-    float ObjectInitialMeterValueP(const UniverseObject& o, MeterType meter_type) {
+    float ObjectInitialMeterValue(const UniverseObject& o, MeterType meter_type) {
         if (auto* m = o.GetMeter(meter_type))
             return m->Initial();
         return 0.0f;
     }
-    std::function<float(const UniverseObject&, MeterType)> ObjectInitialMeterValueFunc = &ObjectInitialMeterValueP;
 
-    const ShipHull* ShipDesignHullP(const ShipDesign& design)
+    const ShipHull* ShipDesignHull(const ShipDesign& design)
     { return GetShipHull(design.Hull()); }
-    std::function<const ShipHull*(const ShipDesign& ship)> ShipDesignHullFunc = &ShipDesignHullP;
 
     const std::string& ShipDesignName(const ShipDesign& ship_design)
     { return ship_design.Name(false); }
-    std::function<const std::string& (const ShipDesign&)> ShipDesignNameFunc = &ShipDesignName;
 
     const std::string& ShipDesignDescription(const ShipDesign& ship_design)
     { return ship_design.Description(false); }
-    std::function<const std::string& (const ShipDesign&)> ShipDesignDescriptionFunc = &ShipDesignDescription;
 
     bool                    (*ValidDesignHullAndParts)(const std::string& hull,
                                                        const std::vector<std::string>& parts) = &ShipDesign::ValidDesign;
 
     const std::vector<std::string>& (ShipDesign::*PartsVoid)(void) const =                      &ShipDesign::Parts;
-    // The following (PartsSlotType) is not currently used, but left as an example for this kind of wrapper
-    //std::vector<std::string>        (ShipDesign::*PartsSlotType)(ShipSlotType) const =          &ShipDesign::Parts;
 
-    std::vector<int> AttackStatsP(const ShipDesign& ship_design) {
+    std::vector<int> AttackStats(const ShipDesign& ship_design) {
         std::vector<int> results;
         results.reserve(ship_design.Parts().size());
         for (const std::string& part_name : ship_design.Parts()) {
@@ -236,7 +208,6 @@ namespace {
         }
         return results;
     }
-    std::function<std::vector<int> (const ShipDesign&)> AttackStatsFunc = &AttackStatsP;
 
     std::vector<ShipSlotType> HullSlots(const ShipHull& hull) {
         std::vector<ShipSlotType> retval;
@@ -244,7 +215,6 @@ namespace {
             retval.push_back(slot.type);
         return retval;
     }
-    std::function<std::vector<ShipSlotType> (const ShipHull&)> HullSlotsFunc = &HullSlots;
 
     unsigned int            (ShipHull::*NumSlotsTotal)(void) const =                            &ShipHull::NumSlots;
     unsigned int            (ShipHull::*NumSlotsOfSlotType)(ShipSlotType) const =               &ShipHull::NumSlots;
@@ -401,7 +371,7 @@ namespace FreeOrionPython {
                                                               py::return_value_policy<py::return_by_value>()))
 
             .def("systemHasStarlane",           make_function(
-                                                    SystemHasVisibleStarlanesFunc,
+                                                    SystemHasVisibleStarlanes,
                                                     py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<bool, const Universe&, int, int>()
                                                 ))
@@ -411,13 +381,13 @@ namespace FreeOrionPython {
                                                                                     py::return_value_policy<py::reference_existing_object>()))
 
             .def("linearDistance",              make_function(
-                                                    LinearDistanceFunc,
+                                                    LinearDistance,
                                                     py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<double, const Universe&, int, int>()
                                                 ))
 
             .def("jumpDistance",                make_function(
-                                                    JumpDistanceFunc,
+                                                    JumpDistanceBetweenObjects,
                                                     py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<int, const Universe&, int, int>()
                                                 ),
@@ -429,13 +399,13 @@ namespace FreeOrionPython {
                                                 )
 
             .def("shortestPath",                make_function(
-                                                    ShortestPathFunc,
+                                                    ShortestPath,
                                                     py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<std::vector<int>, const Universe&, int, int, int>()
                                                 ))
 
             .def("shortestNonHostilePath",      make_function(
-                                                    ShortestNonHostilePathFunc,
+                                                    ShortestNonHostilePath,
                                                     py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<std::vector<int>, const Universe&, int, int, int>()
                                                 ),
@@ -445,31 +415,31 @@ namespace FreeOrionPython {
                                                 )
 
             .def("shortestPathDistance",        make_function(
-                                                    ShortestPathDistanceFunc,
+                                                    ShortestPathDistance,
                                                     py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<double, const Universe&, int, int>()
                                                 ))
 
             .def("leastJumpsPath",              make_function(
-                                                    LeastJumpsFunc,
+                                                    LeastJumpsPath,
                                                     py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<std::vector<int>, const Universe&, int, int, int>()
                                                 ))
 
             .def("systemsConnected",            make_function(
-                                                    SystemsConnectedFunc,
+                                                    SystemsConnected,
                                                     py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<bool, const Universe&, int, int, int>()
                                                 ))
 
             .def("getImmediateNeighbors",       make_function(
-                                                    ImmediateNeighborsFunc,
+                                                    ImmediateNeighbors,
                                                     py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<std::vector<int>, const Universe&, int, int>()
                                                 ))
 
             .def("getSystemNeighborsMap",       make_function(
-                                                    SystemNeighborsMapFunc,
+                                                    SystemNeighborsMap,
                                                     py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<std::map<int, double>, const Universe&, int, int>()
                                                 ))
@@ -494,7 +464,7 @@ namespace FreeOrionPython {
                                                 "number (int), pointing to the statisic value (double)."
                                                 )
 
-            .def("dump",                        &DumpObjects)
+            .def("dump",                        DumpObjects)
         ;
 
         ////////////////////
@@ -519,24 +489,24 @@ namespace FreeOrionPython {
             .add_property("containedObjects",   make_function(&UniverseObject::ContainedObjectIDs,  py::return_value_policy<py::return_by_value>()))
             .add_property("containerObject",    &UniverseObject::ContainerObjectID)
             .def("currentMeterValue",           make_function(
-                                                    ObjectCurrentMeterValueFunc,
+                                                    ObjectCurrentMeterValue,
                                                     py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<float, const UniverseObject&, MeterType>()
                                                 ))
             .def("initialMeterValue",           make_function(
-                                                    ObjectInitialMeterValueFunc,
+                                                    ObjectInitialMeterValue,
                                                     py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<float, const UniverseObject&, MeterType>()
                                                 ))
             .add_property("tags",               make_function(&UniverseObject::Tags,        py::return_value_policy<py::return_by_value>()))
             .def("hasTag",                      &UniverseObject::HasTag)
             .add_property("meters",             make_function(
-                                                    ObjectMetersFunc,
+                                                    ObjectMeters,
                                                     py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<std::map<MeterType, Meter>, const UniverseObject&>()
                                                 ))
             .def("getMeter",                    make_function(ObjectGetMeter,               py::return_internal_reference<>()))
-            .def("dump",                        make_function(&ObjectDump,                  py::return_value_policy<py::return_by_value>()), "Returns string with debug information.")
+            .def("dump",                        make_function(ObjectDump,                   py::return_value_policy<py::return_by_value>()), "Returns string with debug information.")
         ;
 
         ///////////////////
@@ -598,12 +568,12 @@ namespace FreeOrionPython {
         py::class_<ShipDesign, boost::noncopyable>("shipDesign", py::no_init)
             .add_property("id",                 make_function(&ShipDesign::ID,              py::return_value_policy<py::return_by_value>()))
             .add_property("name",               make_function(
-                                                    ShipDesignNameFunc,
+                                                    ShipDesignName,
                                                     py::return_value_policy<py::copy_const_reference>(),
                                                     boost::mpl::vector<const std::string&, const ShipDesign&>()
                                                 ))
             .add_property("description",        make_function(
-                                                    ShipDesignDescriptionFunc,
+                                                    ShipDesignDescription,
                                                     py::return_value_policy<py::copy_const_reference>(),
                                                     boost::mpl::vector<const std::string&, const ShipDesign&>()
                                                 ))
@@ -634,13 +604,13 @@ namespace FreeOrionPython {
                                                 &ShipDesign::ProductionCostTimeLocationInvariant)
             .add_property("hull",               make_function(&ShipDesign::Hull,            py::return_value_policy<py::return_by_value>()))
             .add_property("ship_hull",          make_function(
-                                                    ShipDesignHullFunc,
+                                                    ShipDesignHull,
                                                     py::return_value_policy<py::reference_existing_object>(),
                                                     boost::mpl::vector<const ShipHull*, const ShipDesign&>()
                                                 ))
             .add_property("parts",              make_function(PartsVoid,                    py::return_internal_reference<>()))
             .add_property("attackStats",        make_function(
-                                                    AttackStatsFunc,
+                                                    AttackStats,
                                                     py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<std::vector<int>, const ShipDesign&>()
                                                 ))
@@ -678,7 +648,7 @@ namespace FreeOrionPython {
             .add_property("speed",              &ShipHull::Speed)
             .def("numSlotsOfSlotType",          NumSlotsOfSlotType)
             .add_property("slots",              make_function(
-                                                    HullSlotsFunc,
+                                                    HullSlots,
                                                     py::return_value_policy<py::return_by_value>(),
                                                     boost::mpl::vector<std::vector<ShipSlotType>, const ShipHull&>()
                                                 ))

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -74,36 +74,6 @@ auto get_pointer<const volatile Universe>(const volatile Universe* p) -> const v
 #endif
 
 namespace {
-    void DumpObjects(const Universe& universe)
-    { DebugLogger() << universe.Objects().Dump(); }
-
-    auto ObjectDump(const UniverseObject& obj) -> std::string
-    { return obj.Dump(0); }
-
-    // We're returning the result of operator-> here so that python doesn't
-    // need to deal with std::shared_ptr class.
-    // Please don't use this trick elsewhere to grab a raw UniverseObject*!
-    auto GetUniverseObjectP(const Universe& universe, int id) -> const UniverseObject*
-    { return ::Objects().get<UniverseObject>(id).operator->(); }
-
-    auto GetShipP(const Universe& universe, int id) -> const Ship*
-    { return ::Objects().get<Ship>(id).operator->(); }
-
-    auto GetFleetP(const Universe& universe, int id) -> const Fleet*
-    { return ::Objects().get<Fleet>(id).operator->(); }
-
-    auto GetPlanetP(const Universe& universe, int id) -> const Planet*
-    { return ::Objects().get<Planet>(id).operator->(); }
-
-    auto GetSystemP(const Universe& universe, int id) -> const System*
-    { return ::Objects().get<System>(id).operator->(); }
-
-    auto GetFieldP(const Universe& universe, int id) -> const Field*
-    { return ::Objects().get<Field>(id).operator->();  }
-
-    auto GetBuildingP(const Universe& universe, int id) -> const Building*
-    { return ::Objects().get<Building>(id).operator->(); }
-
     template<typename T>
     auto ObjectIDs(const Universe& universe) -> std::vector<int>
     {
@@ -130,12 +100,6 @@ namespace {
         GetUniverse().UpdateMeterEstimates(objvec);
     }
 
-    auto LinearDistance(const Universe& universe, int system1_id, int system2_id) -> double
-    { return universe.GetPathfinder()->LinearDistance(system1_id, system2_id); }
-
-    auto JumpDistanceBetweenObjects(const Universe& universe, int object1_id, int object2_id) -> int
-    { return universe.GetPathfinder()->JumpDistanceBetweenObjects(object1_id, object2_id); }
-
     auto ShortestPath(const Universe& universe, int start_sys, int end_sys, int empire_id) -> std::vector<int>
     {
         std::vector<int> retval;
@@ -153,9 +117,6 @@ namespace {
         return retval;
     }
 
-    auto ShortestPathDistance(const Universe& universe, int object1_id, int object2_id) -> double
-    { return universe.GetPathfinder()->ShortestPathDistance(object1_id, object2_id); }
-
     auto LeastJumpsPath(const Universe& universe, int start_sys, int end_sys, int empire_id) -> std::vector<int>
     {
         std::vector<int> retval;
@@ -163,12 +124,6 @@ namespace {
         std::copy(path.first.begin(), path.first.end(), std::back_inserter(retval));
         return retval;
     }
-
-    auto SystemsConnected(const Universe& universe, int system1_id, int system2_id, int empire_id) -> bool
-    { return universe.GetPathfinder()->SystemsConnected(system1_id, system2_id, empire_id); }
-
-    auto SystemHasVisibleStarlanes(const Universe& universe, int system_id, int empire_id) -> bool
-    { return universe.GetPathfinder()->SystemHasVisibleStarlanes(system_id, empire_id); }
 
     auto ImmediateNeighbors(const Universe& universe, int system1_id, int empire_id) -> std::vector<int>
     {
@@ -186,12 +141,6 @@ namespace {
         return retval;
     }
 
-    auto ObjectGetMeter(const UniverseObject& object, MeterType type) -> const Meter*
-    { return object.GetMeter(type); }
-
-    auto ObjectMeters(const UniverseObject& object) -> std::map<MeterType, Meter>
-    { return std::map<MeterType, Meter>{object.Meters().begin(), object.Meters().end()}; }
-
     auto ObjectSpecials(const UniverseObject& object) -> std::vector<std::string>
     {
         std::vector<std::string> retval;
@@ -200,12 +149,6 @@ namespace {
         { retval.push_back(special.first); }
         return retval;
     }
-
-    auto ShipGetPartMeter(const Ship& ship, MeterType type, const std::string& part_name) -> const Meter*
-    { return ship.GetPartMeter(type, part_name); }
-
-    auto ShipPartMeters(const Ship& ship) -> const Ship::PartMeterMap&
-    { return ship.PartMeters(); }
 
     auto ObjectCurrentMeterValue(const UniverseObject& o, MeterType meter_type) -> float
     {
@@ -220,21 +163,6 @@ namespace {
             return m->Initial();
         return 0.0f;
     }
-
-    auto ShipDesignHull(const ShipDesign& design) -> const ShipHull*
-    { return GetShipHull(design.Hull()); }
-
-    auto ShipDesignName(const ShipDesign& ship_design) -> const std::string&
-    { return ship_design.Name(false); }
-
-    auto ShipDesignDescription(const ShipDesign& ship_design) -> const std::string&
-    { return ship_design.Description(false); }
-
-    auto ValidDesignHullAndParts(const ShipDesign& design, const std::string& hull, const std::vector<std::string>& parts) -> bool
-    { return design.ValidDesign(hull, parts); }
-
-    auto PartsVoid(const ShipDesign& design) -> const std::vector<std::string>&
-    { return design.Parts(); }
 
     auto AttackStats(const ShipDesign& ship_design) -> std::vector<int>
     {
@@ -255,24 +183,6 @@ namespace {
             retval.push_back(slot.type);
         return retval;
     }
-
-    auto NumSlotsTotal(const ShipHull& hull) -> unsigned int
-    { return hull.NumSlots(); }
-
-    auto NumSlotsOfSlotType(const ShipHull& hull, ShipSlotType slot_type) -> unsigned int
-    { return hull.NumSlots(slot_type); }
-
-    bool ObjectInField(const Field& field, const UniverseObject& obj)
-    { return field.InField(obj.X(), obj.Y()); }
-
-    auto LocationInField(const Field& field, double x, double y) -> bool
-    { return field.InField(x, y); }
-
-    auto SpecialInitialCapacityOnObject(const Special& special, int obj_id) -> float
-    { return special.InitialCapacity(obj_id); }
-
-    auto EnqueueLocationTest(const BuildingType& building_type, int empire_id, int loc_id) -> bool
-    { return building_type.EnqueueLocation(empire_id, loc_id);}
 
     auto HullProductionLocation(const ShipHull& hull, int location_id) -> bool
     {
@@ -295,12 +205,6 @@ namespace {
         ScriptingContext location_as_source_context(location, location);
         return part_type.Location()->Eval(location_as_source_context, location);
     }
-
-    auto RuleExistsAnyType(const GameRules& rules, const std::string& name) -> bool
-    { return rules.RuleExists(name); }
-
-    auto RuleExistsWithType(const GameRules& rules, const std::string& name, GameRules::Type type) -> bool
-    { return rules.RuleExists(name, type); }
 }
 
 namespace FreeOrionPython {
@@ -400,13 +304,20 @@ namespace FreeOrionPython {
         //    Universe    //
         ////////////////////
         py::class_<Universe, boost::noncopyable>("universe", py::no_init)
-            .def("getObject",                   make_function(GetUniverseObjectP,   py::return_value_policy<py::reference_existing_object>()))
-            .def("getFleet",                    make_function(GetFleetP,            py::return_value_policy<py::reference_existing_object>()))
-            .def("getShip",                     make_function(GetShipP,             py::return_value_policy<py::reference_existing_object>()))
-            .def("getPlanet",                   make_function(GetPlanetP,           py::return_value_policy<py::reference_existing_object>()))
-            .def("getSystem",                   make_function(GetSystemP,           py::return_value_policy<py::reference_existing_object>()))
-            .def("getField",                    make_function(GetFieldP,            py::return_value_policy<py::reference_existing_object>()))
-            .def("getBuilding",                 make_function(GetBuildingP,         py::return_value_policy<py::reference_existing_object>()))
+            .def("getObject",                   +[](const Universe&, int id) -> const UniverseObject* { return ::Objects().get<UniverseObject>(id).operator->(); },
+                                                py::return_value_policy<py::reference_existing_object>())
+            .def("getFleet",                    +[](const Universe&, int id) -> const Fleet* { return ::Objects().get<Fleet>(id).operator->(); },
+                                                py::return_value_policy<py::reference_existing_object>())
+            .def("getShip",                     +[](const Universe&, int id) -> const Ship* { return ::Objects().get<Ship>(id).operator->(); },
+                                                py::return_value_policy<py::reference_existing_object>())
+            .def("getPlanet",                   +[](const Universe&, int id) -> const Planet* { return ::Objects().get<Planet>(id).operator->(); },
+                                                py::return_value_policy<py::reference_existing_object>())
+            .def("getSystem",                   +[](const Universe&, int id) -> const System* { return ::Objects().get<System>(id).operator->(); },
+                                                py::return_value_policy<py::reference_existing_object>())
+            .def("getField",                    +[](const Universe&, int id) -> const Field* { return ::Objects().get<Field>(id).operator->(); },
+                                                py::return_value_policy<py::reference_existing_object>())
+            .def("getBuilding",                 +[](const Universe&, int id) -> const Building* { return ::Objects().get<Building>(id).operator->(); },
+                                                py::return_value_policy<py::reference_existing_object>())
             .def("getGenericShipDesign",        &Universe::GetGenericShipDesign,    py::return_value_policy<py::reference_existing_object>(), "Returns the ship design (ShipDesign) with the indicated name (string).")
 
             .add_property("allObjectIDs",       make_function(ObjectIDs<UniverseObject>,py::return_value_policy<py::return_by_value>()))
@@ -420,9 +331,8 @@ namespace FreeOrionPython {
                                                               py::return_value_policy<py::return_by_value>()))
 
             .def("systemHasStarlane",           make_function(
-                                                    SystemHasVisibleStarlanes,
-                                                    py::return_value_policy<py::return_by_value>(),
-                                                    boost::mpl::vector<bool, const Universe&, int, int>()
+                                                    +[](const Universe& universe, int system_id, int empire_id) -> bool { return universe.GetPathfinder()->SystemHasVisibleStarlanes(system_id, empire_id); },
+                                                    py::return_value_policy<py::return_by_value>()
                                                 ))
 
             .def("updateMeterEstimates",        &UpdateMetersWrapper)
@@ -430,15 +340,13 @@ namespace FreeOrionPython {
                                                                                     py::return_value_policy<py::reference_existing_object>()))
 
             .def("linearDistance",              make_function(
-                                                    LinearDistance,
-                                                    py::return_value_policy<py::return_by_value>(),
-                                                    boost::mpl::vector<double, const Universe&, int, int>()
+                                                    +[](const Universe& universe, int system1_id, int system2_id) -> double { return universe.GetPathfinder()->LinearDistance(system1_id, system2_id); },
+                                                    py::return_value_policy<py::return_by_value>()
                                                 ))
 
             .def("jumpDistance",                make_function(
-                                                    JumpDistanceBetweenObjects,
-                                                    py::return_value_policy<py::return_by_value>(),
-                                                    boost::mpl::vector<int, const Universe&, int, int>()
+                                                    +[](const Universe& universe, int object1_id, int object2_id) -> int { return universe.GetPathfinder()->JumpDistanceBetweenObjects(object1_id, object2_id); },
+                                                    py::return_value_policy<py::return_by_value>()
                                                 ),
                                                 "If two system ids are passed or both objects are within a system, "
                                                 "return the jump distance between the two systems. If one object "
@@ -464,9 +372,8 @@ namespace FreeOrionPython {
                                                 )
 
             .def("shortestPathDistance",        make_function(
-                                                    ShortestPathDistance,
-                                                    py::return_value_policy<py::return_by_value>(),
-                                                    boost::mpl::vector<double, const Universe&, int, int>()
+                                                    +[](const Universe& universe, int object1_id, int object2_id) -> double { return universe.GetPathfinder()->ShortestPathDistance(object1_id, object2_id); },
+                                                    py::return_value_policy<py::return_by_value>()
                                                 ))
 
             .def("leastJumpsPath",              make_function(
@@ -476,9 +383,8 @@ namespace FreeOrionPython {
                                                 ))
 
             .def("systemsConnected",            make_function(
-                                                    SystemsConnected,
-                                                    py::return_value_policy<py::return_by_value>(),
-                                                    boost::mpl::vector<bool, const Universe&, int, int, int>()
+                                                    +[](const Universe& universe, int system1_id, int system2_id, int empire_id) -> bool { return universe.GetPathfinder()->SystemsConnected(system1_id, system2_id, empire_id); },
+                                                    py::return_value_policy<py::return_by_value>()
                                                 ))
 
             .def("getImmediateNeighbors",       make_function(
@@ -513,7 +419,7 @@ namespace FreeOrionPython {
                                                 "number (int), pointing to the statisic value (double)."
                                                 )
 
-            .def("dump",                        DumpObjects)
+            .def("dump",                        +[](const Universe& universe) { DebugLogger() << universe.Objects().Dump(); })
         ;
 
         ////////////////////
@@ -550,12 +456,14 @@ namespace FreeOrionPython {
             .add_property("tags",               make_function(&UniverseObject::Tags,        py::return_value_policy<py::return_by_value>()))
             .def("hasTag",                      &UniverseObject::HasTag)
             .add_property("meters",             make_function(
-                                                    ObjectMeters,
-                                                    py::return_value_policy<py::return_by_value>(),
-                                                    boost::mpl::vector<std::map<MeterType, Meter>, const UniverseObject&>()
+                                                    +[](const UniverseObject& object) -> std::map<MeterType, Meter> { return std::map<MeterType, Meter>{object.Meters().begin(), object.Meters().end()}; },
+                                                    py::return_value_policy<py::return_by_value>()
                                                 ))
-            .def("getMeter",                    make_function(ObjectGetMeter,               py::return_internal_reference<>()))
-            .def("dump",                        make_function(ObjectDump,                   py::return_value_policy<py::return_by_value>()), "Returns string with debug information.")
+            .def("getMeter",                    +[](const UniverseObject& object, MeterType type) -> const Meter* { return object.GetMeter(type); },
+                                                py::return_internal_reference<>())
+            .def("dump",                        +[](const UniverseObject& obj) -> std::string { return obj.Dump(); },
+                                                py::return_value_policy<py::return_by_value>(),
+                                                "Returns string with debug information.")
         ;
 
         ///////////////////
@@ -607,8 +515,12 @@ namespace FreeOrionPython {
             .add_property("orderedInvadePlanet",    &Ship::OrderedInvadePlanet)
             .def("initialPartMeterValue",           &Ship::InitialPartMeterValue)
             .def("currentPartMeterValue",           &Ship::CurrentPartMeterValue)
-            .add_property("partMeters",             make_function(ShipPartMeters,           py::return_internal_reference<>()))
-            .def("getMeter",                        make_function(ShipGetPartMeter,         py::return_internal_reference<>()))
+            .add_property("partMeters",             make_function(
+                                                        +[](const Ship& ship) -> const Ship::PartMeterMap& { return ship.PartMeters(); },
+                                                        py::return_internal_reference<>()
+                                                    ))
+            .def("getMeter",                        +[](const Ship& ship, MeterType type, const std::string& part_name) -> const Meter* { return ship.GetPartMeter(type, part_name); },
+                                                    py::return_internal_reference<>())
         ;
 
         //////////////////
@@ -617,14 +529,12 @@ namespace FreeOrionPython {
         py::class_<ShipDesign, boost::noncopyable>("shipDesign", py::no_init)
             .add_property("id",                 make_function(&ShipDesign::ID,              py::return_value_policy<py::return_by_value>()))
             .add_property("name",               make_function(
-                                                    ShipDesignName,
-                                                    py::return_value_policy<py::copy_const_reference>(),
-                                                    boost::mpl::vector<const std::string&, const ShipDesign&>()
+                                                    +[](const ShipDesign& ship_design) -> const std::string& { return ship_design.Name(false); },
+                                                    py::return_value_policy<py::copy_const_reference>()
                                                 ))
             .add_property("description",        make_function(
-                                                    ShipDesignDescription,
-                                                    py::return_value_policy<py::copy_const_reference>(),
-                                                    boost::mpl::vector<const std::string&, const ShipDesign&>()
+                                                    +[](const ShipDesign& ship_design) -> const std::string& { return ship_design.Description(false); },
+                                                    py::return_value_policy<py::copy_const_reference>()
                                                 ))
             .add_property("designedOnTurn",     make_function(&ShipDesign::DesignedOnTurn,  py::return_value_policy<py::return_by_value>()))
             .add_property("speed",              make_function(&ShipDesign::Speed,           py::return_value_policy<py::return_by_value>()))
@@ -653,11 +563,13 @@ namespace FreeOrionPython {
                                                 &ShipDesign::ProductionCostTimeLocationInvariant)
             .add_property("hull",               make_function(&ShipDesign::Hull,            py::return_value_policy<py::return_by_value>()))
             .add_property("ship_hull",          make_function(
-                                                    ShipDesignHull,
-                                                    py::return_value_policy<py::reference_existing_object>(),
-                                                    boost::mpl::vector<const ShipHull*, const ShipDesign&>()
+                                                    +[](const ShipDesign& design) -> const ShipHull* { return GetShipHull(design.Hull()); },
+                                                    py::return_value_policy<py::reference_existing_object>()
                                                 ))
-            .add_property("parts",              make_function(PartsVoid,                    py::return_internal_reference<>()))
+            .add_property("parts",              make_function(
+                                                    +[](const ShipDesign& design) -> const std::vector<std::string>& { return design.Parts(); },
+                                                    py::return_internal_reference<>()
+                                                ))
             .add_property("attackStats",        make_function(
                                                     AttackStats,
                                                     py::return_value_policy<py::return_by_value>(),
@@ -667,7 +579,14 @@ namespace FreeOrionPython {
             .def("productionLocationForEmpire", &ShipDesign::ProductionLocation)
             .def("dump",                        &ShipDesign::Dump,                          py::return_value_policy<py::return_by_value>(), "Returns string with debug information, use '0' as argument.")
         ;
-        py::def("validShipDesign",                  ValidDesignHullAndParts, "Returns true (boolean) if the passed hull (string) and parts (StringVec) make up a valid ship design, and false (boolean) otherwise. Valid ship designs don't have any parts in slots that can't accept that type of part, and contain only hulls and parts that exist (and may also need to contain the correct number of parts - this needs to be verified).");
+        py::def("validShipDesign",
+                +[](const ShipDesign& design, const std::string& hull, const std::vector<std::string>& parts) -> bool { return design.ValidDesign(hull, parts); },
+                "Returns true (boolean) if the passed hull (string) and parts"
+                " (StringVec) make up a valid ship design, and false (boolean)"
+                " otherwise. Valid ship designs don't have any parts in slots"
+                " that can't accept that type of part, and contain only hulls"
+                " and parts that exist (and may also need to contain the"
+                " correct number of parts - this needs to be verified).");
         py::def("getShipDesign",                    &GetShipDesign,                             py::return_value_policy<py::reference_existing_object>(), "Returns the ship design (ShipDesign) with the indicated id number (int).");
         py::def("getPredefinedShipDesign",          &GetPredefinedShipDesign,                   py::return_value_policy<py::reference_existing_object>(), "Returns the ship design (ShipDesign) with the indicated name (string).");
 
@@ -689,13 +608,16 @@ namespace FreeOrionPython {
 
         py::class_<ShipHull, boost::noncopyable>("shipHull", py::no_init)
             .add_property("name",               make_function(&ShipHull::Name,              py::return_value_policy<py::copy_const_reference>()))
-            .add_property("numSlots",           make_function(NumSlotsTotal,                py::return_value_policy<py::return_by_value>()))
+            .add_property("numSlots",           make_function(
+                                                    +[](const ShipHull& hull) -> unsigned int { return hull.NumSlots(); },
+                                                    py::return_value_policy<py::return_by_value>()
+                                                ))
             .add_property("structure",          &ShipHull::Structure)
             .add_property("stealth",            &ShipHull::Stealth)
             .add_property("fuel",               &ShipHull::Fuel)
             .add_property("starlaneSpeed",      &ShipHull::Speed) // TODO: Remove this after transition period
             .add_property("speed",              &ShipHull::Speed)
-            .def("numSlotsOfSlotType",          NumSlotsOfSlotType)
+            .def("numSlotsOfSlotType",          +[](const ShipHull& hull, ShipSlotType slot_type) -> unsigned int { return hull.NumSlots(slot_type); })
             .add_property("slots",              make_function(
                                                     HullSlots,
                                                     py::return_value_policy<py::return_by_value>(),
@@ -731,7 +653,7 @@ namespace FreeOrionPython {
             .def("perTurnCost",                 &BuildingType::PerTurnCost)
             .def("captureResult",               &BuildingType::GetCaptureResult)
             .def("canBeProduced",               &BuildingType::ProductionLocation)  //(int empire_id, int location_id)
-            .def("canBeEnqueued",               &EnqueueLocationTest)  //(int empire_id, int location_id)
+            .def("canBeEnqueued",               +[](const BuildingType& building_type, int empire_id, int loc_id) -> bool { return building_type.EnqueueLocation(empire_id, loc_id); })
             .add_property("costTimeLocationInvariant",
                                                 &BuildingType::ProductionCostTimeLocationInvariant)
             .def("dump",                        &BuildingType::Dump,                        py::return_value_policy<py::return_by_value>(), "Returns string with debug information, use '0' as argument.")
@@ -800,8 +722,8 @@ namespace FreeOrionPython {
         //////////////////
         py::class_<Field, py::bases<UniverseObject>, boost::noncopyable>("field", py::no_init)
             .add_property("fieldTypeName",      make_function(&Field::FieldTypeName,        py::return_value_policy<py::copy_const_reference>()))
-            .def("inField",                     &ObjectInField)
-            .def("inField",                     LocationInField)
+            .def("inField",                     +[](const Field& field, const UniverseObject& obj) -> bool { return field.InField(obj.X(), obj.Y()); })
+            .def("inField",                     +[](const Field& field, double x, double y) -> bool { return field.InField(x, y); })
         ;
 
         //////////////////
@@ -824,7 +746,7 @@ namespace FreeOrionPython {
             .add_property("spawnrate",          make_function(&Special::SpawnRate,      py::return_value_policy<py::return_by_value>()))
             .add_property("spawnlimit",         make_function(&Special::SpawnLimit,     py::return_value_policy<py::return_by_value>()))
             .def("dump",                        &Special::Dump,                         py::return_value_policy<py::return_by_value>(), "Returns string with debug information, use '0' as argument.")
-            .def("initialCapacity",             SpecialInitialCapacityOnObject)
+            .def("initialCapacity",             +[](const Special& special, int obj_id) -> float { return special.InitialCapacity(obj_id); })
         ;
         py::def("getSpecial",                       &GetSpecial,                            py::return_value_policy<py::reference_existing_object>(), "Returns the special (Special) with the indicated name (string).");
 
@@ -865,8 +787,8 @@ namespace FreeOrionPython {
         py::class_<GameRules, boost::noncopyable>("GameRules", py::no_init)
             .add_property("empty",              make_function(&GameRules::Empty,                py::return_value_policy<py::return_by_value>()))
             .def("getRulesAsStrings",           make_function(&GameRules::GetRulesAsStrings,    py::return_value_policy<py::return_by_value>()))
-            .def("ruleExists",                  RuleExistsAnyType)
-            .def("ruleExistsWithType",          RuleExistsWithType)
+            .def("ruleExists",                  +[](const GameRules& rules, const std::string& name) -> bool { return rules.RuleExists(name); })
+            .def("ruleExistsWithType",          +[](const GameRules& rules, const std::string& name, GameRules::Type type) -> bool { return rules.RuleExists(name, type); })
             .def("getDescription",              make_function(&GameRules::GetDescription,       py::return_value_policy<py::copy_const_reference>()))
             .def("getToggle",                   &GameRules::Get<bool>)
             .def("getInt",                      &GameRules::Get<int>)

--- a/server/ServerFramework.cpp
+++ b/server/ServerFramework.cpp
@@ -47,16 +47,16 @@ BOOST_PYTHON_MODULE(freeorion) {
     FreeOrionPython::SetWrapper<std::string>::Wrap("StringSet");
 }
 
-namespace {
-}
 
-bool PythonServer::InitImports() {
+auto PythonServer::InitImports() -> bool
+{
     DebugLogger() << "Initializing server Python imports";
     // Allow the "freeorion" C++ module to be imported within Python code
     return PyImport_AppendInittab("freeorion", &PyInit_freeorion) != -1;
 }
 
-bool PythonServer::InitModules() {
+auto PythonServer::InitModules() -> bool
+{
     DebugLogger() << "Initializing server Python modules";
 
     // Confirm existence of the directory containing the universe generation
@@ -106,7 +106,8 @@ bool PythonServer::InitModules() {
     return true;
 }
 
-bool PythonServer::IsRequireAuthOrReturnRoles(const std::string& player_name, bool &result, Networking::AuthRoles& roles) const {
+auto PythonServer::IsRequireAuthOrReturnRoles(const std::string& player_name, bool &result, Networking::AuthRoles& roles) const -> bool
+{
     py::object auth_provider = m_python_module_auth.attr("__dict__")["auth_provider"];
     if (!auth_provider) {
         ErrorLogger() << "Unable to get Python object auth_provider";
@@ -131,7 +132,8 @@ bool PythonServer::IsRequireAuthOrReturnRoles(const std::string& player_name, bo
     return true;
 }
 
-bool PythonServer::IsSuccessAuthAndReturnRoles(const std::string& player_name, const std::string& auth, bool &result, Networking::AuthRoles& roles) const {
+auto PythonServer::IsSuccessAuthAndReturnRoles(const std::string& player_name, const std::string& auth, bool &result, Networking::AuthRoles& roles) const -> bool
+{
     py::object auth_provider = m_python_module_auth.attr("__dict__")["auth_provider"];
     if (!auth_provider) {
         ErrorLogger() << "Unable to get Python object auth_provider";
@@ -158,7 +160,8 @@ bool PythonServer::IsSuccessAuthAndReturnRoles(const std::string& player_name, c
     return true;
 }
 
-bool PythonServer::FillListPlayers(std::list<PlayerSetupData>& players) const {
+auto PythonServer::FillListPlayers(std::list<PlayerSetupData>& players) const -> bool
+{
     py::object auth_provider = m_python_module_auth.attr("__dict__")["auth_provider"];
     if (!auth_provider) {
         ErrorLogger() << "Unable to get Python object auth_provider";
@@ -183,7 +186,8 @@ bool PythonServer::FillListPlayers(std::list<PlayerSetupData>& players) const {
     return true;
 }
 
-bool PythonServer::GetPlayerDelegation(const std::string& player_name, std::list<std::string> &result) const {
+auto PythonServer::GetPlayerDelegation(const std::string& player_name, std::list<std::string> &result) const -> bool
+{
     py::object auth_provider = m_python_module_auth.attr("__dict__")["auth_provider"];
     if (!auth_provider) {
         ErrorLogger() << "Unable to get Python object auth_provider";
@@ -209,7 +213,8 @@ bool PythonServer::GetPlayerDelegation(const std::string& player_name, std::list
     return true;
 }
 
-bool PythonServer::LoadChatHistory(boost::circular_buffer<ChatHistoryEntity>& chat_history) {
+auto PythonServer::LoadChatHistory(boost::circular_buffer<ChatHistoryEntity>& chat_history) -> bool
+{
     py::object chat_provider = m_python_module_chat.attr("__dict__")["chat_history_provider"];
     if (!chat_provider) {
         ErrorLogger() << "Unable to get Python object chat_history_provider";
@@ -237,7 +242,8 @@ bool PythonServer::LoadChatHistory(boost::circular_buffer<ChatHistoryEntity>& ch
     return true;
 }
 
-bool PythonServer::PutChatHistoryEntity(const ChatHistoryEntity& chat_history_entity) {
+auto PythonServer::PutChatHistoryEntity(const ChatHistoryEntity& chat_history_entity) -> bool
+{
     py::object chat_provider = m_python_module_chat.attr("__dict__")["chat_history_provider"];
     if (!chat_provider) {
         ErrorLogger() << "Unable to get Python object chat_history_provider";
@@ -255,7 +261,8 @@ bool PythonServer::PutChatHistoryEntity(const ChatHistoryEntity& chat_history_en
              chat_history_entity.text_color);
 }
 
-bool PythonServer::CreateUniverse(std::map<int, PlayerSetupData>& player_setup_data) {
+auto PythonServer::CreateUniverse(std::map<int, PlayerSetupData>& player_setup_data) -> bool
+{
     // Confirm existence of the directory containing the universe generation
     // Python scripts and add it to Pythons sys.path to make sure Python will
     // find our scripts
@@ -287,7 +294,8 @@ bool PythonServer::CreateUniverse(std::map<int, PlayerSetupData>& player_setup_d
     return f(py_player_setup_data);
 }
 
-bool PythonServer::ExecuteTurnEvents() {
+auto PythonServer::ExecuteTurnEvents() -> bool
+{
     py::object f = m_python_module_turn_events.attr("execute_turn_events");
     if (!f) {
         ErrorLogger() << "Unable to call Python function execute_turn_events ";
@@ -296,14 +304,14 @@ bool PythonServer::ExecuteTurnEvents() {
     return f();
 }
 
-const std::string GetPythonUniverseGeneratorDir()
+auto GetPythonUniverseGeneratorDir() -> const std::string
 { return GetPythonDir() + "/universe_generation"; }
 
-const std::string GetPythonTurnEventsDir()
+auto GetPythonTurnEventsDir() -> const std::string
 { return GetPythonDir() + "/turn_events"; }
 
-const std::string GetPythonAuthDir()
+auto GetPythonAuthDir() -> const std::string
 { return GetPythonDir() + "/auth"; }
 
-const std::string GetPythonChatDir()
+auto GetPythonChatDir() -> const std::string
 { return GetPythonDir() + "/chat"; }

--- a/server/ServerWrapper.cpp
+++ b/server/ServerWrapper.cpp
@@ -61,23 +61,6 @@ FO_COMMON_API extern const int INVALID_DESIGN_ID;
 // Helper stuff (classes, functions etc.) exposed to the
 // server side Python scripts
 namespace {
-    // Functions that return various important constants
-    auto AllEmpires() -> int
-    { return ALL_EMPIRES; }
-
-    auto InvalidObjectID() -> int
-    { return INVALID_OBJECT_ID; }
-
-    auto LargeMeterValue() -> float
-    { return Meter::LARGE_VALUE; }
-
-    auto InvalidPosition() -> double
-    { return UniverseObject::INVALID_POSITION; }
-
-    // Wrapper for GetResourceDir
-    auto GetResourceDirWrapper() -> py::object
-    { return py::object(PathToString(GetResourceDir())); }
-
     // Wrapper for getting empire objects
     auto GetAllEmpires() -> py::list
     {
@@ -117,11 +100,6 @@ namespace {
             empire->AddSitRepEntry(CreateSitRep(template_string, sitrep_turn, icon, params));
         }
     }
-
-    void GenerateSitRep1(int empire_id,
-                         const std::string& template_string,
-                         const std::string& icon)
-    { GenerateSitRep(empire_id, template_string, py::dict(), icon); }
 
     // Wrappers for Species / SpeciesManager class (member) functions
     auto SpeciesPreferredFocus(const std::string& species_name) -> py::object
@@ -647,19 +625,6 @@ namespace {
         obj->RemoveSpecial(special_name);
     }
 
-    // Wrappers for Universe class
-    auto GetUniverseWidth() -> double
-    { return GetUniverse().UniverseWidth(); }
-
-    void SetUniverseWidth(double width)
-    { GetUniverse().SetUniverseWidth(width); }
-
-    auto LinearDistance(int system1_id, int system2_id) -> double
-    { return GetPathfinder()->LinearDistance(system1_id, system2_id); }
-
-    auto JumpDistanceBetweenSystems(int system1_id, int system2_id) -> int
-    { return GetPathfinder()->JumpDistanceBetweenSystems(system1_id, system2_id); }
-
     auto GetAllObjects() -> py::list
     {
         py::list py_all_objects;
@@ -900,12 +865,6 @@ namespace {
         //return the new ships id
         return ship->ID();
     }
-
-    auto CreateMonsterFleet(int system_id) -> int
-    { return CreateFleet(UserString("MONSTERS"), system_id, ALL_EMPIRES, true); }
-
-    auto CreateMonster(const std::string& design_name, int fleet_id) -> int
-    { return CreateShip(NewMonsterName(), design_name, "", fleet_id); }
 
     auto CreateFieldImpl(const std::string& field_type_name, double x, double y, double size) -> std::shared_ptr<Field>
     {
@@ -1343,17 +1302,17 @@ namespace FreeOrionPython {
 
         py::def("user_string",                      make_function(&UserString,      py::return_value_policy<py::copy_const_reference>()));
         py::def("roman_number",                     RomanNumber);
-        py::def("get_resource_dir",                 GetResourceDirWrapper);
+        py::def("get_resource_dir",                 +[]() -> py::object { return py::object(PathToString(GetResourceDir())); });
 
-        py::def("all_empires",                      AllEmpires);
-        py::def("invalid_object",                   InvalidObjectID);
-        py::def("large_meter_value",                LargeMeterValue);
-        py::def("invalid_position",                 InvalidPosition);
+        py::def("all_empires",                      +[]() -> int { return ALL_EMPIRES; });
+        py::def("invalid_object",                   +[]() -> int { return INVALID_OBJECT_ID; });
+        py::def("large_meter_value",                +[]() -> float { return Meter::LARGE_VALUE; });
+        py::def("invalid_position",                 +[]() -> double { return UniverseObject::INVALID_POSITION; });
 
         py::def("get_galaxy_setup_data",            GetGalaxySetupData,             py::return_value_policy<py::reference_existing_object>());
         py::def("current_turn",                     CurrentTurn);
         py::def("generate_sitrep",                  GenerateSitRep);
-        py::def("generate_sitrep",                  GenerateSitRep1);
+        py::def("generate_sitrep",                  +[](int empire_id, const std::string& template_string, const std::string& icon) { GenerateSitRep(empire_id, template_string, py::dict(), icon); });
         py::def("generate_starlanes",               GenerateStarlanes);
 
         py::def("species_preferred_focus",          SpeciesPreferredFocus);
@@ -1394,10 +1353,10 @@ namespace FreeOrionPython {
         py::def("add_special",                      AddSpecial);
         py::def("remove_special",                   RemoveSpecial);
 
-        py::def("get_universe_width",               GetUniverseWidth);
-        py::def("set_universe_width",               SetUniverseWidth);
-        py::def("linear_distance",                  LinearDistance);
-        py::def("jump_distance",                    JumpDistanceBetweenSystems);
+        py::def("get_universe_width",               +[]() -> double { return GetUniverse().UniverseWidth(); });
+        py::def("set_universe_width",               +[](double width) { GetUniverse().SetUniverseWidth(width); });
+        py::def("linear_distance",                  +[](int system1_id, int system2_id) -> double { return GetPathfinder()->LinearDistance(system1_id, system2_id); });
+        py::def("jump_distance",                    +[](int system1_id, int system2_id) -> int { return GetPathfinder()->JumpDistanceBetweenSystems(system1_id, system2_id); });
         py::def("get_all_objects",                  GetAllObjects);
         py::def("get_systems",                      GetSystems);
         py::def("create_system",                    CreateSystem);
@@ -1405,8 +1364,8 @@ namespace FreeOrionPython {
         py::def("create_building",                  CreateBuilding);
         py::def("create_fleet",                     CreateFleet);
         py::def("create_ship",                      CreateShip);
-        py::def("create_monster_fleet",             CreateMonsterFleet);
-        py::def("create_monster",                   CreateMonster);
+        py::def("create_monster_fleet",             +[](int system_id) -> int { return CreateFleet(UserString("MONSTERS"), system_id, ALL_EMPIRES, true); });
+        py::def("create_monster",                   +[](const std::string& design_name, int fleet_id) -> int { return CreateShip(NewMonsterName(), design_name, "", fleet_id); });
         py::def("create_field",                     CreateField);
         py::def("create_field_in_system",           CreateFieldInSystem);
 

--- a/server/ServerWrapper.cpp
+++ b/server/ServerWrapper.cpp
@@ -62,24 +62,25 @@ FO_COMMON_API extern const int INVALID_DESIGN_ID;
 // server side Python scripts
 namespace {
     // Functions that return various important constants
-    int     AllEmpires()
+    auto AllEmpires() -> int
     { return ALL_EMPIRES; }
 
-    int     InvalidObjectID()
+    auto InvalidObjectID() -> int
     { return INVALID_OBJECT_ID; }
 
-    float   LargeMeterValue()
+    auto LargeMeterValue() -> float
     { return Meter::LARGE_VALUE; }
 
-    double  InvalidPosition()
+    auto InvalidPosition() -> double
     { return UniverseObject::INVALID_POSITION; }
 
     // Wrapper for GetResourceDir
-    py::object GetResourceDirWrapper()
+    auto GetResourceDirWrapper() -> py::object
     { return py::object(PathToString(GetResourceDir())); }
 
     // Wrapper for getting empire objects
-    py::list GetAllEmpires() {
+    auto GetAllEmpires() -> py::list
+    {
         py::list empire_list;
         for (const auto& entry : Empires())
             empire_list.append(entry.second->EmpireID());
@@ -123,7 +124,8 @@ namespace {
     { GenerateSitRep(empire_id, template_string, py::dict(), icon); }
 
     // Wrappers for Species / SpeciesManager class (member) functions
-    py::object SpeciesPreferredFocus(const std::string& species_name) {
+    auto SpeciesPreferredFocus(const std::string& species_name) -> py::object
+    {
         const Species* species = GetSpecies(species_name);
         if (!species) {
             ErrorLogger() << "SpeciesPreferredFocus: couldn't get species " << species_name;
@@ -132,7 +134,8 @@ namespace {
         return py::object(species->PreferredFocus());
     }
 
-    PlanetEnvironment SpeciesGetPlanetEnvironment(const std::string& species_name, PlanetType planet_type) {
+    auto SpeciesGetPlanetEnvironment(const std::string& species_name, PlanetType planet_type) -> PlanetEnvironment
+    {
         const Species* species = GetSpecies(species_name);
         if (!species) {
             ErrorLogger() << "SpeciesGetPlanetEnvironment: couldn't get species " << species_name;
@@ -141,7 +144,8 @@ namespace {
         return species->GetPlanetEnvironment(planet_type);
     }
 
-    void SpeciesAddHomeworld(const std::string& species_name, int homeworld_id) {
+    void SpeciesAddHomeworld(const std::string& species_name, int homeworld_id)
+    {
         Species* species = SpeciesManager::GetSpeciesManager().GetSpecies(species_name);
         if (!species) {
             ErrorLogger() << "SpeciesAddHomeworld: couldn't get species " << species_name;
@@ -150,7 +154,8 @@ namespace {
         species->AddHomeworld(homeworld_id);
     }
 
-    void SpeciesRemoveHomeworld(const std::string& species_name, int homeworld_id) {
+    void SpeciesRemoveHomeworld(const std::string& species_name, int homeworld_id)
+    {
         Species* species = SpeciesManager::GetSpeciesManager().GetSpecies(species_name);
         if (!species) {
             ErrorLogger() << "SpeciesAddHomeworld: couldn't get species " << species_name;
@@ -159,7 +164,8 @@ namespace {
         species->RemoveHomeworld(homeworld_id);
     }
 
-    bool SpeciesCanColonize(const std::string& species_name) {
+    auto SpeciesCanColonize(const std::string& species_name) -> bool
+    {
         Species* species = SpeciesManager::GetSpeciesManager().GetSpecies(species_name);
         if (!species) {
             ErrorLogger() << "SpeciesCanColonize: couldn't get species " << species_name;
@@ -168,7 +174,8 @@ namespace {
         return species->CanColonize();
     }
 
-    py::list GetAllSpecies() {
+    auto GetAllSpecies() -> py::list
+    {
         py::list            species_list;
         for (const auto& entry : GetSpeciesManager()) {
             species_list.append(py::object(entry.first));
@@ -176,7 +183,8 @@ namespace {
         return species_list;
     }
 
-    py::list GetPlayableSpecies() {
+    auto GetPlayableSpecies() -> py::list
+    {
         py::list            species_list;
         SpeciesManager& species_manager = GetSpeciesManager();
         for (auto it = species_manager.playable_begin();
@@ -185,7 +193,8 @@ namespace {
         return species_list;
     }
 
-    py::list GetNativeSpecies() {
+    auto GetNativeSpecies() -> py::list
+    {
         py::list            species_list;
         SpeciesManager& species_manager = GetSpeciesManager();
         for (auto it = species_manager.native_begin();
@@ -197,7 +206,8 @@ namespace {
     //Checks the condition against many objects at once.
     //Checking many systems is more efficient because for example monster fleet plans
     //typically uses WithinStarLaneJumps to exclude placement near empires.
-    py::list FilterIDsWithCondition(const Condition::Condition* cond, const py::list &obj_ids) {
+    auto FilterIDsWithCondition(const Condition::Condition* cond, const py::list &obj_ids) -> py::list
+    {
         py::list permitted_ids;
 
         Condition::ObjectSet objs;
@@ -230,7 +240,8 @@ namespace {
     }
 
     // Wrappers for Specials / SpecialManager functions
-    double SpecialSpawnRate(const std::string special_name) {
+    auto SpecialSpawnRate(const std::string special_name) -> double
+    {
         const Special* special = GetSpecial(special_name);
         if (!special) {
             ErrorLogger() << "SpecialSpawnRate: couldn't get special " << special_name;
@@ -239,7 +250,8 @@ namespace {
         return special->SpawnRate();
     }
 
-    int SpecialSpawnLimit(const std::string special_name) {
+    auto SpecialSpawnLimit(const std::string special_name) -> int
+    {
         const Special* special = GetSpecial(special_name);
         if (!special) {
             ErrorLogger() << "SpecialSpawnLimit: couldn't get special " << special_name;
@@ -248,7 +260,8 @@ namespace {
         return special->SpawnLimit();
     }
 
-    py::list SpecialLocations(const std::string special_name, const py::list& object_ids) {
+    auto SpecialLocations(const std::string special_name, const py::list& object_ids) -> py::list
+    {
         // get special and check if it exists
         const Special* special = GetSpecial(special_name);
         if (!special) {
@@ -259,7 +272,8 @@ namespace {
         return FilterIDsWithCondition(special->Location(), object_ids);
     }
 
-    bool SpecialHasLocation(const std::string special_name) {
+    auto SpecialHasLocation(const std::string special_name) -> bool
+    {
         // get special and check if it exists
         const Special* special = GetSpecial(special_name);
         if (!special) {
@@ -269,7 +283,8 @@ namespace {
         return special->Location();
     }
 
-    py::list GetAllSpecials() {
+    auto GetAllSpecials() -> py::list
+    {
         py::list py_specials;
         for (const auto& special_name : SpecialNames()) {
             py_specials.append(py::object(special_name));
@@ -278,7 +293,8 @@ namespace {
     }
 
     // Wrappers for Empire class member functions
-    void EmpireSetName(int empire_id, const std::string& name) {
+    void EmpireSetName(int empire_id, const std::string& name)
+    {
         Empire* empire = GetEmpire(empire_id);
         if (!empire) {
             ErrorLogger() << "EmpireSetName: couldn't get empire with ID " << empire_id;
@@ -287,7 +303,8 @@ namespace {
         empire->SetName(name);
     }
 
-    bool EmpireSetHomeworld(int empire_id, int planet_id, const std::string& species_name) {
+    auto EmpireSetHomeworld(int empire_id, int planet_id, const std::string& species_name) -> bool
+    {
         Empire* empire = GetEmpire(empire_id);
         if (!empire) {
             ErrorLogger() << "EmpireSetHomeworld: couldn't get empire with ID " << empire_id;
@@ -308,7 +325,8 @@ namespace {
         empire->UnlockItem(item);
     }
 
-    void EmpireAddShipDesign(int empire_id, const std::string& design_name) {
+    void EmpireAddShipDesign(int empire_id, const std::string& design_name)
+    {
         Universe& universe = GetUniverse();
 
         Empire* empire = GetEmpire(empire_id);
@@ -329,7 +347,8 @@ namespace {
     }
 
     // Wrapper for preunlocked items
-    py::list LoadUnlockableItemList() {
+    auto LoadUnlockableItemList() -> py::list
+    {
         py::list py_items;
         auto& items = GetUniverse().InitiallyUnlockedItems();
         for (const auto& item : items) {
@@ -339,7 +358,8 @@ namespace {
     }
 
     // Wrapper for starting buildings
-    py::list LoadStartingBuildings() {
+    auto LoadStartingBuildings() -> py::list
+    {
         py::list py_items;
         auto& buildings = GetUniverse().InitiallyUnlockedBuildings();
         for (auto building : buildings) {
@@ -352,10 +372,10 @@ namespace {
     }
 
     // Wrappers for ship designs and premade ship designs
-    bool ShipDesignCreate(const std::string& name, const std::string& description,
+    auto ShipDesignCreate(const std::string& name, const std::string& description,
                           const std::string& hull, const py::list& py_parts,
                           const std::string& icon, const std::string& model,
-                          bool monster)
+                          bool monster) -> bool
     {
         Universe& universe = GetUniverse();
         // Check for empty name
@@ -397,7 +417,8 @@ namespace {
         return true;
     }
 
-    py::list ShipDesignGetPremadeList() {
+    auto ShipDesignGetPremadeList() -> py::list
+    {
         py::list py_ship_designs;
         for (const auto& design : GetPredefinedShipDesignManager().GetOrderedShipDesigns()) {
             py_ship_designs.append(py::object(design->Name(false)));
@@ -405,7 +426,8 @@ namespace {
         return py::list(py_ship_designs);
     }
 
-    py::list ShipDesignGetMonsterList() {
+    auto ShipDesignGetMonsterList() -> py::list
+    {
         py::list py_monster_designs;
         const auto& manager = GetPredefinedShipDesignManager();
         for (const auto& monster : manager.GetOrderedMonsterDesigns()) {
@@ -451,7 +473,8 @@ namespace {
         std::shared_ptr<FleetPlan> m_fleet_plan;
     };
 
-    py::list LoadFleetPlanList() {
+    auto LoadFleetPlanList() -> py::list
+    {
         py::list py_fleet_plans;
         auto&& fleet_plans = GetUniverse().InitiallyUnlockedFleetPlans();
         for (FleetPlan* fleet_plan : fleet_plans) {
@@ -510,7 +533,8 @@ namespace {
         std::shared_ptr<MonsterFleetPlan> m_monster_fleet_plan;
     };
 
-    py::list LoadMonsterFleetPlanList() {
+    auto LoadMonsterFleetPlanList() -> py::list
+    {
         py::list py_monster_fleet_plans;
         auto&& monster_fleet_plans = GetUniverse().MonsterFleetPlans();
         for (auto* fleet_plan : monster_fleet_plans) {
@@ -526,7 +550,8 @@ namespace {
     // avoided.
     //
     // Wrappers for common UniverseObject class member funtions
-    py::object GetName(int object_id) {
+    auto GetName(int object_id) -> py::object
+    {
         auto obj = Objects().get(object_id);
         if (!obj) {
             ErrorLogger() << "GetName: Couldn't get object with ID " << object_id;
@@ -535,7 +560,8 @@ namespace {
         return py::object(obj->Name());
     }
 
-    void SetName(int object_id, const std::string& name) {
+    void SetName(int object_id, const std::string& name)
+    {
         auto obj = Objects().get(object_id);
         if (!obj) {
             ErrorLogger() << "RenameUniverseObject: Couldn't get object with ID " << object_id;
@@ -544,7 +570,8 @@ namespace {
         obj->Rename(name);
     }
 
-    double GetX(int object_id) {
+    auto GetX(int object_id) -> double
+    {
         auto obj = Objects().get(object_id);
         if (!obj) {
             ErrorLogger() << "GetX: Couldn't get object with ID " << object_id;
@@ -553,7 +580,8 @@ namespace {
         return obj->X();
     }
 
-    double GetY(int object_id) {
+    auto GetY(int object_id) -> double
+    {
         auto obj = Objects().get(object_id);
         if (!obj) {
             ErrorLogger() << "GetY: Couldn't get object with ID " << object_id;
@@ -562,7 +590,8 @@ namespace {
         return obj->Y();
     }
 
-    py::tuple GetPos(int object_id) {
+    auto GetPos(int object_id) -> py::tuple
+    {
         auto obj = Objects().get(object_id);
         if (!obj) {
             ErrorLogger() << "GetPos: Couldn't get object with ID " << object_id;
@@ -572,7 +601,8 @@ namespace {
         return py::make_tuple(obj->X(), obj->Y());
     }
 
-    int GetOwner(int object_id) {
+    auto GetOwner(int object_id) -> int
+    {
         auto obj = Objects().get(object_id);
         if (!obj) {
             ErrorLogger() << "GetOwner: Couldn't get object with ID " << object_id;
@@ -581,7 +611,8 @@ namespace {
         return obj->Owner();
     }
 
-    void AddSpecial(int object_id, const std::string special_name) {
+    void AddSpecial(int object_id, const std::string special_name)
+    {
         // get the universe object and check if it exists
         auto obj = Objects().get(object_id);
         if (!obj) {
@@ -600,7 +631,8 @@ namespace {
         obj->AddSpecial(special_name, capacity);
     }
 
-    void RemoveSpecial(int object_id, const std::string special_name) {
+    void RemoveSpecial(int object_id, const std::string special_name)
+    {
         // get the universe object and check if it exists
         auto obj = Objects().get(object_id);
         if (!obj) {
@@ -616,19 +648,20 @@ namespace {
     }
 
     // Wrappers for Universe class
-    double GetUniverseWidth()
+    auto GetUniverseWidth() -> double
     { return GetUniverse().UniverseWidth(); }
 
     void SetUniverseWidth(double width)
     { GetUniverse().SetUniverseWidth(width); }
 
-    double LinearDistance(int system1_id, int system2_id)
+    auto LinearDistance(int system1_id, int system2_id) -> double
     { return GetPathfinder()->LinearDistance(system1_id, system2_id); }
 
-    int JumpDistanceBetweenSystems(int system1_id, int system2_id)
+    auto JumpDistanceBetweenSystems(int system1_id, int system2_id) -> int
     { return GetPathfinder()->JumpDistanceBetweenSystems(system1_id, system2_id); }
 
-    py::list GetAllObjects() {
+    auto GetAllObjects() -> py::list
+    {
         py::list py_all_objects;
         for (const auto& object : Objects().all()) {
             py_all_objects.append(object->ID());
@@ -636,7 +669,8 @@ namespace {
         return py_all_objects;
     }
 
-    py::list GetSystems() {
+    auto GetSystems() -> py::list
+    {
         py::list py_systems;
         for (const auto& system : Objects().all<System>()) {
             py_systems.append(system->ID());
@@ -644,7 +678,8 @@ namespace {
         return py_systems;
     }
 
-    int CreateSystem(StarType star_type, const std::string& star_name, double x, double y) {
+    auto CreateSystem(StarType star_type, const std::string& star_name, double x, double y) -> int
+    {
         // Check if star type is set to valid value
         if ((star_type == INVALID_STAR_TYPE) || (star_type == NUM_STAR_TYPES)) {
             ErrorLogger() << "CreateSystem : Can't create a system with a star of type " << star_type;
@@ -661,7 +696,8 @@ namespace {
         return system->SystemID();
     }
 
-    int CreatePlanet(PlanetSize size, PlanetType planet_type, int system_id, int orbit, const std::string& name) {
+    auto CreatePlanet(PlanetSize size, PlanetType planet_type, int system_id, int orbit, const std::string& name) -> int
+    {
         auto system = Objects().get<System>(system_id);
 
         // Perform some validity checks
@@ -719,7 +755,8 @@ namespace {
         return planet->ID();
     }
 
-    int CreateBuilding(const std::string& building_type, int planet_id, int empire_id) {
+    auto CreateBuilding(const std::string& building_type, int planet_id, int empire_id) -> int
+    {
         auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "CreateBuilding: couldn't get planet with ID " << planet_id;
@@ -750,7 +787,8 @@ namespace {
         return building->ID();
     }
 
-    int CreateFleet(const std::string& name, int system_id, int empire_id, bool aggressive = false) {
+    auto CreateFleet(const std::string& name, int system_id, int empire_id, bool aggressive = false) -> int
+    {
         // Get system and check if it exists
         auto system = Objects().get<System>(system_id);
         if (!system) {
@@ -780,7 +818,8 @@ namespace {
         return fleet->ID();
     }
 
-    int CreateShip(const std::string& name, const std::string& design_name, const std::string& species, int fleet_id) {
+    auto CreateShip(const std::string& name, const std::string& design_name, const std::string& species, int fleet_id) -> int
+    {
         Universe& universe = GetUniverse();
 
         // check if we got a species name, if yes, check if species exists
@@ -862,14 +901,13 @@ namespace {
         return ship->ID();
     }
 
-    int CreateMonsterFleet(int system_id)
+    auto CreateMonsterFleet(int system_id) -> int
     { return CreateFleet(UserString("MONSTERS"), system_id, ALL_EMPIRES, true); }
 
-    int CreateMonster(const std::string& design_name, int fleet_id)
+    auto CreateMonster(const std::string& design_name, int fleet_id) -> int
     { return CreateShip(NewMonsterName(), design_name, "", fleet_id); }
 
-    std::shared_ptr<Field> CreateFieldImpl(const std::string& field_type_name,
-                                           double x, double y, double size)
+    auto CreateFieldImpl(const std::string& field_type_name, double x, double y, double size) -> std::shared_ptr<Field>
     {
         // check if a field type with the specified field type name exists and get the field type
         const FieldType* field_type = GetFieldType(field_type_name);
@@ -900,7 +938,8 @@ namespace {
         return field;
     }
 
-    int CreateField(const std::string& field_type_name, double x, double y, double size) {
+    auto CreateField(const std::string& field_type_name, double x, double y, double size) -> int
+    {
         auto field = CreateFieldImpl(field_type_name, x, y, size);
         if (field)
             return field->ID();
@@ -908,7 +947,8 @@ namespace {
             return INVALID_OBJECT_ID;
     }
 
-    int CreateFieldInSystem(const std::string& field_type_name, double size, int system_id) {
+    auto CreateFieldInSystem(const std::string& field_type_name, double size, int system_id) -> int
+    {
         // check if system exists and get system
         auto system = Objects().get<System>(system_id);
         if (!system) {
@@ -924,7 +964,8 @@ namespace {
     }
 
     // Return a list of system ids of universe objects with @p obj_ids.
-    py::list ObjectsGetSystems(const py::list& obj_ids) {
+    auto ObjectsGetSystems(const py::list& obj_ids) -> py::list
+    {
         py::list py_systems;
         py::stl_input_iterator<int> end;
         for (py::stl_input_iterator<int> id(obj_ids);
@@ -940,7 +981,8 @@ namespace {
     }
 
     // Return all systems within \p jumps of \p sys_ids
-    py::list SystemsWithinJumps(size_t jumps, const py::list& sys_ids) {
+    auto SystemsWithinJumps(size_t jumps, const py::list& sys_ids) -> py::list
+    {
         py::list py_systems;
         py::stl_input_iterator<int> end;
 
@@ -959,7 +1001,8 @@ namespace {
     }
 
     // Wrappers for System class member functions
-    StarType SystemGetStarType(int system_id) {
+    auto SystemGetStarType(int system_id) -> StarType
+    {
         auto system = Objects().get<System>(system_id);
         if (!system) {
             ErrorLogger() << "SystemGetStarType: couldn't get system with ID " << system_id;
@@ -984,7 +1027,8 @@ namespace {
         system->SetStarType(star_type);
     }
 
-    int SystemGetNumOrbits(int system_id) {
+    auto SystemGetNumOrbits(int system_id) -> int
+    {
         auto system = Objects().get<System>(system_id);
         if (!system) {
             ErrorLogger() << "SystemGetNumOrbits : Couldn't get system with ID " << system_id;
@@ -993,7 +1037,8 @@ namespace {
         return system->Orbits();
     }
 
-    py::list SystemFreeOrbits(int system_id) {
+    auto SystemFreeOrbits(int system_id) -> py::list
+    {
         py::list py_orbits;
         auto system = Objects().get<System>(system_id);
         if (!system) {
@@ -1005,7 +1050,8 @@ namespace {
         return py_orbits;
     }
 
-    bool SystemOrbitOccupied(int system_id, int orbit) {
+    auto SystemOrbitOccupied(int system_id, int orbit) -> bool
+    {
         auto system = Objects().get<System>(system_id);
         if (!system) {
             ErrorLogger() << "SystemOrbitOccupied : Couldn't get system with ID " << system_id;
@@ -1014,7 +1060,8 @@ namespace {
         return system->OrbitOccupied(orbit);
     }
 
-    int SystemOrbitOfPlanet(int system_id, int planet_id) {
+    auto SystemOrbitOfPlanet(int system_id, int planet_id) -> int
+    {
         auto system = Objects().get<System>(system_id);
         if (!system) {
             ErrorLogger() << "SystemOrbitOfPlanet : Couldn't get system with ID " << system_id;
@@ -1023,7 +1070,8 @@ namespace {
         return system->OrbitOfPlanet(planet_id);
     }
 
-    py::list SystemGetPlanets(int system_id) {
+    auto SystemGetPlanets(int system_id) -> py::list
+    {
         py::list py_planets;
         auto system = Objects().get<System>(system_id);
         if (!system) {
@@ -1035,7 +1083,8 @@ namespace {
         return py_planets;
     }
 
-    py::list SystemGetFleets(int system_id) {
+    auto SystemGetFleets(int system_id) -> py::list
+    {
         py::list py_fleets;
         auto system = Objects().get<System>(system_id);
         if (!system) {
@@ -1047,7 +1096,8 @@ namespace {
         return py_fleets;
     }
 
-    py::list SystemGetStarlanes(int system_id) {
+    auto SystemGetStarlanes(int system_id) -> py::list
+    {
         py::list py_starlanes;
         // get source system
         auto system = Objects().get<System>(system_id);
@@ -1068,7 +1118,8 @@ namespace {
         return py_starlanes;
     }
 
-    void SystemAddStarlane(int from_sys_id, int to_sys_id) {
+    void SystemAddStarlane(int from_sys_id, int to_sys_id)
+    {
         // get source and destination system, check that both exist
         auto from_sys = Objects().get<System>(from_sys_id);
         if (!from_sys) {
@@ -1085,7 +1136,8 @@ namespace {
         to_sys->AddStarlane(from_sys_id);
     }
 
-    void SystemRemoveStarlane(int from_sys_id, int to_sys_id) {
+    void SystemRemoveStarlane(int from_sys_id, int to_sys_id)
+    {
         // get source and destination system, check that both exist
         auto from_sys = Objects().get<System>(from_sys_id);
         if (!from_sys) {
@@ -1103,7 +1155,8 @@ namespace {
     }
 
     // Wrapper for Planet class member functions
-    PlanetType PlanetGetType(int planet_id) {
+    auto PlanetGetType(int planet_id) -> PlanetType
+    {
         auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetGetType: Couldn't get planet with ID " << planet_id;
@@ -1112,7 +1165,8 @@ namespace {
         return planet->Type();
     }
 
-    void PlanetSetType(int planet_id, PlanetType planet_type) {
+    void PlanetSetType(int planet_id, PlanetType planet_type)
+    {
         auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetSetType: Couldn't get planet with ID " << planet_id;
@@ -1130,7 +1184,8 @@ namespace {
             planet->SetSize(SZ_HUGE);
     }
 
-    PlanetSize PlanetGetSize(int planet_id) {
+    auto PlanetGetSize(int planet_id) -> PlanetSize
+    {
         auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetGetSize: Couldn't get planet with ID " << planet_id;
@@ -1139,7 +1194,8 @@ namespace {
         return planet->Size();
     }
 
-    void PlanetSetSize(int planet_id, PlanetSize planet_size) {
+    void PlanetSetSize(int planet_id, PlanetSize planet_size)
+    {
         auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetSetSize: Couldn't get planet with ID " << planet_id;
@@ -1155,7 +1211,8 @@ namespace {
             planet->SetType(PT_BARREN);
     }
 
-    py::object PlanetGetSpecies(int planet_id) {
+    auto PlanetGetSpecies(int planet_id) -> py::object
+    {
         auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetGetSpecies: Couldn't get planet with ID " << planet_id;
@@ -1164,7 +1221,8 @@ namespace {
         return py::object(planet->SpeciesName());
     }
 
-    void PlanetSetSpecies(int planet_id, const std::string& species_name) {
+    void PlanetSetSpecies(int planet_id, const std::string& species_name)
+    {
         auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetSetSpecies: Couldn't get planet with ID " << planet_id;
@@ -1173,7 +1231,8 @@ namespace {
         planet->SetSpecies(species_name);
     }
 
-    py::object PlanetGetFocus(int planet_id) {
+    auto PlanetGetFocus(int planet_id) -> py::object
+    {
         auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetGetFocus: Couldn't get planet with ID " << planet_id;
@@ -1182,7 +1241,8 @@ namespace {
         return py::object(planet->Focus());
     }
 
-    void PlanetSetFocus(int planet_id, const std::string& focus) {
+    void PlanetSetFocus(int planet_id, const std::string& focus)
+    {
         auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetSetSpecies: Couldn't get planet with ID " << planet_id;
@@ -1191,7 +1251,8 @@ namespace {
         planet->SetFocus(focus);
     }
 
-    py::list PlanetAvailableFoci(int planet_id) {
+    auto PlanetAvailableFoci(int planet_id) -> py::list
+    {
         py::list py_foci;
         auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
@@ -1204,7 +1265,8 @@ namespace {
         return py_foci;
     }
 
-    bool PlanetMakeOutpost(int planet_id, int empire_id) {
+    auto PlanetMakeOutpost(int planet_id, int empire_id) -> bool
+    {
         auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetMakeOutpost: couldn't get planet with ID:" << planet_id;
@@ -1219,7 +1281,8 @@ namespace {
         return planet->Colonize(empire_id, "", 0.0);
     }
 
-    bool PlanetMakeColony(int planet_id, int empire_id, const std::string& species, double population) {
+    auto PlanetMakeColony(int planet_id, int empire_id, const std::string& species, double population) -> bool
+    {
         auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetMakeColony: couldn't get planet with ID:" << planet_id;
@@ -1242,7 +1305,8 @@ namespace {
         return planet->Colonize(empire_id, species, population);
     }
 
-    py::object PlanetCardinalSuffix(int planet_id) {
+    auto PlanetCardinalSuffix(int planet_id) -> py::object
+    {
         auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetCardinalSuffix: couldn't get planet with ID:" << planet_id;


### PR DESCRIPTION
This PR refactors the implementation of the Python client, server and common bindings.  This covers:

* Remove storing the function pointers of helper functions in a variable when a direct function pointer is sufficient.
* Use trailing return types for helper functions for easier conversion into lambdas.
* Use helper functions instead of `boost::bind` or function pointer casts.
* Use lambdas for signature translation only helper functions.  [Apply unary plus operator to decay lambdas into functions.](https://stackoverflow.com/questions/18889028/a-positive-lambda-what-sorcery-is-this).
* Remove `boost::python::make_function`  on `boost::python::def` and `boost::python::class_<T>::def` calls, as the construction already happens for those compared to `boost::python::class_<T>::add_attribute`.