### PR TITLE
Fix deserialization errors of ShipDesigns

### DIFF
--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -111,6 +111,10 @@ ParsedShipDesign::ParsedShipDesign(
 ////////////////////////////////////////////////
 // ShipDesign
 ////////////////////////////////////////////////
+ShipDesign::ShipDesign() :
+    m_uuid(boost::uuids::nil_generator()())
+{}
+
 ShipDesign::ShipDesign(const boost::optional<std::invalid_argument>& should_throw,
                        std::string name, std::string description,
                        int designed_on_turn, int designed_by_empire,

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -44,6 +44,10 @@ struct FO_COMMON_API ParsedShipDesign {
 
 class FO_COMMON_API ShipDesign {
 public:
+    /** The ShipDesign() constructor constructs invalid designs and is only used by boost
+        serialization. */
+    ShipDesign();
+
     /** The public ShipDesign constructor will only construct valid ship
         designs, as long as the ShipHullManager has at least one hull.
 

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -435,10 +435,6 @@ BOOST_CLASS_VERSION(Ship, 2)
 
 
 template <typename Archive>
-void load_construct_data(Archive& ar, ShipDesign* obj, unsigned int const version)
-{ ::new(obj)ShipDesign(boost::none, "", "", INVALID_GAME_TURN, ALL_EMPIRES, "", {}, "", ""); }
-
-template <typename Archive>
 void serialize(Archive& ar, ShipDesign& obj, unsigned int const version)
 {
     using namespace boost::serialization;


### PR DESCRIPTION
Using the `load_construct_data` boost::serialization interace seems to
not run the regular deserialization function in a second pass, so that
deserialized ShipDesigns are created with empty default attributes
instead of loading the serialization data from the remote instance.

This partially reverts commit 1135b414219f0699obfb5ab5feee713d07594b8ea.

Fixes #3118 

@geoffthemedio FYI