### PR TITLE
Inform about missing optional "value" reference (instead of error)

### DIFF
--- a/util/StringTable.cpp
+++ b/util/StringTable.cpp
@@ -245,7 +245,10 @@ void StringTable::Load(std::shared_ptr<const StringTable> fallback) {
                     entry.second.replace(position, match.length(), substitution);
                     position += substitution.length();
                 } else {
-                    ErrorLogger() << "Unresolved reference: " << match[2] << " in: " << m_filename << ".";
+                    if (match[1] == "value")
+                        InfoLogger() << "Unresolved optional value reference: " << match[2] << " in: " << m_filename << ".";
+                    else
+                        ErrorLogger() << "Unresolved reference: " << match[2] << " in: " << m_filename << ".";
                     position += match.length();
                 }
             }


### PR DESCRIPTION
Expect [[value blabla]] stringtable references to be optional (blabla does not have to exist). Write this to infologger.

Followup to  #3206,  should fix error log for #3170 and #3195