### PR TITLE
Nonintrusive serialization universe

### DIFF
--- a/universe/Building.cpp
+++ b/universe/Building.cpp
@@ -30,7 +30,7 @@ Building* Building::Clone(int empire_id) const {
     if (!(vis >= VIS_BASIC_VISIBILITY && vis <= VIS_FULL_VISIBILITY))
         return nullptr;
 
-    Building* retval = new Building();
+    Building* retval = new Building(Owner(), m_building_type, m_produced_by_empire_id);
     retval->Copy(shared_from_this(), empire_id);
     return retval;
 }

--- a/universe/Building.h
+++ b/universe/Building.h
@@ -2,6 +2,7 @@
 #define _Building_h_
 
 
+#include <boost/serialization/access.hpp>
 #include "ObjectMap.h"
 #include "UniverseObject.h"
 #include "../util/Export.h"

--- a/universe/Building.h
+++ b/universe/Building.h
@@ -32,11 +32,6 @@ public:
     void SetOrderedScrapped(bool b = true);  ///< flags building for scrapping
     void ResetTargetMaxUnpairedMeters() override;
 
-protected:
-    friend class Universe;
-    Building() {}
-
-public:
     Building(int empire_id, const std::string& building_type,
              int produced_by_empire_id = ALL_EMPIRES);
 
@@ -56,9 +51,8 @@ private:
     bool        m_ordered_scrapped = false;
     int         m_produced_by_empire_id = ALL_EMPIRES;
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, Building&, unsigned int const);
 };
 
 

--- a/universe/Field.cpp
+++ b/universe/Field.cpp
@@ -12,9 +12,6 @@
 /////////////////////////////////////////////////
 // Field                                       //
 /////////////////////////////////////////////////
-Field::Field()
-{}
-
 Field::~Field()
 {}
 
@@ -41,7 +38,7 @@ Field* Field::Clone(int empire_id) const {
     if (!(vis >= VIS_BASIC_VISIBILITY && vis <= VIS_FULL_VISIBILITY))
         return nullptr;
 
-    Field* retval = new Field();
+    Field* retval = new Field(m_type_name, X(), Y(), GetMeter(METER_SIZE)->Current());
     retval->Copy(shared_from_this(), empire_id);
     return retval;
 }

--- a/universe/Field.h
+++ b/universe/Field.h
@@ -2,6 +2,7 @@
 #define _Field_h_
 
 
+#include <boost/serialization/access.hpp>
 #include "UniverseObject.h"
 #include "../util/Export.h"
 #include "../util/Pending.h"

--- a/universe/Field.h
+++ b/universe/Field.h
@@ -2,7 +2,6 @@
 #define _Field_h_
 
 
-#include <boost/serialization/access.hpp>
 #include "UniverseObject.h"
 #include "../util/Export.h"
 #include "../util/Pending.h"
@@ -41,11 +40,6 @@ public:
     void ResetTargetMaxUnpairedMeters() override;
     void ClampMeters() override;
 
-protected:
-    friend class Universe;
-    Field();
-
-public:
     Field(const std::string& field_type, double x, double y, double radius);
     ~Field();
 
@@ -58,9 +52,8 @@ protected:
 private:
     std::string m_type_name;
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, Field&, unsigned int const);
 };
 
 

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -95,7 +95,7 @@ Fleet* Fleet::Clone(int empire_id) const {
     if (!(vis >= VIS_BASIC_VISIBILITY && vis <= VIS_FULL_VISIBILITY))
         return nullptr;
 
-    Fleet* retval = new Fleet();
+    Fleet* retval = new Fleet(m_name, X(), Y(), Owner());
     retval->Copy(shared_from_this(), empire_id);
     return retval;
 }

--- a/universe/Fleet.h
+++ b/universe/Fleet.h
@@ -1,8 +1,6 @@
 #ifndef _Fleet_h_
 #define _Fleet_h_
 
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/version.hpp>
 #include "ObjectMap.h"
 #include "UniverseObject.h"
 #include "../util/Export.h"
@@ -136,10 +134,7 @@ public:
     static const int ETA_OUT_OF_RANGE;                      ///< returned by ETA when fleet can't reach destination due to insufficient fuel capacity and lack of fleet resupply on route
 
 protected:
-    friend class Universe;
     friend class ObjectMap;
-
-    Fleet() {}
 
 public:
     Fleet(const std::string& name, double x, double y, int owner);      ///< general ctor taking name, position and owner id
@@ -177,9 +172,8 @@ private:
     bool                        m_arrived_this_turn = false;
     int                         m_arrival_starlane = INVALID_OBJECT_ID; // see comment for ArrivalStarlane()
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, Fleet&, unsigned int const);
 };
 
 

--- a/universe/IDAllocator.h
+++ b/universe/IDAllocator.h
@@ -5,7 +5,6 @@
 #include <random>
 #include <unordered_map>
 #include <vector>
-#include <boost/serialization/access.hpp>
 #include "../util/Logger.h"
 
 

--- a/universe/Meter.h
+++ b/universe/Meter.h
@@ -3,9 +3,6 @@
 
 
 #include <string>
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/nvp.hpp>
-#include <boost/serialization/version.hpp>
 #include "../util/Export.h"
 
 
@@ -52,26 +49,9 @@ private:
     float m_current_value = DEFAULT_VALUE;
     float m_initial_value = DEFAULT_VALUE;
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, Meter&, unsigned int const);
 };
-
-BOOST_CLASS_VERSION(Meter, 1)
-
-
-template <typename Archive>
-void Meter::serialize(Archive& ar, const unsigned int version)
-{
-    if (Archive::is_loading::value && version < 1) {
-        ar  & BOOST_SERIALIZATION_NVP(m_current_value)
-            & BOOST_SERIALIZATION_NVP(m_initial_value);
-    } else {
-        // use minimum size NVP label to reduce archive size bloat for very-often serialized meter values...
-        ar  & boost::serialization::make_nvp("c", m_current_value)
-            & boost::serialization::make_nvp("i", m_initial_value);
-    }
-}
 
 
 #endif

--- a/universe/ObjectMap.h
+++ b/universe/ObjectMap.h
@@ -11,7 +11,6 @@
 #include <boost/range/adaptor/map.hpp>
 #include <boost/range/any_range.hpp>
 #include <boost/range/size.hpp>
-#include <boost/serialization/access.hpp>
 #include "../util/Export.h"
 
 
@@ -216,9 +215,8 @@ private:
     container_type<const UniverseObject>  m_existing_buildings;
     container_type<const UniverseObject>  m_existing_fields;
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, ObjectMap&, unsigned int const);
 };
 
 template <typename T>

--- a/universe/Planet.cpp
+++ b/universe/Planet.cpp
@@ -47,16 +47,6 @@ namespace {
 ////////////////////////////////////////////////////////////
 // Planet
 ////////////////////////////////////////////////////////////
-Planet::Planet() :
-    m_type(PT_TERRAN),
-    m_original_type(PT_TERRAN),
-    m_size(SZ_MEDIUM)
-{
-    //DebugLogger() << "Planet::Planet()";
-    // assumes PopCenter and ResourceCenter don't need to be initialized, due to having been re-created
-    // in functional form by deserialization.  Also assumes planet-specific meters don't need to be re-added.
-}
-
 Planet::Planet(PlanetType type, PlanetSize size) :
     m_type(type),
     m_original_type(type),
@@ -83,7 +73,7 @@ Planet* Planet::Clone(int empire_id) const {
     if (!(vis >= VIS_BASIC_VISIBILITY && vis <= VIS_FULL_VISIBILITY))
         return nullptr;
 
-    Planet* retval = new Planet();
+    Planet* retval = new Planet(m_type, m_size);
     retval->Copy(UniverseObject::shared_from_this(), empire_id);
     return retval;
 }

--- a/universe/Planet.h
+++ b/universe/Planet.h
@@ -2,6 +2,7 @@
 #define _Planet_h_
 
 
+#include <boost/serialization/access.hpp>
 #include "Meter.h"
 #include "PopCenter.h"
 #include "ResourceCenter.h"

--- a/universe/Planet.h
+++ b/universe/Planet.h
@@ -2,7 +2,6 @@
 #define _Planet_h_
 
 
-#include <boost/serialization/access.hpp>
 #include "Meter.h"
 #include "PopCenter.h"
 #include "ResourceCenter.h"
@@ -115,10 +114,7 @@ public:
     static int TypeDifference(PlanetType type1, PlanetType type2);
 
 protected:
-    friend class Universe;
     friend class ObjectMap;
-
-    Planet();
 
 public:
     /** Create planet from @p type and @p size. */
@@ -166,9 +162,8 @@ private:
 
     std::string     m_surface_texture;  // intentionally not serialized; set by local effects
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, Planet&, unsigned int const);
 };
 
 

--- a/universe/PopCenter.h
+++ b/universe/PopCenter.h
@@ -4,7 +4,6 @@
 
 #include <memory>
 #include <string>
-#include <boost/serialization/nvp.hpp>
 #include "EnumsFwd.h"
 #include "../util/Export.h"
 
@@ -47,17 +46,9 @@ private:
 
     std::string m_species_name = "";                            ///< the name of the species that occupies this planet
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, PopCenter&, unsigned int const);
 };
-
-
-template <typename Archive>
-void PopCenter::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_NVP(m_species_name);
-}
 
 
 #endif

--- a/universe/ResourceCenter.h
+++ b/universe/ResourceCenter.h
@@ -3,7 +3,6 @@
 
 
 #include <boost/signals2/signal.hpp>
-#include <boost/serialization/nvp.hpp>
 #include "EnumsFwd.h"
 #include "../util/Export.h"
 
@@ -65,20 +64,9 @@ private:
     virtual Visibility  GetVisibility(int empire_id) const = 0;         ///< implementation should return the visibility of this ResourceCenter for the empire with the specified \a empire_id
     virtual void        AddMeter(MeterType meter_type) = 0;             ///< implementation should add a meter to the object so that it can be accessed with the GetMeter() functions
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, ResourceCenter&, unsigned int const);
 };
-
-
-template <typename Archive>
-void ResourceCenter::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_NVP(m_focus)
-        & BOOST_SERIALIZATION_NVP(m_last_turn_focus_changed)
-        & BOOST_SERIALIZATION_NVP(m_focus_turn_initial)
-        & BOOST_SERIALIZATION_NVP(m_last_turn_focus_changed_turn_initial);
-}
 
 
 #endif

--- a/universe/Ship.h
+++ b/universe/Ship.h
@@ -2,7 +2,6 @@
 #define _Ship_h_
 
 
-#include <boost/serialization/access.hpp>
 #include "Meter.h"
 #include "UniverseObject.h"
 #include "../util/Export.h"
@@ -107,12 +106,10 @@ public:
 
     virtual void    SetShipMetersToMax();
 
-protected:
     friend class Universe;
 
     Ship();
 
-public:
     /** Create a ship from an @p empire_id, @p design_id, @p species_name and
         @p production_by_empire_id. */
     Ship(int empire_id, int design_id, const std::string& species_name,
@@ -138,9 +135,8 @@ private:
     int             m_arrived_on_turn = INVALID_GAME_TURN;
     int             m_last_resupplied_on_turn = BEFORE_FIRST_TURN;
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, Ship&, unsigned int const);
 };
 
 FO_COMMON_API std::string NewMonsterName();

--- a/universe/Ship.h
+++ b/universe/Ship.h
@@ -2,6 +2,7 @@
 #define _Ship_h_
 
 
+#include <boost/serialization/access.hpp>
 #include "Meter.h"
 #include "UniverseObject.h"
 #include "../util/Export.h"

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -111,10 +111,6 @@ ParsedShipDesign::ParsedShipDesign(
 ////////////////////////////////////////////////
 // ShipDesign
 ////////////////////////////////////////////////
-ShipDesign::ShipDesign() :
-    m_uuid(boost::uuids::nil_generator()())
-{}
-
 ShipDesign::ShipDesign(const boost::optional<std::invalid_argument>& should_throw,
                        std::string name, std::string description,
                        int designed_on_turn, int designed_by_empire,

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -4,7 +4,6 @@
 
 #include <boost/functional/hash.hpp>
 #include <boost/optional/optional.hpp>
-#include <boost/serialization/access.hpp>
 #include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 #include "EnumsFwd.h"
@@ -44,11 +43,6 @@ struct FO_COMMON_API ParsedShipDesign {
 };
 
 class FO_COMMON_API ShipDesign {
-public:
-private:
-    /** The ShipDesign() constructor constructs invalid designs and is only used by boost
-        serialization. */
-    ShipDesign();
 public:
     /** The public ShipDesign constructor will only construct valid ship
         designs, as long as the ShipHullManager has at least one hull.
@@ -233,9 +227,8 @@ private:
     std::map<ShipPartClass, int>    m_num_part_classes;
     bool    m_producible = false;
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, ShipDesign&, unsigned int const);
 };
 
 ///< Returns true if the two designs have the same hull and parts.

--- a/universe/System.cpp
+++ b/universe/System.cpp
@@ -15,10 +15,6 @@
 #include "../util/i18n.h"
 
 
-System::System() :
-    m_star(INVALID_STAR_TYPE)
-{}
-
 System::System(StarType star, const std::string& name, double x, double y) :
     UniverseObject(name, x, y),
     m_star(star)
@@ -53,7 +49,7 @@ System* System::Clone(int empire_id) const {
     if (!(vis >= VIS_BASIC_VISIBILITY && vis <= VIS_FULL_VISIBILITY))
         return nullptr;
 
-    System* retval = new System();
+    System* retval = new System(m_star, m_name, X(), Y());
     retval->Copy(shared_from_this(), empire_id);
     return retval;
 }

--- a/universe/System.h
+++ b/universe/System.h
@@ -3,6 +3,7 @@
 
 
 #include <map>
+#include <boost/serialization/access.hpp>
 #include "UniverseObject.h"
 #include "../util/Export.h"
 

--- a/universe/System.h
+++ b/universe/System.h
@@ -3,12 +3,12 @@
 
 
 #include <map>
-#include <boost/serialization/access.hpp>
 #include "UniverseObject.h"
 #include "../util/Export.h"
 
 
 class Fleet;
+class ObjectMap;
 
 FO_COMMON_API extern const int INVALID_OBJECT_ID;
 namespace {
@@ -123,12 +123,6 @@ public:
 
     void SetOverlayTexture(const std::string& texture, double size);
 
-protected:
-    friend class Universe;
-    friend class ObjectMap;
-
-    explicit System();
-
 public:
     System(StarType star, const std::string& name, double x, double y);
 
@@ -160,9 +154,10 @@ private:
     std::string         m_overlay_texture;          // intentionally not serialized; set by local effects
     double              m_overlay_size = 1.0;
 
-    friend class boost::serialization::access;
+    friend ObjectMap;
+
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, System&, unsigned int const);
 };
 
 

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -10,7 +10,6 @@
 #include <unordered_map>
 #include <vector>
 #include <boost/container/flat_map.hpp>
-#include <boost/serialization/access.hpp>
 #include <boost/signals2/signal.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include "EnumsFwd.h"
@@ -578,9 +577,8 @@ private:
     /** Manages allocating and verifying new ship design ids.*/
     std::unique_ptr<IDAllocator> const m_design_id_allocator;
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, Universe&, unsigned int const);
 };
 
 

--- a/universe/UniverseObject.h
+++ b/universe/UniverseObject.h
@@ -7,7 +7,6 @@
 #include <vector>
 #include <boost/container/flat_map.hpp>
 #include <boost/python/detail/destroy.hpp>
-#include <boost/serialization/access.hpp>
 #include <boost/signals2/optional_last_value.hpp>
 #include <boost/signals2/signal.hpp>
 #include "EnumsFwd.h"
@@ -224,9 +223,8 @@ private:
     MeterMap                                        m_meters;
     int                                             m_created_on_turn = INVALID_GAME_TURN;
 
-    friend class boost::serialization::access;
     template <typename Archive>
-    void serialize(Archive& ar, const unsigned int version);
+    friend void serialize(Archive&, UniverseObject&, unsigned int const);
 };
 
 /** A function that returns the correct amount of spacing for an indentation of

--- a/universe/ValueRefs.h
+++ b/universe/ValueRefs.h
@@ -9,7 +9,6 @@
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/format.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/serialization/nvp.hpp>
 #include "Condition.h"
 #include "ScriptingContext.h"
 #include "Universe.h"

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -11,6 +11,7 @@
 
 #include "Export.h"
 
+class Meter;
 class OrderSet;
 class Universe;
 class UniverseObject;
@@ -118,6 +119,15 @@ extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_b
 extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, GalaxySetupData&, unsigned int const);
 extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, GalaxySetupData&, unsigned int const);
 extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, GalaxySetupData&, unsigned int const);
+
+
+template <typename Archive>
+void serialize(Archive&, Meter&, unsigned int const);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, Meter&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, Meter&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, Meter&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, Meter&, unsigned int const);
 
 
 struct MultiplayerLobbyData;

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -12,6 +12,7 @@
 #include "Export.h"
 
 class Meter;
+class PopCenter;
 class OrderSet;
 class Universe;
 class UniverseObject;
@@ -202,6 +203,15 @@ extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_b
 extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, PlayerSetupData&, unsigned int const);
 extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, PlayerSetupData&, unsigned int const);
 extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PlayerSetupData&, unsigned int const);
+
+
+template <typename Archive>
+void serialize(Archive&, PopCenter&, unsigned int const);
+
+extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, PopCenter&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, PopCenter&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, PopCenter&, unsigned int const);
+extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PopCenter&, unsigned int const);
 
 
 class PreviewInformation;

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -20,8 +20,6 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/nil_generator.hpp>
 
-BOOST_CLASS_EXPORT(UniverseObject)
-BOOST_CLASS_VERSION(UniverseObject, 2)
 BOOST_CLASS_EXPORT(System)
 BOOST_CLASS_EXPORT(Field)
 BOOST_CLASS_EXPORT(Planet)
@@ -221,30 +219,35 @@ void Universe::serialize(Archive& ar, const unsigned int version)
     DebugLogger() << "Universe " << serializing_label << " done";
 }
 
+BOOST_CLASS_EXPORT(UniverseObject)
+BOOST_CLASS_VERSION(UniverseObject, 2)
+
 template <typename Archive>
-void UniverseObject::serialize(Archive& ar, const unsigned int version)
+void serialize(Archive& ar, UniverseObject& o, unsigned int const version)
 {
-    ar  & BOOST_SERIALIZATION_NVP(m_id)
-        & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_x)
-        & BOOST_SERIALIZATION_NVP(m_y)
-        & BOOST_SERIALIZATION_NVP(m_owner_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_system_id)
-        & BOOST_SERIALIZATION_NVP(m_specials);
+    using namespace boost::serialization;
+
+    ar  & make_nvp("m_id", o.m_id)
+        & make_nvp("m_name", o.m_name)
+        & make_nvp("m_x", o.m_x)
+        & make_nvp("m_y", o.m_y)
+        & make_nvp("m_owner_empire_id", o.m_owner_empire_id)
+        & make_nvp("m_system_id", o.m_system_id)
+        & make_nvp("m_specials", o.m_specials);
     if (version < 2) {
         std::map<MeterType, Meter> meter_map;
-        ar  & boost::serialization::make_nvp("m_meters", meter_map);
-        m_meters.reserve(meter_map.size());
-        m_meters.insert(meter_map.begin(), meter_map.end());
+        ar  & make_nvp("m_meters", meter_map);
+        o.m_meters.reserve(meter_map.size());
+        o.m_meters.insert(meter_map.begin(), meter_map.end());
     } else {
-        ar  & BOOST_SERIALIZATION_NVP(m_meters);
+        ar  & make_nvp("m_meters", o.m_meters);
 
         // loading the internal vector, like so, was no faster than loading the map
         //auto meters{m_meters.extract_sequence()};
-        //ar  & BOOST_SERIALIZATION_NVP(meters);
+        //ar  & make_nvp("meters", o.meters);
         //m_meters.adopt_sequence(std::move(meters));
     }
-    ar  & BOOST_SERIALIZATION_NVP(m_created_on_turn);
+    ar  & make_nvp("m_created_on_turn", o.m_created_on_turn);
 }
 
 template <typename Archive>

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -22,8 +22,6 @@
 #include <boost/uuid/nil_generator.hpp>
 
 BOOST_CLASS_EXPORT(Field)
-BOOST_CLASS_EXPORT(Planet)
-BOOST_CLASS_VERSION(Planet, 2)
 BOOST_CLASS_EXPORT(Building)
 BOOST_CLASS_EXPORT(Fleet)
 BOOST_CLASS_VERSION(Fleet, 3)
@@ -315,40 +313,51 @@ void Field::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_type_name);
 }
 
+
 template <typename Archive>
-void Planet::serialize(Archive& ar, const unsigned int version)
+void load_construct_data(Archive& ar, Planet* obj, unsigned int const version)
+{ ::new(obj)Planet(PT_TERRAN, SZ_MEDIUM); }
+
+template <typename Archive>
+void serialize(Archive& ar, Planet& obj, unsigned int const version)
 {
-   ar   & BOOST_SERIALIZATION_BASE_OBJECT_NVP(UniverseObject)
-        & BOOST_SERIALIZATION_BASE_OBJECT_NVP(PopCenter)
-        & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ResourceCenter)
-        & BOOST_SERIALIZATION_NVP(m_type)
-        & BOOST_SERIALIZATION_NVP(m_original_type)
-        & BOOST_SERIALIZATION_NVP(m_size)
-        & BOOST_SERIALIZATION_NVP(m_orbital_period)
-        & BOOST_SERIALIZATION_NVP(m_initial_orbital_position)
-        & BOOST_SERIALIZATION_NVP(m_rotational_period)
-        & BOOST_SERIALIZATION_NVP(m_axial_tilt)
-        & BOOST_SERIALIZATION_NVP(m_buildings);
+    using namespace boost::serialization;
+
+    ar  & make_nvp("UniverseObject", base_object<UniverseObject>(obj))
+        & make_nvp("PopCenter", base_object<PopCenter>(obj))
+        & make_nvp("ResourceCenter", base_object<ResourceCenter>(obj))
+        & make_nvp("m_type", obj.m_type)
+        & make_nvp("m_original_type", obj.m_original_type)
+        & make_nvp("m_size", obj.m_size)
+        & make_nvp("m_orbital_period", obj.m_orbital_period)
+        & make_nvp("m_initial_orbital_position", obj.m_initial_orbital_position)
+        & make_nvp("m_rotational_period", obj.m_rotational_period)
+        & make_nvp("m_axial_tilt", obj.m_axial_tilt)
+        & make_nvp("m_buildings", obj.m_buildings);
     if (version < 2) {
         // if deserializing an old save, default to standard default never-colonized turn
-        m_turn_last_colonized = INVALID_GAME_TURN;
-        if (!SpeciesName().empty()) // but if a planet has a species, it must have been colonized, so default to the previous turn
-            m_turn_last_colonized = CurrentTurn() - 1;
+        obj.m_turn_last_colonized = INVALID_GAME_TURN;
+        if (!obj.SpeciesName().empty()) // but if a planet has a species, it must have been colonized, so default to the previous turn
+            obj.m_turn_last_colonized = CurrentTurn() - 1;
     } else {
-        ar   & BOOST_SERIALIZATION_NVP(m_turn_last_colonized);
+        ar   & make_nvp("m_turn_last_colonized", obj.m_turn_last_colonized);
     }
     if (version < 1) {
         bool dummy = false;
         ar   & boost::serialization::make_nvp("m_just_conquered", dummy);
     } else {
-        ar   & BOOST_SERIALIZATION_NVP(m_turn_last_conquered);
+        ar   & make_nvp("m_turn_last_conquered", obj.m_turn_last_conquered);
     }
-    ar  & BOOST_SERIALIZATION_NVP(m_is_about_to_be_colonized)
-        & BOOST_SERIALIZATION_NVP(m_is_about_to_be_invaded)
-        & BOOST_SERIALIZATION_NVP(m_is_about_to_be_bombarded)
-        & BOOST_SERIALIZATION_NVP(m_ordered_given_to_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_last_turn_attacked_by_ship);
+    ar  & make_nvp("m_is_about_to_be_colonized", obj.m_is_about_to_be_colonized)
+        & make_nvp("m_is_about_to_be_invaded", obj.m_is_about_to_be_invaded)
+        & make_nvp("m_is_about_to_be_bombarded", obj.m_is_about_to_be_bombarded)
+        & make_nvp("m_ordered_given_to_empire_id", obj.m_ordered_given_to_empire_id)
+        & make_nvp("m_last_turn_attacked_by_ship", obj.m_last_turn_attacked_by_ship);
 }
+
+BOOST_CLASS_EXPORT(Planet)
+BOOST_CLASS_VERSION(Planet, 2)
+
 
 template <typename Archive>
 void Building::serialize(Archive& ar, const unsigned int version)

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -27,8 +27,6 @@ BOOST_CLASS_VERSION(Planet, 2)
 BOOST_CLASS_EXPORT(Building)
 BOOST_CLASS_EXPORT(Fleet)
 BOOST_CLASS_VERSION(Fleet, 3)
-BOOST_CLASS_EXPORT(Ship)
-BOOST_CLASS_VERSION(Ship, 2)
 BOOST_CLASS_EXPORT(ShipDesign)
 BOOST_CLASS_VERSION(ShipDesign, 2)
 BOOST_CLASS_EXPORT(Universe)
@@ -365,27 +363,34 @@ void Fleet::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_arrival_starlane);
 }
 
+
 template <typename Archive>
-void Ship::serialize(Archive& ar, const unsigned int version)
+void serialize(Archive& ar, Ship& obj, unsigned int const version)
 {
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(UniverseObject)
-        & BOOST_SERIALIZATION_NVP(m_design_id)
-        & BOOST_SERIALIZATION_NVP(m_fleet_id)
-        & BOOST_SERIALIZATION_NVP(m_ordered_scrapped)
-        & BOOST_SERIALIZATION_NVP(m_ordered_colonize_planet_id)
-        & BOOST_SERIALIZATION_NVP(m_ordered_invade_planet_id)
-        & BOOST_SERIALIZATION_NVP(m_ordered_bombard_planet_id)
-        & BOOST_SERIALIZATION_NVP(m_part_meters)
-        & BOOST_SERIALIZATION_NVP(m_species_name)
-        & BOOST_SERIALIZATION_NVP(m_produced_by_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_arrived_on_turn);
+    using namespace boost::serialization;
+
+    ar  & make_nvp("UniverseObject", base_object<UniverseObject>(obj))
+        & make_nvp("m_design_id", obj.m_design_id)
+        & make_nvp("m_fleet_id", obj.m_fleet_id)
+        & make_nvp("m_ordered_scrapped", obj.m_ordered_scrapped)
+        & make_nvp("m_ordered_colonize_planet_id", obj.m_ordered_colonize_planet_id)
+        & make_nvp("m_ordered_invade_planet_id", obj.m_ordered_invade_planet_id)
+        & make_nvp("m_ordered_bombard_planet_id", obj.m_ordered_bombard_planet_id)
+        & make_nvp("m_part_meters", obj.m_part_meters)
+        & make_nvp("m_species_name", obj.m_species_name)
+        & make_nvp("m_produced_by_empire_id", obj.m_produced_by_empire_id)
+        & make_nvp("m_arrived_on_turn", obj.m_arrived_on_turn);
     if (version >= 1) {
-        ar  & BOOST_SERIALIZATION_NVP(m_last_turn_active_in_combat);
+        ar  & make_nvp("m_last_turn_active_in_combat", obj.m_last_turn_active_in_combat);
         if (version >= 2) {
-            ar  & BOOST_SERIALIZATION_NVP(m_last_resupplied_on_turn);
+            ar  & make_nvp("m_last_resupplied_on_turn", obj.m_last_resupplied_on_turn);
         }
     }
 }
+
+BOOST_CLASS_EXPORT(Ship)
+BOOST_CLASS_VERSION(Ship, 2)
+
 
 template <typename Archive>
 void ShipDesign::serialize(Archive& ar, const unsigned int version)

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -71,6 +71,23 @@ template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PopCent
 
 
 template <typename Archive>
+void serialize(Archive& ar, ResourceCenter& rs, unsigned int const version)
+{
+    using namespace boost::serialization;
+
+    ar  & make_nvp("m_focus", rs.m_focus)
+        & make_nvp("m_last_turn_focus_changed", rs.m_last_turn_focus_changed)
+        & make_nvp("m_focus_turn_initial", rs.m_focus_turn_initial)
+        & make_nvp("m_last_turn_focus_changed_turn_initial", rs.m_last_turn_focus_changed_turn_initial);
+}
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, ResourceCenter&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, ResourceCenter&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, ResourceCenter&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, ResourceCenter&, unsigned int const);
+
+
+template <typename Archive>
 void ObjectMap::serialize(Archive& ar, const unsigned int version)
 {
     ar & BOOST_SERIALIZATION_NVP(m_objects);

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -59,6 +59,18 @@ template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, Meter&,
 
 
 template <typename Archive>
+void serialize(Archive& ar, PopCenter& p, unsigned int const version)
+{
+    ar  & boost::serialization::make_nvp("m_species_name", p.m_species_name);
+}
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, PopCenter&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, PopCenter&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, PopCenter&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, PopCenter&, unsigned int const);
+
+
+template <typename Archive>
 void ObjectMap::serialize(Archive& ar, const unsigned int version)
 {
     ar & BOOST_SERIALIZATION_NVP(m_objects);

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -5,6 +5,7 @@
 
 #include "../universe/IDAllocator.h"
 #include "../universe/Building.h"
+#include "../universe/Enums.h"
 #include "../universe/Fleet.h"
 #include "../universe/Ship.h"
 #include "../universe/Planet.h"
@@ -20,7 +21,6 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/nil_generator.hpp>
 
-BOOST_CLASS_EXPORT(System)
 BOOST_CLASS_EXPORT(Field)
 BOOST_CLASS_EXPORT(Planet)
 BOOST_CLASS_VERSION(Planet, 2)
@@ -277,21 +277,36 @@ void serialize(Archive& ar, UniverseObject& o, unsigned int const version)
     ar  & make_nvp("m_created_on_turn", o.m_created_on_turn);
 }
 
+
 template <typename Archive>
-void System::serialize(Archive& ar, const unsigned int version)
+void load_construct_data(Archive& ar, System* obj, unsigned int const version)
+{ ::new(obj)System(INVALID_STAR_TYPE, "", 0.0, 0.0); }
+
+template <typename Archive>
+void serialize(Archive& ar, System& obj, unsigned int const version)
 {
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(UniverseObject)
-        & BOOST_SERIALIZATION_NVP(m_star)
-        & BOOST_SERIALIZATION_NVP(m_orbits)
-        & BOOST_SERIALIZATION_NVP(m_objects)
-        & BOOST_SERIALIZATION_NVP(m_planets)
-        & BOOST_SERIALIZATION_NVP(m_buildings)
-        & BOOST_SERIALIZATION_NVP(m_fleets)
-        & BOOST_SERIALIZATION_NVP(m_ships)
-        & BOOST_SERIALIZATION_NVP(m_fields)
-        & BOOST_SERIALIZATION_NVP(m_starlanes_wormholes)
-        & BOOST_SERIALIZATION_NVP(m_last_turn_battle_here);
+    using namespace boost::serialization;
+
+    ar  & make_nvp("UniverseObject", base_object<UniverseObject>(obj))
+        & make_nvp("m_star", obj.m_star)
+        & make_nvp("m_orbits", obj.m_orbits)
+        & make_nvp("m_objects", obj.m_objects)
+        & make_nvp("m_planets", obj.m_planets)
+        & make_nvp("m_buildings", obj.m_buildings)
+        & make_nvp("m_fleets", obj.m_fleets)
+        & make_nvp("m_ships", obj.m_ships)
+        & make_nvp("m_fields", obj.m_fields)
+        & make_nvp("m_starlanes_wormholes", obj.m_starlanes_wormholes)
+        & make_nvp("m_last_turn_battle_here", obj.m_last_turn_battle_here);
 }
+
+BOOST_CLASS_EXPORT(System)
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, System&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, System&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, System&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, System&, unsigned int const);
+
 
 template <typename Archive>
 void Field::serialize(Archive& ar, const unsigned int version)
@@ -478,18 +493,6 @@ template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, Species
 template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, SpeciesManager&, unsigned int const);
 template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, SpeciesManager&, unsigned int const);
 template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, SpeciesManager&, unsigned int const);
-
-// explicit template initialization of System::serialize needed to avoid bug with GCC 4.5.2.
-template
-void System::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
-template
-void System::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
-
-// explicit template initialization of System::serialize needed to avoid bug with GCC 4.5.2.
-template
-void System::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
-template
-void System::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
 
 template <typename Archive>
 void Serialize(Archive& oa, const Universe& universe)

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -79,13 +79,13 @@ template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, Resourc
 
 
 template <typename Archive>
-void ObjectMap::serialize(Archive& ar, const unsigned int version)
+void serialize(Archive& ar, ObjectMap& objmap, unsigned int const version)
 {
-    ar & BOOST_SERIALIZATION_NVP(m_objects);
+    ar & boost::serialization::make_nvp("m_objects", objmap.m_objects);
 
     // If loading from the archive, propagate the changes to the specialized maps.
     if (Archive::is_loading::value)
-        CopyObjectsToSpecializedMaps();
+        objmap.CopyObjectsToSpecializedMaps();
 }
 
 template <typename Archive>

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -22,7 +22,6 @@
 #include <boost/uuid/nil_generator.hpp>
 
 BOOST_CLASS_EXPORT(Field)
-BOOST_CLASS_EXPORT(Building)
 BOOST_CLASS_EXPORT(Fleet)
 BOOST_CLASS_VERSION(Fleet, 3)
 BOOST_CLASS_EXPORT(ShipDesign)
@@ -366,14 +365,23 @@ BOOST_CLASS_VERSION(Planet, 2)
 
 
 template <typename Archive>
-void Building::serialize(Archive& ar, const unsigned int version)
+void load_construct_data(Archive& ar, Building* obj, unsigned int const version)
+{ ::new(obj)Building(ALL_EMPIRES, "", ALL_EMPIRES); }
+
+template <typename Archive>
+void serialize(Archive& ar, Building& obj, unsigned int const version)
 {
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(UniverseObject)
-        & BOOST_SERIALIZATION_NVP(m_building_type)
-        & BOOST_SERIALIZATION_NVP(m_planet_id)
-        & BOOST_SERIALIZATION_NVP(m_ordered_scrapped)
-        & BOOST_SERIALIZATION_NVP(m_produced_by_empire_id);
+    using namespace boost::serialization;
+
+    ar  & make_nvp("UniverseObject", base_object<UniverseObject>(obj))
+        & make_nvp("m_building_type", obj.m_building_type)
+        & make_nvp("m_planet_id", obj.m_planet_id)
+        & make_nvp("m_ordered_scrapped", obj.m_ordered_scrapped)
+        & make_nvp("m_produced_by_empire_id", obj.m_produced_by_empire_id);
 }
+
+BOOST_CLASS_EXPORT(Building)
+
 
 template <typename Archive>
 void Fleet::serialize(Archive& ar, const unsigned int version)

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -307,10 +307,16 @@ template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, Syst
 
 
 template <typename Archive>
-void Field::serialize(Archive& ar, const unsigned int version)
+void load_construct_data(Archive& ar, Field* obj, unsigned int const version)
+{ ::new(obj)Field("", 0.0, 0.0, 0.0); }
+
+template <typename Archive>
+void serialize(Archive& ar, Field& obj, unsigned int const version)
 {
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(UniverseObject)
-        & BOOST_SERIALIZATION_NVP(m_type_name);
+    using namespace boost::serialization;
+
+    ar  & make_nvp("UniverseObject", base_object<UniverseObject>(obj))
+        & make_nvp("m_type_name", obj.m_type_name);
 }
 
 

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -22,8 +22,6 @@
 #include <boost/uuid/nil_generator.hpp>
 
 BOOST_CLASS_EXPORT(Field)
-BOOST_CLASS_EXPORT(Fleet)
-BOOST_CLASS_VERSION(Fleet, 3)
 BOOST_CLASS_EXPORT(ShipDesign)
 BOOST_CLASS_VERSION(ShipDesign, 2)
 BOOST_CLASS_EXPORT(Universe)
@@ -384,22 +382,31 @@ BOOST_CLASS_EXPORT(Building)
 
 
 template <typename Archive>
-void Fleet::serialize(Archive& ar, const unsigned int version)
+void load_construct_data(Archive& ar, Fleet* obj, unsigned int const version)
+{ ::new(obj)Fleet("", 0.0, 0.0, ALL_EMPIRES); }
+
+template <typename Archive>
+void serialize(Archive& ar, Fleet& obj, unsigned int const version)
 {
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(UniverseObject)
-        & BOOST_SERIALIZATION_NVP(m_ships)
-        & BOOST_SERIALIZATION_NVP(m_prev_system)
-        & BOOST_SERIALIZATION_NVP(m_next_system)
-        & BOOST_SERIALIZATION_NVP(m_aggressive)
-        & BOOST_SERIALIZATION_NVP(m_ordered_given_to_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_travel_route);
+    using namespace boost::serialization;
+
+    ar  & make_nvp("UniverseObject", base_object<UniverseObject>(obj))
+        & make_nvp("m_ships", obj.m_ships)
+        & make_nvp("m_prev_system", obj.m_prev_system)
+        & make_nvp("m_next_system", obj.m_next_system)
+        & make_nvp("m_aggressive", obj.m_aggressive)
+        & make_nvp("m_ordered_given_to_empire_id", obj.m_ordered_given_to_empire_id)
+        & make_nvp("m_travel_route", obj.m_travel_route);
     if (version < 3) {
         double dummy_travel_distance;
         ar & boost::serialization::make_nvp("m_travel_distance", dummy_travel_distance);
     }
-    ar  & BOOST_SERIALIZATION_NVP(m_arrived_this_turn)
-        & BOOST_SERIALIZATION_NVP(m_arrival_starlane);
+    ar  & make_nvp("m_arrived_this_turn", obj.m_arrived_this_turn)
+        & make_nvp("m_arrival_starlane", obj.m_arrival_starlane);
 }
+
+BOOST_CLASS_EXPORT(Fleet)
+BOOST_CLASS_VERSION(Fleet, 3)
 
 
 template <typename Archive>

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -36,6 +36,30 @@ BOOST_CLASS_VERSION(ShipDesign, 2)
 BOOST_CLASS_EXPORT(Universe)
 BOOST_CLASS_VERSION(Universe, 1)
 
+
+BOOST_CLASS_VERSION(Meter, 1)
+
+template <typename Archive>
+void serialize(Archive& ar, Meter& m, unsigned int const version)
+{
+    using namespace boost::serialization;
+
+    if (Archive::is_loading::value && version < 1) {
+        ar  & make_nvp("m_current_value", m.m_current_value)
+            & make_nvp("m_initial_value", m.m_initial_value);
+    } else {
+        // use minimum size NVP label to reduce archive size bloat for very-often serialized meter values...
+        ar  & make_nvp("c", m.m_current_value)
+            & make_nvp("i", m.m_initial_value);
+    }
+}
+
+template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, Meter&, unsigned int const);
+template void serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, Meter&, unsigned int const);
+template void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, Meter&, unsigned int const);
+template void serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, Meter&, unsigned int const);
+
+
 template <typename Archive>
 void ObjectMap::serialize(Archive& ar, const unsigned int version)
 {


### PR DESCRIPTION
This PR uses the nonintrusive interface of boost::serialization on the following classes and structs to reduce the visibility scope of the `boost/serialization/*` headers:

* Meter
* UniverseObject
* PopCenter
* ResourceCenter
* Ship
* System
* Planet
* Field
* Building
* Fleet
* ShipDesign
* ObjectMap
* Universe

Remove unused headers from `universe/ValueRefs.h` and `universe/IDAllocator.h`