### PR TITLE
Fix display of named value refs without string table entry

### DIFF
--- a/util/StringTable.cpp
+++ b/util/StringTable.cpp
@@ -245,11 +245,15 @@ void StringTable::Load(std::shared_ptr<const StringTable> fallback) {
                     entry.second.replace(position, match.length(), substitution);
                     position += substitution.length();
                 } else {
-                    if (match[1] == "value")
+                    if (match[1] == "value") {
                         InfoLogger() << "Unresolved optional value reference: " << match[2] << " in: " << m_filename << ".";
-                    else
+                        const std::string substitution = "<value " + match[2].str() + "></value>";
+                        entry.second.replace(position, match.length(), substitution);
+                        position += substitution.length();
+                    } else {
                         ErrorLogger() << "Unresolved reference: " << match[2] << " in: " << m_filename << ".";
-                    position += match.length();
+                        position += match.length();
+                    }
                 }
             }
         }


### PR DESCRIPTION
Stringtable entries for named value refs are optional (info gets logged instead of reporting errors).

But display did not work as `[[value bla]]` needs to be converted to `<value bla></value>` in StringTables lookup, 
so the LinkText can do formatting and tooltip. With this PR it converts correctly.

@oberlus reported this bug but i dont see an github Issue for this