### PR TITLE
Move FOCS file reading to Directory code

### DIFF
--- a/UI/ShaderProgram.cpp
+++ b/UI/ShaderProgram.cpp
@@ -1,13 +1,7 @@
 #include "ShaderProgram.h"
 
-#include <cassert>
-#include <functional>
-#include <iostream>
-
 #include "../client/human/HumanClientApp.h"
 #include "../util/Logger.h"
-
-#include <boost/filesystem/fstream.hpp>
 
 
 namespace {
@@ -53,27 +47,6 @@ namespace {
             CHECK_ERROR("GetProgramLog", "glGetProgramInfoLog()");
         }
     }
-}
-
-bool ReadFile(const boost::filesystem::path& path, std::string& file_contents) {
-    boost::filesystem::ifstream ifs(path);
-    if (!ifs)
-        return false;
-
-    // skip byte order mark (BOM)
-    for (int BOM : {0xEF, 0xBB, 0xBF}) {
-        if (BOM != ifs.get()) {
-            // no header set stream back to start of file
-            ifs.seekg(0, std::ios::beg);
-            // and continue
-            break;
-        }
-    }
-
-    std::getline(ifs, file_contents, '\0');
-
-    // no problems?
-    return true;
 }
 
 ShaderProgram::ShaderProgram(const std::string& vertex_shader, const std::string& fragment_shader) :

--- a/UI/ShaderProgram.h
+++ b/UI/ShaderProgram.h
@@ -3,13 +3,9 @@
 
 #include <GG/Base.h>
 
-#include <boost/filesystem/operations.hpp>
-
 #include <memory>
 #include <string>
 #include <vector>
-
-bool ReadFile(const boost::filesystem::path& path, std::string& file_contents);
 
 class ShaderProgram {
 private:

--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -76,7 +76,6 @@ namespace parse {
     FO_PARSE_API std::map<std::string, std::unique_ptr<ValueRef::ValueRef<double>>> statistics(const boost::filesystem::path& path);
     FO_PARSE_API std::map<std::string, std::vector<EncyclopediaArticle>> encyclopedia_articles(const boost::filesystem::path& path);
     FO_PARSE_API GameRules game_rules(const boost::filesystem::path& path);
-    FO_PARSE_API bool read_file(const boost::filesystem::path& path, std::string& file_contents);
 
     FO_PARSE_API void file_substitution(std::string& text, const boost::filesystem::path& file_search_path);
     FO_PARSE_API void process_include_substitutions(std::string& text,

--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -734,3 +734,25 @@ auto IsExistingFile(const fs::path& path) -> bool
 
     return false;
 }
+
+auto ReadFile(boost::filesystem::path const& path, std::string& file_contents) -> bool
+{
+    boost::filesystem::ifstream ifs(path);
+    if (!ifs)
+        return false;
+
+    // skip byte order mark (BOM)
+    for (int BOM : {0xEF, 0xBB, 0xBF}) {
+        if (BOM != ifs.get()) {
+            // no header set stream back to start of file
+            ifs.seekg(0, std::ios::beg);
+            // and continue
+            break;
+        }
+    }
+
+    std::getline(ifs, file_contents, '\0');
+
+    // no problems?
+    return true;
+}

--- a/util/Directories.h
+++ b/util/Directories.h
@@ -161,4 +161,7 @@ FO_COMMON_API auto GetPath(std::string const& path_string) -> boost::filesystem:
 
 //! Returns true iff path exists and is a regular file
 FO_COMMON_API auto IsExistingFile(boost::filesystem::path const& path) -> bool;
+
+//! Reads text file content from @p path and returs true if success
+FO_COMMON_API auto ReadFile(boost::filesystem::path const& path, std::string& file_contents) -> bool;
 #endif

--- a/util/StringTable.cpp
+++ b/util/StringTable.cpp
@@ -57,7 +57,7 @@ void StringTable::Load(std::shared_ptr<const StringTable> fallback) {
     auto path = FilenameToPath(m_filename);
     std::string file_contents;
 
-    bool read_success = parse::read_file(path, file_contents);
+    bool read_success = ReadFile(path, file_contents);
     if (!read_success) {
         ErrorLogger() << "StringTable::Load failed to read file at path: " << path.string();
         //m_initialized intentionally left false
@@ -173,7 +173,7 @@ void StringTable::Load(std::shared_ptr<const StringTable> fallback) {
                     ErrorLogger() << "Positional error in key expansion: " << match[1] << " with length: "
                                   << match[1].length() << "and matchlen: " << match.length();
                 // clear out any keywords that have been fully processed
-                for (auto ref_check_it = cyclic_reference_check.begin(); 
+                for (auto ref_check_it = cyclic_reference_check.begin();
                      ref_check_it != cyclic_reference_check.end(); )
                 {
                     if (ref_check_it->second <= position) {
@@ -234,7 +234,7 @@ void StringTable::Load(std::shared_ptr<const StringTable> fallback) {
                 auto map_lookup_it = m_strings.find(match[2]);
                 bool foundmatch = map_lookup_it != m_strings.end();
                 if (!foundmatch && !fallback_lookup_strings.empty()) {
-                    DebugLogger() << "Key reference: " << match[2] << " not found in primary stringtable: " << m_filename 
+                    DebugLogger() << "Key reference: " << match[2] << " not found in primary stringtable: " << m_filename
                                   << "; checking in fallback file" << fallback_table_file;
                     map_lookup_it = fallback_lookup_strings.find(match[2]);
                     foundmatch = map_lookup_it != fallback_lookup_strings.end();


### PR DESCRIPTION
Should simplify access to data unavailable via file operations like Android assets #3202 or use it indirection to implement modding support #3204.