### PR TITLE
Introduce python parser

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -532,7 +532,7 @@ if(BUILD_SERVER)
         PRIVATE
             -DFREEORION_BUILD_SERVER
     )
-    
+
     target_link_libraries(freeoriond
         PRIVATE
             freeorioncommon

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,13 +256,11 @@ find_package(Boost ${MINIMUM_BOOST_VERSION}
         thread
     REQUIRED)
 
-if(BUILD_AI OR BUILD_SERVER)
-    find_package(Boost OPTIONAL_COMPONENTS python${Boost_PYTHON_SUFFIX})
-    if(NOT Boost_PYTHON${Boost_PYTHON_SUFFIX}_FOUND)
-        # try some strange boost installations
-        string(SUBSTRING "${Boost_PYTHON_SUFFIX}" 0 1 Boost_PYTHON_SUFFIX)
-        find_package(Boost COMPONENTS python${Boost_PYTHON_SUFFIX} REQUIRED)
-    endif()
+find_package(Boost OPTIONAL_COMPONENTS python${Boost_PYTHON_SUFFIX})
+if(NOT Boost_PYTHON${Boost_PYTHON_SUFFIX}_FOUND)
+    # try some strange boost installations
+    string(SUBSTRING "${Boost_PYTHON_SUFFIX}" 0 1 Boost_PYTHON_SUFFIX)
+    find_package(Boost COMPONENTS python${Boost_PYTHON_SUFFIX} REQUIRED)
 endif()
 
 find_package(ZLIB REQUIRED)
@@ -406,6 +404,7 @@ target_link_libraries(freeorioncommon
         Boost::locale
         Boost::log_setup
         Boost::log
+        Boost::python${Boost_PYTHON_SUFFIX}
         Boost::thread
         Boost::serialization
         ZLIB::ZLIB
@@ -538,7 +537,6 @@ if(BUILD_SERVER)
         PRIVATE
             freeorioncommon
             freeorionparse
-            Boost::python${Boost_PYTHON_SUFFIX}
     )
     
     target_dependencies_copy_to_build(freeoriond)
@@ -561,9 +559,9 @@ if(BUILD_AI)
     )
     
     target_link_libraries(freeorionca
-        freeorioncommon
-        freeorionparse
-        Boost::python${Boost_PYTHON_SUFFIX}
+        PRIVATE
+            freeorioncommon
+            freeorionparse
     )
     
     target_dependencies_copy_to_build(freeorionca)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -441,6 +441,7 @@ target_compile_definitions(freeorionparseobj
 target_include_directories(freeorionparseobj
     PUBLIC
         $<TARGET_PROPERTY:Boost::boost,INTERFACE_INCLUDE_DIRECTORIES>
+        ${PYTHON_INCLUDE_PATH}
 )
 
 set_property(TARGET freeorionparseobj

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -143,7 +143,7 @@ void AIClientApp::Run() {
         // Start parsing content
         std::promise<void> barrier;
         std::future<void> barrier_future = barrier.get_future();
-        StartBackgroundParsing(std::move(barrier));
+        StartBackgroundParsing(*m_AI, std::move(barrier));
         barrier_future.wait();
 
         // respond to messages until disconnected

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -21,6 +21,8 @@
 #include "../../Empire/Empire.h"
 #include "../../Empire/Diplomacy.h"
 
+#include "../../parse/PythonParser.h"
+
 #include <boost/lexical_cast.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/functional/hash.hpp>
@@ -143,7 +145,7 @@ void AIClientApp::Run() {
         // Start parsing content
         std::promise<void> barrier;
         std::future<void> barrier_future = barrier.get_future();
-        StartBackgroundParsing(*m_AI, std::move(barrier));
+        StartBackgroundParsing(PythonParser(*m_AI), std::move(barrier));
         barrier_future.wait();
 
         // respond to messages until disconnected

--- a/client/AI/AIFramework.cpp
+++ b/client/AI/AIFramework.cpp
@@ -11,7 +11,6 @@
 #include "../../util/ScopedTimer.h"
 #include "../../Empire/Empire.h"
 #include "../../Empire/Diplomacy.h"
-#include "../../python/CommonFramework.h"
 #include "../../python/SetWrapper.h"
 #include "../../python/CommonWrappers.h"
 

--- a/client/AI/AIFramework.h
+++ b/client/AI/AIFramework.h
@@ -1,7 +1,7 @@
 #ifndef _AIFramework_h_
 #define _AIFramework_h_
 
-#include "../../python/CommonFramework.h"
+#include "../../python/PythonBase.h"
 
 #include <string>
 #include <vector>

--- a/client/human/GGHumanClientApp.cpp
+++ b/client/human/GGHumanClientApp.cpp
@@ -23,6 +23,7 @@
 #include "../../util/GameRules.h"
 #include "../../util/OptionsDB.h"
 #include "../../util/Process.h"
+#include "../../util/PythonCommon.h"
 #include "../../util/SaveGamePreviewUtils.h"
 #include "../../util/SitRepEntry.h"
 #include "../../util/Directories.h"
@@ -355,7 +356,9 @@ GGHumanClientApp::GGHumanClientApp(int width, int height, bool calculate_fps, st
     std::future<void> barrier_future = barrier.get_future();
     std::thread background([this] (auto b) {
         DebugLogger() << "Started background parser thread";
-        StartBackgroundParsing(std::move(b));
+        PythonCommon python;
+        python.Initialize();
+        StartBackgroundParsing(python, std::move(b));
     }, std::move(barrier));
     background.detach();
     barrier_future.wait();
@@ -1549,7 +1552,9 @@ void GGHumanClientApp::HandleResoureDirChange() {
         std::future<void> barrier_future = barrier.get_future();
         std::thread background([this] (auto b) {
             DebugLogger() << "Started background parser thread";
-            StartBackgroundParsing(std::move(b));
+            PythonCommon python;
+            python.Initialize();
+            StartBackgroundParsing(python, std::move(b));
         }, std::move(barrier));
         background.detach();
         barrier_future.wait();

--- a/client/human/GGHumanClientApp.cpp
+++ b/client/human/GGHumanClientApp.cpp
@@ -34,6 +34,7 @@
 #include "../../Empire/Empire.h"
 #include "../../combat/CombatLogManager.h"
 #include "../../parse/Parse.h"
+#include "../../parse/PythonParser.h"
 
 #include <GG/BrowseInfoWnd.h>
 #include <GG/dialogs/ThreeButtonDlg.h>
@@ -358,7 +359,7 @@ GGHumanClientApp::GGHumanClientApp(int width, int height, bool calculate_fps, st
         DebugLogger() << "Started background parser thread";
         PythonCommon python;
         python.Initialize();
-        StartBackgroundParsing(python, std::move(b));
+        StartBackgroundParsing(PythonParser(python), std::move(b));
     }, std::move(barrier));
     background.detach();
     barrier_future.wait();
@@ -1554,7 +1555,7 @@ void GGHumanClientApp::HandleResoureDirChange() {
             DebugLogger() << "Started background parser thread";
             PythonCommon python;
             python.Initialize();
-            StartBackgroundParsing(python, std::move(b));
+            StartBackgroundParsing(PythonParser(python), std::move(b));
         }, std::move(barrier));
         background.detach();
         barrier_future.wait();

--- a/msvc2017/Common/Common.vcxproj
+++ b/msvc2017/Common/Common.vcxproj
@@ -256,6 +256,7 @@
     <ClInclude Include="..\..\util\OrderSet.h" />
     <ClInclude Include="..\..\util\Process.h" />
     <ClInclude Include="..\..\util\Pending.h" />
+    <ClInclude Include="..\..\util\PythonCommon.h" />
     <ClInclude Include="..\..\util\Random.h" />
     <ClInclude Include="..\..\util\SaveGamePreviewUtils.h" />
     <ClInclude Include="..\..\util\ScopedTimer.h" />
@@ -333,6 +334,7 @@
     <ClCompile Include="..\..\util\OptionsDB.cpp" />
     <ClCompile Include="..\..\util\Order.cpp" />
     <ClCompile Include="..\..\util\OrderSet.cpp" />
+    <ClCompile Include="..\..\util\PythonCommon.cpp" />
     <ClCompile Include="..\..\util\Random.cpp" />
     <ClCompile Include="..\..\util\SerializeCombat.cpp" />
     <ClCompile Include="..\..\util\SerializeEmpire.cpp" />

--- a/msvc2017/Common/StdAfx.h
+++ b/msvc2017/Common/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/ 
+// https://hownot2code.com/2016/08/16/stdafx-h/
 
 // ----------------
 // includes from .h
@@ -87,6 +87,7 @@
 // includes from .cpp
 #include <sstream>
 
+#include <boost/python.hpp>
 
 #ifdef _MSC_VER
 // Note: This is a workaround for Visual C++ non-conformant pre-processor

--- a/msvc2017/FreeOrionCA/FreeOrionCA.vcxproj
+++ b/msvc2017/FreeOrionCA/FreeOrionCA.vcxproj
@@ -174,7 +174,7 @@
     <ClInclude Include="..\..\network\Message.h" />
     <ClInclude Include="..\..\network\MessageQueue.h" />
     <ClInclude Include="..\..\network\Networking.h" />
-    <ClInclude Include="..\..\python\CommonFramework.h" />
+    <ClInclude Include="..\..\python\PythonBase.h" />
     <ClInclude Include="..\..\python\CommonWrappers.h" />
     <ClInclude Include="..\..\python\SetWrapper.h" />
     <ClInclude Include="..\..\universe\Building.h" />
@@ -225,7 +225,7 @@
     <ClCompile Include="..\..\client\ClientApp.cpp" />
     <ClCompile Include="..\..\client\ClientFSMEvents.cpp" />
     <ClCompile Include="..\..\client\ClientNetworking.cpp" />
-    <ClCompile Include="..\..\python\CommonFramework.cpp" />
+    <ClCompile Include="..\..\python\PythonBase.cpp" />
     <ClCompile Include="..\..\python\ConfigWrapper.cpp" />
     <ClCompile Include="..\..\python\EmpireWrapper.cpp" />
     <ClCompile Include="..\..\python\EnumWrapper.cpp" />

--- a/msvc2017/FreeOrionD/FreeOrionD.vcxproj
+++ b/msvc2017/FreeOrionD/FreeOrionD.vcxproj
@@ -170,7 +170,7 @@
     <ClInclude Include="..\..\Empire\PopulationPool.h" />
     <ClInclude Include="..\..\network\Message.h" />
     <ClInclude Include="..\..\network\Networking.h" />
-    <ClInclude Include="..\..\python\CommonFramework.h" />
+    <ClInclude Include="..\..\python\PythonBase.h" />
     <ClInclude Include="..\..\python\SetWrapper.h" />
     <ClInclude Include="..\..\server\SaveLoad.h" />
     <ClInclude Include="..\..\server\ServerApp.h" />
@@ -221,7 +221,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\combat\CombatSystem.cpp" />
-    <ClCompile Include="..\..\python\CommonFramework.cpp" />
+    <ClCompile Include="..\..\python\PythonBase.cpp" />
     <ClCompile Include="..\..\python\ConfigWrapper.cpp" />
     <ClCompile Include="..\..\python\EmpireWrapper.cpp" />
     <ClCompile Include="..\..\python\EnumWrapper.cpp" />

--- a/msvc2017/Parsers/Parsers.vcxproj
+++ b/msvc2017/Parsers/Parsers.vcxproj
@@ -109,7 +109,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_USRDLL;PARSERS_EXPORTS;FREEORION_WIN32;_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../../../include/;../../../include/python3.5/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
@@ -142,7 +142,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_USRDLL;PARSERS_EXPORTS;FREEORION_WIN32;_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../../../include/;../../../include/python3.5/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
@@ -222,6 +222,7 @@
     <ClCompile Include="..\..\parse\PlanetSizeValueRefParser.cpp" />
     <ClCompile Include="..\..\parse\PlanetTypeValueRefParser.cpp" />
     <ClCompile Include="..\..\parse\PoliciesParser.cpp" />
+    <ClCompile Include="..\..\parse\PythonParser.cpp" />
     <ClCompile Include="..\..\parse\ReportParseError.cpp" />
     <ClCompile Include="..\..\parse\ShipDesignsParser.cpp" />
     <ClCompile Include="..\..\parse\ShipHullsParser.cpp">
@@ -261,6 +262,7 @@
     <ClCompile Include="..\..\parse\UniverseObjectTypeValueRefParser.cpp" />
     <ClCompile Include="..\..\parse\ValueRefParser.cpp" />
     <ClCompile Include="..\..\parse\VisibilityValueRefParser.cpp" />
+    <ClCompile Include="..\..\parse\PythonParser.cpp" />
     <ClCompile Include="StdAfx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Create</PrecompiledHeader>
@@ -295,6 +297,7 @@
     <ClInclude Include="..\..\parse\ReportParseError.h" />
     <ClInclude Include="..\..\parse\Tokens.h" />
     <ClInclude Include="..\..\parse\ValueRefParser.h" />
+    <ClInclude Include="..\..\parse\PythonParser.h" />
     <ClInclude Include="StdAfx.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/msvc2017/Parsers/Parsers.vcxproj.filters
+++ b/msvc2017/Parsers/Parsers.vcxproj.filters
@@ -165,6 +165,9 @@
     <ClCompile Include="..\..\parse\PoliciesParser.cpp">
       <Filter>Source Files\parse</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\parse\PythonParser.cpp">
+      <Filter>Source Files\parse</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\parse\ConditionParser.h">

--- a/msvc2017/Parsers/StdAfx.h
+++ b/msvc2017/Parsers/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus boost headers used in any .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/ 
+// https://hownot2code.com/2016/08/16/stdafx-h/
 
 // ----------------
 // includes from .h or .cpp
@@ -41,6 +41,8 @@
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/xpressive/xpressive.hpp>
+
+#include <boost/python.hpp>
 
 
 #ifdef _MSC_VER

--- a/msvc2019/Common/Common.vcxproj
+++ b/msvc2019/Common/Common.vcxproj
@@ -255,6 +255,7 @@
     <ClInclude Include="..\..\util\Order.h" />
     <ClInclude Include="..\..\util\OrderSet.h" />
     <ClInclude Include="..\..\util\Process.h" />
+    <ClInclude Include="..\..\util\PythonCommon.h" />
     <ClInclude Include="..\..\util\Pending.h" />
     <ClInclude Include="..\..\util\Random.h" />
     <ClInclude Include="..\..\util\SaveGamePreviewUtils.h" />
@@ -333,6 +334,7 @@
     <ClCompile Include="..\..\util\OptionsDB.cpp" />
     <ClCompile Include="..\..\util\Order.cpp" />
     <ClCompile Include="..\..\util\OrderSet.cpp" />
+    <ClCompile Include="..\..\util\PythonCommon.cpp" />
     <ClCompile Include="..\..\util\Random.cpp" />
     <ClCompile Include="..\..\util\SerializeCombat.cpp" />
     <ClCompile Include="..\..\util\SerializeEmpire.cpp" />

--- a/msvc2019/Common/StdAfx.h
+++ b/msvc2019/Common/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/ 
+// https://hownot2code.com/2016/08/16/stdafx-h/
 
 // ----------------
 // includes from .h
@@ -87,6 +87,7 @@
 // includes from .cpp
 #include <sstream>
 
+#include <boost/python.hpp>
 
 #ifdef _MSC_VER
 // Note: This is a workaround for Visual C++ non-conformant pre-processor

--- a/msvc2019/FreeOrionCA/FreeOrionCA.vcxproj
+++ b/msvc2019/FreeOrionCA/FreeOrionCA.vcxproj
@@ -174,7 +174,7 @@
     <ClInclude Include="..\..\network\Message.h" />
     <ClInclude Include="..\..\network\MessageQueue.h" />
     <ClInclude Include="..\..\network\Networking.h" />
-    <ClInclude Include="..\..\python\CommonFramework.h" />
+    <ClInclude Include="..\..\python\PythonBase.h" />
     <ClInclude Include="..\..\python\CommonWrappers.h" />
     <ClInclude Include="..\..\python\SetWrapper.h" />
     <ClInclude Include="..\..\universe\Building.h" />
@@ -225,7 +225,7 @@
     <ClCompile Include="..\..\client\ClientApp.cpp" />
     <ClCompile Include="..\..\client\ClientFSMEvents.cpp" />
     <ClCompile Include="..\..\client\ClientNetworking.cpp" />
-    <ClCompile Include="..\..\python\CommonFramework.cpp" />
+    <ClCompile Include="..\..\python\PythonBase.cpp" />
     <ClCompile Include="..\..\python\ConfigWrapper.cpp" />
     <ClCompile Include="..\..\python\EmpireWrapper.cpp" />
     <ClCompile Include="..\..\python\EnumWrapper.cpp" />

--- a/msvc2019/FreeOrionD/FreeOrionD.vcxproj
+++ b/msvc2019/FreeOrionD/FreeOrionD.vcxproj
@@ -170,7 +170,7 @@
     <ClInclude Include="..\..\Empire\PopulationPool.h" />
     <ClInclude Include="..\..\network\Message.h" />
     <ClInclude Include="..\..\network\Networking.h" />
-    <ClInclude Include="..\..\python\CommonFramework.h" />
+    <ClInclude Include="..\..\python\PythonBase.h" />
     <ClInclude Include="..\..\python\SetWrapper.h" />
     <ClInclude Include="..\..\server\SaveLoad.h" />
     <ClInclude Include="..\..\server\ServerApp.h" />
@@ -221,7 +221,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\combat\CombatSystem.cpp" />
-    <ClCompile Include="..\..\python\CommonFramework.cpp" />
+    <ClCompile Include="..\..\python\PythonBase.cpp" />
     <ClCompile Include="..\..\python\ConfigWrapper.cpp" />
     <ClCompile Include="..\..\python\EmpireWrapper.cpp" />
     <ClCompile Include="..\..\python\EnumWrapper.cpp" />

--- a/msvc2019/Parsers/Parsers.vcxproj
+++ b/msvc2019/Parsers/Parsers.vcxproj
@@ -109,7 +109,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_USRDLL;PARSERS_EXPORTS;FREEORION_WIN32;_DLL;BOOST_ALLOW_DEPRECATED_HEADERS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../../../include/;../../../include/python3.5/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
@@ -142,7 +142,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_USRDLL;PARSERS_EXPORTS;FREEORION_WIN32;_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../../../include/;../../../include/python3.5/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
@@ -222,6 +222,7 @@
     <ClCompile Include="..\..\parse\PlanetSizeValueRefParser.cpp" />
     <ClCompile Include="..\..\parse\PlanetTypeValueRefParser.cpp" />
     <ClCompile Include="..\..\parse\PoliciesParser.cpp" />
+    <ClCompile Include="..\..\parse\PythonParser.cpp" />
     <ClCompile Include="..\..\parse\ReportParseError.cpp" />
     <ClCompile Include="..\..\parse\ShipDesignsParser.cpp" />
     <ClCompile Include="..\..\parse\ShipHullsParser.cpp">

--- a/msvc2019/Parsers/Parsers.vcxproj.filters
+++ b/msvc2019/Parsers/Parsers.vcxproj.filters
@@ -165,6 +165,9 @@
     <ClCompile Include="..\..\parse\PoliciesParser.cpp">
       <Filter>Source Files\parse</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\parse\PythonParser.cpp">
+      <Filter>Source Files\parse</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\parse\ConditionParser.h">

--- a/msvc2019/Parsers/StdAfx.h
+++ b/msvc2019/Parsers/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus boost headers used in any .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/ 
+// https://hownot2code.com/2016/08/16/stdafx-h/
 
 // ----------------
 // includes from .h or .cpp
@@ -42,6 +42,7 @@
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/xpressive/xpressive.hpp>
 
+#include <boost/python.hpp>
 
 #ifdef _MSC_VER
 // Note: This is a workaround for Visual C++ non-conformant pre-processor

--- a/parse/CMakeLists.txt
+++ b/parse/CMakeLists.txt
@@ -4,6 +4,7 @@ if(BUILD_PARSERS)
         PUBLIC
             ${CMAKE_CURRENT_LIST_DIR}/MovableEnvelope.h
             ${CMAKE_CURRENT_LIST_DIR}/Parse.h
+            ${CMAKE_CURRENT_LIST_DIR}/PythonParser.h
         PRIVATE
             ${CMAKE_CURRENT_LIST_DIR}/CommonParamsParser.h
             ${CMAKE_CURRENT_LIST_DIR}/ConditionParser.h
@@ -78,12 +79,15 @@ if(BUILD_PARSERS)
             ${CMAKE_CURRENT_LIST_DIR}/UniverseObjectTypeValueRefParser.cpp
             ${CMAKE_CURRENT_LIST_DIR}/ValueRefParser.cpp
             ${CMAKE_CURRENT_LIST_DIR}/VisibilityValueRefParser.cpp
+            ${CMAKE_CURRENT_LIST_DIR}/PythonParser.cpp
     )
 else()
     target_sources(freeorionparseobj
         PUBLIC
             ${CMAKE_CURRENT_LIST_DIR}/Parse.h
+            ${CMAKE_CURRENT_LIST_DIR}/PythonParser.h
         PRIVATE
             ${CMAKE_CURRENT_LIST_DIR}/DummyParsers.cpp
+            ${CMAKE_CURRENT_LIST_DIR}/PythonParser.cpp
     )
 endif()

--- a/parse/PythonParser.cpp
+++ b/parse/PythonParser.cpp
@@ -4,7 +4,9 @@
 #include "../util/PythonCommon.h"
 #include <stdexcept>
 
-PythonParser::PythonParser(const PythonCommon& python) {
+PythonParser::PythonParser(PythonCommon& _python)
+    : python(_python)
+{
     if (!python.IsPythonRunning()) {
         ErrorLogger() << "Python parse given non-initialized python!";
         throw std::runtime_error("Python isn't initialized");

--- a/parse/PythonParser.cpp
+++ b/parse/PythonParser.cpp
@@ -1,0 +1,16 @@
+#include "PythonParser.h"
+
+#include "../util/Logger.h"
+#include "../util/PythonCommon.h"
+#include <stdexcept>
+
+PythonParser::PythonParser(const PythonCommon& python) {
+    if (!python.IsPythonRunning()) {
+        ErrorLogger() << "Python parse given non-initialized python!";
+        throw std::runtime_error("Python isn't initialized");
+    }
+}
+
+PythonParser::~PythonParser() {
+}
+

--- a/parse/PythonParser.h
+++ b/parse/PythonParser.h
@@ -9,6 +9,14 @@ class FO_PARSE_API PythonParser {
 public:
     PythonParser(PythonCommon& _python);
     ~PythonParser();
+
+    PythonParser(const PythonParser&) = delete;
+
+    PythonParser(PythonParser&&) = delete;
+
+    const PythonParser& operator=(const PythonParser&) = delete;
+
+    PythonParser& operator=(PythonParser&&) = delete;
 private:
     PythonCommon& python;
 };

--- a/parse/PythonParser.h
+++ b/parse/PythonParser.h
@@ -7,8 +7,10 @@ class PythonCommon;
 
 class FO_PARSE_API PythonParser {
 public:
-    PythonParser(const PythonCommon& python);
+    PythonParser(PythonCommon& _python);
     ~PythonParser();
+private:
+    PythonCommon& python;
 };
 
 #endif

--- a/parse/PythonParser.h
+++ b/parse/PythonParser.h
@@ -1,0 +1,15 @@
+#ifndef _Python_Parse_h_
+#define _Python_Parse_h_
+
+#include "Parse.h"
+
+class PythonCommon;
+
+class FO_PARSE_API PythonParser {
+public:
+    PythonParser(const PythonCommon& python);
+    ~PythonParser();
+};
+
+#endif
+

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,11 +1,11 @@
 if(BUILD_SERVER)
     target_sources(freeoriond
         PUBLIC
-            ${CMAKE_CURRENT_LIST_DIR}/CommonFramework.h
+            ${CMAKE_CURRENT_LIST_DIR}/PythonBase.h
             ${CMAKE_CURRENT_LIST_DIR}/CommonWrappers.h
             ${CMAKE_CURRENT_LIST_DIR}/SetWrapper.h
         PRIVATE
-            ${CMAKE_CURRENT_LIST_DIR}/CommonFramework.cpp
+            ${CMAKE_CURRENT_LIST_DIR}/PythonBase.cpp
             ${CMAKE_CURRENT_LIST_DIR}/ConfigWrapper.cpp
             ${CMAKE_CURRENT_LIST_DIR}/EmpireWrapper.cpp
             ${CMAKE_CURRENT_LIST_DIR}/EnumWrapper.cpp
@@ -17,11 +17,11 @@ endif()
 if(BUILD_AI)
     target_sources(freeorionca
         PUBLIC
-            ${CMAKE_CURRENT_LIST_DIR}/CommonFramework.h
+            ${CMAKE_CURRENT_LIST_DIR}/PythonBase.h
             ${CMAKE_CURRENT_LIST_DIR}/CommonWrappers.h
             ${CMAKE_CURRENT_LIST_DIR}/SetWrapper.h
         PRIVATE
-            ${CMAKE_CURRENT_LIST_DIR}/CommonFramework.cpp
+            ${CMAKE_CURRENT_LIST_DIR}/PythonBase.cpp
             ${CMAKE_CURRENT_LIST_DIR}/ConfigWrapper.cpp
             ${CMAKE_CURRENT_LIST_DIR}/EmpireWrapper.cpp
             ${CMAKE_CURRENT_LIST_DIR}/EnumWrapper.cpp

--- a/python/PythonBase.cpp
+++ b/python/PythonBase.cpp
@@ -113,9 +113,6 @@ bool PythonBase::Initialize() {
     return true;
 }
 
-bool PythonBase::IsPythonRunning()
-{ return Py_IsInitialized(); }
-
 void PythonBase::HandleErrorAlreadySet() {
     if (!Py_IsInitialized()) {
         ErrorLogger() << "Python interpreter not initialized and exception handler called.";

--- a/python/PythonBase.cpp
+++ b/python/PythonBase.cpp
@@ -1,4 +1,4 @@
-#include "CommonFramework.h"
+#include "PythonBase.h"
 
 #include "../util/Directories.h"
 #include "../util/Logger.h"

--- a/python/PythonBase.h
+++ b/python/PythonBase.h
@@ -15,18 +15,6 @@ public:
     PythonBase();
     virtual ~PythonBase();
 
-    /**
-       Handles boost::python::error_already_set.
-       If the error is SystemExit the python interpreter is finalized
-       and no longer available.
-
-       Call PyErr_Print() if the exception is an error.
-
-       HandleErrorAlreadySet is idempotent, calling it multiple times
-       won't crash or hang the process.
-     */
-    void HandleErrorAlreadySet();
-
     bool         Initialize();                         // initializes and runs the Python interpreter, prepares the Python environment
     virtual bool InitCommonImports() override;         // initializes Python imports, must be implemented by derived classes
     virtual bool InitImports() = 0;                    // initializes Python imports, must be implemented by derived classes
@@ -39,9 +27,6 @@ public:
 
 private:
     void         Finalize();                           // stops Python interpreter and releases its resources
-    // A copy of the systemExit exception to compare with returned
-    // exceptions.  It can't be created in the exception handler.
-    boost::python::object   m_system_exit;
 
     boost::optional<boost::python::dict> m_namespace;           // stores main namespace in optional to be finalized before Python interpreter
     boost::python::object*  m_python_module_error = nullptr;    // used to track if and which Python module contains the "error_report" function ErrorReport should call

--- a/python/PythonBase.h
+++ b/python/PythonBase.h
@@ -8,8 +8,9 @@
 #include <vector>
 #include <string>
 
+#include "../util/PythonCommon.h"
 
-class PythonBase {
+class PythonBase : public PythonCommon {
 public:
     PythonBase();
     virtual ~PythonBase();
@@ -25,14 +26,6 @@ public:
        won't crash or hang the process.
      */
     void HandleErrorAlreadySet();
-
-    /**
-       IsPythonRunning returns true is the python interpreter is
-       initialized.  It is typically called after
-       HandleErrorAlreadySet() to determine if the error caused the
-       interpreter to shutdown.
-     */
-    bool IsPythonRunning();
 
     bool         Initialize();                         // initializes and runs the Python interpreter, prepares the Python environment
     virtual bool InitImports() = 0;                    // initializes Python imports, must be implemented by derived classes
@@ -65,4 +58,4 @@ const std::string GetPythonDir();
 const std::string GetPythonCommonDir();
 
 
-#endif /* defined(__FreeOrion__Python__CommonFramework__) */
+#endif /* defined(__FreeOrion__Python__PythonBase__) */

--- a/python/PythonBase.h
+++ b/python/PythonBase.h
@@ -1,5 +1,5 @@
-#ifndef __FreeOrion__Python__CommonFramework__
-#define __FreeOrion__Python__CommonFramework__
+#ifndef __FreeOrion__Python__PythonBase__
+#define __FreeOrion__Python__PythonBase__
 
 #include <boost/optional.hpp>
 #include <boost/python.hpp>

--- a/python/PythonBase.h
+++ b/python/PythonBase.h
@@ -28,6 +28,7 @@ public:
     void HandleErrorAlreadySet();
 
     bool         Initialize();                         // initializes and runs the Python interpreter, prepares the Python environment
+    virtual bool InitCommonImports() override;         // initializes Python imports, must be implemented by derived classes
     virtual bool InitImports() = 0;                    // initializes Python imports, must be implemented by derived classes
     virtual bool InitModules() = 0;                    // initializes Python modules, must be implemented by derived classes
     void         SetCurrentDir(const std::string dir); // sets Python current work directory or throws error_already_set
@@ -42,11 +43,6 @@ private:
     // exceptions.  It can't be created in the exception handler.
     boost::python::object   m_system_exit;
 
-    // some helper objects needed to initialize and run the Python interface
-#if defined(FREEORION_MACOSX) || defined(FREEORION_WIN32)
-    wchar_t*                m_home_dir = nullptr;
-    wchar_t*                m_program_name = nullptr;
-#endif
     boost::optional<boost::python::dict> m_namespace;           // stores main namespace in optional to be finalized before Python interpreter
     boost::python::object*  m_python_module_error = nullptr;    // used to track if and which Python module contains the "error_report" function ErrorReport should call
 };

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -121,7 +121,7 @@ ServerApp::ServerApp() :
     // to have data initialized before autostart execution
     std::promise<void> barrier;
     std::future<void> barrier_future = barrier.get_future();
-    StartBackgroundParsing(std::move(barrier));
+    StartBackgroundParsing(m_python_server, std::move(barrier));
     barrier_future.wait();
 
     m_fsm->initiate();
@@ -171,8 +171,8 @@ namespace {
 #include <stdlib.h>
 #endif
 
-void ServerApp::StartBackgroundParsing(std::promise<void>&& barrier) {
-    IApp::StartBackgroundParsing(std::move(barrier));
+void ServerApp::StartBackgroundParsing(const PythonCommon& python, std::promise<void>&& barrier) {
+    IApp::StartBackgroundParsing(python, std::move(barrier));
     const auto& rdir = GetResourceDir();
 
     if (fs::exists(rdir / "scripting/starting_unlocks/items.inf"))

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -19,6 +19,7 @@
 #include "../combat/CombatSystem.h"
 #include "../Empire/Empire.h"
 #include "../parse/Parse.h"
+#include "../parse/PythonParser.h"
 #include "../universe/Building.h"
 #include "../universe/Condition.h"
 #include "../universe/Fleet.h"
@@ -121,7 +122,7 @@ ServerApp::ServerApp() :
     // to have data initialized before autostart execution
     std::promise<void> barrier;
     std::future<void> barrier_future = barrier.get_future();
-    StartBackgroundParsing(m_python_server, std::move(barrier));
+    StartBackgroundParsing(PythonParser(m_python_server), std::move(barrier));
     barrier_future.wait();
 
     m_fsm->initiate();
@@ -171,7 +172,7 @@ namespace {
 #include <stdlib.h>
 #endif
 
-void ServerApp::StartBackgroundParsing(const PythonCommon& python, std::promise<void>&& barrier) {
+void ServerApp::StartBackgroundParsing(const PythonParser& python, std::promise<void>&& barrier) {
     IApp::StartBackgroundParsing(python, std::move(barrier));
     const auto& rdir = GetResourceDir();
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -92,7 +92,7 @@ public:
 
     void operator()(); ///< external interface to Run()
 
-    void StartBackgroundParsing(const PythonCommon& python, std::promise<void>&& barrier) override;
+    void StartBackgroundParsing(const PythonParser& python, std::promise<void>&& barrier) override;
 
     /** Returns the galaxy setup data used for the current game */
     GalaxySetupData&    GetGalaxySetupData() { return m_galaxy_setup_data; }

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -92,7 +92,7 @@ public:
 
     void operator()(); ///< external interface to Run()
 
-    void StartBackgroundParsing(std::promise<void>&& barrier) override;
+    void StartBackgroundParsing(const PythonCommon& python, std::promise<void>&& barrier) override;
 
     /** Returns the galaxy setup data used for the current game */
     GalaxySetupData&    GetGalaxySetupData() { return m_galaxy_setup_data; }

--- a/server/ServerFramework.h
+++ b/server/ServerFramework.h
@@ -1,7 +1,7 @@
 #ifndef _ServerFramework_h_
 #define _ServerFramework_h_
 
-#include "../python/CommonFramework.h"
+#include "../python/PythonBase.h"
 #include "../util/MultiplayerCommon.h"
 
 #include <boost/circular_buffer.hpp>

--- a/test/parse/CMakeLists.txt
+++ b/test/parse/CMakeLists.txt
@@ -46,6 +46,7 @@ set(FO_TEST_PARSE
     #TestValueRefStringParser
     #TestValueRefUniverseObjectTypeParser
     TestScriptParser
+    TestPythonParser
 )
 
 foreach(_TEST ${FO_TEST_PARSE})

--- a/test/parse/ParserAppFixture.cpp
+++ b/test/parse/ParserAppFixture.cpp
@@ -8,6 +8,8 @@ namespace fs = boost::filesystem;
 ParserAppFixture::ParserAppFixture() {
     InitDirs(boost::unit_test::framework::master_test_suite().argv[0]);
 
+    BOOST_REQUIRE(m_python.Initialize());
+
     m_scripting_dir = fs::system_complete(GetBinDir() / "test-scripting");
     BOOST_TEST_MESSAGE("Test scripting directory: " << m_scripting_dir);
     BOOST_REQUIRE(m_scripting_dir.is_absolute());

--- a/test/parse/ParserAppFixture.h
+++ b/test/parse/ParserAppFixture.h
@@ -7,6 +7,7 @@
 #include "universe/Universe.h"
 #include "util/AppInterface.h"
 #include "util/MultiplayerCommon.h"
+#include "util/PythonCommon.h"
 
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/path.hpp>
@@ -48,6 +49,7 @@ public:
     int EffectsProcessingThreads() const override;
 protected:
     boost::filesystem::path m_scripting_dir;
+    PythonCommon            m_python;
 
     // Gamestate...
     Universe                    m_universe;

--- a/test/parse/TestPythonParser.cpp
+++ b/test/parse/TestPythonParser.cpp
@@ -4,14 +4,12 @@
 #include "util/Directories.h"
 #include "util/PythonCommon.h"
 
-BOOST_FIXTURE_TEST_SUITE(TestPythonParser, PythonCommon)
+#include "ParserAppFixture.h"
+
+BOOST_FIXTURE_TEST_SUITE(TestPythonParser, ParserAppFixture)
 
 BOOST_AUTO_TEST_CASE(parse0) {
-    InitDirs("");
-
-    BOOST_REQUIRE(Initialize());
-
-    PythonParser parser(*this);
+    PythonParser parser(m_python);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/test/parse/TestPythonParser.cpp
+++ b/test/parse/TestPythonParser.cpp
@@ -1,0 +1,18 @@
+#include <boost/test/unit_test.hpp>
+
+#include "parse/PythonParser.h"
+#include "util/Directories.h"
+#include "util/PythonCommon.h"
+
+BOOST_FIXTURE_TEST_SUITE(TestPythonParser, PythonCommon)
+
+BOOST_AUTO_TEST_CASE(parse0) {
+    InitDirs("");
+
+    BOOST_REQUIRE(Initialize());
+
+    PythonParser parser(*this);
+}
+
+BOOST_AUTO_TEST_SUITE_END()
+

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -8,6 +8,7 @@
 #include "util/i18n.h"
 #include "util/Version.h"
 #include "util/PythonCommon.h"
+#include "parse/PythonParser.h"
 
 #include <boost/format.hpp>
 #include <boost/uuid/nil_generator.hpp>
@@ -41,7 +42,7 @@ ClientAppFixture::ClientAppFixture() :
         DebugLogger() << "Started background parser thread";
         PythonCommon python;
         python.Initialize();
-        StartBackgroundParsing(python, std::move(b));
+        StartBackgroundParsing(PythonParser(python), std::move(b));
     }, std::move(barrier));
     background.detach();
     barrier_future.wait();

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -7,6 +7,7 @@
 #include "util/GameRules.h"
 #include "util/i18n.h"
 #include "util/Version.h"
+#include "util/PythonCommon.h"
 
 #include <boost/format.hpp>
 #include <boost/uuid/nil_generator.hpp>
@@ -38,7 +39,9 @@ ClientAppFixture::ClientAppFixture() :
     std::future<void> barrier_future = barrier.get_future();
     std::thread background([this] (auto b) {
         DebugLogger() << "Started background parser thread";
-        StartBackgroundParsing(std::move(b));
+        PythonCommon python;
+        python.Initialize();
+        StartBackgroundParsing(python, std::move(b));
     }, std::move(barrier));
     background.detach();
     barrier_future.wait();

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -16,6 +16,7 @@
 #include "Directories.h"
 #include "GameRules.h"
 #include "Pending.h"
+#include "PythonCommon.h"
 
 #include <boost/filesystem.hpp>
 
@@ -50,13 +51,19 @@ int IApp::MAX_AI_PLAYERS() {
     return max_number_AIs;
 }
 
-void IApp::StartBackgroundParsing(std::promise<void>&& barrier) {
+void IApp::StartBackgroundParsing(const PythonCommon& python, std::promise<void>&& barrier) {
     namespace fs = boost::filesystem;
 
     const auto& rdir = GetResourceDir();
     if (!IsExistingDir(rdir)) {
         ErrorLogger() << "Background parse given non-existant resources directory: " << rdir.string() ;
         barrier.set_exception(std::make_exception_ptr(std::runtime_error("non-existant resources directory")));
+        return;
+    }
+
+    if (!python.IsPythonRunning()) {
+        ErrorLogger() << "Background parse given non-initialized python!";
+        barrier.set_exception(std::make_exception_ptr(std::runtime_error("non-initialized python")));
         return;
     }
 

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -51,19 +51,13 @@ int IApp::MAX_AI_PLAYERS() {
     return max_number_AIs;
 }
 
-void IApp::StartBackgroundParsing(const PythonCommon& python, std::promise<void>&& barrier) {
+void IApp::StartBackgroundParsing(const PythonParser& python, std::promise<void>&& barrier) {
     namespace fs = boost::filesystem;
 
     const auto& rdir = GetResourceDir();
     if (!IsExistingDir(rdir)) {
         ErrorLogger() << "Background parse given non-existant resources directory: " << rdir.string() ;
         barrier.set_exception(std::make_exception_ptr(std::runtime_error("non-existant resources directory")));
-        return;
-    }
-
-    if (!python.IsPythonRunning()) {
-        ErrorLogger() << "Background parse given non-initialized python!";
-        barrier.set_exception(std::make_exception_ptr(std::runtime_error("non-initialized python")));
         return;
     }
 

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -21,7 +21,7 @@ class Ship;
 class Fleet;
 class Building;
 class Field;
-class PythonCommon;
+class PythonParser;
 struct GalaxySetupData;
 
 class FO_COMMON_API IApp {
@@ -56,7 +56,7 @@ public:
       * or the other asynchronous parsing may still be ongoing
       * at that time.
       * Requires \a python to be initialized. */
-    virtual void StartBackgroundParsing(const PythonCommon& python, std::promise<void>&& barrier);
+    virtual void StartBackgroundParsing(const PythonParser& python, std::promise<void>&& barrier);
 
     /** Returns the set of known Empires for this application. */
     virtual EmpireManager& Empires() = 0;

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -21,6 +21,7 @@ class Ship;
 class Fleet;
 class Building;
 class Field;
+class PythonCommon;
 struct GalaxySetupData;
 
 class FO_COMMON_API IApp {
@@ -53,8 +54,9 @@ public:
       * unblocked when the asynchronous parsing of named value refs is
       * completed, but the synchronous parsing of in the calling thread
       * or the other asynchronous parsing may still be ongoing
-      * at that time. */
-    virtual void StartBackgroundParsing(std::promise<void>&& barrier);
+      * at that time.
+      * Requires \a python to be initialized. */
+    virtual void StartBackgroundParsing(const PythonCommon& python, std::promise<void>&& barrier);
 
     /** Returns the set of known Empires for this application. */
     virtual EmpireManager& Empires() = 0;

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -17,6 +17,7 @@ target_sources(freeorioncommon
         ${CMAKE_CURRENT_LIST_DIR}/OrderSet.h
         ${CMAKE_CURRENT_LIST_DIR}/Pending.h
         ${CMAKE_CURRENT_LIST_DIR}/Process.h
+        ${CMAKE_CURRENT_LIST_DIR}/PythonCommon.h
         ${CMAKE_CURRENT_LIST_DIR}/Random.h
         ${CMAKE_CURRENT_LIST_DIR}/SaveGamePreviewUtils.h
         ${CMAKE_CURRENT_LIST_DIR}/ScopedTimer.h
@@ -41,6 +42,7 @@ target_sources(freeorioncommon
         ${CMAKE_CURRENT_LIST_DIR}/Order.cpp
         ${CMAKE_CURRENT_LIST_DIR}/OrderSet.cpp
         ${CMAKE_CURRENT_LIST_DIR}/Process.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/PythonCommon.cpp
         ${CMAKE_CURRENT_LIST_DIR}/Random.cpp
         ${CMAKE_CURRENT_LIST_DIR}/SaveGamePreviewUtils.cpp
         ${CMAKE_CURRENT_LIST_DIR}/ScopedTimer.cpp

--- a/util/PythonCommon.cpp
+++ b/util/PythonCommon.cpp
@@ -2,15 +2,71 @@
 
 #include <boost/python.hpp>
 
-PythonCommon::PythonCommon() {
-}
+#include "../util/Logger.h"
 
-PythonCommon::~PythonCommon() {
-}
+PythonCommon::PythonCommon()
+{ }
 
-bool PythonCommon::IsPythonRunning()
+PythonCommon::~PythonCommon()
+{ Finalize(); }
+
+bool PythonCommon::IsPythonRunning() const
 { return Py_IsInitialized(); }
 
-bool PythonCommon::Initialize()
+bool PythonCommon::Initialize() {
+    DebugLogger() << "Initializing FreeOrion Python interface";
+
+    try {
+#if defined(FREEORION_MACOSX) || defined(FREEORION_WIN32)
+        // There have been recurring issues on Windows and OSX to get FO to use the
+        // Python framework shipped with the app (instead of falling back on the ones
+        // provided by the system). These API calls have been added in an attempt to
+        // solve the problems. Not sure if they are really required, but better save
+        // than sorry... ;)
+        m_home_dir = Py_DecodeLocale(GetPythonHome().string().c_str(), nullptr);
+        Py_SetPythonHome(m_home_dir);
+        DebugLogger() << "Python home set to " << Py_GetPythonHome();
+        m_program_name = Py_DecodeLocale((GetPythonHome() / "Python").string().c_str(), nullptr);
+        Py_SetProgramName(m_program_name);
+        DebugLogger() << "Python program name set to " << Py_GetProgramFullPath();
+#endif
+        if (!InitCommonImports()) {
+            ErrorLogger() << "Unable to initialize imports";
+            return false;
+        }
+        // initializes Python interpreter, allowing Python functions to be called from C++
+        Py_Initialize();
+        DebugLogger() << "Python initialized";
+        DebugLogger() << "Python version: " << Py_GetVersion();
+        DebugLogger() << "Python prefix: " << Py_GetPrefix();
+        DebugLogger() << "Python module search path: " << Py_GetPath();
+    }
+    catch (...) {
+        ErrorLogger() << "Unable to initialize Python interpreter";
+        return false;
+    }
+    return true;
+}
+
+bool PythonCommon::InitCommonImports()
 { return true; }
+
+void PythonCommon::Finalize() {
+    try {
+        Py_Finalize();
+#if defined(FREEORION_MACOSX) || defined(FREEORION_WIN32)
+        if (m_home_dir != nullptr) {
+            PyMem_RawFree(m_home_dir);
+            m_home_dir = nullptr;
+        }
+        if (m_program_name != nullptr) {
+            PyMem_RawFree(m_program_name);
+            m_program_name = nullptr;
+        }
+#endif
+    } catch (const std::exception& e) {
+        ErrorLogger() << "Caught exception when cleaning up FreeOrion Python interface: " << e.what();
+        return;
+    }
+}
 

--- a/util/PythonCommon.cpp
+++ b/util/PythonCommon.cpp
@@ -1,0 +1,16 @@
+#include "PythonCommon.h"
+
+#include <boost/python.hpp>
+
+PythonCommon::PythonCommon() {
+}
+
+PythonCommon::~PythonCommon() {
+}
+
+bool PythonCommon::IsPythonRunning()
+{ return Py_IsInitialized(); }
+
+bool PythonCommon::Initialize()
+{ return true; }
+

--- a/util/PythonCommon.cpp
+++ b/util/PythonCommon.cpp
@@ -1,9 +1,11 @@
 #include "PythonCommon.h"
 
-#include <boost/python.hpp>
+#include <boost/algorithm/string/trim.hpp>
 
 #include "../util/Directories.h"
 #include "../util/Logger.h"
+
+namespace py = boost::python;
 
 PythonCommon::PythonCommon()
 { }
@@ -46,28 +48,81 @@ bool PythonCommon::Initialize() {
         ErrorLogger() << "Unable to initialize Python interpreter";
         return false;
     }
+
+    try {
+        m_system_exit = py::import("builtins").attr("SystemExit");
+    } catch (const py::error_already_set& err) {
+        HandleErrorAlreadySet();
+        ErrorLogger() << "Unable to initialize FreeOrion Python SystemExit";
+        return false;
+    } catch (...) {
+        ErrorLogger() << "Unable to initialize FreeOrion Python SystemExit";
+        return false;
+    }
+
     return true;
 }
 
 bool PythonCommon::InitCommonImports()
 { return true; }
 
-void PythonCommon::Finalize() {
-    try {
-        Py_Finalize();
-#if defined(FREEORION_MACOSX) || defined(FREEORION_WIN32)
-        if (m_home_dir != nullptr) {
-            PyMem_RawFree(m_home_dir);
-            m_home_dir = nullptr;
-        }
-        if (m_program_name != nullptr) {
-            PyMem_RawFree(m_program_name);
-            m_program_name = nullptr;
-        }
-#endif
-    } catch (const std::exception& e) {
-        ErrorLogger() << "Caught exception when cleaning up FreeOrion Python interface: " << e.what();
+void PythonCommon::HandleErrorAlreadySet() {
+    if (!Py_IsInitialized()) {
+        ErrorLogger() << "Python interpreter not initialized and exception handler called.";
         return;
+    }
+
+    // Matches system exit
+    if (PyErr_ExceptionMatches(m_system_exit.ptr()))
+    {
+        Finalize();
+        ErrorLogger() << "Python interpreter exited with SystemExit(), sys.exit(), exit, quit or some other alias.";
+        return;
+    }
+
+    PyObject *extype, *value, *traceback;
+    PyErr_Fetch(&extype, &value, &traceback);
+    PyErr_NormalizeException(&extype, &value, &traceback);
+    if (extype == nullptr) {
+        ErrorLogger() << "Missing python exception type";
+        return;
+    }
+
+    py::object o_extype(py::handle<>(py::borrowed(extype)));
+    py::object o_value(py::handle<>(py::borrowed(value)));
+    py::object o_traceback = traceback != nullptr ? py::object(py::handle<>(py::borrowed(traceback))) : py::object();
+
+    py::object mod_traceback = py::import("traceback");
+    py::object lines = mod_traceback.attr("format_exception")(o_extype, o_value, o_traceback);
+    for (int i = 0; i < len(lines); ++i) {
+        std::string line = py::extract<std::string>(lines[i])();
+        boost::algorithm::trim_right(line);
+        ErrorLogger() << line;
+    }
+
+    return;
+}
+
+void PythonCommon::Finalize() {
+    if (Py_IsInitialized()) {
+        // cleanup python objects before interpterer shutdown
+        m_system_exit = py::object();
+        try {
+            Py_Finalize();
+#if defined(FREEORION_MACOSX) || defined(FREEORION_WIN32)
+            if (m_home_dir != nullptr) {
+                PyMem_RawFree(m_home_dir);
+                m_home_dir = nullptr;
+            }
+            if (m_program_name != nullptr) {
+                PyMem_RawFree(m_program_name);
+                m_program_name = nullptr;
+            }
+#endif
+        } catch (const std::exception& e) {
+            ErrorLogger() << "Caught exception when cleaning up FreeOrion Python interface: " << e.what();
+            return;
+        }
     }
 }
 

--- a/util/PythonCommon.cpp
+++ b/util/PythonCommon.cpp
@@ -2,6 +2,7 @@
 
 #include <boost/python.hpp>
 
+#include "../util/Directories.h"
 #include "../util/Logger.h"
 
 PythonCommon::PythonCommon()

--- a/util/PythonCommon.h
+++ b/util/PythonCommon.h
@@ -1,0 +1,23 @@
+#ifndef __FreeOrion__Util__PythonCommon__
+#define __FreeOrion__Util__PythonCommon__
+
+#include "Export.h"
+
+class FO_COMMON_API PythonCommon {
+public:
+    PythonCommon();
+    virtual ~PythonCommon();
+
+    /**
+       IsPythonRunning returns true is the python interpreter is
+       initialized.  It is typically called after
+       HandleErrorAlreadySet() to determine if the error caused the
+       interpreter to shutdown.
+     */
+    bool IsPythonRunning();
+
+    bool Initialize();
+};
+
+#endif /* defined(__FreeOrion__Util__PythonCommon__) */
+

--- a/util/PythonCommon.h
+++ b/util/PythonCommon.h
@@ -1,6 +1,8 @@
 #ifndef __FreeOrion__Util__PythonCommon__
 #define __FreeOrion__Util__PythonCommon__
 
+#include <boost/python.hpp>
+
 #include "Export.h"
 
 class FO_COMMON_API PythonCommon {
@@ -16,6 +18,18 @@ public:
      */
     bool         IsPythonRunning() const;
 
+    /**
+       Handles boost::python::error_already_set.
+       If the error is SystemExit the python interpreter is finalized
+       and no longer available.
+
+       Call PyErr_Print() if the exception is an error.
+
+       HandleErrorAlreadySet is idempotent, calling it multiple times
+       won't crash or hang the process.
+     */
+    void HandleErrorAlreadySet();
+
     bool         Initialize();        // initializes and runs the Python interpreter, prepares the Python environment
 
     virtual bool InitCommonImports(); // initializes Python imports
@@ -27,6 +41,9 @@ private:
     wchar_t*                m_home_dir = nullptr;
     wchar_t*                m_program_name = nullptr;
 #endif
+    // A copy of the systemExit exception to compare with returned
+    // exceptions.  It can't be created in the exception handler.
+    boost::python::object   m_system_exit;
 };
 
 #endif /* defined(__FreeOrion__Util__PythonCommon__) */

--- a/util/PythonCommon.h
+++ b/util/PythonCommon.h
@@ -14,9 +14,19 @@ public:
        HandleErrorAlreadySet() to determine if the error caused the
        interpreter to shutdown.
      */
-    bool IsPythonRunning();
+    bool         IsPythonRunning() const;
 
-    bool Initialize();
+    bool         Initialize();        // initializes and runs the Python interpreter, prepares the Python environment
+
+    virtual bool InitCommonImports(); // initializes Python imports
+
+    void         Finalize();          // stops Python interpreter and releases its resources
+private:
+    // some helper objects needed to initialize and run the Python interface
+#if defined(FREEORION_MACOSX) || defined(FREEORION_WIN32)
+    wchar_t*                m_home_dir = nullptr;
+    wchar_t*                m_program_name = nullptr;
+#endif
 };
 
 #endif /* defined(__FreeOrion__Util__PythonCommon__) */


### PR DESCRIPTION
Preparation for using python's parser.

Moves minimal python initialization and finalization to common library.

Should be usable in both cases if we use python ast or python interpretation.

Follows #3342