### PR TITLE
Tech groups better error reporting

### DIFF
--- a/default/python/AI/TechsListsAI.py
+++ b/default/python/AI/TechsListsAI.py
@@ -82,12 +82,10 @@ class TechGroup:
                     # Do not display error message as those should be shown only once per game session
                     # by the initial test_tech_integrity() call.
                     msg = "[step %s]: Try to enqueue tech from empty list" % step
-                    warning(msg)
                     self._errors.append(msg)
                     continue
             if tech_name in self._tech_queue:
                 msg = "[step %s]: Tech is already in queue: %s" % (step, tech_name)
-                warning(msg)
                 self._errors.append(msg)
             else:
                 self._tech_queue.append(tech_name)

--- a/default/python/AI/TechsListsAI.py
+++ b/default/python/AI/TechsListsAI.py
@@ -72,22 +72,21 @@ class TechGroup:
         :type tech_lists: list[list | str]
         """
 
-        for this_list in tech_lists:
+        for step, this_list in enumerate(tech_lists, start=1):
             if isinstance(this_list, str):
                 tech_name = this_list
             else:
-
                 try:
                     tech_name = this_list.pop(0)
                 except IndexError:
                     # Do not display error message as those should be shown only once per game session
                     # by the initial test_tech_integrity() call.
-                    msg = "Try to enqueue tech from empty list"
+                    msg = "[step %s]: Try to enqueue tech from empty list" % step
                     warning(msg)
                     self._errors.append(msg)
                     continue
             if tech_name in self._tech_queue:
-                msg = "Tech is already in queue: %s" % tech_name
+                msg = "[step %s]: Tech is already in queue: %s" % (step, tech_name)
                 warning(msg)
                 self._errors.append(msg)
             else:

--- a/default/python/AI/TechsListsAI.py
+++ b/default/python/AI/TechsListsAI.py
@@ -686,7 +686,7 @@ def test_tech_integrity():
                 warning("In %s: Tech %s seems not to exist!" % (group.__name__, tech))
                 error_occured = True
         for err in this_group.get_errors():
-            warning(err, exc_info=True)
+            warning(err)
             error_occured = True
         if not error_occured:
             debug("Seems to be OK!")


### PR DESCRIPTION
Don't print error twice.
Add step info to error, this will help debugging.
Don't print exception info, when no exception handled. 

It is not a fix for https://github.com/freeorion/freeorion/issues/3111 but will make logs cleaner. 

