### PR TITLE
Use github actions for checks

### DIFF
--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -1,0 +1,35 @@
+name: AI and string tables checks
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.6', '3.9']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install development dependencies
+        run: |
+          pip install -r default/python/requirements-dev.txt
+      - name: Lint with flake8
+        run: |
+          flake8 default/python --config=default/python/tox.ini --format="::error file=%(path)s,line=%(row)d,col=%(col)d::%(path)s:%(row)d:%(col)d: %(code)s %(text)s"
+      - name: Test with pytest
+        run: |
+           pytest -v default/python/tests
+      - name: Check string tables formatting
+        run: |
+          diff -u default/stringtables/en.txt <(check/st-tool.py format default/stringtables/en.txt) || { echo "String table is not properly formatted"; exit 1; }
+      - name: Validate string tables
+        run: |
+          ./check/st-tool.py check --reference default/stringtables/en.txt default/stringtables/*.txt

--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -19,17 +19,25 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install development dependencies
-        run: |
-          pip install -r default/python/requirements-dev.txt
+        run: pip install -r default/python/requirements-dev.txt
       - name: Lint with flake8
-        run: |
-          flake8 default/python --config=default/python/tox.ini --format="::error file=%(path)s,line=%(row)d,col=%(col)d::%(path)s:%(row)d:%(col)d: %(code)s %(text)s"
+        # Run from root to preserve full path in output
+        run: >
+          flake8 default/python
+          --config=default/python/tox.ini
+          --format="::error file=%(path)s,line=%(row)d,col=%(col)d::%(path)s:%(row)d:%(col)d: %(code)s %(text)s"
       - name: Lint FOCS with flake8
-        run: |
-          flake8 default/scripting --config=default/python/tox.ini --format="::error file=%(path)s,line=%(row)d,col=%(col)d::%(path)s:%(row)d:%(col)d: %(code)s %(text)s"
+        # Run from root to preserve full path in output
+        run: >
+          flake8 default/scripting
+          --config=default/scripting/tox.ini
+          --format="::error file=%(path)s,line=%(row)d,col=%(col)d::%(path)s:%(row)d:%(col)d: %(code)s %(text)s"
       - name: Lint FOCS tests with flake8
-        run: |
-          flake8 test-scripting --config=test-scripting/tox.ini --format="::error file=%(path)s,line=%(row)d,col=%(col)d::%(path)s:%(row)d:%(col)d: %(code)s %(text)s"
+        # Run from root to preserve full path in output
+        run: >
+          flake8 test-scripting
+          --config=test-scripting/tox.ini
+          --format="::error file=%(path)s,line=%(row)d,col=%(col)d::%(path)s:%(row)d:%(col)d: %(code)s %(text)s"
       - name: Test with pytest
-        run: |
-           pytest -v default/python/tests
+        # Run from root to preserve full path in output
+        run: pytest -v default/python/tests

--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -32,4 +32,4 @@ jobs:
           diff -u default/stringtables/en.txt <(check/st-tool.py format default/stringtables/en.txt) || { echo "String table is not properly formatted"; exit 1; }
       - name: Validate string tables
         run: |
-          ./check/st-tool.py check --reference default/stringtables/en.txt default/stringtables/*.txt
+          ./check/st-tool.py check --reference default/stringtables/en.txt default/stringtables/??.txt

--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -26,7 +26,7 @@ jobs:
           flake8 default/python --config=default/python/tox.ini --format="::error file=%(path)s,line=%(row)d,col=%(col)d::%(path)s:%(row)d:%(col)d: %(code)s %(text)s"
       - name: Lint FOCS with flake8
         run: |
-          flake8 default/scripting --config=default/test-scripting/tox.ini --format="::error file=%(path)s,line=%(row)d,col=%(col)d::%(path)s:%(row)d:%(col)d: %(code)s %(text)s"
+          flake8 default/scripting --config=default/python/tox.ini --format="::error file=%(path)s,line=%(row)d,col=%(col)d::%(path)s:%(row)d:%(col)d: %(code)s %(text)s"
       - name: Lint FOCS tests with flake8
         run: |
           flake8 test-scripting --config=test-scripting/tox.ini --format="::error file=%(path)s,line=%(row)d,col=%(col)d::%(path)s:%(row)d:%(col)d: %(code)s %(text)s"

--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -24,6 +24,12 @@ jobs:
       - name: Lint with flake8
         run: |
           flake8 default/python --config=default/python/tox.ini --format="::error file=%(path)s,line=%(row)d,col=%(col)d::%(path)s:%(row)d:%(col)d: %(code)s %(text)s"
+      - name: Lint FOCS with flake8
+        run: |
+          flake8 default/scripting --config=default/test-scripting/tox.ini --format="::error file=%(path)s,line=%(row)d,col=%(col)d::%(path)s:%(row)d:%(col)d: %(code)s %(text)s"
+      - name: Lint FOCS tests with flake8
+        run: |
+          flake8 test-scripting --config=test-scripting/tox.ini --format="::error file=%(path)s,line=%(row)d,col=%(col)d::%(path)s:%(row)d:%(col)d: %(code)s %(text)s"
       - name: Test with pytest
         run: |
            pytest -v default/python/tests

--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -1,4 +1,4 @@
-name: AI and string tables checks
+name: AI linters and tests
 on:
   pull_request:
     types:

--- a/.github/workflows/string-tables-check.yml
+++ b/.github/workflows/string-tables-check.yml
@@ -11,19 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.9']
+        python-version: ['3.9']
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install development dependencies
+      - name: Check string tables formatting
         run: |
-          pip install -r default/python/requirements-dev.txt
-      - name: Lint with flake8
+          diff -u default/stringtables/en.txt <(check/st-tool.py format default/stringtables/en.txt) || { echo "String table is not properly formatted"; exit 1; }
+      - name: Validate string tables
         run: |
-          flake8 default/python --config=default/python/tox.ini --format="::error file=%(path)s,line=%(row)d,col=%(col)d::%(path)s:%(row)d:%(col)d: %(code)s %(text)s"
-      - name: Test with pytest
-        run: |
-           pytest -v default/python/tests
+          ./check/st-tool.py check --reference default/stringtables/en.txt default/stringtables/??.txt

--- a/.github/workflows/string-tables-check.yml
+++ b/.github/workflows/string-tables-check.yml
@@ -1,4 +1,4 @@
-name: AI and string tables checks
+name: String tables checks
 on:
   pull_request:
     types:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 ---
 stages:
-  - lint
   - build
   - test
 
@@ -33,8 +32,6 @@ _linux_setup_common: &_linux_setup_common
       libvorbis-dev
       cppcheck
       doxygen
-      python3-pip
-    - python3 -m pip install flake8==3.7.9
   before_script:
     - mkdir build
     - cd build
@@ -44,43 +41,11 @@ _linux_setup_common: &_linux_setup_common
     - ccache --cleanup
     - ccache --show-stats
 
-_test_python_common: &_test_python_common
-  stage: test
-  os: linux
-  dist: bionic
-  language: python
-  install:
-    - pip install pytest==5.4.1
-  script:
-    - pytest
-
 
 jobs:
   allow_failures:
     dist: focal
-
   include:
-    - name: Lint AI with Python 3.6
-      <<: *_linux_setup_common
-      stage: lint
-      script:
-        - cmake ..
-        - cmake --build . --target check-pep8
-        - cmake --build . --target check-pep8-focs
-        - cmake --build . --target check-pep8-focs-test
-
-
-    - name: Lint string tables
-      stage: lint
-      os: linux
-      dist: bionic
-      language: python
-      python: 3.6
-      script:
-        - ./check/st-tool.py check --reference default/stringtables/en.txt default/stringtables/??.txt
-        - diff -u default/stringtables/en.txt <(check/st-tool.py format default/stringtables/en.txt) || { echo "String table is not properly formatted"; exit 1; }
-
-
     - name: Build C++ API documentation
       <<: *_linux_setup_common
       stage: build
@@ -141,8 +106,6 @@ jobs:
           libvorbis-dev
           cppcheck
           doxygen
-          python3-pip
-        - python3 -m pip install flake8==3.7.9
       before_script:
         - mkdir build
         - cd build
@@ -223,17 +186,3 @@ jobs:
       before_cache:
         - ccache --cleanup
         - ccache --show-stats
-
-
-    - name: Unittest AI with Python 3.6
-      <<: *_test_python_common
-      python: 3.6
-      before_install:
-        - alias pip=/usr/bin/pip3
-
-
-    - name: Unittest AI with Python 3.9
-      <<: *_test_python_common
-      python: 3.9
-      before_install:
-        - alias pip=/usr/bin/pip3

--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -19,7 +19,6 @@ if(TARGET Flake8::flake8)
         COMMAND "$<TARGET_FILE:Flake8::flake8>"
         COMMENT "Check python code for PEP-8 style conformance"
         VERBATIM
-        SOURCES "${PROJECT_SOURCE_DIR}/default/python/tox.ini"
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/default/python"
     )
 

--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -26,7 +26,6 @@ if(TARGET Flake8::flake8)
         COMMAND "$<TARGET_FILE:Flake8::flake8>"
         COMMENT "Check python FreeOrion content scripts for PEP-8 style conformance"
         VERBATIM
-        SOURCES "${PROJECT_SOURCE_DIR}/default/scripting/tox.ini"
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/default/scripting"
     )
 
@@ -34,7 +33,6 @@ if(TARGET Flake8::flake8)
         COMMAND "$<TARGET_FILE:Flake8::flake8>"
         COMMENT "Check python FreeOrion content scripts for PEP-8 style conformance"
         VERBATIM
-        SOURCES "${PROJECT_SOURCE_DIR}/test-scripting/tox.ini"
         WORKING_DIRECTORY "${PROJECT_SOURCE_DIR}/test-scripting"
     )
 endif()

--- a/default/python/README.md
+++ b/default/python/README.md
@@ -57,7 +57,7 @@ Settings for it located in the `tox.ini`.
 ## Install dependencies
 
 ```sh
-pip install flake8==3.7.9
+pip isntall -r default/python/requirements-dev.txt
 ```
 
 ## Run checks

--- a/default/python/requirements-dev.txt
+++ b/default/python/requirements-dev.txt
@@ -1,0 +1,3 @@
+flake8==3.7.9
+pytest==5.4.3
+pytest-github-actions-annotate-failures==0.0.5

--- a/default/python/tox.ini
+++ b/default/python/tox.ini
@@ -7,17 +7,17 @@ extend-ignore =
     W504  # Line break occurred after a binary operator
 
 per-file-ignores =
-  **/__init__.py: F401, F403
-  AI/FreeOrionAI.py:E402
-  AI/AIDependencies.py: E241
-  auth/auth.py: E402
-  chat/chat.py: E402
-  turn_events/turn_events.py: E402
-  universe_generation/teams.py: E402
-  universe_generation/universe_generator.py: E402
-  universe_generation/universe_tables.py: E201,E122,E231
-  stub_generator/__init__.py: F401
-  tests/conftest.py: E402,F401
+  *__init__.py: F401, F403
+  *FreeOrionAI.py:E402
+  *AIDependencies.py: E241
+  *auth/auth.py: E402
+  *chat/chat.py: E402
+  *turn_events/turn_events.py: E402
+  *universe_generation/teams.py: E402
+  *universe_generation/universe_generator.py: E402
+  *universe_generation/universe_tables.py: E201,E122,E231
+  *stub_generator/__init__.py: F401
+  *tests/conftest.py: E402,F401
 
 exclude =
   *_venv/


### PR DESCRIPTION
This is a rework of the https://github.com/freeorion/freeorion/pull/3098

This PR is ready for merge but will require more steps after that.  I expect the following workflow:

- merge this PR, action will become available and will be triggered on each build.
- configure this action as required for PRs to master. [Enabling required status checks](https://docs.github.com/en/github/administering-a-repository/enabling-required-status-checks) 

## Important changes
I have removed a pytest run on Python 3.8.  Python backward compatibility is good enough. 

## Benefits
- GitHub action has a cool feature, it is possible to leave a comment at the line that caused an error. It is already enabled for flake8 and pytest.
- It takes less time to finish tests.
- Code is simpler (we don't need to put C++ and python configuration into the same file, as we do with Travis)


## Next steps
- Add annotation to the string tables check
- Allow skipping checks if no corresponding files are affected.
- Move C++ checks to GitHub actions
- Automate the creation of the windows build

