### PR TITLE
Use expr instead of primary_expr when parsing NamedReal in the middle…

### DIFF
--- a/parse/DoubleValueRefParser.cpp
+++ b/parse/DoubleValueRefParser.cpp
@@ -123,7 +123,7 @@ parse::double_parser_rules::double_parser_rules(
     named_real_valueref
         = (     tok.Named_ >> tok.Real_
             >>  label(tok.Name_) > tok.string
-             >  label(tok.Value_) > primary_expr
+             >  label(tok.Value_) > expr
           ) [
              // Register the value ref under the given name by lazy invoking RegisterValueRef
              parse::detail::open_and_register_as_string_(_2, _3, _pass),


### PR DESCRIPTION
… of another valueref - seems to fix precedence

Not sure what exactly is the difference, but it seems to fix the precedence and not to break anything.

Intended to fix issue #3188 
  NamedReal/NamedInteger value declaration precedence is odd

Issue:

When writing this:
(NamedReal name = "GARRISON_2_MAXTROOPS_EFFECT" value = 2 * [[TROOPS_PER_POP]])

This is intended:
(NamedReal name = "GARRISON_2_MAXTROOPS_EFFECT" value = (2 * [[TROOPS_PER_POP]]))

But this is what we get:
((NamedReal name = "GARRISON_2_MAXTROOPS_EFFECT" value = 2) * [[TROOPS_PER_POP]])

Analysis was:

It seems precedence is working for integer, but not for floats:

(NamedReal name = "TWO_BY_THREE" value = 2 * 3) registers 2.0

(NamedReal name = "TWO_BY_THREE" value = 2.0 * 3.0) registers 2.0

(NamedInteger name = "TWO_BY_THREE" value = 2 * 3) registers 6

Also it seems this precedence is working for top level named value refs, so the only thing known to be broken is name-in-the-middle Real value refs.