### PR TITLE
Lower monster&special freq., fine-tuned native freq.

### DIFF
--- a/default/python/universe_generation/universe_tables.py
+++ b/default/python/universe_generation/universe_tables.py
@@ -109,28 +109,28 @@ GALAXY_SHAPE_MOD_TO_PLANET_SIZE_DIST = {
 # Whenever any special might be placed, the following probability is the chance
 # that it actually will be (after other factors are considered).
 SPECIALS_FREQUENCY = {
-    fo.galaxySetupOption.none:    0,
-    fo.galaxySetupOption.low:    .1,
-    fo.galaxySetupOption.medium: .3,
-    fo.galaxySetupOption.high:   .8,
+    fo.galaxySetupOption.none:   .0,
+    fo.galaxySetupOption.low:    .08,
+    fo.galaxySetupOption.medium: .2,
+    fo.galaxySetupOption.high:   .5,
 }
 
 # Whenever a monster might be placed, the following probability is the chance
 # that it actually will be (after other factors are considered).
 MONSTER_FREQUENCY = {
-    fo.galaxySetupOption.none:   0,
-    fo.galaxySetupOption.low:    0.033,
-    fo.galaxySetupOption.medium: 0.125,
-    fo.galaxySetupOption.high:   0.333,
+    fo.galaxySetupOption.none:   .0,
+    fo.galaxySetupOption.low:    .08,
+    fo.galaxySetupOption.medium: .2,
+    fo.galaxySetupOption.high:   .5,
 }
 
 # Whenever natives might be placed on a planet, the following probability is
 # the chance that they actually will be (after other factors are considered).
 NATIVE_FREQUENCY = {
-    fo.galaxySetupOption.none:   0,
-    fo.galaxySetupOption.low:    0.083,
-    fo.galaxySetupOption.medium: 0.143,
-    fo.galaxySetupOption.high:   0.200,
+    fo.galaxySetupOption.none:   .0,
+    fo.galaxySetupOption.low:    .05,
+    fo.galaxySetupOption.medium: .125,
+    fo.galaxySetupOption.high:   .3,
 }
 
 # This is the maximum size of the shortest path via starlane that the generator


### PR DESCRIPTION
This PR makes monsters and specials less frequent, specially for High, and adjusts natives frequency a bit.

Playtested for galaxies with 150 systems and 7 empires.
With low settings, on average, there is 3-5 monste nests, half of the growth specials are present (around 10 for 200 planets, with not all growth specials available) and around 6 native worlds.
High settings still give plenty of everything, enough monsters to be surrounded in every game (must kill monsters to get to other empires), most often getting all types of growth specials/monster nests and most of the available native species, several computronium moons and a honeycomb. 

It's hard to get a combination of values for low, medium and high that can comply with all players' expectations. Adding very low and very high galaxy options would allow for more versatility, but that's out of this PR's scope.

[Forum thread](https://www.freeorion.org/forum/viewtopic.php?f=28&t=11818&p=104020#p104020).