### PR TITLE
Fix segfault when use multiple signal arguments

### DIFF
--- a/godot/godot-cpp/godot_headers/gdnative/variant.h
+++ b/godot/godot-cpp/godot_headers/gdnative/variant.h
@@ -37,7 +37,7 @@ extern "C" {
 
 #include <stdint.h>
 
-#define GODOT_VARIANT_SIZE (16 + sizeof(void *))
+#define GODOT_VARIANT_SIZE (16 + sizeof(int64_t))
 
 #ifndef GODOT_CORE_API_GODOT_VARIANT_TYPE_DEFINED
 #define GODOT_CORE_API_GODOT_VARIANT_TYPE_DEFINED


### PR DESCRIPTION
Fixes `godot_variant` size mismatch on some architectures where `uint64_t` and `void*` have different size like Android armeabi-v7a.

Related to https://github.com/godotengine/godot-cpp/issues/473 in our copy of `godot-cpp` sources.