### PR TITLE
Fix #3161

### DIFF
--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -646,7 +646,7 @@ private:
         {
             button = Wnd::Create<CUIButton>("-");
             button->LeftClickedSignal.connect(boost::bind(&ToggleData::Toggle, this));
-            parent_->AttachChild(std::move(button));
+            parent_->AttachChild(button);
             SetValue(GetValue());
         }
     };


### PR DESCRIPTION
Removes std:move() around button as per https://github.com/freeorion/freeorion/issues/3161#issuecomment-688836237

Fixes #3161 

Works on Ubuntu 18.04.