### PR TITLE
Make imperial stockpile stringtable entries slightly better

### DIFF
--- a/default/scripting/encyclopedia/game_concepts/STOCKPILE.focs.txt
+++ b/default/scripting/encyclopedia/game_concepts/STOCKPILE.focs.txt
@@ -1,0 +1,8 @@
+Article
+    name = "STOCKPILE_TITLE"
+    category = "CATEGORY_GAME_CONCEPTS"
+    short_description = ""
+    description = "STOCKPILE_TEXT"
+    icon = "icons/meter/stockpile.png"
+
+

--- a/default/scripting/encyclopedia/game_concepts/STOCKPILE_TRANSFER.focs.txt
+++ b/default/scripting/encyclopedia/game_concepts/STOCKPILE_TRANSFER.focs.txt
@@ -4,3 +4,5 @@ Article
     short_description = "PROJECT_BT_STOCKPILE_SHORT_DESC"
     description = "PROJECT_BT_STOCKPILE_DESC"
     icon = "icons/meter/stockpile.png"
+
+# Note the transfer project is added as encyclopedia entry because there currently no direct support for projects in the pedia (this is neither a building nor a ship)

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5679,7 +5679,7 @@ There are two ways two store PP in the imperial stockpile:
 * PP explicitly allocated to a [[encyclopedia PROJECT_BT_STOCKPILE]] are also transferred to the stockpile.
 
 The imperial stockpile use limit is the total of the [[metertype METER_STOCKPILE]] of each planet.
-Species stockpiling ability, buildings, technologies, and setting the [[encyclopedia STOCKPILE_FOCUS_TITLE]] increase it.
+Species stockpile distribution ability, buildings, technologies, and setting the [[encyclopedia STOCKPILE_FOCUS_TITLE]] increase it.
 
 Information about imperial stockpile, the use, and the use limit can be seen in the top of the [[encyclopedia MAP_WINDOW_ARTICLE_TITLE]].
 Details for production can be seen in the [[encyclopedia PRODUCTION_WINDOW_ARTICLE_TITLE]].
@@ -5835,7 +5835,7 @@ Industry
 METER_INDUSTRY_VALUE_DESC
 '''Industry represents the production and modification of physical goods. It is needed to produce buildings, space ships and other projects.
 
-The Industry of a planet can be used for any production projects of [[metertype METER_SUPPLY]] line connected planets. Unallocated Industry gets added to the Imperial Stockpile.
+The Industry of a planet can be used for any production projects of [[metertype METER_SUPPLY]] line connected planets. Unallocated Industry gets added to the [[encyclopedia STOCKPILE_TITLE]].
 
 The Target Industry is the stable Industry output level a planet will approach, given the current factors influencing the Industry resources. Its value is connected to [[encyclopedia ENC_BUILDING_TYPE]]s built on the planet, [[encyclopedia ENC_TECH]] researched by the empire, [[encyclopedia ENC_SPECIAL]]s linked to the planet, and various other game effects. If these factors change, then the Target Industry value is likely to shift.
 
@@ -5940,12 +5940,12 @@ Supply lines can also be used to refill the [[metertype METER_FUEL]] supply of s
 Supply lines will be obstructed by armed enemy ships belonging to empires with which an empire is at [[encyclopedia WAR_TITLE]]. At the opposite end of the spectrum, empires in an [[encyclopedia ALLIANCE_TITLE]] will share supply lines and all their associated benefits.'''
 
 METER_STOCKPILE_VALUE_LABEL
-Stockpile
+Stockpile Distribution
 
 METER_STOCKPILE_VALUE_DESC
-'''The stockpile meter of a planet represents how much it contributes to the [[encyclopedia STOCKPILE_TITLE]] use limit. The imperial stockpile use limit indicates an empire's ability to use stockpiled Production Points (PP). An empire's stockpile use limit is the sum of all its planets' stockpile meters plus technology bonus. The total determines how many PP can be taken out of the stockpile each turn to be used for production.
+'''The stockpile distribution meter of a planet represents how much it contributes to the [[encyclopedia STOCKPILE_TITLE]] use limit. The imperial stockpile use limit indicates an empire's ability to use stockpiled Production Points (PP). An empire's stockpile use limit is the sum of all its planets' stockpile distribution meters plus technology bonus. The total determines how many PP can be taken out of the stockpile each turn to be used for production.
 
-Species have various innate levels of stockpiling ability.'''
+Species have various innate levels of stockpile distribution ability.'''
 
 METER_TROOPS_VALUE_LABEL
 Troops
@@ -6104,12 +6104,12 @@ Each turn, there is a 10% chance of taking control of each ship, unless the enem
 When the Psychic Domination Focus is engaged, it also reduces the chance that [[predefinedshipdesign SM_PSIONIC_SNOWFLAKE]]s will take control of ships controlled by the planet's empire within the system.'''
 
 STOCKPILE_FOCUS_TITLE
-Stockpile Focus
+Stockpile Distribution Focus
 
 STOCKPILE_FOCUS_TEXT
-'''The Stockpile focus increases the [[metertype METER_STOCKPILE]] of a planet.
+'''The Stockpile Distribution focus increases the [[metertype METER_STOCKPILE]] of a planet.
 
-A Homeworld focused on Stockpile also helps other planets of the same species and increases the [[metertype METER_STOCKPILE]] there by an additional 0.04 per population.
+A Homeworld focused on Stockpile Distribution also helps other planets of the same species and increases the [[metertype METER_STOCKPILE]] there by an additional 0.04 per population.
 
 [[METER_STOCKPILE_VALUE_DESC]]'''
 
@@ -9225,7 +9225,7 @@ Industry
 
 # Focus types
 FOCUS_STOCKPILE
-Stockpile
+Stockpile Distribution
 
 FOCUS_STOCKPILE_DESC
 Allows stockpile techs to boost stockpile withdrawal capacity
@@ -9340,7 +9340,7 @@ Max Supply
 
 # Meter types
 METER_MAX_STOCKPILE
-Max Stockpile
+Max Stockpile Distribution
 
 # Meter types
 METER_MAX_TROOPS
@@ -9400,7 +9400,7 @@ Supply
 
 # Meter types
 METER_STOCKPILE
-Stockpile
+Stockpile Distribution
 
 # Meter types
 METER_TROOPS
@@ -11004,7 +11004,7 @@ PLC_CENTRALIZATION
 Centralization
 
 PLC_CENTRALIZATION_DESC
-Increases resourse output at the capital but reduces supply range and stockpiling.
+Increases resourse output at the capital but reduces supply range and stockpile distribution.
 
 PLC_CENTRALIZATION_SHORT_DESC
 Boosts Capital
@@ -11070,7 +11070,7 @@ PLC_STOCKPILE_LIQUIDATION
 Stockpile Liquidation
 
 PLC_STOCKPILE_LIQUIDATION_DESC
-Doubles the contribution of stockpile-focused planets to the [[encyclopedia STOCKPILE_TITLE]] use limit.
+Doubles the contribution of stockpile-distribution-focused planets to the [[encyclopedia STOCKPILE_TITLE]] use limit.
 
 PLC_STOCKPILE_LIQUIDATION_SHORT_DESC
 Increases Stockpile Use Limit
@@ -11496,10 +11496,10 @@ PRO_PREDICTIVE_STOCKPILING_DESC
 The imperial stockpile service has a fleet for distributing raw materials to places where important projects are predicted to be started.
 This task is difficult as the service has to predict when demand happens, where it happens, what materials and goods are demanded and also who the users will be.
 
-Unused Production Points (PP) will automatically be transferred to the Imperial Production Stockpile.
+Unused Production Points (PP) will automatically be transferred to the [[encyclopedia STOCKPILE_TITLE]]].
 An item on the production queue draws automatically on the Imperial Stockpile if the item has not been explicitly disabled from doing so.
 
-This is the basic technology for the imperial stockpile, which increases the [[metertype METER_STOCKPILE]] of stockpile-focused planets by 1.'''
+This is the basic technology for the imperial stockpile, which increases the [[metertype METER_STOCKPILE]] of stockpile-distribution-focused planets by 1.'''
 
 PRO_GENERIC_SUPPLIES
 Generic Supplies
@@ -11512,7 +11512,7 @@ Reaching this state of sophistication, Generic Supplies can be used to construct
 
 This frees the imperial stockpile service from having to know which goods will be demanded exactly. Predicting the location and amount is enough.
 
-This is an upgrade technology for the imperial stockpile. The [[metertype METER_STOCKPILE]] is increased by 2, plus an additional 0.01 per [[metertype METER_POPULATION]], plus an additional 3 for each stockpiling-focused planet.
+This is an upgrade technology for the [[encyclopedia STOCKPILE_TITLE]]]. The [[metertype METER_STOCKPILE]] is increased by 2, plus an additional 0.01 per [[metertype METER_POPULATION]], plus an additional 3 for each stockpile-distribution-focused planet.
 These improvements are cumulative with that provided by [[tech PRO_PREDICTIVE_STOCKPILING]].'''
 
 PRO_INTERSTELLAR_ENTANGLEMENT_FACTORY
@@ -11522,7 +11522,7 @@ PRO_INTERSTELLAR_ENTANGLEMENT_FACTORY_DESC
 '''Quantum entanglement of factory control rooms allows the operation of machines remotely from other star systems.
 Decoupling workforce and the means of production helps to produce just in time and increases efficiency of the imperial stockpile service.
 
-This is an upgrade technology for the imperial stockpile. The [[metertype METER_STOCKPILE]] is increased by 6 plus an additional 0.02 per [[metertype METER_POPULATION]].
+This is an upgrade technology for the [[encyclopedia STOCKPILE_TITLE]]].. The [[metertype METER_STOCKPILE]] is increased by 6 plus an additional 0.02 per [[metertype METER_POPULATION]].
 These improvements are cumulative with those provided by [[tech PRO_PREDICTIVE_STOCKPILING]], [[tech PRO_GENERIC_SUPPLIES]] and [[tech PRO_VOID_PREDICTION]].
 
 This also unlocks the [[buildingtype BLD_STOCKPILING_CENTER]] which additionally increases the [[metertype METER_STOCKPILE]] by 0.1 per [[metertype METER_INDUSTRY]].'''
@@ -11534,7 +11534,7 @@ PRO_VOID_PREDICTION_DESC
 '''While classic prediction always relies on statistical knowledge of the past, studying the chaotic wisdom of the void leads to robust predictions of first-time and freak occurences.
 For the imperial stockpile service, void prediction is the quintessential tool to deliver the right goods even before the need occurs.
 
-This is an upgrade technology for the imperial stockpile. The [[metertype METER_STOCKPILE]] is increased by 0.2 per [[metertype METER_POPULATION]].
+This is an upgrade technology for the [[encyclopedia STOCKPILE_TITLE]]].. The [[metertype METER_STOCKPILE]] is increased by 0.2 per [[metertype METER_POPULATION]].
 These improvements are cumulative with those provided by [[tech PRO_PREDICTIVE_STOCKPILING]], [[tech PRO_GENERIC_SUPPLIES]] and [[tech PRO_INTERSTELLAR_ENTANGLEMENT_FACTORY]].'''
 
 PRO_MICROGRAV_MAN
@@ -13166,7 +13166,7 @@ BLD_INTERSPECIES_ACADEMY
 Species InterDesign Academy
 
 BLD_INTERSPECIES_ACADEMY_DESC
-'''Increases the imperial stockpile use limit by increasing the stockpile use capacity on a planet by 10, if that planet has stockpiling focus.
+'''Increases the imperial stockpile use limit by increasing the stockpile use capacity on a planet by 10, if that planet has [[encyclopedia STOCKPILE_FOCUS_TITLE]].
 Increases [[metertype METER_RESEARCH]] on its planet by 5, if that planet has research focus.
 
 Learning to design devices for use by different species is crucial for developing universally usable tools.
@@ -15608,27 +15608,27 @@ ULTIMATE_SUPPLY_LABEL
 # %1% FIXME
 # %2% FIXME
 BAD_STOCKPILE_LABEL
-%2% Bad Stockpiling
+%2% Bad Stockpile Distribution
 
 # %1% FIXME
 # %2% FIXME
 AVERAGE_STOCKPILE_LABEL
-%2% Average Stockpiling
+%2% Average Stockpile Distribution
 
 # %1% FIXME
 # %2% FIXME
 GOOD_STOCKPILE_LABEL
-%2% Good Stockpiling
+%2% Good Stockpile Distribution
 
 # %1% FIXME
 # %2% FIXME
 GREAT_STOCKPILE_LABEL
-%2% Great Stockpiling
+%2% Great Stockpile Distribution
 
 # %1% FIXME
 # %2% FIXME
 ULTIMATE_STOCKPILE_LABEL
-%2% Ultimate Stockpiling
+%2% Ultimate Stockpile Distribution
 
 # %1% FIXME
 # %2% FIXME

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -351,7 +351,7 @@ PROJECT_BT_STOCKPILE_SHORT_DESC
 Transfers PP into the imperial stockpile
 
 PROJECT_BT_STOCKPILE_DESC
-'''PP allocated to the transfer project are added to the imperial stockpile. The amount to transfer and how many times the transfer should repeat can be specified.
+'''Production Points (PP) allocated to the transfer project are added to the imperial stockpile. The amount to transfer and how many times the transfer should repeat can be specified.
 
 Only PP that are produced in the same supply-group (and none from the imperial stockpile) are allocated to the stockpile transfer project.
 
@@ -4397,7 +4397,7 @@ It also allows for some interaction with the [[encyclopedia MAP_WINDOW_ARTICLE_T
 <u>Production Summary panel</u>
 
 (default position: top left)
-The Production Summary panel shows available Production Points.
+The Production Summary panel shows available Production Points (PP).
 If a system is selected, there are two columns shown. The left column shows production points across your entire empire. The right column gives production points for the selected system (but is absent if no system is selected).
 Available Points relates to the PP available for production. The right value are the maximum available production points for the selected system. This may be less than the total available when all of your empire's systems are not [[metertype METER_SUPPLY]] connected.
 Stockpile relates to the PP available for production using the imperial stockpile. Production items are enabled to use PP from the Imperial Stockpile by default and have to be explicitly disabled from doing so.
@@ -5914,9 +5914,9 @@ Supply
 METER_SUPPLY_VALUE_DESC
 '''The supply meter on a planet represents the number of star-lanes supply can extend through. Smaller planets can supply greater distances, large planets reduced distances.
 
-Supply lines are shown by coloring star-lanes with an empire's color. Planets connected by supply lines form a 'Resource Group' and can share physical resources. Production Points created on one planet can be used on any connected planet to build ships or structures.
+Supply lines are shown by coloring star-lanes with an empire's color. Planets connected by supply lines form a 'Resource Group' and can share physical resources. Production Points (PP) created on one planet can be used on any connected planet to build ships or structures.
 
-A set of core supply starlanes for an empire (the set of least-jump starlanes connecting the resource-producing systems of each Resource Group) will have greater thickness than the non-core starlanes. If PP is currently being wasted within a Resource Group, the outer bands of the core starlanes will be a contrasting color.
+A set of core supply starlanes for an empire (the set of least-jump starlanes connecting the resource-producing systems of each Resource Group) will have greater thickness than the non-core starlanes. If PP are currently unalloted within a Resource Group, the outer bands of the core starlanes will be a contrasting color.
 
 Supply lines can also be used to refill the [[metertype METER_FUEL]] supply of ships.
 
@@ -5926,7 +5926,7 @@ METER_STOCKPILE_VALUE_LABEL
 Stockpile
 
 METER_STOCKPILE_VALUE_DESC
-'''The imperial stockpile capacity indicates an empire's ability to take in excess and to use stockpiled production points. An empire's total stockpiling capacity is the sum of all its planets' stockpile meters plus technology bonus. The total determines how many PP can be taken out of the stockpile each turn to be used for production.
+'''The stockpile meter of a planet represents how much it contributes to the imperial stockpile use limit. The imperial stockpile use limit indicates an empire's ability to use stockpiled Production Points (PP). An empire's stockpile use limit is the sum of all its planets' stockpile meters plus technology bonus. The total determines how many PP can be taken out of the stockpile each turn to be used for production.
 
 Species have various innate levels of stockpiling ability.'''
 
@@ -11053,10 +11053,10 @@ PLC_STOCKPILE_LIQUIDATION
 Stockpile Liquidation
 
 PLC_STOCKPILE_LIQUIDATION_DESC
-Doubles stockpiling on stockpile-focused planets.
+Doubles stockpile use capacity added by stockpile-focused planets.
 
 PLC_STOCKPILE_LIQUIDATION_SHORT_DESC
-Increases stockpiling
+Increases Stockpile Use Limit
 
 PLC_ALLIED_REPAIR
 Allied Repair
@@ -11479,7 +11479,7 @@ PRO_PREDICTIVE_STOCKPILING_DESC
 The imperial stockpile service has a fleet for distributing raw materials to places where important projects are predicted to be started.
 This task is difficult as the service has to predict when demand happens, where it happens, what materials and goods are demanded and also who the users will be.
 
-Unused PP will automatically be transferred to the Imperial Production Stockpile.
+Unused Production Points (PP) will automatically be transferred to the Imperial Production Stockpile.
 An item on the production queue draws automatically on the Imperial Stockpile if the item has not been explicitly disabled from doing so.
 
 This is the basic technology for the imperial stockpile, which increases the [[metertype METER_STOCKPILE]] of stockpile-focused planets by 1.'''
@@ -13149,7 +13149,7 @@ BLD_INTERSPECIES_ACADEMY
 Species InterDesign Academy
 
 BLD_INTERSPECIES_ACADEMY_DESC
-'''Increases stockpile extraction on its planet by 10, if that planet has stockpiling focus.
+'''Increases the imperial stockpile use limit by increasing the stockpile use capacity on a planet by 10, if that planet has stockpiling focus.
 Increases [[metertype METER_RESEARCH]] on its planet by 5, if that planet has research focus.
 
 Learning to design devices for use by different species is crucial for developing universally usable tools.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5916,7 +5916,7 @@ METER_SUPPLY_VALUE_DESC
 
 Supply lines are shown by coloring star-lanes with an empire's color. Planets connected by supply lines form a 'Resource Group' and can share physical resources. Production Points (PP) created on one planet can be used on any connected planet to build ships or structures.
 
-A set of core supply starlanes for an empire (the set of least-jump starlanes connecting the resource-producing systems of each Resource Group) will have greater thickness than the non-core starlanes. If PP are currently unalloted within a Resource Group, the outer bands of the core starlanes will be a contrasting color.
+A set of core supply starlanes for an empire (the set of least-jump starlanes connecting the resource-producing systems of each Resource Group) will have greater thickness than the non-core starlanes. If PP are currently unused within a Resource Group, the outer bands of the core starlanes will be a contrasting color.
 
 Supply lines can also be used to refill the [[metertype METER_FUEL]] supply of ships.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5683,9 +5683,7 @@ Species stockpiling ability, buildings, technologies, and setting the [[encyclop
 
 Information about imperial stockpile, the use, and the use limit can be seen in the top of the [[encyclopedia MAP_WINDOW_ARTICLE_TITLE]].
 Details for production can be seen in the [[encyclopedia PRODUCTION_WINDOW_ARTICLE_TITLE]].
-The effects which contribute to the planetary [[metertype METER_STOCKPILE]] can be found in the [[PLANET_PANEL]] in the system overview.
-'''
-
+The effects which contribute to the planetary [[metertype METER_STOCKPILE]] can be found in the [[PLANET_PANEL]] in the system overview.'''
 
 PLANET_MANAGEMENT_TITLE
 Planet Management

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -351,7 +351,7 @@ PROJECT_BT_STOCKPILE_SHORT_DESC
 Transfers PP into the imperial stockpile
 
 PROJECT_BT_STOCKPILE_DESC
-'''Production Points (PP) allocated to the transfer project are added to the imperial stockpile. The amount to transfer and how many times the transfer should repeat can be specified.
+'''Production Points (PP) allocated to the transfer project are added to the [[encyclopedia STOCKPILE_TITLE]]. The amount to transfer and how many times the transfer should repeat can be specified.
 
 Only PP that are produced in the same supply-group (and none from the imperial stockpile) are allocated to the stockpile transfer project.
 
@@ -5668,6 +5668,25 @@ Metabolism
 METABOLISM_TEXT
 The Metabolism of [[encyclopedia ENC_SPECIES]] in the galaxy fall into one of the types listed here.
 
+STOCKPILE_TITLE
+Imperial Stockpile
+
+STOCKPILE_TEXT
+'''Most industry is used immediately for producing buildings or ships. An empire can also store Production Points (PP) for later use in the imperial stockpile. Usually PP can only be used for production if the production site is in the supply network where the PP are generated. Contrary to this PP from the imperial stockpile can be used at any owned production site. Only a small amount of PP-no more than the imperial use limit-can be used for production each turn.
+
+There are two ways two store PP in the imperial stockpile:
+* Surplus PP (PP not allocated to anything on the queue) at any other location are automatically transferred to the stockpile. This may trigger a warning.
+* PP explicitly allocated to a [[encyclopedia PROJECT_BT_STOCKPILE]] are also transferred to the stockpile.
+
+The imperial stockpile use limit is the total of the [[metertype METER_STOCKPILE]] of each planet.
+Species stockpiling ability, buildings, technologies, and setting the [[encyclopedia STOCKPILE_FOCUS_TITLE]] increase it.
+
+Information about imperial stockpile, the use, and the use limit can be seen in the top of the [[encyclopedia MAP_WINDOW_ARTICLE_TITLE]].
+Details for production can be seen in the [[encyclopedia PRODUCTION_WINDOW_ARTICLE_TITLE]].
+The effects which contribute to the planetary [[metertype METER_STOCKPILE]] can be found in the [[PLANET_PANEL]] in the system overview.
+'''
+
+
 PLANET_MANAGEMENT_TITLE
 Planet Management
 
@@ -5926,7 +5945,7 @@ METER_STOCKPILE_VALUE_LABEL
 Stockpile
 
 METER_STOCKPILE_VALUE_DESC
-'''The stockpile meter of a planet represents how much it contributes to the imperial stockpile use limit. The imperial stockpile use limit indicates an empire's ability to use stockpiled Production Points (PP). An empire's stockpile use limit is the sum of all its planets' stockpile meters plus technology bonus. The total determines how many PP can be taken out of the stockpile each turn to be used for production.
+'''The stockpile meter of a planet represents how much it contributes to the [[encyclopedia STOCKPILE_TITLE]] use limit. The imperial stockpile use limit indicates an empire's ability to use stockpiled Production Points (PP). An empire's stockpile use limit is the sum of all its planets' stockpile meters plus technology bonus. The total determines how many PP can be taken out of the stockpile each turn to be used for production.
 
 Species have various innate levels of stockpiling ability.'''
 
@@ -6252,7 +6271,7 @@ MAP_WINDOW_ARTICLE_TEXT
 
 In the upper left corner is the Turn Button, which reads as "Turn n" (where n is the current turn); left clicking the Turn Button causes the game to advance to the next turn. Immediately to its right is the Auto Advance Toggle; when showing as a double arrow, the game will not auto-advance; if clicked to toggle to circular arcing arrows, the game will autoadvance to the next turn once all other empires have submitted their orders for the turn.
 
-Next are icons showing the player empire total [[metertype METER_INDUSTRY]], total [[metertype METER_RESEARCH]], number of existing ships, and Empire [[encyclopedia DETECTION_TITLE]].
+Next are icons showing the player empire total [[metertype METER_INDUSTRY]], [[metertype METER_STOCKPILE]], total [[metertype METER_RESEARCH]], number of existing ships, and Empire [[encyclopedia DETECTION_TITLE]].
 
 On the right hand side of the control bar are a number of icons for toggling display of other significant UI windows. Tooltips are available for these.'''
 
@@ -11053,7 +11072,7 @@ PLC_STOCKPILE_LIQUIDATION
 Stockpile Liquidation
 
 PLC_STOCKPILE_LIQUIDATION_DESC
-Doubles planetary stockpile use capacity of stockpile-focused planets which increases the imperial stockpile use limit.
+Doubles the contribution of stockpile-focused planets to the [[encyclopedia STOCKPILE_TITLE]] use limit.
 
 PLC_STOCKPILE_LIQUIDATION_SHORT_DESC
 Increases Stockpile Use Limit

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -11053,7 +11053,7 @@ PLC_STOCKPILE_LIQUIDATION
 Stockpile Liquidation
 
 PLC_STOCKPILE_LIQUIDATION_DESC
-Doubles stockpile use capacity added by stockpile-focused planets.
+Doubles planetary stockpile use capacity of stockpile-focused planets which increases the imperial stockpile use limit.
 
 PLC_STOCKPILE_LIQUIDATION_SHORT_DESC
 Increases Stockpile Use Limit


### PR DESCRIPTION
As new players regularly have problems understanding the imperial stockpile this makes the entries slightly more consistent and clear. 

* In detail entries, when production points are referenced first, write it as: "Production Points (PP)"
* Some consistency in casing of technical terms
* Some consistency in naming of extraction limit (e.g. never calling it extraction limit)
* a little bit more clarity for stockpiling focus
* a little bit more clarity for stockpile liquidation policy

Actually we should find a better term than stockpiling which expresses the following:
* planets have a local max-capacity, which may be increased by policy, buildings, species..
* this local capacity adds up to a global/imperial value which describes a limit
* there is also an imperial value which tracks a resource
** excess industry gets converted into it
** it can be used to build buildings and ships anywhere in your empire ("convert it back in PP")
** the imperial limit limits the amount which may be converted/used for that

The current difficulty arises that you increase a local capacity, which actually increases your
conversion limit somewhere else...

ideas: smuggling, hidden reserve, shipping, teleporting, transport, deep space, deep aid, courier...
...stash...

Should also be cherry-picked for 0.4.10 