### PR TITLE
Make influence upkeep tractable

### DIFF
--- a/default/customizations/custom_sitreps.txt
+++ b/default/customizations/custom_sitreps.txt
@@ -5,16 +5,12 @@
 // a suitable place to start is http://www.freeorion.org/index.php/Free_Orion_Content_Script_(FOCS)
 
 
-// Important, the following line "effectsgroups = [" is functional and important, do not change it
-effectsgroups = [
-
-
 // normally, for a custom sitrep the player will write their own message here, and label, and not look them up in the Stringtable.  For this first custom sitrep,
 // however, since it is the primary way we introduce the custom sitrep capability to players, we use stringtable references so that the message and label may be more 
 // readily translated into multiple languages as part of our standard distribution.
 
-
-EffectsGroup
+CUSTOM_SITREPS
+'''EffectsGroup
     scope = Source
     activation = Turn low = 0 high = 0
     effects =
@@ -160,7 +156,7 @@ EffectsGroup
                 Unowned
             ]
             VisibleToEmpire empire = Source.Owner
-            Turn low = [[ETA_NEXT_TURN]] high = [[ETA_NEXT_TURN]]
+            Turn low = (CurrentTurn + LocalCandidate.ETA - 1) high = (CurrentTurn + LocalCandidate.ETA - 1)
             (RootCandidate.ID = LocalCandidate.NextSystemID)
         ]
         effects = GenerateSitRepMessage
@@ -171,9 +167,6 @@ EffectsGroup
                 tag = "system"  data = Target.ID
             ]
             empire = Source.Owner
-
-ETA_NEXT_TURN
-'''(CurrentTurn + LocalCandidate.ETA - 1)'''
 
 
 //*********************************************************************************************************************************************************
@@ -313,8 +306,6 @@ EffectsGroup
             ]
             empire = Source.Owner
     ]
-
-// Note, the "]" on the following line is functional and important; it must be present and all EffectsGroups must be above it.
-]
+'''
 
 #include "/scripting/common/priorities.macros"

--- a/default/scripting/policies/CENTRALIZATION.focs.txt
+++ b/default/scripting/policies/CENTRALIZATION.focs.txt
@@ -25,9 +25,7 @@ Policy
                 SetTargetConstruction value = Value
                     + (NamedReal name = "PLC_CENTRALIZATION_TARGET_CONSTRUCTION_FLAT" value = 10)
                 SetMaxSupply value = Value
-                    + (NamedReal name = "PLC_CENTRALIZATION_MAX_SUPPLY_FLAT" value = -2)
-                SetMaxStockpile value = Value
-                    + (NamedReal name = "PLC_CENTRALIZATION_MAX_STOCKPILE_FLAT" value = -2)
+                    + (NamedReal name = "PLC_CENTRALIZATION_CAPITAL_MAX_SUPPLY_FLAT" value = 1)
             ]
 
         EffectsGroup
@@ -42,24 +40,19 @@ Policy
                 ]
             ]
             effects = SetTargetInfluence value = Value
-                        + (NamedReal name = "PLC_CENTRALIZATION_TARGET_INFLUENCE_FLAT" value = -3)
+                        + (NamedReal name = "PLC_CENTRALIZATION_TARGET_INFLUENCE_FLAT" value = -2)
 
         EffectsGroup
             scope = And [
                 Planet
                 OwnedBy empire = Source.Owner
                 Population low = 0.001
-                ResourceSupplyConnected empire = LocalCandidate.Owner condition = And [
-                    Planet
-                    OwnedBy empire = Source.Owner
-                    Capital
-                ]
                 Not Capital
             ]
-            effects = SetTargetInfluence value = Value + max(
-                        (NamedReal name = "PLC_CENTRALIZATION_TARGET_INFLUENCE_MAX" value = -3),
-                        (NamedReal name = "PLC_CENTRALIZATION_TARGET_INFLUENCE_PERJUMP" value = -0.2)
-                            * JumpsBetween object = Source.ID object = Target.ID)
+            effects = [
+                SetMaxSupply value = Value + (NamedReal name = "PLC_CENTRALIZATION_MAX_SUPPLY_FLAT" value = -1)
+                SetMaxStockpile value = Value + (NamedReal name = "PLC_CENTRALIZATION_MAX_STOCKPILE_FLAT" value = -1)
+            ]
     ]
     graphic = "icons/policies/centralization.png"
 

--- a/default/scripting/species/common/influence.macros
+++ b/default/scripting/species/common/influence.macros
@@ -1,21 +1,6 @@
 
 BASE_INFLUENCE_COSTS
-'''EffectsGroup      // colonies consume influence, proportional to how many planets the empire controls
-            scope = Source
-            activation = And [
-                Planet
-                Not Unowned
-                Not Capital
-            ]
-            stackinggroup = "IMPERIAL_PALACE_MANY_PLANETS_INFLUENCE_PENALTY"
-            accountinglabel = "COLONY_ADMIN_COSTS_LABEL"
-            effects = SetTargetInfluence value = Value - (NamedReal name = "OLONY_ADMIN_COSTS_PER_PLANET" value = 0.2) *
-                Statistic Count condition = And [
-                    Planet
-                    OwnedBy empire = Source.Owner
-                ]
-
-        EffectsGroup      // species homeworlds consume more influence
+'''        EffectsGroup      // species homeworlds consume more influence
             scope = Source
             activation = And [
                 Planet
@@ -39,7 +24,8 @@ BASE_INFLUENCE_COSTS
             ]
             accountinglabel = "CAPITAL_DISCONNECTION_LABEL"
             effects = SetTargetInfluence value = Value
-                        - NamedReal name = "SUPPLY_DISCONNECTED_INFLUENCE_MALUS"
+                        - Statistic If condition = Not EmpireHasAdoptedPolicy empire = Source.Owner name = "PLC_CONFEDERATION"
+                            * NamedReal name = "SUPPLY_DISCONNECTED_INFLUENCE_MALUS"
                                     value = [[SUPPLY_DISCONNECTED_INFLUENCE_MALUS]]
 
         EffectsGroup      // gives human bonuses when AI Aggression set to Beginner

--- a/default/scripting/techs/spy/CUSTOM_ADVISORIES.focs.txt
+++ b/default/scripting/techs/spy/CUSTOM_ADVISORIES.focs.txt
@@ -6,4 +6,28 @@ Tech
     researchcost = 1
     researchturns = 1
     tags = [ "PEDIA_SPY_CATEGORY" ]
+    effectsgroups = [
+        [[CUSTOM_SITREPS]]
+
+        EffectsGroup      // colonies consume influence proportional to how many planets the empire controls
+            scope = And [
+                Planet
+                OwnedBy empire = Source.Owner
+                Population low = 0.001
+                Not Capital
+            ]
+            stackinggroup = "IMPERIAL_PALACE_MANY_PLANETS_INFLUENCE_PENALTY"
+            accountinglabel = "COLONY_ADMIN_COSTS_LABEL"
+            effects = SetTargetInfluence value = Value
+                + Statistic If condition = Not EmpireHasAdoptedPolicy empire = Source.Owner name = "PLC_CENTRALIZATION"
+                    * (NamedReal name = "TARGET_INFLUENCE_PER_COLONY" value = -0.2)
+                    * (Statistic Count condition = And [
+                        Planet
+                        OwnedBy empire = Source.Owner
+                    ])^0.5
+                + Statistic If condition = Not EmpireHasAdoptedPolicy empire = Source.Owner name = "PLC_CONFEDERATION"
+                    * (NamedReal name = "TARGET_INFLUENCE_PER_JUMP" value = -0.2)
+                    * JumpsBetween object = Source.ID object = Target.ID
+    ]
+
 #include "/customizations/custom_sitreps.txt"


### PR DESCRIPTION
Influence upkeep is untractable currently: after a certain number of planets you can't keep positive influence.

This PR deals with that:

- Move influence upkeep maluses to a tech (custom advisories, in lack of a proper tech for empire upkeep/management) from species influence macros and centralization policy.
- Make upkeep based in number of colonies use square root to make it tractable later game.
- Make Centralization incur into penalization stronger than usual and negate number-based upkeep.
- Make Confederation negate distance-based upkeep and supply-disconnected malus.
- Make Centralization penalize colony supply and bonus capital supply.
