### PR TITLE
Refactor savegame codec tests

### DIFF
--- a/default/python/tests/AI/save_game_codec/conftest.py
+++ b/default/python/tests/AI/save_game_codec/conftest.py
@@ -1,0 +1,14 @@
+import pytest
+
+import aistate_interface
+from savegame_codec import build_savegame_string
+
+
+@pytest.fixture()
+def pack_object(monkeypatch):
+    def do_decoding(obj):
+        def get_aistate():
+            return obj
+        monkeypatch.setattr(aistate_interface, "get_aistate", get_aistate)
+        return build_savegame_string().decode('utf-8')
+    return do_decoding

--- a/default/python/tests/AI/save_game_codec/test_save_game_decoding.py
+++ b/default/python/tests/AI/save_game_codec/test_save_game_decoding.py
@@ -1,26 +1,14 @@
 from collections import OrderedDict
 
 import pytest
-from pytest import fixture, raises, mark
 
-import aistate_interface
 from ColonisationAI import OrbitalColonizationManager
 from EnumsAI import MissionType
-from savegame_codec import build_savegame_string, load_savegame_string, CanNotSaveGameException
+from savegame_codec import CanNotSaveGameException, load_savegame_string
 from savegame_codec._decoder import SaveDecompressException
 
 
-@fixture
-def pack_object(monkeypatch):
-    def do_decoding(obj):
-        def get_aistate():
-            return obj
-        monkeypatch.setattr(aistate_interface, "get_aistate", get_aistate)
-        return build_savegame_string().decode('utf-8')
-    return do_decoding
-
-
-@fixture
+@pytest.fixture()
 def patch_orb_col_management(monkeypatch):
     def eq(self, other):
         self_tuple = self._colonization_plans, self.num_enqueued_bases
@@ -29,7 +17,7 @@ def patch_orb_col_management(monkeypatch):
     monkeypatch.setattr(OrbitalColonizationManager, '__eq__', eq)
 
 
-@fixture(params=[
+@pytest.fixture(params=[
     True,
     False,
     None,
@@ -62,23 +50,23 @@ def test_inherited_trusted_object_is_not_encoded(pack_object):
     class Inherited(OrbitalColonizationManager):
         pass
 
-    with raises(CanNotSaveGameException, match='Class .*.Inherited is not trusted'):
+    with pytest.raises(CanNotSaveGameException, match='Class .*.Inherited is not trusted'):
         pack_object(Inherited())
 
 
-@mark.parametrize("obj", ['"', '\\', '\n', '\t'])
+@pytest.mark.parametrize("obj", ['"', '\\', '\n', '\t'])
 def test_string_with_sepcial_caracters_encoded_and_decoded_back(obj, pack_object):
     encoded = pack_object(obj)
     assert obj == load_savegame_string(encoded)
 
 
-@mark.usefixtures('patch_orb_col_management')
+@pytest.mark.usefixtures('patch_orb_col_management')
 def test_string_decode_to_object(serialized_object):
     obj, serialized_string = serialized_object
     assert obj == load_savegame_string(serialized_string)
 
 
-@mark.usefixtures('patch_orb_col_management')
+@pytest.mark.usefixtures('patch_orb_col_management')
 def test_bytes_decode_to_object(serialized_object):
     obj, serialized_bytes = serialized_object
     assert obj == load_savegame_string(serialized_bytes.encode("utf-8"))


### PR DESCRIPTION
Extract the pack code to a separate fixture, so it can be reused for other tests.
Fix operation with trusted_scope, it was left empty after tests.
Refactor pytest to use `import pytest` style.