### PR TITLE
cmake: Ignore Git errors when generating version

### DIFF
--- a/cmake/make_versioncpp.py
+++ b/cmake/make_versioncpp.py
@@ -6,7 +6,7 @@ import sys
 import os
 from string import Template
 from datetime import datetime
-from subprocess import check_output
+from subprocess import check_output, CalledProcessError
 from platform import system
 from glob import glob
 
@@ -136,7 +136,7 @@ try:
     commit = check_output(["git", "show", "--no-show-signature", "-s", "--format=%h", "--abbrev=7", "HEAD"], universal_newlines=True).strip()
     timestamp = float(check_output(["git", "show", "--no-show-signature", "-s", "--format=%ct", "HEAD"], universal_newlines=True).strip())
     build_no = ".".join([datetime.utcfromtimestamp(timestamp).strftime("%Y-%m-%d"), commit])
-except IOError:
+except (IOError, CalledProcessError):
     print("WARNING: git not installed or not setup correctly")
 
 for generator in generators:


### PR DESCRIPTION
Ignore Git errors that may happen when we are building from a release
tarball and not from a Git cloned repository.

Fixes: https://github.com/freeorion/freeorion/issues/3129