### PR TITLE
show named value user string only when hovering

### DIFF
--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -514,7 +514,7 @@ namespace {
 
                 sorted_entries_list.emplace(
                     entry.first,
-                    std::make_pair(entry.first + pre + LinkTaggedPresetText(VarText::FOCS_VALUE_TAG, entry.first, vref.Description()) +
+                    std::make_pair(entry.first + pre + LinkTaggedText(VarText::FOCS_VALUE_TAG, entry.first) +
                                    " '" + UserString(entry.first) + "' " + vref.InvariancePattern() + "\n", dir_name));
             }
 

--- a/parse/IntValueRefParser.cpp
+++ b/parse/IntValueRefParser.cpp
@@ -138,7 +138,7 @@ parse::int_arithmetic_rules::int_arithmetic_rules(
     named_int_valueref
         = (     tok.Named_ >> tok.Integer_
              >>  label(tok.Name_) > tok.string
-             >  label(tok.Value_) > primary_expr
+             >  label(tok.Value_) > expr
           ) [
              // Register the value ref under the given name by lazy invoking RegisterValueRef
              parse::detail::open_and_register_as_string_(_2, _3, _pass),


### PR DESCRIPTION
Fixes precedence for Integer case and presentation of named values in pedia:

Change named value UI: ignore missing UserStrings, change format
    
    * missing named value stringtable entries are now handled like empty ones
    * named value text now always shows only the calculated value
    * named value tooltip shows the calculated value, the optional userstring enty, and the calculation definition (e.g. "0.5000 (per fuel tank: 0.5)"
    * adjust stringtable lint tool to only inform about missing named value stringtable instead of failing the build
    * bugfix: encyclopedia panel shows the value text as it is shown in other places
