### PR TITLE
Introduce server-side auto-turn

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1017,6 +1017,18 @@ bool Empire::Ready() const
 void Empire::SetReady(bool ready)
 { m_ready = ready; }
 
+void Empire::AutoTurnSetReady() {
+    if (m_auto_turn_count > 0) {
+        m_auto_turn_count --;
+    }
+    SetReady(m_auto_turn_count != 0);
+}
+
+void Empire::SetAutoTurn(int turns_count) {
+    m_auto_turn_count = turns_count;
+    SetReady(m_auto_turn_count != 0);
+}
+
 void Empire::UpdateSystemSupplyRanges(const std::set<int>& known_objects) {
     //std::cout << "Empire::UpdateSystemSupplyRanges() for empire " << this->Name() << std::endl;
     m_supply_system_ranges.clear();

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -290,6 +290,8 @@ public:
     void Eliminate();                                ///< Marks empire as eliminated and cleans up empire after it is eliminated.  Queues are cleared, capital is reset, and other state info not relevant to an eliminated empire is cleared
     void Win(const std::string& reason);             ///< Marks this empire as having won for this reason, and sends the appropriate sitreps
     void SetReady(bool ready);                       ///< Marks this empire with readiness status
+    void AutoTurnSetReady();                         ///< Decreases auto-turn counter and set empire ready if not expired or set unready
+    void SetAutoTurn(int turns_count);               ///< Set auto-turn counter and set empire ready if not expired
 
     /** Inserts the given SitRep entry into the empire's sitrep list. */
     void AddSitRepEntry(const SitRepEntry& entry);
@@ -580,6 +582,7 @@ private:
     std::map<int, std::set<int>>    m_preserved_system_exit_lanes;  ///< for each system known to this empire, the set of exit lanes preserved for fleet travel even if otherwise blockaded
     std::map<int, std::set<int>>    m_pending_system_exit_lanes;    ///< pending updates to m_preserved_system_exit_lanes
     bool                            m_ready = false;                ///< readiness status of empire
+    int                             m_auto_turn_count = 0;          ///< auto-turn counter value
 
     friend class boost::serialization::access;
     Empire();

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -722,6 +722,11 @@ Message PlayerInfoMessage(const std::map<int, PlayerInfo>& players) {
     return Message(Message::MessageType::PLAYER_INFO, os.str());
 }
 
+Message AutoTurnMessage(int turns_count) {
+    return Message(Message::MessageType::AUTO_TURN,
+                   std::to_string(turns_count));
+}
+
 ////////////////////////////////////////////////
 // Message data extractors
 ////////////////////////////////////////////////

--- a/network/Message.h
+++ b/network/Message.h
@@ -107,6 +107,7 @@ public:
         ((TURN_PARTIAL_ORDERS))    ///< sent to the server by a client that has changes in orders to be stored
         ((TURN_TIMEOUT))           ///< sent by server to client to notify about remaining time before turn advance
         ((PLAYER_INFO))            ///< sent by server to client to notify about changes in the player data
+        ((AUTO_TURN))              ///< sent by client to server to move into auto-turn state
     )
 
     FO_ENUM(
@@ -366,6 +367,10 @@ FO_COMMON_API Message UnreadyMessage();
 
 /** creates a PLAYER_INFO message to notify player about changes in the player list. */
 FO_COMMON_API Message PlayerInfoMessage(const std::map<int, PlayerInfo>& players);
+
+/** creates a AUTO_TURN message to set empire in auto-turn state for \a turns_count turns,
+ *  inifinity turns if -1 or set empire to playing state if 0. */
+FO_COMMON_API Message AutoTurnMessage(int turns_count);
 
 ////////////////////////////////////////////////
 // Message data extractors

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -419,6 +419,7 @@ void ServerApp::HandleMessage(const Message& msg, PlayerConnectionPtr player_con
     case Message::MessageType::DIPLOMACY:                m_fsm->process_event(Diplomacy(msg, player_connection));        break;
     case Message::MessageType::MODERATOR_ACTION:         m_fsm->process_event(ModeratorAct(msg, player_connection));     break;
     case Message::MessageType::ELIMINATE_SELF:           m_fsm->process_event(EliminateSelf(msg, player_connection));    break;
+    case Message::MessageType::AUTO_TURN:                m_fsm->process_event(AutoTurn(msg, player_connection));         break;
 
     case Message::MessageType::ERROR_MSG:
     case Message::MessageType::DEBUG:                    break;
@@ -2011,7 +2012,7 @@ void ServerApp::ClearEmpireTurnOrders() {
         }
     }
     for (auto& empire : Empires()) {
-        empire.second->SetReady(false);
+        empire.second->AutoTurnSetReady();
     }
 }
 

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -88,6 +88,7 @@ struct MessageEventBase {
     (ModeratorAct)                          \
     (AuthResponse)                          \
     (EliminateSelf)                         \
+    (AutoTurn)                              \
     (Error)
 
 
@@ -296,6 +297,7 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
         sc::custom_reaction<JoinGame>,
         sc::custom_reaction<AuthResponse>,
         sc::custom_reaction<EliminateSelf>,
+        sc::custom_reaction<AutoTurn>,
         sc::custom_reaction<Error>,
         sc::custom_reaction<LobbyUpdate>
     > reactions;
@@ -312,6 +314,7 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
     sc::result react(const JoinGame& msg);
     sc::result react(const AuthResponse& msg);
     sc::result react(const EliminateSelf& msg);
+    sc::result react(const AutoTurn& msg);
     sc::result react(const Error& msg);
     sc::result react(const LobbyUpdate& msg);
 

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -305,10 +305,16 @@ void Empire::serialize(Archive& ar, const unsigned int version)
         ar  & BOOST_SERIALIZATION_NVP(m_ready);
     }
 
+    if (Archive::is_loading::value && version < 5) {
+        m_auto_turn_count = 0;
+    } else {
+        ar  & BOOST_SERIALIZATION_NVP(m_auto_turn_count);
+    }
+
     TraceLogger() << "DONE serializing empire " << m_id << ": " << m_name;
 }
 
-BOOST_CLASS_VERSION(Empire, 5)
+BOOST_CLASS_VERSION(Empire, 6)
 
 template void Empire::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
 template void Empire::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);


### PR DESCRIPTION
Server-side part for https://github.com/freeorion/freeorion/issues/3182

Adds counter which make empire automatically ready:
- -1 means infinity auto-turn.
- 0 means no auto-turn.

Other values are automatically decreasing each turn.