### PR TITLE
GiGi: Added missing include to Clr.h

### DIFF
--- a/GG/GG/Clr.h
+++ b/GG/GG/Clr.h
@@ -15,6 +15,7 @@
 #define _GG_Clr_h_
 
 
+#include <algorithm>
 #include <sstream>
 #include <stdexcept>
 #include <string>


### PR DESCRIPTION
In file **GG/GG/Clr.h** function `std::min` is used. This function is declared
in `<algorithm>`. The standard library header is not included in **Clr.h**.

While this seems to build fine, it is essentially an error. It might
break the build when include directives order in other files or compiler
version changes.

See: [std::min - cppreference.com](https://en.cppreference.com/w/cpp/algorithm/min)
See also: [Why can std::max and std::min still be used even if I didn't #include <algorithm>?](https://stackoverflow.com/questions/19897722/why-can-stdmax-and-stdmin-still-be-used-even-if-i-didnt-include-algorithm)