### PR TITLE
Remove unnecessary step (check-python)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,6 @@ jobs:
       stage: lint
       script:
         - cmake ..
-        - cmake --build . --target check-python
         - cmake --build . --target check-pep8
 
     - name: Lint string tables

--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -24,14 +24,6 @@ if(TARGET Flake8::flake8)
     )
 endif()
 
-if(PYTHON_EXECUTABLE)
-    add_custom_target(check-python
-        COMMAND
-        "${PYTHON_EXECUTABLE}" -m compileall -qf .
-        WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/default/python"
-    )
-endif()
-
 if(NOT TARGET check)
     add_custom_target(check
         COMMENT "Run code quality checks"
@@ -44,8 +36,4 @@ endif()
 
 if(TARGET check-pep8)
     add_dependencies(check check-pep8)
-endif()
-
-if(TARGET check-python)
-    add_dependencies(check check-python)
 endif()


### PR DESCRIPTION
`check-python` step is obsolete, it is already checked inside `check-pep8` 