### PR TITLE
Make Bad..Ultimate Def. Troops start at minimum 6 troops

### DIFF
--- a/default/scripting/common/named_values.focs.txt
+++ b/default/scripting/common/named_values.focs.txt
@@ -1,3 +1,12 @@
+// Proposed naming convention: <EFFECT_NAME> _ <METER_NAME> _ FLAT/PERPOP/<others>
+// Examples:
+// - PLC_CONFEDERATION_TARGET_HAPPINESS_FLAT (flat bonus/malus to TargetHappiness from policy PLC_CONFEDERATION)
+// - GARRISON_2_TROOPREGEN_FLAT (flat bonus/malus to troop regen from tech Garrison_2
+// - GRO_CYBORGS_MAX_TROOPS_PERPOP (bonus/malus per population to MaxTroops from tech GRO_CYBORGS)
+
+
+NamedReal name = "IMPERIAL_GARRISON_MAX_TROOPS_FLAT" value = 6
+
 NamedReal name = "SHP_REINFORCED_HULL_BONUS" value = (5 * [[SHIP_STRUCTURE_FACTOR]]) 
 
 NamedInteger name = "NUM_COMBAT_ROUNDS" value = (GameRule name = "RULE_NUM_COMBAT_ROUNDS")

--- a/default/scripting/policies/CONFEDERATION.focs.txt
+++ b/default/scripting/policies/CONFEDERATION.focs.txt
@@ -7,7 +7,7 @@ Policy
     exclusions = [ "PLC_CENTRALIZATION" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
-    
+
         // compensates for species influence effect that reduces influence when not supply connected to capital
         EffectsGroup
             scope = And [
@@ -17,21 +17,21 @@ Policy
                 Not ResourceSupplyConnected empire = LocalCandidate.Owner condition = Source
             ]
             priority = [[DEFAULT_PRIORITY]]
-            effects = 
-                SetTargetInfluence value = value + 1
+            effects = SetTargetInfluence value = value +
+                          (NamedReal name = "PLC_CONFEDERATION_TARGET_INFLUENCE_FLAT" value = 1)
 
         // makes all planets less stable
         EffectsGroup
-        scope = And [
-            Planet
-            OwnedBy empire = Source.Owner
-            Population low = 0.001
-        ]
-        priority = [[DEFAULT_PRIORITY]]
-        effects = [
-            SetTargetHappiness value = Value - 1
-            SetMaxTroops value = Value + 5
-        ]
+            scope = And [
+                Planet
+                OwnedBy empire = Source.Owner
+                Population low = 0.001
+            ]
+            priority = [[VERY_EARLY_PRIORITY]]
+            effects = [
+                SetTargetHappiness value = Value + (NamedReal name = "PLC_CONFEDERATION_TARGET_HAPPINESS_FLAT" value = (-1))
+                SetMaxTroops value = Value + (NamedReal name = "PLC_CONFEDERATION_MAX_TROOPS_FLAT" value = 5)
+            ]
     ]
     graphic = "icons/policies/confederation.png"
 

--- a/default/scripting/species/common/troops.macros
+++ b/default/scripting/species/common/troops.macros
@@ -27,6 +27,17 @@ BASIC_DEFENSE_TROOPS
             scope = Source
             activation = And [
                 Planet
+                Not Unowned
+            ]
+            priority = [[VERY_EARLY_PRIORITY]]
+            effects = SetMaxTroops value = Value
+                        + (NamedRealLookup name = "IMPERIAL_GARRISON_MAX_TROOPS_FLAT")
+            accountinglabel = "IMPERIAL_GARRISON_LABEL"
+
+        EffectsGroup
+            scope = Source
+            activation = And [
+                Planet
                 Unowned
             ]
             stackinggroup = "BASIC_TROOPS_STACK"
@@ -39,7 +50,9 @@ BASIC_DEFENSE_TROOPS
             activation = Planet
             stackinggroup = "POPULATION_TROOPS_STACK"
             priority = [[VERY_EARLY_PRIORITY]]
-            effects = SetMaxTroops Value = Value + Target.Population * [[TROOPS_PER_POP]]
+            effects = SetMaxTroops Value = Value
+                        + (NamedReal name = "BASIC_DEFENSE_TROOPS_MAX_TROOPS_PERPOP"
+                                     value = (Target.Population * [[TROOPS_PER_POP]]))
             accountinglabel = "DEF_ROOT_DEFENSE"
             
         EffectsGroup      // gives human bonuses when AI Aggression set to Beginner
@@ -53,15 +66,16 @@ BASIC_DEFENSE_TROOPS
             priority = [[DEFAULT_PRIORITY]]
             effects = SetMaxTroops value = max(6, Value * 2)
 
-        EffectsGroup // increase 1 per turn, up to max
+        EffectsGroup // base troops regeneration
             scope = Source
             activation = And [
                 Planet
                 (LocalCandidate.LastTurnConquered < CurrentTurn)
-                (LocalCandidate.LastTurnAttackedByShip  < CurrentTurn)
+                (LocalCandidate.LastTurnAttackedByShip < CurrentTurn)
             ]
             priority = [[AFTER_ALL_TARGET_MAX_METERS_PRIORITY]]
-            effects = SetTroops value = min(Value(Target.MaxTroops), Value + 1)
+            effects = SetTroops value = min(Value(Target.MaxTroops),
+                                            Value + (NamedReal name = "BASIC_DEFENSE_TROOPS_TROOPREGEN_FLAT" value = 1))
 '''
 
 AFTER_SPECIES_MULTIPLICATOR_TROOPS

--- a/default/scripting/techs/construction/OUTPOST.focs.txt
+++ b/default/scripting/techs/construction/OUTPOST.focs.txt
@@ -22,12 +22,10 @@ Tech
             accountinglabel = "OUTPOST_TROOP_LABEL"
 
         // Ensure construction minimum value of one, as this is necessary for being attacked
-        // For colonies see STANDARD_CONSTRUCTION in default/scripting/species/common/general.macros
         EffectsGroup
             scope = And [
                 Planet
                 OwnedBy empire = Source.Owner
-                Population high = 0
             ]
             // has to happen after e.g. FORCE_ENERGY_STRC effects which also happens at AFTER_ALL_TARGET_MAX_METERS_PRIORITY
             priority = [[METER_OVERRIDE_PRIORITY]]

--- a/default/scripting/techs/defense/Defense.focs.txt
+++ b/default/scripting/techs/defense/Defense.focs.txt
@@ -13,14 +13,14 @@ Tech
                 OwnedBy empire = Source.Owner
             ]
             stackinggroup = "PLANET_SHIELDS_STACK_ROOT"
-            priority = [[DEFAULT_PRIORITY]]
             effects = SetMaxShield value = Value + 1 accountinglabel = "DEF_ROOT_DEFENSE"
-        
-        EffectsGroup    // regenerate 1 per turn
+
+        EffectsGroup    // base regeneration of troops, defense and shields if not attacked
             scope = And [
                 Planet
                 OwnedBy empire = Source.Owner
-                (LocalCandidate.LastTurnAttackedByShip   < CurrentTurn)
+                (LocalCandidate.LastTurnAttackedByShip < CurrentTurn)
+                (LocalCandidate.LastTurnConquered < CurrentTurn)
             ]
             priority = [[AFTER_ALL_TARGET_MAX_METERS_PRIORITY]]
             effects = [
@@ -28,6 +28,16 @@ Tech
                 SetDefense value = min(Value + [[PLANET_DEFENSE_FACTOR]], Value(Target.MaxDefense))
                 SetTroops value = min(Value + 1, Value(Target.MaxTroops))
             ]
+
+        EffectsGroup    // set minimum troops for just-colonized planets
+            scope = And [
+                Planet
+                OwnedBy empire = Source.Owner
+                (LocalCandidate.LastTurnColonized = CurrentTurn)
+            ]
+            priority = [[AFTER_ALL_TARGET_MAX_METERS_PRIORITY]]
+            effects = SetTroops value = min((NamedRealLookup name = "IMPERIAL_GARRISON_MAX_TROOPS_FLAT"),
+                                            Value(Target.MaxTroops))
     ]
     graphic = ""
 

--- a/default/scripting/techs/defense/Garrison.focs.txt
+++ b/default/scripting/techs/defense/Garrison.focs.txt
@@ -15,7 +15,8 @@ Tech
             ]
             stackinggroup = "GARRISON_1_TROOPS_STACK"
             priority = [[LATE_PRIORITY]]
-            effects = SetMaxTroops value = Value + 10 accountinglabel = "DEF_GARRISON_1"
+            effects = SetMaxTroops value = Value + (NamedReal name = "GARRISON_1_MAX_TROOPS_FLAT" value = 6)
+                accountinglabel = "DEF_GARRISON_1"
     ]
     graphic = "icons/tech/troops.png"
 
@@ -34,9 +35,12 @@ Tech
             scope = And [
                 Planet
                 OwnedBy empire = Source.Owner
-                (LocalCandidate.LastTurnAttackedByShip   < CurrentTurn)
+                (LocalCandidate.LastTurnConquered < CurrentTurn)
+                (LocalCandidate.LastTurnAttackedByShip < CurrentTurn)
             ]
-            effects = SetTroops value = Value + 1
+            priority = [[AFTER_ALL_TARGET_MAX_METERS_PRIORITY]]
+            effects = SetTroops value = min(Value(Target.MaxTroops),
+                                            Value + (NamedReal name = "GARRISON_2_TROOPREGEN_FLAT" value = 1))
 
         EffectsGroup
             scope = And [
@@ -46,7 +50,9 @@ Tech
             ]
             stackinggroup = "GARRISON_2_TROOPS_STACK"
             priority = [[EARLY_PRIORITY]]
-            effects = SetMaxTroops value = Value + Target.Population * 2 * [[TROOPS_PER_POP]] accountinglabel = "DEF_GARRISON_2"
+            effects = SetMaxTroops value = Value + Target.Population *
+                (NamedReal name = "GARRISON_2_MAXTROOPS_FLAT" value = (2 * [[TROOPS_PER_POP]]))
+                accountinglabel = "DEF_GARRISON_2"
     ]
     graphic = "icons/tech/troops.png"
 
@@ -64,9 +70,12 @@ Tech
             scope = And [
                 Planet
                 OwnedBy empire = Source.Owner
-                (LocalCandidate.LastTurnAttackedByShip   < CurrentTurn)
+                (LocalCandidate.LastTurnConquered < CurrentTurn)
+                (LocalCandidate.LastTurnAttackedByShip < CurrentTurn)
             ]
-            effects = SetTroops value = Value + 2
+            priority = [[AFTER_ALL_TARGET_MAX_METERS_PRIORITY]]
+            effects = SetTroops value = min(Value(Target.MaxTroops),
+                                            Value + (NamedReal name = "GARRISON_3_TROOPREGEN_FLAT" value = 2))
 
         EffectsGroup
             scope = And [
@@ -75,7 +84,8 @@ Tech
             ]
             stackinggroup = "GARRISON_3_TROOPS_STACK"
             priority = [[LATE_PRIORITY]]
-            effects = SetMaxTroops value = Value + 16 accountinglabel = "DEF_GARRISON_3"
+            effects = SetMaxTroops value = Value + (NamedReal name = "GARRISON_3_MAX_TROOPS_FLAT" value = 18)
+                accountinglabel = "DEF_GARRISON_3"
     ]
     graphic = "icons/tech/troops.png"
 
@@ -93,9 +103,12 @@ Tech
             scope = And [
                 Planet
                 OwnedBy empire = Source.Owner
-                (LocalCandidate.LastTurnAttackedByShip   < CurrentTurn)
+                (LocalCandidate.LastTurnConquered < CurrentTurn)
+                (LocalCandidate.LastTurnAttackedByShip < CurrentTurn)
             ]
-            effects = SetTroops value = Value + 3
+            priority = [[AFTER_ALL_TARGET_MAX_METERS_PRIORITY]]
+            effects = SetTroops value = min(Value(Target.MaxTroops),
+                                            Value + (NamedReal name = "GARRISON_4_TROOPREGEN_FLAT" value = 3))
 
         EffectsGroup
             scope = And [
@@ -105,12 +118,11 @@ Tech
             ]
             stackinggroup = "GARRISON_4_TROOPS_STACK"
             priority = [[EARLY_PRIORITY]]
-            effects = SetMaxTroops value = Value + Target.Population * 2 * [[TROOPS_PER_POP]] accountinglabel = "DEF_GARRISON_4"
+            effects = SetMaxTroops value = Value + Target.Population *
+                (NamedReal name = "GARRISON_4_MAX_TROOPS_FLAT" value = (3 * [[TROOPS_PER_POP]]))
+                accountinglabel = "DEF_GARRISON_4"
     ]
     graphic = "icons/tech/troops.png"
 
-#include "../techs.macros"
-
 #include "/scripting/common/base_prod.macros"
-
 #include "/scripting/common/priorities.macros"

--- a/default/scripting/techs/growth/CYBORG.focs.txt
+++ b/default/scripting/techs/growth/CYBORG.focs.txt
@@ -15,7 +15,8 @@ Tech
                 Planet environment = [ Hostile ]
             ]
             priority = [[TARGET_POPULATION_BEFORE_SCALING_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 2 * Target.HabitableSize  accountinglabel = "GRO_CYBORG"
+            effects = SetTargetPopulation value = Value + 2 * Target.HabitableSize
+                accountinglabel = "GRO_CYBORG"
 
         EffectsGroup
             scope = And [
@@ -24,10 +25,11 @@ Tech
             ]
             stackinggroup = "CYBORG_TROOPS_STACK"
             priority = [[VERY_EARLY_PRIORITY]]
-            effects = SetMaxTroops value = Value + Target.Population * [[TROOPS_PER_POP]] accountinglabel = "GRO_CYBORG"
+            effects = SetMaxTroops value = Value + Target.Population *
+                (NamedReal name = "CYBORG_MAX_TROOPS_PERPOP" value = (1.5 * [[TROOPS_PER_POP]]))
+                accountinglabel = "GRO_CYBORG" 
     ]
     graphic = "icons/tech/cyborgs.png"
 
 #include "/scripting/common/base_prod.macros"
-
 #include "/scripting/common/priorities.macros"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1121,6 +1121,9 @@ Ships cost 1 PP and take 1 turn to produce.
 NUM_COMBAT_ROUNDS
 per combat
 
+NUM_COMBAT_ROUNDS_FIGHTERS
+per combat
+
 RULE_NUM_COMBAT_ROUNDS
 Combat Rounds
 
@@ -7538,6 +7541,12 @@ The %empire% ship %ship% has been psychically controlled!
 EFFECT_PSY_DOM_LABEL
 Psychogenic Domination
 
+IMPERIAL_GARRISON_ACTIVATED
+Imperial garrison: %empire% colonized %planet% at %system%.
+
+IMPERIAL_GARRISON_ACTIVATED_LABEL
+New colony
+
 EFFECT_MINES
 At %system%: Mines caused %rawtext% damage to the %empire% fleet %fleet%.
 
@@ -11360,7 +11369,10 @@ PLC_CONFEDERATION
 Confederation
 
 PLC_CONFEDERATION_DESC
-Planets are organized in a confederacy of independent system, and do not suffer reduce influence if not connected to the capital, but are slightly less stable in general. Ground troops are also boosted slightly.
+'''Planets are organized in a confederacy of independent system, and do not suffer reduce influence if not connected to the capital, but are slightly less stable in general.
+
+Increases max [[metertype METER_TROOPS]] by [[value PLC_CONFEDERATION_MAX_TROOPS_FLAT]] but reduces [[metertype METER_TARGET_HAPPINESS]] ([[value PLC_CONFEDERATION_TARGET_HAPPINESS_FLAT]]) in all planets.
+Increases [[metertype METER_TARGET_INFLUENCE]] on colonies disconnected from the capital by [[value PLC_CONFEDERATION_TARGET_INFLUENCE_FLAT]].'''
 
 PLC_CONFEDERATION_SHORT_DESC
 Supports disconnected systems
@@ -12401,9 +12413,12 @@ Cyborgs
 
 GRO_CYBORG_DESC
 '''Increases the [[metertype METER_TARGET_POPULATION]] on [[PE_HOSTILE]] planets by planet size: ([[SZ_TINY]] +2) ([[SZ_SMALL]] +4) ([[SZ_MEDIUM]] +6) ([[SZ_LARGE]] +8) ([[SZ_HUGE]] +10).
-Increases max [[metertype METER_TROOPS]] on all planets by 0.2 per [[metertype METER_POPULATION]].
+Increases max [[metertype METER_TROOPS]] on all planets by [[value CYBORG_MAX_TROOPS_PERPOP]] per [[metertype METER_POPULATION]].
 
 A highly versatile fusion of organism and machine, capable of adapting to a tremendous variety of circumstances. Spontaneous generation of specialized organs and mechanically enhanced strength permit cyborgs to exist with ease in nearly any environment.'''
+
+CYBORG_MAX_TROOPS_PERPOP
+per population
 
 GRO_GAIA_TRANS
 Gaia Transformation
@@ -12610,33 +12625,42 @@ DEF_ROOT_DEFENSE
 Self Defense
 
 DEF_ROOT_DEFENSE_DESC
-'''Increases max [[metertype METER_SHIELD]] by 1 on each owned planet. Regenerates 1 [[metertype METER_SHIELD]] per turn, on turns when the planet has not been attacked in combat. For species with basic defensive troops, increases max [[metertype METER_TROOPS]] on the planet by 0.2 per [[metertype METER_POPULATION]].
+'''Increases max [[metertype METER_SHIELD]] by 1 on each owned planet. Regenerates 1 [[metertype METER_SHIELD]] per turn, on turns when the planet has not been attacked in combat. For species with basic defensive troops, increases max [[metertype METER_TROOPS]] on the planet by [[value BASIC_DEFENSE_TROOPS_MAX_TROOPS_PERPOP]] per [[metertype METER_POPULATION]].
 
 The concept of 'self defense' is at the root of many avenues of technological advance.'''
+
+BASIC_DEFENSE_TROOPS_MAX_TROOPS_PERPOP
+per population
 
 DEF_GARRISON_1
 Planetary Bunker Complex
 
 DEF_GARRISON_1_DESC
-Increases max [[metertype METER_TROOPS]] on all planets by 10, unmodified by species traits.
+Increases max [[metertype METER_TROOPS]] on all planets by [[value GARRISON_1_MAX_TROOPS_FLAT]], unmodified by species traits.
 
 DEF_GARRISON_2
 Defensive Militia Training
 
 DEF_GARRISON_2_DESC
-Increases max [[metertype METER_TROOPS]] on all planets by 0.4 per [[metertype METER_POPULATION]] (modified by species defensive trait), and causes troops to regenerate by an additional 1 per turn.
+Increases max [[metertype METER_TROOPS]] on all planets by [[value GARRISON_2_MAX_TROOPS_PERPOP]] per [[metertype METER_POPULATION]] (modified by species defensive trait), and causes troops to regenerate by an additional [[value GARRISON_2_TROOPREGEN_FLAT]] per turn.
+
+GARRISON_2_MAX_TROOPS_PERPOP
+per population
 
 DEF_GARRISON_3
 Planetary Fortification Network
 
 DEF_GARRISON_3_DESC
-Increases max [[metertype METER_TROOPS]] on all planets by 16 (unmodified by species traits) and causes troops to regenerate by an additional 2 per turn in addition to that from [[DEF_GARRISON_2]].
+Increases max [[metertype METER_TROOPS]] on all planets by [[value GARRISON_3_MAX_TROOPS_FLAT]] (unmodified by species traits) and causes troops to regenerate by an additional [[value GARRISON_3_TROOPREGEN_FLAT]] per turn in addition to that from [[DEF_GARRISON_2]].
 
 DEF_GARRISON_4
 Planetary Guard Brigades
 
 DEF_GARRISON_4_DESC
-Increases max [[metertype METER_TROOPS]] on all planets by 0.4 per [[metertype METER_POPULATION]] (modified by species defensive trait), and causes troops to regenerate by an additional 3 per turn in addition to that from [[DEF_GARRISON_3]] and [[DEF_GARRISON_2]].
+Increases max [[metertype METER_TROOPS]] on all planets by [[value GARRISON_4_MAX_TROOPS_PERPOP]] per [[metertype METER_POPULATION]] (modified by species defensive trait), and causes troops to regenerate by an additional [[value GARRISON_4_TROOPREGEN_FLAT]] per turn in addition to that from [[DEF_GARRISON_3]] and [[DEF_GARRISON_2]].
+
+GARRISON_4_MAX_TROOPS_PERPOP
+per population
 
 DEF_PLANET_CLOAK
 Planetary Cloaking Device
@@ -12657,10 +12681,6 @@ SHP_REINFORCED_HULL_DESC
 '''Increases max [[metertype METER_STRUCTURE]] of all ships by [[value SHP_REINFORCED_HULL_BONUS]].
 
 Standard ship hulls are designed and constructed with advanced microgravity architectural techniques and highly resistant materials. However, the limitations of physical matter impose a severe limitation on the strength of hulls. By enhancing the hull with structural integrity fields, a sizable increase in strength can be obtained.'''
-
-# value ref description
-SHP_REINFORCED_HULL_BONUS
-''''''
 
 SHP_BASIC_DAM_CONT
 Basic Damage Control
@@ -16097,6 +16117,12 @@ ULTIMATE_TROOPS_LABEL
 
 INDEPENDENT_TROOP_LABEL
 Independent Homeworld
+
+IMPERIAL_GARRISON_LABEL
+Imperial Garrison
+
+IMPERIAL_GARRISON_MAX_TROOPS_FLAT
+''''''
 
 MEGALITH_LABEL
 Megalith


### PR DESCRIPTION
- Fix priorities of garrison techs troop regeneration
- Rebalance troop bonuses from Garrison and Cyborg techs

Alleviates probable exploit of coordinated species exchange via fake conquest when species gifting is forbidden.
Nerfs Garrison 1 flat troops bonus to compensate for the extra starting troops.
Boosts a bit end-game def. troop techs (Garrison 4 and Cyborgs).

Forum thread: https://www.freeorion.org/forum/viewtopic.php?p=103436#p103436

Depends on #3206.
