### PR TITLE
Bump minimum Boost version from 1.58 to 1.60

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,7 @@ include(TestForBug2795)
 ##
 
 set(MINIMUM_PYTHON_VERSION 3.5)
-set(MINIMUM_BOOST_VERSION 1.58.0)
+set(MINIMUM_BOOST_VERSION 1.60.0)
 
 find_package(Threads)
 find_package(PythonInterp ${MINIMUM_PYTHON_VERSION} REQUIRED)

--- a/GG/CMakeLists.txt
+++ b/GG/CMakeLists.txt
@@ -58,7 +58,7 @@ endif()
 ## Collect project dependencies.
 ##
 
-set(MINIMUM_BOOST_VERSION 1.58.0)
+set(MINIMUM_BOOST_VERSION 1.60.0)
 
 find_package(Boost ${MINIMUM_BOOST_VERSION} COMPONENTS filesystem regex system REQUIRED)
 


### PR DESCRIPTION
As noted in https://github.com/freeorion/freeorion/issues/3172 there are various uses of the `boost::placeholders` namespace, which wasn't added until Boost 1.60:

https://www.boost.org/doc/libs/1_60_0/boost/bind/placeholders.hpp
https://www.boost.org/doc/libs/1_59_0/boost/bind/placeholders.hpp

It could be probably be worked around to support the older version, but at present it seems the newer version is required.