### PR TITLE
Fix Experimentors sitrep about spotted monsters

### DIFF
--- a/default/scripting/buildings/EXPERIMENTOR_OUTPOST.focs.txt
+++ b/default/scripting/buildings/EXPERIMENTOR_OUTPOST.focs.txt
@@ -92,7 +92,7 @@ BuildingType
                         tag = "system" data = Source.SystemID
                         tag = "predefinedshipdesign" data = "SM_BLACK_KRAKEN"
                         tag = "species" data = "SP_EXPERIMENTOR"
-                        tag = "rawtext" data = "3"
+                        tag = "rawtext" data = "2"
                     ]
                 [[EXPERIMENTOR_ADD_STARLANE]]
             ]
@@ -137,7 +137,7 @@ BuildingType
                         tag = "system" data = Source.SystemID
                         tag = "predefinedshipdesign" data = "SM_BLOATED_JUGGERNAUT"
                         tag = "species" data = "SP_EXPERIMENTOR"
-                        tag = "rawtext" data = "3"
+                        tag = "rawtext" data = "2"
                     ]
                 [[EXPERIMENTOR_ADD_STARLANE]]
             ]
@@ -182,7 +182,7 @@ BuildingType
                         tag = "system" data = Source.SystemID
                         tag = "predefinedshipdesign" data = "SM_PSIONIC_SNOWFLAKE"
                         tag = "species" data = "SP_EXPERIMENTOR"
-                        tag = "rawtext" data = "3"
+                        tag = "rawtext" data = "2"
                     ]
                 [[EXPERIMENTOR_ADD_STARLANE]]
             ]


### PR DESCRIPTION
Fixes the number of reported monsters created by the Experimentors on each way (before it was 3 on the first phase of each monster, now it's always 2).

Cherrypick for release, it won't need playtesting or a RC2.

