### PR TITLE
Rebalance research

### DIFF
--- a/default/scripting/specials/planet/TEMPORAL_ANOMOLY.focs.txt
+++ b/default/scripting/specials/planet/TEMPORAL_ANOMOLY.focs.txt
@@ -15,9 +15,10 @@ Special
                 Source
                 Focus type = "FOCUS_RESEARCH"
             ]
+            priority = [[TARGET_AFTER_SCALING_PRIORITY]]
             effects = SetTargetResearch value = Value + Target.Population
                           * (NamedReal name = "TEMPORAL_ANOMALY_TARGET_RESEARCH_PERPOP"
-                                       value = 25 * [[RESEARCH_PER_POP]])
+                                       value = 15 * [[RESEARCH_PER_POP]])
 
         EffectsGroup
             scope = Object id = Source.PlanetID

--- a/default/scripting/techs/learning/PSIONICS.focs.txt
+++ b/default/scripting/techs/learning/PSIONICS.focs.txt
@@ -3,7 +3,7 @@ Tech
     description = "LRN_PSIONICS_DESC"
     short_description = "THEORY_SHORT_DESC"
     category = "LEARNING_CATEGORY"
-    researchcost = 300 * [[TECH_COST_MULTIPLIER]] - (250 * [[TECH_COST_MULTIPLIER]] * Statistic If condition = And [
+    researchcost = 300 * [[TECH_COST_MULTIPLIER]] - (150 * [[TECH_COST_MULTIPLIER]] * Statistic If condition = And [
         Or [
             Planet
             Ship


### PR DESCRIPTION
Temporal Anomaly is overpowered. See for example [here](https://www.freeorion.org/forum/viewtopic.php?p=104786#p104786) and [here](https://www.freeorion.org/forum/viewtopic.php?p=104696#p104696).
This PR reduces it's bonus to 60% of current power and makes it not affected by species trait.

Telepathy (species trait) reduction to Psionics tech cost makes it overpowered to have a telepahtic species early on. See for example [here](https://www.freeorion.org/forum/viewtopic.php?p=104834#p104834) and the screenshots in that thread. This PR nerfs the reduction from -250 (-83.3%) to -150 (-50%).