### PR TITLE
Reduce Conc. Camps industry boost

### DIFF
--- a/default/scripting/buildings/CONC_CAMP.focs.txt
+++ b/default/scripting/buildings/CONC_CAMP.focs.txt
@@ -25,7 +25,7 @@ BuildingType
             priority = [[TARGET_AFTER_SCALING_PRIORITY]]
             effects = SetTargetIndustry value = Value + Target.Population
                         * (NamedReal name = "BLD_CONC_CAMP_TARGET_INDUSTRY_PERPOP"
-                                     value = 10 * [[INDUSTRY_PER_POP]])
+                                     value = 3.75 * [[INDUSTRY_PER_POP]])
 
         EffectsGroup
             scope = And [


### PR DESCRIPTION
Reduce concentration camps industry bonus from 2 x population to 0.75 x population.
It should have been reduced when the rest of bonuses.

Discussion thread: https://www.freeorion.org/forum/viewtopic.php?p=104842#p104842