### PR TITLE
Colo threshold sitrep takes growth rate from macro

### DIFF
--- a/default/scripting/techs/ship_hulls/SHP_GAL_EXPLO.focs.txt
+++ b/default/scripting/techs/ship_hulls/SHP_GAL_EXPLO.focs.txt
@@ -68,7 +68,7 @@ Tech
                 
                 (LocalCandidate.Population              <  LocalCandidate.TargetPopulation)
                 (LocalCandidate.Population +
-                    LocalCandidate.Population*0.01*(LocalCandidate.TargetPopulation + 1 - LocalCandidate.Population)
+                    LocalCandidate.Population*[[GROWTH_RATE_FACTOR]]*(LocalCandidate.TargetPopulation + 1 - LocalCandidate.Population)
                     >= [[MIN_RECOLONIZING_SIZE]])
                     
                 (LocalCandidate.TargetHappiness         >= [[MIN_RECOLONIZING_HAPPINESS]]           )
@@ -105,3 +105,5 @@ Tech
 #include "/scripting/common/misc.macros"
 #include "/scripting/common/priorities.macros"
 #include "/scripting/common/base_prod.macros"
+#include "/scripting/species/common/population.macros"
+


### PR DESCRIPTION
When PLC_NO_GROWTH and PLC_POPULATION effects were added to species/common/population.macros, the base rate factor was changed from 0.01 to 0.005. This wasn't updated in techs/ship_hulls/SHP_GAL_EXPLO.focs.txt, which continued to use the old 0.01 value. This causes premature SitReps about colonizing threshold.

This PR fixed that.