### PR TITLE
Use std::array instead of GG::Clr in common and server code

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -68,7 +68,7 @@ Empire::Empire() :
 { Init(); }
 
 Empire::Empire(std::string name, std::string player_name,
-               int empire_id, const GG::Clr& color, bool authenticated) :
+               int empire_id, const EmpireColor& color, bool authenticated) :
     m_id(empire_id),
     m_name(std::move(name)),
     m_player_name(std::move(player_name)),
@@ -113,7 +113,7 @@ bool Empire::IsAuthenticated() const
 int Empire::EmpireID() const
 { return m_id; }
 
-const GG::Clr& Empire::Color() const
+const EmpireColor& Empire::Color() const
 { return m_color; }
 
 int Empire::CapitalID() const
@@ -2544,7 +2544,7 @@ void Empire::CheckInfluenceProgress() {
     m_resource_pools[ResourceType::RE_INFLUENCE]->SetStockpile(new_stockpile);
 }
 
-void Empire::SetColor(const GG::Clr& color)
+void Empire::SetColor(const EmpireColor& color)
 { m_color = color; }
 
 void Empire::SetName(const std::string& name)

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -3,7 +3,6 @@
 
 
 #include <string>
-#include <GG/Clr.h>
 #include <GG/Enum.h>
 #include "InfluenceQueue.h"
 #include "PopulationPool.h"
@@ -26,6 +25,9 @@ FO_COMMON_API extern const int INVALID_DESIGN_ID;
 FO_COMMON_API extern const int INVALID_GAME_TURN;
 FO_COMMON_API extern const int INVALID_OBJECT_ID;
 FO_COMMON_API extern const int ALL_EMPIRES;
+
+
+typedef std::array<unsigned char, 4> EmpireColor;
 
 
 //! Research status of techs, relating to whether they have been or can be
@@ -60,14 +62,14 @@ public:
     //@}
 
     Empire(std::string name, std::string player_name, int ID,
-           const GG::Clr& color, bool authenticated);
+           const EmpireColor& color, bool authenticated);
     ~Empire();
 
     const std::string&  Name() const;            ///< Returns the Empire's name
     const std::string&  PlayerName() const;      ///< Returns the Empire's player's name
     bool                IsAuthenticated() const; ///< Returns the Empire's player's authentication status
     int                 EmpireID() const;        ///< Returns the Empire's unique numeric ID
-    const GG::Clr&      Color() const;           ///< Returns the Empire's color
+    const EmpireColor&  Color() const;           ///< Returns the Empire's color
     int                 CapitalID() const;       ///< Returns the numeric ID of the empire's capital
 
     /** Returns an object id that is owned by the empire or INVALID_OBJECT_ID. */
@@ -344,7 +346,7 @@ public:
       * stockpile to account for influence production and expenditures.*/
     void CheckInfluenceProgress();
 
-    void SetColor(const GG::Clr& color);                 ///< Mutator for empire color
+    void SetColor(const EmpireColor& color);                 ///< Mutator for empire color
     void SetName(const std::string& name);               ///< Mutator for empire name
     void SetPlayerName(const std::string& player_name);  ///< Mutator for empire's player name
 
@@ -483,7 +485,7 @@ private:
         should play this empire. */
     bool        m_authenticated = false;
 
-    GG::Clr     m_color;
+    EmpireColor m_color;
     int         m_capital_id = INVALID_OBJECT_ID;  ///< the ID of the empire's capital planet
 
     struct PolicyAdoptionInfo {

--- a/Empire/EmpireManager.h
+++ b/Empire/EmpireManager.h
@@ -5,8 +5,6 @@
 #include "../universe/EnumsFwd.h"
 #include "../util/Export.h"
 
-#include <GG/Clr.h>
-
 #include <boost/filesystem.hpp>
 #include <boost/signals2/signal.hpp>
 
@@ -66,7 +64,7 @@ public:
       * caller's responsibility to make sure that universe updates planet
       * ownership. */
     void        CreateEmpire(int empire_id, std::string name, std::string player_name,
-                             const GG::Clr& color, bool authenticated);
+                             const std::array<unsigned char, 4>& color, bool authenticated);
 
     /** Removes and deletes all empires from the manager. */
     void        Clear();
@@ -97,7 +95,7 @@ private:
 };
 
 /** The colors that are available for use for empires in the game. */
-FO_COMMON_API const std::vector<GG::Clr>& EmpireColors();
+FO_COMMON_API const std::vector<std::array<unsigned char, 4>>& EmpireColors();
 
 /** Initialize empire colors from \p path */
 FO_COMMON_API void InitEmpireColors(const boost::filesystem::path& path);

--- a/GG/GG/Clr.h
+++ b/GG/GG/Clr.h
@@ -15,6 +15,7 @@
 #define _GG_Clr_h_
 
 
+#include <array>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -43,6 +44,14 @@ struct Clr
                   unsigned char b_,
                   unsigned char a_) :
         r(r_), g(g_), b(b_), a(a_)
+        {}
+
+    /** ctor that constructs a Clr from std::array that represents the color channels */
+    constexpr Clr(const std::array<unsigned char, 4>& clr) :
+        r(std::get<0>(clr)),
+        g(std::get<1>(clr)),
+        b(std::get<2>(clr)),
+        a(std::get<3>(clr))
         {}
 
     unsigned char r;   ///< the red channel

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -353,7 +353,7 @@ namespace {
             DataChangedSignal();
         }
         void ColorChanged(const GG::Clr& clr) {
-            m_player_data.empire_color = clr;
+            m_player_data.empire_color = {clr.r, clr.g, clr.b, clr.a};
             DataChangedSignal();
         }
         void SpeciesChanged(const std::string& str) {
@@ -1029,7 +1029,7 @@ bool MultiPlayerLobbyWnd::PopulatePlayerList() {
                 boost::bind(&MultiPlayerLobbyWnd::PlayerDataChangedLocally, this));
 
         } else {
-            bool immutable_row = 
+            bool immutable_row =
                 (!HasAuthRole(Networking::RoleType::ROLE_HOST) &&
                     (data_player_id != HumanClientApp::GetApp()->PlayerID()) &&
                     !(psd.client_type == Networking::ClientType::CLIENT_TYPE_AI_PLAYER &&
@@ -1159,10 +1159,10 @@ bool MultiPlayerLobbyWnd::PlayerDataAcceptable() const {
             empire_names.insert(prow.m_player_data.empire_name);
 
             unsigned int color_as_uint =
-                prow.m_player_data.empire_color.r << 24 |
-                prow.m_player_data.empire_color.g << 16 |
-                prow.m_player_data.empire_color.b << 8 |
-                prow.m_player_data.empire_color.a;
+                std::get<0>(prow.m_player_data.empire_color) << 24 |
+                std::get<1>(prow.m_player_data.empire_color) << 16 |
+                std::get<2>(prow.m_player_data.empire_color) << 8 |
+                std::get<3>(prow.m_player_data.empire_color);
             empire_colors.insert(color_as_uint);
         } else if (prow.m_player_data.client_type == Networking::ClientType::CLIENT_TYPE_HUMAN_OBSERVER ||
                    prow.m_player_data.client_type == Networking::ClientType::CLIENT_TYPE_HUMAN_MODERATOR)

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -569,10 +569,10 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
 
     // DB stores index into array of available colours, so need to get that array to look up value of index.
     // if stored value is invalid, use a default colour
-    const std::vector<GG::Clr>& empire_colours = EmpireColors();
+    const std::vector<EmpireColor>& empire_colours = EmpireColors();
     int colour_index = GetOptionsDB().Get<int>("setup.empire.color.index");
     if (colour_index >= 0 && colour_index < static_cast<int>(empire_colours.size()))
-        human_player_setup_data.empire_color = empire_colours[colour_index];
+        human_player_setup_data.empire_color = GG::Clr(empire_colours[colour_index]);
     else
         human_player_setup_data.empire_color = GG::CLR_GREEN;
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -572,9 +572,9 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
     const std::vector<EmpireColor>& empire_colours = EmpireColors();
     int colour_index = GetOptionsDB().Get<int>("setup.empire.color.index");
     if (colour_index >= 0 && colour_index < static_cast<int>(empire_colours.size()))
-        human_player_setup_data.empire_color = GG::Clr(empire_colours[colour_index]);
+        human_player_setup_data.empire_color = empire_colours[colour_index];
     else
-        human_player_setup_data.empire_color = GG::CLR_GREEN;
+        human_player_setup_data.empire_color = {GG::CLR_GREEN.r, GG::CLR_GREEN.g, GG::CLR_GREEN.b, GG::CLR_GREEN.a};
 
     human_player_setup_data.starting_species_name = GetOptionsDB().Get<std::string>("setup.initial.species");
     if (human_player_setup_data.starting_species_name == "1")
@@ -604,7 +604,6 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
 
         ai_setup_data.player_name = "AI_" + std::to_string(ai_i);
         ai_setup_data.empire_name.clear();                // leave blank, to be set by server in Universe::GenerateEmpires
-        ai_setup_data.empire_color = GG::CLR_ZERO;        // to be set by server
         ai_setup_data.starting_species_name.clear();      // leave blank, to be set by server
         ai_setup_data.save_game_empire_id = ALL_EMPIRES;  // not used for new games
         ai_setup_data.client_type = Networking::ClientType::CLIENT_TYPE_AI_PLAYER;

--- a/combat/CombatEvents.cpp
+++ b/combat/CombatEvents.cpp
@@ -62,13 +62,13 @@ namespace {
     }
 
     //Copied pasted from Font.cpp due to Font not being linked into AI and server code
-    std::string WrapColorTag(std::string const & text, const GG::Clr& c) {
+    std::string WrapColorTag(std::string const & text, const EmpireColor& c) {
         std::stringstream stream;
         stream << "<rgba "
-               << static_cast<int>(c.r) << " "
-               << static_cast<int>(c.g) << " "
-               << static_cast<int>(c.b) << " "
-               << static_cast<int>(c.a)
+               << static_cast<int>(std::get<0>(c)) << " "
+               << static_cast<int>(std::get<1>(c)) << " "
+               << static_cast<int>(std::get<2>(c)) << " "
+               << static_cast<int>(std::get<3>(c))
                << ">" << text << "</rgba>";
         return stream.str();
     }
@@ -77,7 +77,7 @@ namespace {
         // TODO: refactor this to somewhere that links with the UI code.
         // Hardcoded default color becauses not linked with UI code.
         const Empire* empire = GetEmpire(empire_id);
-        GG::Clr c = (empire ? empire->Color() : GG::Clr(80,255,128,255));
+        EmpireColor c = (empire ? empire->Color() : EmpireColor{80,255,128,255});
         return WrapColorTag(text, c);
     }
 

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -300,7 +300,7 @@ def generateOrders():  # pylint: disable=invalid-name
           " Turn: {turn}".format(empire=empire, p_id=fo.playerID(), p_name=fo.playerName(),
                                  res_idx=ResearchAI.get_research_index(), turn=turn,
                                  aggression=aggression_name.capitalize()))
-    debug("EmpireColors: {0.colour.r} {0.colour.g} {0.colour.b} {0.colour.a}".format(empire))
+    debug("EmpireColors: {0.colour[0]} {0.colour[1]} {0.colour[2]} {0.colour[3]}".format(empire))
     if planet:
         debug("CapitalID: " + str(planet_id) + " Name: " + planet.name + " Species: " + planet.speciesName)
     else:

--- a/default/python/chat/chat.py
+++ b/default/python/chat/chat.py
@@ -18,10 +18,10 @@ class ChatHistoryProvider:
         Loads chat history from external sources.
 
         Returns list of tuples:
-            (unixtime timestamp, player name, text, text color of type freeorion.GGColor)
+            (unixtime timestamp, player name, text, text color of type tuple with 4 elements)
         """
         info("Loading history...")
-        # c = fo.GGColor(255, 128, 128, 255)
+        # c = (255, 128, 128, 255)
         # e = (123456789012, "P1", "Test1", c)
         # return [e]
         return []
@@ -36,7 +36,7 @@ class ChatHistoryProvider:
         timestamp -- unixtime, number of seconds from 1970-01-01 00:00:00 UTC
         player_name -- player name
         text -- chat text
-        text_color -- freeorion.GGColor
+        text_color -- tuple wit 4 elements
         """
         info("Chat %s: %s %s" % (player_name, text, text_color))
         return True

--- a/parse/Parse.cpp
+++ b/parse/Parse.cpp
@@ -22,7 +22,6 @@
 #if DEBUG_PARSERS
 namespace std {
     inline ostream& operator<<(ostream& os, const std::vector<Effect::Effect*>&) { return os; }
-    inline ostream& operator<<(ostream& os, const GG::Clr&) { return os; }
     inline ostream& operator<<(ostream& os, const UnlockableItem&) { return os; }
 }
 #endif
@@ -223,7 +222,7 @@ namespace parse {
     std::set<std::string> missing_include_files;
 
     /** \brief Resolve script directives
-     * 
+     *
      * @param[in,out] text contents to search through
      * @param[in] file_search_path base path of content
      */
@@ -244,13 +243,13 @@ namespace parse {
     }
 
     /** \brief Replace all include statements with contents of file
-     * 
+     *
      * Search for any include statements in *text* and replace them with the contents
      * of the file given.  File lookup is relative to *file_search_path* and will not
      * be included if found in *files_included*.
      * Each included file is added to *files_included*.
      * This is a recursive function, processing the contents of any included files.
-     * 
+     *
      * @param[in,out] text content to search through
      * @param[in] file_search_path base path of content
      * @param[in,out] files_included canonical path of any files previously included
@@ -415,13 +414,24 @@ namespace parse {
 #endif
     }
 
+    typedef std::array<unsigned char, 4> ColorType;
+
+    inline std::array<unsigned char, 4> construct_color(
+        unsigned char r,
+        unsigned char g,
+        unsigned char b,
+        unsigned char a)
+    { return {r, g, b, a}; }
+
+    BOOST_PHOENIX_ADAPT_FUNCTION(ColorType, construct_color_, construct_color, 4)
+
     color_parser_grammar::color_parser_grammar(const parse::lexer& tok) :
         color_parser_grammar::base_type(start, "color_parser_grammar")
     {
         namespace phoenix = boost::phoenix;
         namespace qi = boost::spirit::qi;
 
-        using phoenix::construct;
+        using phoenix::static_cast_;
         using phoenix::if_;
 
         qi::_1_type _1;
@@ -440,7 +450,7 @@ namespace parse {
             >    (',' >> channel )
             >    alpha
             >    ')'
-               ) [ _val  = construct<GG::Clr>(_1, _2, _3, _4)]
+               ) [ _val  = construct_color_(_1, _2, _3, _4)]
             ;
 
         channel.name("colour channel (0 to 255)");
@@ -483,7 +493,7 @@ namespace parse {
 
 
     /** \brief Load and parse script file(s) from given path
-        * 
+        *
         * @param[in] path absolute path to a regular file
         * @param[in] l lexer instance to use
         * @param[out] filename filename of the given path

--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -10,6 +10,7 @@
 #include <boost/filesystem/path.hpp>
 #include <boost/uuid/uuid.hpp>
 
+#include <array>
 #include <map>
 #include <set>
 #include <vector>

--- a/parse/ParseImpl.h
+++ b/parse/ParseImpl.h
@@ -5,11 +5,11 @@
 #include "../util/Logger.h"
 #include "../util/ScopedTimer.h"
 
+#include <array>
+
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/spirit/include/qi.hpp>
-
-#include <GG/Clr.h>
 
 
 namespace Condition {
@@ -137,7 +137,7 @@ namespace parse { namespace detail {
         single_or_repeated_string<std::set<std::string>> one_or_more_string_tokens;
     };
 
-    using color_parser_signature = GG::Clr ();
+    using color_parser_signature = std::array<unsigned char, 4> ();
     using color_rule_type = rule<color_parser_signature>;
     using color_grammar_type = grammar<color_parser_signature>;
 

--- a/parse/TechsParser.cpp
+++ b/parse/TechsParser.cpp
@@ -73,7 +73,7 @@ namespace {
     BOOST_PHOENIX_ADAPT_FUNCTION(void, insert_tech_, insert_tech, 7)
 
     void insert_category(std::map<std::string, std::unique_ptr<TechCategory>>& categories,
-                         std::string& name, std::string& graphic, const GG::Clr& color)
+                         std::string& name, std::string& graphic, const std::array<unsigned char, 4>& color)
     {
         auto category_ptr = std::make_unique<TechCategory>(name, std::move(graphic), color);
         categories.emplace(std::move(name), std::move(category_ptr));

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -13,6 +13,8 @@
 #include "../util/SitRepEntry.h"
 #include "SetWrapper.h"
 
+#include <GG/Clr.h>
+
 #include <boost/mpl/vector.hpp>
 #include <boost/python.hpp>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -13,8 +13,6 @@
 #include "../util/SitRepEntry.h"
 #include "SetWrapper.h"
 
-#include <GG/Clr.h>
-
 #include <boost/mpl/vector.hpp>
 #include <boost/python.hpp>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
@@ -233,7 +231,7 @@ namespace FreeOrionPython {
             .add_property("empireID",               &Empire::EmpireID)
             .add_property("capitalID",              &Empire::CapitalID)
 
-            .add_property("colour",                 make_function(&Empire::Color,                   py::return_value_policy<py::copy_const_reference>()))
+            .add_property("colour",                 +[](const Empire& empire) { EmpireColor color = empire.Color(); return py::make_tuple(std::get<0>(color), std::get<1>(color), std::get<2>(color), std::get<3>(color)); })
 
             .def("buildingTypeAvailable",           &Empire::BuildingTypeAvailable)
             .add_property("availableBuildingTypes", make_function(&Empire::AvailableBuildingTypes,  py::return_internal_reference<>()))

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -13,8 +13,6 @@
 #include "../util/SitRepEntry.h"
 #include "SetWrapper.h"
 
-#include <GG/Clr.h>
-
 #include <boost/mpl/vector.hpp>
 #include <boost/python.hpp>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
@@ -495,16 +493,6 @@ namespace FreeOrionPython {
             .add_property("status",             &DiplomaticStatusUpdateInfo::diplo_status)
             .add_property("empire1",            &DiplomaticStatusUpdateInfo::empire1_id)
             .add_property("empire2",            &DiplomaticStatusUpdateInfo::empire2_id)
-        ;
-
-        ///////////
-        // Color //
-        ///////////
-        py::class_<GG::Clr>("GGColor", py::init<unsigned char, unsigned char, unsigned char, unsigned char>())
-            .add_property("r",                  &GG::Clr::r)
-            .add_property("g",                  &GG::Clr::g)
-            .add_property("b",                  &GG::Clr::b)
-            .add_property("a",                  &GG::Clr::a)
         ;
     }
 }

--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -17,6 +17,7 @@
 #include "../combat/CombatLogManager.h"
 
 #include <boost/filesystem/fstream.hpp>
+#include <boost/serialization/array.hpp>
 #include <boost/serialization/deque.hpp>
 #include <boost/serialization/list.hpp>
 #include <boost/serialization/map.hpp>

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1030,7 +1030,7 @@ void ServerApp::LoadChatHistory() {
 
 void ServerApp::PushChatMessage(const std::string& text,
                                 const std::string& player_name,
-                                GG::Clr text_color,
+                                std::array<unsigned char, 4> text_color,
                                 const boost::posix_time::ptime& timestamp)
 {
     ChatHistoryEntity chat{timestamp, player_name, text, text_color};

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -207,7 +207,7 @@ public:
 
     void PushChatMessage(const std::string& text,
                          const std::string& player_name,
-                         GG::Clr text_color,
+                         std::array<unsigned char, 4> text_color,
                          const boost::posix_time::ptime& timestamp);
 
     ServerNetworking&           Networking();     ///< returns the networking object for the server

--- a/server/ServerFramework.cpp
+++ b/server/ServerFramework.cpp
@@ -234,7 +234,13 @@ auto PythonServer::LoadChatHistory(boost::circular_buffer<ChatHistoryEntity>& ch
             e.timestamp = boost::posix_time::from_time_t(py::extract<time_t>((*it)[0]));;
             e.player_name = py::extract<std::string>((*it)[1]);
             e.text = py::extract<std::string>((*it)[2]);
-            e.text_color = py::extract<GG::Clr>((*it)[3]);
+            py::tuple color = py::extract<py::tuple>((*it)[3]);
+            e.text_color = std::array<unsigned char, 4>{
+                py::extract<unsigned char>(color[0]),
+                py::extract<unsigned char>(color[1]),
+                py::extract<unsigned char>(color[2]),
+                py::extract<unsigned char>(color[3])
+            };
             chat_history.push_back(e);
         }
     }
@@ -255,10 +261,12 @@ auto PythonServer::PutChatHistoryEntity(const ChatHistoryEntity& chat_history_en
         return false;
     }
 
+    auto color = chat_history_entity.text_color;
+
     return f(py::long_(to_time_t(chat_history_entity.timestamp)),
              chat_history_entity.player_name,
              chat_history_entity.text,
-             chat_history_entity.text_color);
+             py::make_tuple(std::get<0>(color), std::get<1>(color), std::get<2>(color), std::get<3>(color)));
 }
 
 auto PythonServer::CreateUniverse(std::map<int, PlayerSetupData>& player_setup_data) -> bool

--- a/server/ServerWrapper.cpp
+++ b/server/ServerWrapper.cpp
@@ -1275,6 +1275,16 @@ namespace {
 
         return py::object(planet->CardinalSuffix());
     }
+
+    auto PlayerEmpireColor(const PlayerSetupData* psd) -> py::tuple
+    {
+        EmpireColor color = psd->empire_color;
+        return py::make_tuple(
+            std::get<0>(color),
+            std::get<1>(color),
+            std::get<2>(color),
+            std::get<3>(color));
+    }
 }
 
 namespace FreeOrionPython {
@@ -1282,7 +1292,7 @@ namespace FreeOrionPython {
         py::class_<PlayerSetupData>("PlayerSetupData")
             .def_readwrite("player_name",        &PlayerSetupData::player_name)
             .def_readwrite("empire_name",        &PlayerSetupData::empire_name)
-            .def_readonly("empire_color",        &PlayerSetupData::empire_color)
+            .add_property("empire_color",        PlayerEmpireColor)
             .def_readwrite("starting_species",   &PlayerSetupData::starting_species_name)
             .def_readwrite("starting_team",      &PlayerSetupData::starting_team);
 

--- a/server/UniverseGenerator.cpp
+++ b/server/UniverseGenerator.cpp
@@ -12,9 +12,6 @@
 #include "../universe/System.h"
 #include "../universe/Species.h"
 
-#include <GG/Clr.h>
-#include <GG/ClrConstants.h>
-
 #include <limits>
 
 namespace {
@@ -869,7 +866,7 @@ void InitEmpires(const std::map<int, PlayerSetupData>& player_setup_data) {
             ErrorLogger() << "InitEmpires empire id (" << empire_id << ") is invalid";
 
         const auto& player_name =   entry.second.player_name;
-        auto        empire_colour = GG::Clr(entry.second.empire_color);
+        auto        empire_colour = entry.second.empire_color;
         bool        authenticated = entry.second.authenticated;
 
         // validate or generate empire colour
@@ -878,18 +875,20 @@ void InitEmpires(const std::map<int, PlayerSetupData>& player_setup_data) {
         if (color_it != colors.end())
             colors.erase(color_it);
 
+        constexpr EmpireColor CLR_ZERO{0, 0, 0, 0};
+
         // if no colour already set, do so automatically
-        if (empire_colour == GG::CLR_ZERO) {
+        if (empire_colour == CLR_ZERO) {
             if (!colors.empty()) {
                 // take next colour from list
                 empire_colour = colors[0];
                 colors.erase(colors.begin());
             } else {
                 // as a last resort, make up a colour
-                empire_colour = GG::FloatClr(static_cast<float>(RandZeroToOne()),
-                                             static_cast<float>(RandZeroToOne()),
-                                             static_cast<float>(RandZeroToOne()),
-                                             1.0f);
+                empire_colour = {static_cast<unsigned char>(RandInt(0, 255)),
+                                 static_cast<unsigned char>(RandInt(0, 255)),
+                                 static_cast<unsigned char>(RandInt(0, 255)),
+                                 255};
             }
         }
 
@@ -900,9 +899,8 @@ void InitEmpires(const std::map<int, PlayerSetupData>& player_setup_data) {
                       << " for player: " << player_name << " in team: " << entry.second.starting_team;
 
         // create new Empire object through empire manager
-        EmpireColor colour{empire_colour.r, empire_colour.g, empire_colour.b, empire_colour.a};
         Empires().CreateEmpire(empire_id, std::move(empire_name), player_name,
-                               colour, authenticated);
+                               empire_colour, authenticated);
     }
 
     Empires().ResetDiplomacy();

--- a/server/UniverseGenerator.cpp
+++ b/server/UniverseGenerator.cpp
@@ -897,8 +897,9 @@ void InitEmpires(const std::map<int, PlayerSetupData>& player_setup_data) {
                       << " for player: " << player_name << " in team: " << entry.second.starting_team;
 
         // create new Empire object through empire manager
+        EmpireColor colour{empire_colour.r, empire_colour.g, empire_colour.b, empire_colour.a};
         Empires().CreateEmpire(empire_id, std::move(empire_name), player_name,
-                               empire_colour, authenticated);
+                               colour, authenticated);
     }
 
     Empires().ResetDiplomacy();

--- a/server/UniverseGenerator.cpp
+++ b/server/UniverseGenerator.cpp
@@ -12,6 +12,9 @@
 #include "../universe/System.h"
 #include "../universe/Species.h"
 
+#include <GG/Clr.h>
+#include <GG/ClrConstants.h>
+
 #include <limits>
 
 namespace {
@@ -866,7 +869,7 @@ void InitEmpires(const std::map<int, PlayerSetupData>& player_setup_data) {
             ErrorLogger() << "InitEmpires empire id (" << empire_id << ") is invalid";
 
         const auto& player_name =   entry.second.player_name;
-        auto        empire_colour = entry.second.empire_color;
+        auto        empire_colour = GG::Clr(entry.second.empire_color);
         bool        authenticated = entry.second.authenticated;
 
         // validate or generate empire colour

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -7,8 +7,6 @@
 #include "util/GameRules.h"
 #include "util/Version.h"
 
-#include "GG/GG/ClrConstants.h"
-
 #include <boost/format.hpp>
 #include <boost/uuid/nil_generator.hpp>
 #include <boost/thread/thread.hpp>
@@ -74,7 +72,7 @@ void ClientAppFixture::HostSPGame(unsigned int num_AIs) {
     PlayerSetupData human_player_setup_data;
     human_player_setup_data.player_name = "TestPlayer";
     human_player_setup_data.empire_name = "TestEmpire";
-    human_player_setup_data.empire_color = GG::CLR_GREEN;
+    human_player_setup_data.empire_color = {0, 255, 0, 255};
 
     human_player_setup_data.starting_species_name = "SP_HUMAN";
     human_player_setup_data.save_game_empire_id = ALL_EMPIRES; // not used for new games
@@ -90,7 +88,7 @@ void ClientAppFixture::HostSPGame(unsigned int num_AIs) {
 
         ai_setup_data.player_name = "AI_" + std::to_string(ai_i);
         ai_setup_data.empire_name.clear();                // leave blank, to be set by server in Universe::GenerateEmpires
-        ai_setup_data.empire_color = GG::CLR_ZERO;        // to be set by server
+        ai_setup_data.empire_color = {0, 0, 0, 0};        // to be set by server
         ai_setup_data.starting_species_name.clear();      // leave blank, to be set by server
         ai_setup_data.save_game_empire_id = ALL_EMPIRES;  // not used for new games
         ai_setup_data.client_type = Networking::ClientType::CLIENT_TYPE_AI_PLAYER;

--- a/universe/Tech.cpp
+++ b/universe/Tech.cpp
@@ -84,10 +84,7 @@ namespace CheckSums {
         TraceLogger() << "CheckSumCombine(Slot): " << typeid(cat).name();
         CheckSumCombine(sum, cat.name);
         CheckSumCombine(sum, cat.graphic);
-        CheckSumCombine(sum, cat.colour.r);
-        CheckSumCombine(sum, cat.colour.g);
-        CheckSumCombine(sum, cat.colour.b);
-        CheckSumCombine(sum, cat.colour.a);
+        CheckSumCombine(sum, cat.colour);
     }
 }
 

--- a/universe/Tech.h
+++ b/universe/Tech.h
@@ -2,6 +2,7 @@
 #define _Tech_h_
 
 
+#include <array>
 #include <map>
 #include <set>
 #include <string>
@@ -11,7 +12,6 @@
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/multi_index_container.hpp>
 #include <boost/optional/optional.hpp>
-#include <GG/Clr.h>
 #include "EnumsFwd.h"
 #include "../util/Export.h"
 #include "../util/Pending.h"
@@ -132,14 +132,14 @@ private:
 struct FO_COMMON_API TechCategory {
     TechCategory() = default;
     TechCategory(std::string name_, std::string&& graphic_,
-                 GG::Clr colour_):
+                 const std::array<unsigned char, 4>& colour_):
         name(std::move(name_)),
         graphic(std::move(graphic_)),
         colour(colour_)
     {}
     std::string name;                       ///< name of category
     std::string graphic;                    ///< icon that represents catetegory
-    GG::Clr     colour{255, 255, 255, 255}; ///< colour associatied with category
+    std::array<unsigned char, 4> colour{255, 255, 255, 255}; ///< colour associatied with category
 };
 
 namespace CheckSums {

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -145,7 +145,7 @@ struct FO_COMMON_API SaveGameEmpireData {
     int         empire_id = ALL_EMPIRES;
     std::string empire_name;
     std::string player_name;
-    GG::Clr     color;
+    std::array<unsigned char, 4> color;
     bool        authenticated = false;
     bool        eliminated = false;
     bool        won = false;

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -8,8 +8,6 @@
 #include "OrderSet.h"
 #include "Pending.h"
 
-#include <GG/Clr.h>
-#include <GG/ClrConstants.h>
 #include <GG/Enum.h>
 
 #include <list>
@@ -192,7 +190,7 @@ struct PlayerSetupData {
     std::string             player_name;
     int                     player_id = Networking::INVALID_PLAYER_ID;
     std::string             empire_name;
-    GG::Clr                 empire_color = GG::CLR_ZERO;
+    std::array<unsigned char, 4> empire_color{0, 0, 0, 0};
     std::string             starting_species_name;
     //! When loading a game, the ID of the empire that this player will control
     int                     save_game_empire_id = ALL_EMPIRES;
@@ -280,7 +278,7 @@ struct FO_COMMON_API ChatHistoryEntity {
     boost::posix_time::ptime    timestamp;
     std::string                 player_name;
     std::string                 text;
-    GG::Clr                     text_color;
+    std::array<unsigned char, 4> text_color;
 };
 
 /** Information about one player that other players are informed of.  Assembled by server and sent to players. */

--- a/util/SaveGamePreviewUtils.h
+++ b/util/SaveGamePreviewUtils.h
@@ -7,7 +7,6 @@
 
 #include <vector>
 #include <string>
-#include <GG/Clr.h>
 #include "Export.h"
 #include "MultiplayerCommon.h"
 
@@ -28,7 +27,7 @@ struct FO_COMMON_API SaveGamePreviewData {
 
     std::string         main_player_name;               /// The name of the hosting player, or the single human player in single player games
     std::string         main_player_empire_name;        /// The name of the empire of the main player
-    GG::Clr             main_player_empire_colour;      /// The colour of the empire of the main player
+    std::array<unsigned char, 4> main_player_empire_colour;      /// The colour of the empire of the main player
     int                 current_turn = -1;              /// The turn the game as saved one
     std::string         save_time;                      /// The time the game was saved as ISO 8601 YYYY-MM-DD"T"HH:MM:SS±HH:MM or Z
     short               number_of_empires = -1;         /// The number of empires in the game

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -183,7 +183,7 @@ struct SaveGamePreviewData;
 template<typename Archive>
 void serialize(Archive&, SaveGamePreviewData&, unsigned int const);
 
-BOOST_CLASS_VERSION(SaveGamePreviewData, 4);
+BOOST_CLASS_VERSION(SaveGamePreviewData, 5);
 
 extern template FO_COMMON_API void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, SaveGamePreviewData&, unsigned int const);
 extern template FO_COMMON_API void serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, SaveGamePreviewData&, unsigned int const);
@@ -226,7 +226,7 @@ extern template FO_COMMON_API void serialize<freeorion_xml_iarchive>(freeorion_x
 
 struct SaveGameEmpireData;
 
-BOOST_CLASS_VERSION(SaveGameEmpireData, 2);
+BOOST_CLASS_VERSION(SaveGameEmpireData, 3);
 
 template <typename Archive>
 void serialize(Archive&, SaveGameEmpireData&, unsigned int const);

--- a/util/Serialize.ipp
+++ b/util/Serialize.ipp
@@ -4,11 +4,6 @@
 
 #include <boost/version.hpp>
 
-#if BOOST_VERSION == 105800
-// HACK: The following two includes work around a bug in boost 1.58
-#include <boost/archive/basic_archive.hpp>
-#endif
-
 #include <boost/serialization/export.hpp>
 #include <boost/serialization/deque.hpp>
 #include <boost/serialization/list.hpp>
@@ -23,17 +18,3 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/serialization/optional.hpp>
 
-#include <GG/Clr.h>
-
-namespace boost { namespace serialization {
-
-    template <typename Archive>
-    void serialize(Archive& ar, GG::Clr& clr, const unsigned int version)
-    {
-        ar  & BOOST_SERIALIZATION_NVP(clr.r)
-            & BOOST_SERIALIZATION_NVP(clr.g)
-            & BOOST_SERIALIZATION_NVP(clr.b)
-            & BOOST_SERIALIZATION_NVP(clr.a);
-    }
-
-} }

--- a/util/Serialize.ipp
+++ b/util/Serialize.ipp
@@ -18,3 +18,25 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/serialization/optional.hpp>
 
+/** \brief Structure to have compatibility with saves made with GG::Clr.
+ *  \todo Remove it on compatibility breakage. */
+struct CompatColor {
+    unsigned char r;   ///< the red channel
+    unsigned char g;   ///< the green channel
+    unsigned char b;   ///< the blue channel
+    unsigned char a;   ///< the alpha channel
+};
+
+namespace boost { namespace serialization {
+
+    template <typename Archive>
+    void serialize(Archive& ar, CompatColor& clr, const unsigned int version)
+    {
+        ar  & BOOST_SERIALIZATION_NVP(clr.r)
+            & BOOST_SERIALIZATION_NVP(clr.g)
+            & BOOST_SERIALIZATION_NVP(clr.b)
+            & BOOST_SERIALIZATION_NVP(clr.a);
+    }
+
+} }
+

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -170,9 +170,15 @@ void Empire::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_id)
         & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_player_name)
-        & BOOST_SERIALIZATION_NVP(m_color)
-        & BOOST_SERIALIZATION_NVP(m_capital_id)
+        & BOOST_SERIALIZATION_NVP(m_player_name);
+    if (Archive::is_loading::value && version < 5) {
+        CompatColor old_color;
+        ar & boost::serialization::make_nvp("m_color", old_color);
+        m_color = {old_color.r, old_color.g, old_color.b, old_color.a};
+    } else {
+        ar & BOOST_SERIALIZATION_NVP(m_color);
+    }
+    ar  & BOOST_SERIALIZATION_NVP(m_capital_id)
         & BOOST_SERIALIZATION_NVP(m_source_id)
         & BOOST_SERIALIZATION_NVP(m_eliminated)
         & BOOST_SERIALIZATION_NVP(m_victories);
@@ -302,7 +308,7 @@ void Empire::serialize(Archive& ar, const unsigned int version)
     TraceLogger() << "DONE serializing empire " << m_id << ": " << m_name;
 }
 
-BOOST_CLASS_VERSION(Empire, 4)
+BOOST_CLASS_VERSION(Empire, 5)
 
 template void Empire::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
 template void Empire::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -11,6 +11,7 @@
 #include "GameRules.h"
 
 #include "Serialize.ipp"
+#include <boost/serialization/array.hpp>
 #include <boost/serialization/version.hpp>
 #include <boost/uuid/random_generator.hpp>
 

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -11,6 +11,7 @@
 #include "Serialize.ipp"
 
 #include <boost/date_time/posix_time/time_serialize.hpp>
+#include <boost/serialization/array.hpp>
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
 

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -115,9 +115,15 @@ void serialize(Archive& ar, SaveGamePreviewData& obj, unsigned int const version
     }
     ar & make_nvp("magic_number", obj.magic_number)
        & make_nvp("main_player_name", obj.main_player_name);
-    ar & make_nvp("main_player_empire_name", obj.main_player_empire_name)
-       & make_nvp("main_player_empire_colour", obj.main_player_empire_colour)
-       & make_nvp("save_time", obj.save_time)
+    ar & make_nvp("main_player_empire_name", obj.main_player_empire_name);
+    if (Archive::is_loading::value && version < 5) {
+        CompatColor old_color;
+        ar & make_nvp("main_player_empire_colour", old_color);
+        obj.main_player_empire_colour = {old_color.r, old_color.g, old_color.b, old_color.a};
+    } else {
+        ar & make_nvp("main_player_empire_colour", obj.main_player_empire_colour);
+    }
+    ar & make_nvp("save_time", obj.save_time)
        & make_nvp("current_turn", obj.current_turn);
     if (version > 0) {
         ar & make_nvp("number_of_empires", obj.number_of_empires)
@@ -232,8 +238,14 @@ void serialize(Archive& ar, SaveGameEmpireData& obj, unsigned int const version)
 
     ar  & make_nvp("m_empire_id", obj.empire_id)
         & make_nvp("m_empire_name", obj.empire_name)
-        & make_nvp("m_player_name", obj.player_name)
-        & make_nvp("m_color", obj.color);
+        & make_nvp("m_player_name", obj.player_name);
+    if (Archive::is_loading::value && version < 3) {
+        CompatColor old_color;
+        ar & make_nvp("m_color", old_color);
+        obj.color = {old_color.r, old_color.g, old_color.b, old_color.a};
+    } else {
+        ar & make_nvp("m_color", obj.color);
+    }
     if (version >= 1) {
         ar & make_nvp("m_authenticated", obj.authenticated);
     }


### PR DESCRIPTION
Removes usage of GG in the non-client code.