### PR TITLE
[AI] Remove situation report binding from AI interface

### DIFF
--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -610,12 +610,12 @@ class AIstate:
                 debug("In system %s: Ignoring lost fleets since known threats could cause it.", system)
                 lost_fleet_rating = 0
 
-            # TODO use sitrep combat info rather than estimating stealthed enemies by fleets lost to them
             # TODO also only consider past stealthed fleet threat to still be present if the system is still obstructed
             # TODO: track visibility across turns in order to distinguish the blip of visibility in (losing) combat,
             #       which FO currently treats as being for the previous turn,
             #       partially superseding the previous visibility for that turn
 
+            # Estimating stealthed enemies by fleets lost to them
             if not partial_vis_turn == current_turn:
                 sys_status.setdefault('local_fleet_threats', set())
                 sys_status['currently_visible'] = False

--- a/default/python/handlers/shared_instances_code.py
+++ b/default/python/handlers/shared_instances_code.py
@@ -48,8 +48,6 @@ def get_common_instances() -> Generator:
     planet = universe.getPlanet(empire_of_first_ai.capitalID)
     yield planet
 
-    yield empire_of_first_ai.getSitRep(0)
-
     yield universe.getSystem(planet.systemID)
 
     tech = fo.getTech('SHP_WEAPON_2_1')

--- a/default/python/stub_generator/parse_docs.py
+++ b/default/python/stub_generator/parse_docs.py
@@ -31,7 +31,6 @@ normalization_dict = {
     'resPool': 'res_pool',
     'researchQueueElement': 'research_queue_element',
     'shipSlotType': 'ship_slot_type',
-    'sitrep': 'sitrep_object',
     'IntIntMap': 'int_int_map',
     'IntPairVec': 'int_pair_list',
     'IntSet': 'int_set',

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -10,7 +10,6 @@
 #include "../universe/Tech.h"
 #include "../util/AppInterface.h"
 #include "../util/Logger.h"
-#include "../util/SitRepEntry.h"
 #include "SetWrapper.h"
 
 #include <boost/mpl/vector.hpp>
@@ -37,15 +36,6 @@ namespace {
     typedef PairToTupleConverter<int, int> IntIntPairConverter;
 
     typedef PairToTupleConverter<float, int> FloatIntPairConverter;
-
-
-    auto GetSitRep(const Empire& empire, int index) -> const SitRepEntry&
-    {
-        static SitRepEntry EMPTY_ENTRY;
-        if (index < 0 || index >= empire.NumSitRepEntries())
-            return EMPTY_ENTRY;
-        return *std::next(empire.SitRepBegin(), index);
-    }
 
     auto obstructedStarlanes(const Empire& empire) -> std::vector<std::pair<int, int>>
     {
@@ -301,9 +291,6 @@ namespace FreeOrionPython {
             .add_property("supplyUnobstructedSystems",  make_function(&Empire::SupplyUnobstructedSystems,   py::return_internal_reference<>()))
             .add_property("systemSupplyRanges",         make_function(&Empire::SystemSupplyRanges,          py::return_internal_reference<>()))
 
-            .def("numSitReps",                      &Empire::NumSitRepEntries)
-            .def("getSitRep",                       GetSitRep,
-                                                    py::return_internal_reference<>())
             .def("obstructedStarlanes",             obstructedStarlanes,
                                                     py::return_value_policy<py::return_by_value>())
             .def("supplyProjections",               jumpsToSuppliedSystem,
@@ -462,18 +449,6 @@ namespace FreeOrionPython {
                 py::return_value_policy<py::return_by_value>(),
                 "Returns the names of all policies (StringVec) in the"
                 " indicated policy category name (string).");
-
-        ///////////////////
-        //  SitRepEntry  //
-        ///////////////////
-        py::class_<SitRepEntry, boost::noncopyable>("sitrep", py::no_init)
-            .add_property("typeString",         make_function(&SitRepEntry::GetTemplateString,  py::return_value_policy<py::copy_const_reference>()))
-            .def("getDataString",               &SitRepEntry::GetDataString,
-                                                py::return_value_policy<py::copy_const_reference>())
-            .def("getDataIDNumber",             &SitRepEntry::GetDataIDNumber)
-            .add_property("getTags",            make_function(&SitRepEntry::GetVariableTags,    py::return_value_policy<py::return_by_value>()))
-            .add_property("getTurn",            &SitRepEntry::GetTurn)
-        ;
 
         ///////////////////////
         // DiplomaticMessage //


### PR DESCRIPTION
- This code is not used by AI.
- Some sitrep object methods are broken, for example: `getTags`.
- Probably AI could get some useful information from situation reports, but this general implementation is too general.

This binding introduced in the commit https://github.com/freeorion/freeorion/commit/e01c6fbc757206c1ae661c76c328fccff0630309