### PR TITLE
Fixes empire selection for loaded game

### DIFF
--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -474,18 +474,22 @@ namespace {
                 ErrorLogger() << "Empire changed to no empire.  Ignoring change.";
                 return;
             }
-            auto it = m_save_game_empire_data.begin();
-            std::advance(it, m_empire_list->IteratorToIndex(selected_it));
-            m_player_data.empire_name =           it->second.empire_name;
-            m_player_data.empire_color =          it->second.color;
-            m_player_data.save_game_empire_id =   it->second.empire_id;
-            m_color_selector->SelectColor(m_player_data.empire_color);
+            const std::string& empire_name = boost::polymorphic_downcast<GG::Label*>((*selected_it)->at(0))->Text();
+            for (const auto& it : m_save_game_empire_data) {
+                if (it.second.empire_name == empire_name) {
+                    m_player_data.empire_name = empire_name;
+                    m_player_data.empire_color = it.second.color;
+                    m_player_data.save_game_empire_id = it.second.empire_id;
+                    m_color_selector->SelectColor(m_player_data.empire_color);
 
-            // set previous player name indication
-            if (size() >= 5)
-                boost::polymorphic_downcast<GG::Label*>(at(4))->SetText(it->second.player_name);
+                    // set previous player name indication
+                    if (size() >= 5)
+                        boost::polymorphic_downcast<GG::Label*>(at(4))->SetText(it.second.player_name);
 
-            DataChangedSignal();
+                    DataChangedSignal();
+                    return;
+                }
+            }
         }
 
         std::shared_ptr<EmpireColorSelector>                     m_color_selector;


### PR DESCRIPTION
If some empires was eliminated position of empire in list couldn't be used to address empire in the saved empires list.

Fixes #3147 