### PR TITLE
[AI] Extract work with designs from production to separate module

### DIFF
--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -11,7 +11,6 @@ import InvasionAI
 import MilitaryAI
 import PlanetUtilsAI
 import PriorityAI
-import ProductionAI
 from AIDependencies import (
     INVALID_ID, OUTPOSTING_TECH, POP_CONST_MOD_MAP,
     POP_SIZE_MOD_MAP_MODIFIED_BY_SPECIES, POP_SIZE_MOD_MAP_NOT_MODIFIED_BY_SPECIES,
@@ -32,6 +31,7 @@ from turn_state import (
     get_unowned_empty_planets, have_computronium, population_with_industry_focus, population_with_research_focus,
     set_best_pilot_rating, set_have_asteroids, set_have_gas_giant, set_have_nest, set_medium_pilot_rating,
 )
+from turn_state.design import get_best_ship_info
 
 colonization_timer = AITimer('getColonyFleets()')
 
@@ -1410,7 +1410,7 @@ class OrbitalColonizationPlan:
 
         # find the best possible base design for the source planet
         universe = fo.getUniverse()
-        best_ship, _, _ = ProductionAI.get_best_ship_info(PriorityType.PRODUCTION_ORBITAL_OUTPOST, self.source)
+        best_ship, _, _ = get_best_ship_info(PriorityType.PRODUCTION_ORBITAL_OUTPOST, self.source)
         if best_ship is None:
             warning("Can't find optimized outpost base design at %s" % (universe.getPlanet(self.source)))
             try:

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -32,6 +32,7 @@ import PriorityAI
 import ProductionAI
 import ResearchAI
 import ResourcesAI
+import ShipDesignAI
 import TechsListsAI
 from aistate_interface import create_new_aistate, load_aistate, get_aistate
 from AIDependencies import INVALID_ID
@@ -329,7 +330,7 @@ def generateOrders():  # pylint: disable=invalid-name
     debug("Calling AI Modules")
     # call AI modules
     action_list = [ColonisationAI.survey_universe,
-                   ProductionAI.find_best_designs_this_turn,
+                   ShipDesignAI.Cache.update_for_new_turn,
                    PriorityAI.calculate_priorities,
                    ExplorationAI.assign_scouts_to_explore_systems,
                    ColonisationAI.assign_colony_fleets_to_colonise,

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -12,13 +12,13 @@ import EspionageAI
 import FleetUtilsAI
 import MilitaryAI
 import PlanetUtilsAI
-import ProductionAI
 from AIDependencies import INVALID_ID, Tags
 from EnumsAI import MissionType, PriorityType
 from common.print_utils import Table, Text, Float
 from freeorion_tools import tech_is_complete, AITimer, get_partial_visibility_turn, get_species_tag_grade
 from target import TargetPlanet, TargetSystem
 from turn_state import get_colonized_planets_in_system
+from turn_state.design import get_best_ship_info
 
 MAX_BASE_TROOPERS_GOOD_INVADERS = 20
 MAX_BASE_TROOPERS_POOR_INVADERS = 10
@@ -118,8 +118,7 @@ def get_invasion_fleets():
                 planet2 = universe.getPlanet(pid2)
                 if not planet2 or planet2.speciesName not in ColonisationAI.empire_ship_builders:
                     continue
-                best_base_trooper_here = \
-                    ProductionAI.get_best_ship_info(PriorityType.PRODUCTION_ORBITAL_INVASION, pid2)[1]
+                best_base_trooper_here = get_best_ship_info(PriorityType.PRODUCTION_ORBITAL_INVASION, pid2)[1]
                 if not best_base_trooper_here:
                     continue
                 troops_per_ship = best_base_trooper_here.troopCapacity
@@ -165,7 +164,7 @@ def get_invasion_fleets():
                 # don't immediately delete from qualifyingTroopBaseTargets or it will be opened up for regular troops
                 continue
             loc = aistate.qualifyingTroopBaseTargets[pid][0]
-            best_base_trooper_here = ProductionAI.get_best_ship_info(PriorityType.PRODUCTION_ORBITAL_INVASION, loc)[1]
+            best_base_trooper_here = get_best_ship_info(PriorityType.PRODUCTION_ORBITAL_INVASION, loc)[1]
             loc_planet = universe.getPlanet(loc)
             if best_base_trooper_here is None:  # shouldn't be possible at this point, but just to be safe
                 warning("Could not find a suitable orbital invasion design at %s" % loc_planet)
@@ -177,8 +176,7 @@ def get_invasion_fleets():
             if not troops_per_ship:
                 warning("The best orbital invasion design at %s seems not to have any troop capacity." % loc_planet)
                 continue
-            _, col_design, build_choices = ProductionAI.get_best_ship_info(PriorityType.PRODUCTION_ORBITAL_INVASION,
-                                                                           loc)
+            _, col_design, build_choices = get_best_ship_info(PriorityType.PRODUCTION_ORBITAL_INVASION, loc)
             if not col_design:
                 continue
             if loc not in build_choices:
@@ -458,7 +456,7 @@ def evaluate_invasion_planet(planet_id, secure_fleet_missions, verbose=True):
     threat_exponent = 2  # TODO: make this a character trait; higher aggression with a lower exponent
     threat_factor = min(1, preferred_max_portion * total_max_mil_rating/(sys_total_threat+0.001))**threat_exponent
 
-    design_id, _, locs = ProductionAI.get_best_ship_info(PriorityType.PRODUCTION_INVASION)
+    design_id, _, locs = get_best_ship_info(PriorityType.PRODUCTION_INVASION)
     if not locs or not universe.getPlanet(locs[0]):
         # We are in trouble anyway, so just calculate whatever approximation...
         build_time = 4

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -7,7 +7,6 @@ import FleetUtilsAI
 import InvasionAI
 import PlanetUtilsAI
 import PriorityAI
-import ProductionAI
 from AIDependencies import INVALID_ID
 from aistate_interface import get_aistate
 from CombatRatingsAI import (
@@ -21,6 +20,7 @@ from turn_state import (
     get_distance_to_enemy_supply, get_owned_planets, get_owned_planets_in_system,
     get_systems_by_supply_tier,
 )
+from turn_state.design import cur_best_military_design_rating
 
 MinThreat = 10  # the minimum threat level that will be ascribed to an unknown threat capable of killing scouts
 _military_allocations = []
@@ -38,7 +38,7 @@ def cur_best_mil_ship_rating(include_designs=False):
     if current_turn in _best_ship_rating_cache:
         best_rating = _best_ship_rating_cache[current_turn]
         if include_designs:
-            best_design_rating = ProductionAI.cur_best_military_design_rating()
+            best_design_rating = cur_best_military_design_rating()
             best_rating = max(best_rating, best_design_rating)
         return best_rating
     best_rating = 0.001
@@ -51,7 +51,7 @@ def cur_best_mil_ship_rating(include_designs=False):
             best_rating = max(best_rating, ship_rating)
     _best_ship_rating_cache[current_turn] = best_rating
     if include_designs:
-        best_design_rating = ProductionAI.cur_best_military_design_rating()
+        best_design_rating = cur_best_military_design_rating()
         best_rating = max(best_rating, best_design_rating)
     return max(best_rating, 0.001)
 

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -13,12 +13,12 @@ from aistate_interface import get_aistate
 import InvasionAI
 import MilitaryAI
 import PlanetUtilsAI
-import ProductionAI
 import ResearchAI
 from AIDependencies import INVALID_ID
 from EnumsAI import EmpireProductionTypes, MissionType, PriorityType, ShipRoleType, get_priority_production_types
 from freeorion_tools import AITimer, tech_is_complete
 from turn_state import get_number_of_colonies, get_owned_planets, have_asteroids, have_gas_giant
+from turn_state.design import cur_best_military_design_rating, get_best_ship_info
 
 prioritiees_timer = AITimer('calculate_priorities()')
 
@@ -376,7 +376,7 @@ def _calculate_invasion_priority():
                                                            ShipRoleType.BASE_INVASION]:
                 design = fo.getShipDesign(element.designID)
                 queued_troop_capacity += element.remaining * element.blocksize * design.troopCapacity
-    _, best_design, _ = ProductionAI.get_best_ship_info(PriorityType.PRODUCTION_INVASION)
+    _, best_design, _ = get_best_ship_info(PriorityType.PRODUCTION_INVASION)
     if best_design:
         troops_per_best_ship = best_design.troopCapacity
     else:
@@ -435,7 +435,7 @@ def _calculate_military_priority():
     my_systems = set(get_owned_planets())
     target_systems = set(PlanetUtilsAI.get_systems(target_planet_ids))
 
-    cur_ship_rating = ProductionAI.cur_best_military_design_rating()
+    cur_ship_rating = cur_best_military_design_rating()
     current_turn = fo.currentTurn()
     ships_needed = 0
     defense_ships_needed = 0

--- a/default/python/AI/turn_state/design.py
+++ b/default/python/AI/turn_state/design.py
@@ -13,7 +13,6 @@ from turn_state._planet_state import get_inhabited_planets
 @cache_for_current_turn
 def get_design_repository() -> Dict[PriorityType, Tuple[float, int, int, float]]:
     """Calculate the best designs for each ship class available at this turn."""
-
     design_repository = {}  # dict of tuples (rating,pid,designID,cost) sorted by rating and indexed by priority type
 
     design_timer = AITimer('ShipDesigner')
@@ -84,6 +83,8 @@ def get_best_ship_info(
 ) -> Tuple[Optional[int], Optional["fo.shipDesign"], Optional[List[int]]]:
     """Returns 3 item tuple: designID, design, buildLocList."""
     planet_ids = _get_locations(loc)
+    if not planet_ids:
+        return None, None, None
     return _get_best_ship_info(priority, tuple(planet_ids))
 
 

--- a/default/python/AI/turn_state/design.py
+++ b/default/python/AI/turn_state/design.py
@@ -1,0 +1,160 @@
+import math
+import random
+from typing import Dict, FrozenSet, Iterable, Iterator, List, Optional, Tuple, Union
+
+import ColonisationAI
+import freeOrionAIInterface as fo
+import ShipDesignAI
+from EnumsAI import PriorityType
+from freeorion_tools import AITimer, cache_for_current_turn
+from turn_state._planet_state import get_inhabited_planets
+
+
+@cache_for_current_turn
+def _fill_design_cache() -> Dict[PriorityType, Tuple[float, int, int, float]]:
+    """Calculate the best designs for each ship class available at this turn."""
+
+    design_cache = {}  # dict of tuples (rating,pid,designID,cost) sorted by rating and indexed by priority type
+
+    design_timer = AITimer('ShipDesigner')
+    design_timer.start('Updating cache for new turn')
+
+    # TODO Dont use PriorityType but introduce more reasonable Enum
+    designers = [
+        ('Orbital Invasion', PriorityType.PRODUCTION_ORBITAL_INVASION, ShipDesignAI.OrbitalTroopShipDesigner),
+        ('Invasion', PriorityType.PRODUCTION_INVASION, ShipDesignAI.StandardTroopShipDesigner),
+        ('Orbital Colonization', PriorityType.PRODUCTION_ORBITAL_COLONISATION,
+         ShipDesignAI.OrbitalColonisationShipDesigner),
+        ('Colonization', PriorityType.PRODUCTION_COLONISATION, ShipDesignAI.StandardColonisationShipDesigner),
+        ('Orbital Outposter', PriorityType.PRODUCTION_ORBITAL_OUTPOST, ShipDesignAI.OrbitalOutpostShipDesigner),
+        ('Outposter', PriorityType.PRODUCTION_OUTPOST, ShipDesignAI.StandardOutpostShipDesigner),
+        ('Orbital Defense', PriorityType.PRODUCTION_ORBITAL_DEFENSE, ShipDesignAI.OrbitalDefenseShipDesigner),
+        ('Scouts', PriorityType.PRODUCTION_EXPLORATION, ShipDesignAI.ScoutShipDesigner),
+    ]
+
+    for timer_name, priority_type, designer in designers:
+        design_timer.start(timer_name)
+        design_cache[priority_type] = designer().optimize_design()
+    best_military_stats = ShipDesignAI.WarShipDesigner().optimize_design()
+    best_carrier_stats = ShipDesignAI.CarrierShipDesigner().optimize_design()
+    best_stats = best_military_stats + best_carrier_stats if random.random() < .8 else best_military_stats
+    best_stats.sort(reverse=True)
+    design_cache[PriorityType.PRODUCTION_MILITARY] = best_stats
+    design_timer.start('Krill Spawner')
+    ShipDesignAI.KrillSpawnerShipDesigner().optimize_design()  # just designing it, building+mission not supported yet
+    if fo.currentTurn() % 10 == 0:
+        design_timer.start('Printing')
+        ShipDesignAI.Cache.print_best_designs()
+    design_timer.stop_print_and_clear()
+    return design_cache
+
+
+@cache_for_current_turn
+def cur_best_military_design_rating() -> float:
+    """
+    Find and return the default combat rating of our best military design.
+    """
+    design_cache = _fill_design_cache()
+
+    priority = PriorityType.PRODUCTION_MILITARY
+    if design_cache.get(priority, None) and design_cache[priority][0]:
+        # the rating provided by the ShipDesigner does not
+        # reflect the rating used in threat considerations
+        # but takes additional factors (such as cost) into
+        # account. Therefore, we want to calculate the actual
+        # rating of the design as provided by CombatRatingsAI.
+        _, _, _, _, stats = design_cache[priority][0]
+        # TODO: Should this consider enemy stats?
+        rating = stats.convert_to_combat_stats().get_rating()
+        return max(rating, 0.001)
+    return 0.001
+
+
+def _get_locations(locations: Union[int, Iterable[int], None]) -> FrozenSet[int]:
+    if locations is None:
+        return get_inhabited_planets()
+
+    if isinstance(locations, int):
+        locations = (int,)
+    return get_inhabited_planets().intersection(locations)
+
+
+def get_best_ship_info(
+        priority: PriorityType, loc: Union[int, Iterable[int], None] = None
+) -> Tuple[Optional[int], Optional["fo.shipDesign"], Optional[List[int]]]:
+    """Returns 3 item tuple: designID, design, buildLocList."""
+    planet_ids = _get_locations(loc)
+    return _get_best_ship_info(priority, tuple(planet_ids))
+
+
+def _get_best_ship_info(
+        priority: PriorityType,
+        planet_ids: Tuple[int]
+) -> Tuple[Optional[int], Optional["fo.shipDesign"], Optional[List[int]]]:
+    design_cache = _fill_design_cache()
+
+    if priority in design_cache:
+        best_designs = design_cache[priority]
+        if not best_designs:
+            return None, None, None
+
+        # best_designs are already sorted by rating high to low, so the top rating is the first encountered within
+        # our planet search list
+        for design_stats in best_designs:
+            top_rating, pid, top_id, cost, stats = design_stats
+            if pid in planet_ids:
+                break
+        else:
+            return None, None, None  # apparently can't build for this priority within the desired planet group
+        valid_locs = [pid_ for rating, pid_, design_id, _, _ in best_designs if
+                      rating == top_rating and design_id == top_id and pid_ in planet_ids]
+        return top_id, fo.getShipDesign(top_id), valid_locs
+    else:
+        return None, None, None  # must be missing a Shipyard or other orbital (or missing tech)
+
+
+def get_best_ship_ratings(planet_ids: Tuple[int]) -> List[Tuple[float, int, int, "fo.shipDesign"]]:
+    """
+    Returns list of [partition, pid, designID, design] tuples, currently only for military ships.
+
+    Since we haven't yet implemented a way to target military ship construction at/near particular locations
+    where they are most in need, and also because our rating system is presumably useful-but-not-perfect, we want to
+    distribute the construction across the Resource Group and across similarly rated designs, preferentially choosing
+    the best rated design/loc combo, but if there are multiple design/loc combos with the same or similar ratings then
+    we want some chance of choosing  those alternate designs/locations.
+
+    The approach to this taken below is to treat the ratings akin to an energy to be used in a statistical mechanics
+    type partition function. 'tally' will compute the normalization constant.
+    So first go through and calculate the tally as well as convert each individual contribution to
+    the running total up to that point, to facilitate later sampling.  Then those running totals are
+    renormalized by the final tally, so that a later random number selector in the range [0,1) can be
+    used to select the chosen design/loc.
+    """
+    return list(_get_best_ship_ratings(tuple(planet_ids)))
+
+
+@cache_for_current_turn
+def _get_best_ship_ratings(planet_ids: Tuple[int]) -> Iterator[Tuple[float, int, int, "fo.shipDesign"]]:
+    _design_cache = _fill_design_cache()
+    priority = PriorityType.PRODUCTION_MILITARY
+    planet_ids = set(planet_ids).intersection(ColonisationAI.empire_shipyards)
+
+    if priority not in _design_cache:
+        return
+
+    build_choices = _design_cache[priority]
+    loc_choices = [[rating, pid, design_id, fo.getShipDesign(design_id)]
+                   for (rating, pid, design_id, cost, stats) in build_choices if pid in planet_ids]
+    if not loc_choices:
+        return
+    best_rating = loc_choices[0][0]
+    tally = 0
+    ret_val = []
+    for rating, pid, design_id, design in loc_choices:
+        if rating < 0.7 * best_rating:
+            break
+        p = math.exp(10 * (rating / best_rating - 1))
+        tally += p
+        ret_val.append((tally, pid, design_id, design))
+    for base_tally, pid, design_id, design in ret_val:
+        yield base_tally / tally, pid, design_id, design

--- a/default/python/AI/turn_state/design.py
+++ b/default/python/AI/turn_state/design.py
@@ -74,7 +74,7 @@ def _get_locations(locations: Union[int, Iterable[int], None]) -> FrozenSet[int]
         return get_inhabited_planets()
 
     if isinstance(locations, int):
-        locations = (int,)
+        locations = (locations,)
     return get_inhabited_planets().intersection(locations)
 
 


### PR DESCRIPTION
- Make design cache calculation lazy, no need to call it during turn preparation explicitly
- Separate function to two parts: outer is to normalize arguments and shape return type and inner to do data aggregation staff,
- Remove unused get_design_cost
- Use a new approach to import from submodule: `from turn_state.design import ...`, this allows to handle circular imports,
- Annotate arguments and return types, update usages.



