### PR TITLE
Xcode Macos Version Bump for C++17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -125,7 +125,7 @@ jobs:
     - name: Build FreeOrion on MacOS
       stage: build
       os: osx
-      osx_image: xcode9.4
+      osx_image: xcode10.1
       language: cpp
       compiler: clang
       cache: ccache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
 cmake_policy(SET CMP0042 NEW)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_HOME_DIRECTORY}/cmake ${CMAKE_HOME_DIRECTORY}/GG/cmake)
-set(CMAKE_OSX_DEPLOYMENT_TARGET 10.9 CACHE STRING "Set the minimum OSX deployment target version")
+set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "Set the minimum OSX deployment target version")
 set(CMAKE_OSX_ARCHITECTURES x86_64 CACHE STRING "Set the architecture the universal binaries for OSX should be built for")
 
 IF(CMAKE_GENERATOR STREQUAL "Xcode")

--- a/GG/GG/Texture.h
+++ b/GG/GG/Texture.h
@@ -19,9 +19,9 @@
 
 
 #include <boost/filesystem/path.hpp>
-#include <boost/thread/mutex.hpp>
 #include <GG/Base.h>
 #include <GG/Exception.h>
+#include <mutex>
 
 
 namespace GG {
@@ -255,7 +255,7 @@ private:
         name and not loaded from a path. */
     std::map<std::string, std::shared_ptr<Texture>> m_textures;
 
-    mutable boost::mutex m_texture_access_guard;
+    mutable std::mutex m_texture_access_guard;
 
     friend GG_API TextureManager& GetTextureManager();
 };

--- a/GG/src/Texture.cpp
+++ b/GG/src/Texture.cpp
@@ -45,7 +45,6 @@ namespace {
             value *= 2;
         return value;
     }
-
 }
 
 ///////////////////////////////////////
@@ -565,7 +564,7 @@ TextureManager::TextureManager()
 
 std::map<std::string, std::shared_ptr<const Texture>> TextureManager::Textures() const
 {
-    boost::mutex::scoped_lock lock(m_texture_access_guard);
+    std::scoped_lock lock(m_texture_access_guard);
     return {m_textures.begin(), m_textures.end()};
 }
 
@@ -574,14 +573,14 @@ std::shared_ptr<Texture> TextureManager::StoreTexture(Texture* texture, std::str
 
 std::shared_ptr<Texture> TextureManager::StoreTexture(std::shared_ptr<Texture> texture, std::string texture_name)
 {
-    boost::mutex::scoped_lock lock(m_texture_access_guard);
+    std::scoped_lock lock(m_texture_access_guard);
     m_textures[std::move(texture_name)] = texture;
     return texture;
 }
 
 std::shared_ptr<Texture> TextureManager::GetTexture(const boost::filesystem::path& path, bool mipmap/* = false*/)
 {
-    boost::mutex::scoped_lock lock(m_texture_access_guard);
+    std::scoped_lock lock(m_texture_access_guard);
     auto it = m_textures.find(path.generic_string());
     if (it == m_textures.end()) { // if no such texture was found, attempt to load it now, using name as the filename
         //std::cout << "TextureManager::GetTexture storing new texture under name: " << path.generic_string();
@@ -596,7 +595,7 @@ void TextureManager::FreeTexture(const boost::filesystem::path& path)
 
 void TextureManager::FreeTexture(const std::string& name)
 {
-    boost::mutex::scoped_lock lock(m_texture_access_guard);
+    std::scoped_lock lock(m_texture_access_guard);
     auto it = m_textures.find(name);
     if (it != m_textures.end())
         m_textures.erase(it);

--- a/client/human/GGHumanClientApp.cpp
+++ b/client/human/GGHumanClientApp.cpp
@@ -950,7 +950,7 @@ void GGHumanClientApp::HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id
 }
 
 boost::intrusive_ptr<const boost::statechart::event_base> GGHumanClientApp::GetDeferredPostedEvent() {
-    boost::mutex::scoped_lock lock(m_event_queue_guard);
+    std::scoped_lock lock(m_event_queue_guard);
     if (m_posted_event_queue.empty())
         return nullptr;
     auto retval = m_posted_event_queue.front();
@@ -961,7 +961,7 @@ boost::intrusive_ptr<const boost::statechart::event_base> GGHumanClientApp::GetD
 void GGHumanClientApp::PostDeferredEvent(
     boost::intrusive_ptr<const boost::statechart::event_base> event)
 {
-    boost::mutex::scoped_lock lock(m_event_queue_guard);
+    std::scoped_lock lock(m_event_queue_guard);
     m_posted_event_queue.push_back(std::move(event));
 }
 

--- a/client/human/GGHumanClientApp.h
+++ b/client/human/GGHumanClientApp.h
@@ -7,8 +7,8 @@
 #include "../../UI/ClientUI.h"
 #include "../../util/OptionsDB.h"
 #include <boost/statechart/event_base.hpp>
-#include <boost/thread/mutex.hpp>
 #include <memory>
+#include <mutex>
 #include <queue>
 #include <string>
 
@@ -143,7 +143,7 @@ private:
     void FreeServer();
 
 
-    boost::mutex m_event_queue_guard;
+    std::mutex m_event_queue_guard;
     std::list<boost::intrusive_ptr<const boost::statechart::event_base>> m_posted_event_queue;
 
     void HandleSystemEvents() override;

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -19,7 +19,6 @@
 #include "../../UI/MapWnd.h"
 
 #include <boost/format.hpp>
-#include <boost/thread/mutex.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/nil_generator.hpp>
 #include <thread>

--- a/msvc2017/FreeOrion/StdAfx.h
+++ b/msvc2017/FreeOrion/StdAfx.h
@@ -76,8 +76,6 @@
 #include <boost/signals2/optional_last_value.hpp>
 #include <boost/signals2/signal.hpp>
 #include <boost/thread/condition.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/shared_mutex.hpp>
 #include <boost/type_traits/remove_const.hpp>
 #include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid.hpp>

--- a/msvc2017/FreeOrionCA/StdAfx.h
+++ b/msvc2017/FreeOrionCA/StdAfx.h
@@ -76,8 +76,6 @@
 #include <boost/signals2/optional_last_value.hpp>
 #include <boost/signals2/signal.hpp>
 #include <boost/thread/condition.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/shared_mutex.hpp>
 #include <boost/type_traits/remove_const.hpp>
 #include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid.hpp>

--- a/msvc2017/FreeOrionD/StdAfx.h
+++ b/msvc2017/FreeOrionD/StdAfx.h
@@ -76,8 +76,6 @@
 #include <boost/signals2/optional_last_value.hpp>
 #include <boost/signals2/signal.hpp>
 #include <boost/thread/condition.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/thread/shared_mutex.hpp>
 #include <boost/type_traits/remove_const.hpp>
 #include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid.hpp>

--- a/network/MessageQueue.cpp
+++ b/network/MessageQueue.cpp
@@ -4,32 +4,32 @@
 
 #include <boost/optional/optional.hpp>
 
-MessageQueue::MessageQueue(boost::mutex& monitor) :
+MessageQueue::MessageQueue(std::mutex& monitor) :
     m_monitor{monitor}
 {}
 
 bool MessageQueue::Empty() const {
-    boost::mutex::scoped_lock lock(m_monitor);
+    std::scoped_lock lock(m_monitor);
     return m_queue.empty();
 }
 
 std::size_t MessageQueue::Size() const {
-    boost::mutex::scoped_lock lock(m_monitor);
+    std::scoped_lock lock(m_monitor);
     return m_queue.size();
 }
 
 void MessageQueue::Clear() {
-    boost::mutex::scoped_lock lock(m_monitor);
+    std::scoped_lock lock(m_monitor);
     m_queue.clear();
 }
 
 void MessageQueue::PushBack(Message message) {
-    boost::mutex::scoped_lock lock(m_monitor);
+    std::scoped_lock lock(m_monitor);
     m_queue.push_back(std::move(message));
 }
 
 boost::optional<Message> MessageQueue::PopFront() {
-    boost::mutex::scoped_lock lock(m_monitor);
+    std::scoped_lock lock(m_monitor);
     if (m_queue.empty())
         return boost::none;
     Message message;

--- a/network/MessageQueue.h
+++ b/network/MessageQueue.h
@@ -2,10 +2,10 @@
 #define _MessageQueue_h_
 
 #include <boost/thread/condition.hpp>
-#include <boost/thread/mutex.hpp>
 #include <boost/optional/optional_fwd.hpp>
 
 #include <list>
+#include <mutex>
 
 #include "../util/Export.h"
 
@@ -16,7 +16,7 @@ class Message;
 class FO_COMMON_API MessageQueue
 {
 public:
-    MessageQueue(boost::mutex& monitor);
+    MessageQueue(std::mutex& monitor);
 
     /** Returns true iff the queue is empty. */
     bool Empty() const;
@@ -35,7 +35,7 @@ public:
 
 private:
     std::list<Message> m_queue;
-    boost::mutex&      m_monitor;
+    std::mutex&        m_monitor;
 };
 
 

--- a/universe/NamedValueRefManager.cpp
+++ b/universe/NamedValueRefManager.cpp
@@ -156,16 +156,17 @@ namespace {
                               std::string&& valueref_name, std::unique_ptr<VR>&& vref)
     {
         TraceLogger() << "Register " << label << " valueref for " << valueref_name << ": " << vref->Description();
-        if (container.count(valueref_name)>0) {
+        if (container.count(valueref_name) > 0) {
             TraceLogger() << "Skip registration for already registered " << label << " valueref for " << valueref_name;
             TraceLogger() << "Number of registered " << label << " ValueRefs: " << container.size();
             return;
         }
         TraceLogger() << "RegisterValueRefImpl Check invariances for info. Then add the value ref in a thread safe way.";
-        const std::lock_guard<std::mutex> lock(mutex);
+        std::scoped_lock lock(mutex);
         if (!(vref->RootCandidateInvariant() && vref->LocalCandidateInvariant() &&
              vref->TargetInvariant() && vref->SourceInvariant()))
         { ErrorLogger() << "Currently only invariant value refs can be named. " << valueref_name; }
+
         container.emplace(std::move(valueref_name), std::move(vref));
         TraceLogger() << "Number of registered " << label << " ValueRefs: " << container.size();
     }

--- a/universe/Species.cpp
+++ b/universe/Species.cpp
@@ -375,12 +375,12 @@ namespace {
 }
 
 void SpeciesManager::SetSpeciesTypes(Pending::Pending<std::pair<SpeciesTypeMap, CensusOrder>>&& future) {
-    std::lock_guard<std::mutex> lock(species_mutex);
+    std::scoped_lock lock(species_mutex);
     s_pending_types = std::move(future);
 }
 
 void SpeciesManager::CheckPendingSpeciesTypes() {
-    std::lock_guard<std::mutex> lock(species_mutex);
+    std::scoped_lock lock(species_mutex);
 
     if (!s_pending_types) {
         if (s_species.empty())

--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -514,7 +514,7 @@ namespace {
     fs::path res_dir;
 
     void RefreshResDir() {
-        std::lock_guard<std::mutex> res_dir_lock(res_dir_mutex);
+        std::scoped_lock res_dir_lock(res_dir_mutex);
         // if resource dir option has been set, use specified location. otherwise,
         // use default location
         res_dir = FilenameToPath(GetOptionsDB().Get<std::string>("resource.path"));
@@ -526,7 +526,7 @@ namespace {
 
 auto GetResourceDir() -> fs::path const
 {
-    std::lock_guard<std::mutex> res_dir_lock(res_dir_mutex);
+    std::scoped_lock res_dir_lock(res_dir_mutex);
     if (init) {
         init = false;
         res_dir = FilenameToPath(GetOptionsDB().Get<std::string>("resource.path"));

--- a/util/Logger.cpp
+++ b/util/Logger.cpp
@@ -176,7 +176,7 @@ namespace {
         void AddOrReplaceLoggerName(const std::string& channel_name,
                                     boost::shared_ptr<LoggerTextFileSinkFrontend> front_end = nullptr)
         {
-            std::lock_guard<std::mutex> lock(m_mutex);
+            std::scoped_lock lock(m_mutex);
 
             // Remove the old front end if it is different.
             const auto& name_and_old_frontend = m_names_to_front_ends.find(channel_name);
@@ -204,7 +204,7 @@ namespace {
         void StoreConfigurerWithLoggerName(const std::string& channel_name,
                                            const LoggerFileSinkFrontEndConfigurer& configure_front_end)
         {
-            std::lock_guard<std::mutex> lock(m_mutex);
+            std::scoped_lock lock(m_mutex);
 
             // Remove the old front end if it is different.
             m_names_to_front_end_configurers.erase(channel_name);
@@ -218,7 +218,7 @@ namespace {
         }
 
         std::vector<std::string> LoggersNames() {
-            std::lock_guard<std::mutex> lock(m_mutex);
+            std::scoped_lock lock(m_mutex);
 
             std::vector<std::string> retval;
             retval.reserve(m_names_to_front_ends.size());
@@ -228,7 +228,7 @@ namespace {
         }
 
         void ShutdownFileSinks() {
-            std::lock_guard<std::mutex> lock(m_mutex);
+            std::scoped_lock lock(m_mutex);
 
             for (const auto& name_and_frontend : m_names_to_front_ends)
                 logging::core::get()->remove_sink(name_and_frontend.second);
@@ -297,7 +297,7 @@ namespace {
         public:
         // Set the logger threshold and return the logger name and threshold used.
         std::pair<std::string, LogLevel> SetThreshold(const std::string& source, LogLevel threshold) {
-            std::lock_guard<std::mutex> lock(m_mutex);
+            std::scoped_lock lock(m_mutex);
 
             auto used_threshold = ForcedThreshold() ? *ForcedThreshold() : threshold;
             m_min_channel_severity[source] = used_threshold;

--- a/util/Pending.h
+++ b/util/Pending.h
@@ -87,7 +87,7 @@ namespace Pending {
     boost::optional<T> WaitForPending(boost::optional<Pending<T>>& pending, bool do_not_care_about_result = false) {
         if (!pending)
             return boost::none;
-        std::lock_guard<std::mutex> lock(pending->m_mutex);
+        std::scoped_lock lock(pending->m_mutex);
         if (!pending || !(pending->pending)) {
             // another thread in the meantime transferred the pending to stored
             return boost::none;
@@ -106,7 +106,7 @@ namespace Pending {
     template <typename T>
     T& SwapPending(boost::optional<Pending<T>>& pending, T& stored) {
         if (pending) {
-            std::lock_guard<std::mutex> lock(pending->m_mutex);
+            std::scoped_lock lock(pending->m_mutex);
             if (!pending) {
                 // another thread in the meantime transferred the pending to stored
                 return stored;
@@ -114,7 +114,7 @@ namespace Pending {
             if (auto tt = WaitForPendingUnlocked(std::move(*pending))) {
                 std::swap(*tt, stored);
             }
-	    pending = boost::none;
+        pending = boost::none;
         }
         return stored;
     }

--- a/util/Random.cpp
+++ b/util/Random.cpp
@@ -8,9 +8,7 @@
 
 #include <mutex>
 
-
-typedef std::lock_guard<std::mutex> lock_guard;
-typedef std::mt19937 GeneratorType;
+using GeneratorType = std::mt19937;
 
 
 namespace {
@@ -19,12 +17,12 @@ namespace {
 }
 
 void Seed(unsigned int seed) {
-    lock_guard lock(s_prng_mutex);
+    std::scoped_lock lock(s_prng_mutex);
     gen.seed(static_cast<GeneratorType::result_type>(seed));
 }
 
 void ClockSeed() {
-    lock_guard lock(s_prng_mutex);
+    std::scoped_lock lock(s_prng_mutex);
     boost::posix_time::time_duration diff = boost::posix_time::microsec_clock::local_time().time_of_day();
     gen.seed(static_cast<GeneratorType::result_type>(diff.total_milliseconds()));
 }
@@ -33,14 +31,14 @@ int RandInt(int min, int max) {
     if (min >= max)
         return min;
     {
-        lock_guard lock(s_prng_mutex);
+        std::scoped_lock lock(s_prng_mutex);
         static boost::random::uniform_smallint<> dis;
         return dis(gen, decltype(dis)::param_type{min, max});
     }
 }
 
 double RandZeroToOne() {
-    lock_guard lock(s_prng_mutex);
+    std::scoped_lock lock(s_prng_mutex);
     static boost::random::uniform_01<> dis;
     return dis(gen);
 }
@@ -49,7 +47,7 @@ double RandDouble(double min, double max) {
     if (min >= max)
         return min;
     {
-        lock_guard lock(s_prng_mutex);
+        std::scoped_lock lock(s_prng_mutex);
         static boost::random::uniform_real_distribution<> dis;
         return dis(gen, decltype(dis)::param_type{min, max});
     }
@@ -59,18 +57,18 @@ double RandGaussian(double mean, double sigma) {
     if (sigma <= 0.0)
         return mean;
     {
-        lock_guard lock(s_prng_mutex);
+        std::scoped_lock lock(s_prng_mutex);
         static boost::random::normal_distribution<> dis;
         return dis(gen, decltype(dis)::param_type{mean, sigma});
     }
 }
 
 void RandomShuffle(std::vector<bool>& c) {
-    lock_guard lock(s_prng_mutex);
+    std::scoped_lock lock(s_prng_mutex);
     std::shuffle(c.begin(), c.end(), gen);
 }
 
 void RandomShuffle(std::vector<int>& c) {
-    lock_guard lock(s_prng_mutex);
+    std::scoped_lock lock(s_prng_mutex);
     std::shuffle(c.begin(), c.end(), gen);
 }

--- a/util/StringTable.cpp
+++ b/util/StringTable.cpp
@@ -29,12 +29,12 @@ StringTable::~StringTable()
 {}
 
 bool StringTable::StringExists(const std::string& key) const {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::scoped_lock lock(m_mutex);
     return m_strings.count(key);
 }
 
 const std::string& StringTable::operator[] (const std::string& key) const {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::scoped_lock lock(m_mutex);
 
     auto it = m_strings.find(key);
     if (it != m_strings.end())
@@ -45,7 +45,7 @@ const std::string& StringTable::operator[] (const std::string& key) const {
 }
 
 void StringTable::Load(std::shared_ptr<const StringTable> fallback) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::scoped_lock lock(m_mutex);
 
     if (fallback && !fallback->m_initialized) {
         // this prevents deadlock if two stringtables were to be loaded
@@ -71,7 +71,7 @@ void StringTable::Load(std::shared_ptr<const StringTable> fallback) {
     std::map<std::string, std::string> fallback_lookup_strings;
     std::string fallback_table_file;
     if (fallback) {
-        std::lock_guard<std::mutex> fallback_lock(fallback->m_mutex);
+        std::scoped_lock fallback_lock(fallback->m_mutex);
         fallback_table_file = fallback->Filename();
         fallback_lookup_strings.insert(fallback->m_strings.begin(), fallback->m_strings.end());
     }

--- a/util/i18n.cpp
+++ b/util/i18n.cpp
@@ -115,7 +115,7 @@ namespace {
     // get currently set stringtable filename option value, or the default value
     // if the currenty value is empty
     std::string GetStringTableFileName() {
-        std::lock_guard<std::recursive_mutex> stringtable_lock(stringtable_access_mutex);
+        std::scoped_lock<std::recursive_mutex> stringtable_lock(stringtable_access_mutex);
         // initialize option value and default on first call
         if (!stringtable_filename_init)
             InitStringtableFileName();
@@ -128,7 +128,7 @@ namespace {
     }
 
     const StringTable& GetStringTable(boost::filesystem::path stringtable_path) {
-        std::lock_guard<std::recursive_mutex> stringtable_lock(stringtable_access_mutex);
+        std::scoped_lock<std::recursive_mutex> stringtable_lock(stringtable_access_mutex);
 
         if (!stringtable_filename_init)
             InitStringtableFileName();
@@ -196,12 +196,12 @@ std::locale GetLocale(const std::string& name) {
 }
 
 void FlushLoadedStringTables() {
-    std::lock_guard<std::recursive_mutex> stringtable_lock(stringtable_access_mutex);
+    std::scoped_lock<std::recursive_mutex> stringtable_lock(stringtable_access_mutex);
     stringtables.clear();
 }
 
 const std::map<std::string, std::string>& AllStringtableEntries(bool default_table) {
-    std::lock_guard<std::recursive_mutex> stringtable_lock(stringtable_access_mutex);
+    std::scoped_lock<std::recursive_mutex> stringtable_lock(stringtable_access_mutex);
     if (default_table)
         return GetDevDefaultStringTable().AllStrings();
     else
@@ -209,14 +209,14 @@ const std::map<std::string, std::string>& AllStringtableEntries(bool default_tab
 }
 
 const std::string& UserString(const std::string& str) {
-    std::lock_guard<std::recursive_mutex> stringtable_lock(stringtable_access_mutex);
+    std::scoped_lock<std::recursive_mutex> stringtable_lock(stringtable_access_mutex);
     if (GetStringTable().StringExists(str))
         return GetStringTable()[str];
     return GetDevDefaultStringTable()[str];
 }
 
 std::vector<std::string> UserStringList(const std::string& key) {
-    std::lock_guard<std::recursive_mutex> stringtable_lock(stringtable_access_mutex);
+    std::scoped_lock<std::recursive_mutex> stringtable_lock(stringtable_access_mutex);
     std::vector<std::string> result;
     std::istringstream template_stream(UserString(key));
     std::string item;
@@ -226,7 +226,7 @@ std::vector<std::string> UserStringList(const std::string& key) {
 }
 
 bool UserStringExists(const std::string& str) {
-    std::lock_guard<std::recursive_mutex> stringtable_lock(stringtable_access_mutex);
+    std::scoped_lock<std::recursive_mutex> stringtable_lock(stringtable_access_mutex);
     return GetStringTable().StringExists(str) || GetDevDefaultStringTable().StringExists(str);
 }
 
@@ -244,7 +244,7 @@ boost::format FlexibleFormat(const std::string &string_to_format) {
 }
 
 const std::string& Language() {
-    std::lock_guard<std::recursive_mutex> stringtable_lock(stringtable_access_mutex);
+    std::scoped_lock<std::recursive_mutex> stringtable_lock(stringtable_access_mutex);
     return GetStringTable().Language();
 }
 


### PR DESCRIPTION
`std::scoped_lock` needs at least MacOS 10.12.

Other C++17 stuff apparently needs 10.14 but that would remove too much old MacOS version support.