### PR TITLE
Remove getOrders from AI interface

### DIFF
--- a/client/AI/AIWrapper.cpp
+++ b/client/AI/AIWrapper.cpp
@@ -13,7 +13,6 @@
 #include "../../util/i18n.h"
 #include "../../util/MultiplayerCommon.h"
 #include "../../util/OptionsDB.h"
-#include "../../util/OrderSet.h"
 #include "../../util/Order.h"
 #include "../../Empire/Empire.h"
 #include "../../Empire/EmpireManager.h"
@@ -736,21 +735,6 @@ namespace FreeOrionPython {
         py::def("issuePauseProductionOrder",            IssuePauseProductionOrder, "Orders the item on the production queue at index queueIndex (int) to be paused (or unpaused). Returns 1 (int) on success or 0 (int) on failure if the queue index is less than 0 or greater than the largest indexed item on the queue.");
         py::def("issueAllowStockpileProductionOrder",   IssueAllowStockpileProductionOrder, "Orders the item on the production queue at index queueIndex (int) to be enabled (or disabled) to use the imperial stockpile. Returns 1 (int) on success or 0 (int) on failure if the queue index is less than 0 or greater than the largest indexed item on the queue.");
         py::def("issueCreateShipDesignOrder",           IssueCreateShipDesignOrder, "Orders the creation of a new ship design with the name (string), description (string), hull (string), parts vector partsVec (StringVec), graphic (string) and model (string). model should be left as an empty string as of this writing. There is currently no easy way to find the id of the new design, though the client's empire should have the new design after this order is issued successfully. Returns 1 (int) on success or 0 (int) on failure if any of the name, description, hull or graphic are empty strings, if the design is invalid (due to not following number and type of slot requirements for the hull) or if creating the design fails for some reason.");
-
-        py::class_<OrderSet, boost::noncopyable>("OrderSet", py::no_init)
-            .def(py::map_indexing_suite<OrderSet>())
-            .add_property("size",       &OrderSet::size)
-        ;
-
-        py::class_<Order, boost::noncopyable>("Order", py::no_init)
-            .add_property("empireID",   &Order::EmpireID)
-            .add_property("executed",   &Order::Executed)
-        ;
-
-        py::def("getOrders",
-                +[]() -> OrderSet& { return AIClientApp::GetApp()->Orders(); },
-                py::return_value_policy<py::reference_existing_object>(),
-                "Returns the orders the client empire has issued (OrderSet).");
 
         py::def("sendChatMessage",
                 +[](int recipient, const std::string& message) { AIClientApp::GetApp()->Networking().SendMessage(PlayerChatMessage(message, {recipient}, false)); },

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -158,8 +158,6 @@ def resumeLoadedGame(saved_state_string):  # pylint: disable=invalid-name
                   % e, exc_info=True)
     _pre_game_start(fo.getEmpire().empireID, aistate)
 
-    debug('Size of already issued orders: ' + str(fo.getOrders().size))
-
 
 @error_handler
 def prepareForSave():  # pylint: disable=invalid-name
@@ -355,8 +353,6 @@ def generateOrders():  # pylint: disable=invalid-name
             error("Exception %s while trying to %s" % (e, action.__name__), exc_info=True)
     main_timer.stop_print_and_clear()
     turn_timer.stop_print_and_clear()
-
-    debug('Size of issued orders: ' + str(fo.getOrders().size))
 
     turn_timer.start("Server_Processing")
 


### PR DESCRIPTION
This code was added for debugging purposes, so now it can be removed.
Only `size` method of OrderSet is working, conversion set to list leads to error: `No to_python (by-value) converter found for C++ type: class std::shared_ptr<class Order>.`

Python code was introduced with the commit message: "Added debug output of size of issued orders when loading and when done issuing orders."

PS. I have not compiled it myself. 