### PR TITLE
Split fighter and shortrange techs, pilot balancing

### DIFF
--- a/default/scripting/species/common/weapons.macros
+++ b/default/scripting/species/common/weapons.macros
@@ -80,9 +80,9 @@ GOOD_WEAPONS
                 ]
             ]
             effects = [
-                SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 1)
-                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 1)
-                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 1)
+                SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 1.5)
+                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 1.5)
+                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 1.5)
             ]
 
         EffectsGroup
@@ -129,9 +129,9 @@ GREAT_WEAPONS
                 ]
             ]
             effects = [
-                SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 2)
-                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 2)
-                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 2)
+                SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 3)
+                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 3)
+                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 3)
             ]
 
         EffectsGroup
@@ -178,9 +178,9 @@ ULTIMATE_WEAPONS
                 ]
             ]
             effects = [
-                SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 3)
-                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 3)
-                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 3)
+                SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 4.5)
+                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 4.5)
+                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value + ([[FIGHTER_DAMAGE_FACTOR]] * 4.5)
             ]
 
         EffectsGroup

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_2.focs.txt
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_2.focs.txt
@@ -3,13 +3,10 @@ Tech
     description = "SHP_FIGHTERS_2_DESC"
     short_description = "SHIP_WEAPON_IMPROVE_SHORT_DESC"
     category = "SHIP_WEAPONS_CATEGORY"
-    researchcost = 20 * [[TECH_COST_MULTIPLIER]]
-    researchturns = 2
+    researchcost = 45 * [[TECH_COST_MULTIPLIER]]
+    researchturns = 9
     tags = [ "PEDIA_FIGHTER_TECHS" ]
-    prerequisites = [
-        "SHP_WEAPON_2_1"
-        "SHP_FIGHTERS_1"
-            ]
+    prerequisites = [ "SHP_FIGHTERS_1" ]
     effectsgroups =
         EffectsGroup
             scope = And [

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_3.focs.txt
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_3.focs.txt
@@ -3,13 +3,10 @@ Tech
     description = "SHP_FIGHTERS_3_DESC"
     short_description = "SHIP_WEAPON_IMPROVE_SHORT_DESC"
     category = "SHIP_WEAPONS_CATEGORY"
-    researchcost = 100 * [[TECH_COST_MULTIPLIER]]
-    researchturns = 2
+    researchcost = 225 * [[TECH_COST_MULTIPLIER]]
+    researchturns = 9
     tags = [ "PEDIA_FIGHTER_TECHS" ]
-    prerequisites = [
-        "SHP_WEAPON_3_1"
-        "SHP_FIGHTERS_2"
-        ]
+    prerequisites = [ "SHP_FIGHTERS_2" ]
     effectsgroups =
         EffectsGroup
             scope = And [

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_4.focs.txt
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_4.focs.txt
@@ -3,13 +3,10 @@ Tech
     description = "SHP_FIGHTERS_4_DESC"
     short_description = "SHIP_WEAPON_IMPROVE_SHORT_DESC"
     category = "SHIP_WEAPONS_CATEGORY"
-    researchcost = 500 * [[TECH_COST_MULTIPLIER]]
-    researchturns = 3
+    researchcost = 1125 * [[TECH_COST_MULTIPLIER]]
+    researchturns = 12
     tags = [ "PEDIA_FIGHTER_TECHS" ]
-    prerequisites = [
-        "SHP_WEAPON_4_1"
-        "SHP_FIGHTERS_3"
-            ]
+    prerequisites = [ "SHP_FIGHTERS_3" ]
     effectsgroups =
         EffectsGroup
             scope = And [


### PR DESCRIPTION
[forum discussion](https://www.freeorion.org/forum/viewtopic.php?f=15&t=11858)

* 1st Fighter tech costs 50% more than researching Mass Drivers 2
* 2nd Fighter tech costs 10% off from researching Lasers+Laser Fighters and takes a turn less to research
* 3rd Fighter tech costs 10% off from researching Plasma+Plasma Fighters and takes a turn less to research
* 4th Fighter tech costs 10% off from researching Death Rays+DR Fighters and takes a turn less to research

Pilot skill effect gets upped 50% to give fighters more reason - this should be on par
* 2nd Fighter tech costs about 90% of researching Lasers+Laser 2
* bomber damage gets increased about a fourth by a skill level
* shortrange weapon (level 2) damage gets increased about a fourth by a skill level