### PR TITLE
Some Godot fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,7 @@ _linux_setup_common: &_linux_setup_common
       cppcheck
       doxygen
       python3-pip
-      scons
     - python3 -m pip install flake8==3.7.9
-    - if [[ "$BUILD_GODOT" == "yes" ]]; then pushd .. && git clone --recursive https://github.com/GodotNativeTools/godot-cpp -b 3.2 --depth 1 && cd godot-cpp/ && scons platform=linux generate_bindings=yes target=release -j2 && popd; fi
   before_script:
     - mkdir build
     - cd build
@@ -122,17 +120,6 @@ jobs:
         - CMAKE_BUILD_PARALLEL_LEVEL=2
       script:
         - cmake -DBUILD_CLIENT_GG=OFF -DBUILD_TESTING=ON ..
-        - cmake --build .
-
-    - name: Build FreeOrion Godot client library on Ubunutu 18.04 (Bionic)
-      <<: *_linux_setup_common
-      stage: build
-      env:
-        - CACHE_NAME=linux-godot
-        - CMAKE_BUILD_PARALLEL_LEVEL=2
-        - BUILD_GODOT=yes
-      script:
-        - cmake -DGODOT_CPP_ROOT=`readlink -f ../../godot-cpp/` -DBUILD_CLIENT_GG=OFF -DBUILD_SERVER=OFF -DBUILD_AI=OFF -DBUILD_CLIENT_GODOT=ON -DBUILD_TESTING=ON ..
         - cmake --build .
 
     - name: Build FreeOrion on MacOS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -639,11 +639,17 @@ if(BUILD_CLIENT_GG)
 endif()
 
 if(BUILD_CLIENT_GODOT)
+    if(CMAKE_BUILD_TYPE MATCHES Debug)
+        set(GODOT_CPP_BUILD_TYPE Debug)
+    else()
+        set(GODOT_CPP_BUILD_TYPE Release)
+    endif()
+
     include(ExternalProject)
     ExternalProject_Add(godotcpp
         SOURCE_DIR ${PROJECT_SOURCE_DIR}/godot/godot-cpp
         BINARY_DIR ${PROJECT_SOURCE_DIR}/godot/godot-cpp/build
-        CMAKE_ARGS -D CMAKE_BUILD_TYPE=$<IF:$<CONFIG:Debug>,Debug,Release>
+        CMAKE_ARGS -D CMAKE_BUILD_TYPE=${GODOT_CPP_BUILD_TYPE}
         INSTALL_COMMAND ""
     )
     
@@ -675,7 +681,7 @@ if(BUILD_CLIENT_GODOT)
     endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
 
     string(TOLOWER ${CMAKE_SYSTEM_NAME} SYSTEM_NAME)
-    string(TOLOWER ${CMAKE_BUILD_TYPE} BUILD_TYPE)
+    string(TOLOWER ${GODOT_CPP_BUILD_TYPE} BUILD_TYPE)
     if(CMAKE_VERSION VERSION_GREATER "3.13")
         target_link_directories(freeoriongodot
             PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -759,13 +759,13 @@ endif()
 if(BUILD_CLIENT_GODOT)
     add_custom_command(TARGET freeoriongodot POST_BUILD
         COMMAND
-           ${CMAKE_COMMAND} -E make_directory ${CMAKE_SOURCE_DIR}/godot/client/bin/
+           ${CMAKE_COMMAND} -E make_directory ${CMAKE_SOURCE_DIR}/godot/client/bin/${SYSTEM_NAME}.${BITS}
         COMMAND
-           ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freeorioncommon>" "${CMAKE_SOURCE_DIR}/godot/client/bin/"
+           ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freeorioncommon>" "${CMAKE_SOURCE_DIR}/godot/client/bin/${SYSTEM_NAME}.${BITS}"
         COMMAND
-           ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freeorionparse>" "${CMAKE_SOURCE_DIR}/godot/client/bin/"
+           ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freeorionparse>" "${CMAKE_SOURCE_DIR}/godot/client/bin/${SYSTEM_NAME}.${BITS}"
         COMMAND
-           ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freeoriongodot>" "${CMAKE_SOURCE_DIR}/godot/client/bin/"
+           ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freeoriongodot>" "${CMAKE_SOURCE_DIR}/godot/client/bin/${SYSTEM_NAME}.${BITS}"
     )
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -666,18 +666,27 @@ if(BUILD_CLIENT_GODOT)
     
     add_dependencies(freeoriongodot godotcpp)
 
-    string(TOLOWER ${CMAKE_SYSTEM_NAME} SYSTEM_NAME)    
+    # Create the correct name (godot.os.build_type.system_bits)
+    # Synchronized with godot-cpp's CMakeLists.txt
+
+    set(BITS 32)
+    if(CMAKE_SIZEOF_VOID_P EQUAL 8)
+        set(BITS 64)
+    endif(CMAKE_SIZEOF_VOID_P EQUAL 8)
+
+    string(TOLOWER ${CMAKE_SYSTEM_NAME} SYSTEM_NAME)
+    string(TOLOWER ${CMAKE_BUILD_TYPE} BUILD_TYPE)
     if(CMAKE_VERSION VERSION_GREATER "3.13")
         target_link_directories(freeoriongodot
             PRIVATE
                 ${GODOT_CPP_ROOT}/bin/
         )
         target_link_libraries(freeoriongodot
-            godot-cpp.${SYSTEM_NAME}.$<IF:$<CONFIG:Debug>,debug,release>.$<IF:$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>,64,32>
+            godot-cpp.${SYSTEM_NAME}.${BUILD_TYPE}.${BITS}
         )
     else()
         target_link_libraries(freeoriongodot
-            ${GODOT_CPP_ROOT}/bin/libgodot-cpp.${SYSTEM_NAME}.$<IF:$<CONFIG:Debug>,debug,release>.$<IF:$<EQUAL:${CMAKE_SIZEOF_VOID_P},8>,64,32>.a
+            ${GODOT_CPP_ROOT}/bin/libgodot-cpp.${SYSTEM_NAME}.${BUILD_TYPE}.${BITS}.a
         )
     endif()
 

--- a/godot/client/gdcpptest.gdnlib
+++ b/godot/client/gdcpptest.gdnlib
@@ -8,9 +8,11 @@ reloadable=true
 [entry]
 
 OSX.64="res://bin/libfreeoriongodot.dylib"
-X11.64="res://bin/libfreeoriongodot.so"
+X11.64="res://bin/linux.64/libfreeoriongodot.so"
+X11.32="res://bin/linux.32/libfreeoriongodot.so"
 
 [dependencies]
 
 OSX.64=[ "res://bin/libfreeorioncommon.dylib", "res://bin/libfreeorionparse.dylib" ]
-X11.64=[ "res://bin/libfreeorioncommon.so", "res://bin/libfreeorionparse.so" ]
+X11.64=[ "res://bin/linux.64/libfreeorioncommon.so", "res://bin/linux.64/libfreeorionparse.so" ]
+X11.32=[ "res://bin/linux.32/libfreeorioncommon.so", "res://bin/linux.32/libfreeorionparse.so" ]

--- a/godot/gdfreeorion.cpp
+++ b/godot/gdfreeorion.cpp
@@ -172,7 +172,7 @@ void GDFreeOrion::_init() {
         DebugLogger() << "Resources directory from config.xml missing or does not contain expected files. Resetting to default.";
 
         // GetOptionsDB().Set<std::string>("resource.path", "");
-        GetOptionsDB().Set<std::string>("resource.path", "../../default"); // Temporary default for Godot client prototype development
+        GetOptionsDB().Set<std::string>("resource.path", PathToString(boost::filesystem::canonical("../../default"))); // Temporary default for Godot client prototype development
 
         // double-check that resetting actually fixed things...
         if (!boost::filesystem::exists(GetResourceDir()) ||


### PR DESCRIPTION
- Removes unneeded CI check for separate `godot-cpp` library.
- Uses subfolders for Godot architectures.
- Fixes default resources search.