### PR TITLE
ScriptingContext State Passing

### DIFF
--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -151,19 +151,19 @@ public:
 
     /** Return true iff this empire can produce the specified item at the specified location. */
     bool                    ProducibleItem(BuildType build_type, int location,
-                                           const ScriptingContext& context = ScriptingContext()) const;
+                                           const ScriptingContext& context = ScriptingContext{}) const;
     bool                    ProducibleItem(BuildType build_type, const std::string& name, int location,
-                                           const ScriptingContext& context = ScriptingContext()) const;
+                                           const ScriptingContext& context = ScriptingContext{}) const;
     bool                    ProducibleItem(BuildType build_type, int design_id, int location,
-                                           const ScriptingContext& context = ScriptingContext()) const;
+                                           const ScriptingContext& context = ScriptingContext{}) const;
     bool                    ProducibleItem(const ProductionQueue::ProductionItem& item, int location,
-                                           const ScriptingContext& context = ScriptingContext()) const;
+                                           const ScriptingContext& context = ScriptingContext{}) const;
 
     /** Return true iff this empire can enqueue the specified item at the specified location. */
     bool                    EnqueuableItem(BuildType build_type, const std::string& name, int location,
-                                           const ScriptingContext& context = ScriptingContext()) const;
+                                           const ScriptingContext& context = ScriptingContext{}) const;
     bool                    EnqueuableItem(const ProductionQueue::ProductionItem& item, int location,
-                                           const ScriptingContext& context = ScriptingContext()) const;
+                                           const ScriptingContext& context = ScriptingContext{}) const;
 
     bool                    HasExploredSystem(int ID) const;                            ///< returns  true if the given item is in the appropriate list, false if it is not.
 

--- a/Empire/ProductionQueue.h
+++ b/Empire/ProductionQueue.h
@@ -55,7 +55,7 @@ struct FO_COMMON_API ProductionQueue {
           * turns required to produce the indicated item, or (-1.0, -1) if the item
           * is unknown, unavailable, or invalid. */
         std::pair<float, int> ProductionCostAndTime(int empire_id, int location_id,
-                                                    const ScriptingContext& context = ScriptingContext()) const;
+                                                    const ScriptingContext& context = ScriptingContext{}) const;
 
         bool operator<(const ProductionItem& rhs) const;
 
@@ -90,7 +90,7 @@ struct FO_COMMON_API ProductionQueue {
         /** Returns the total cost per item (blocksize 1) and the minimum number of
           * turns required to produce the indicated item, or (-1.0, -1) if the item
           * is unknown, unavailable, or invalid. */
-        std::pair<float, int> ProductionCostAndTime(const ScriptingContext& context = ScriptingContext()) const;
+        std::pair<float, int> ProductionCostAndTime(const ScriptingContext& context = ScriptingContext{}) const;
 
 
         ProductionItem      item;

--- a/UI/FleetButton.cpp
+++ b/UI/FleetButton.cpp
@@ -176,7 +176,8 @@ void FleetButton::Refresh(SizeType size_type) {
     for (const auto& fleet : fleets) {
         if (fleet) {
             num_ships += fleet->NumShips();
-            if (!m_fleet_blockaded && fleet->Blockaded(ScriptingContext{}))
+            if (!m_fleet_blockaded && fleet->Blockaded(ScriptingContext{GetUniverse(), Empires(), GetGalaxySetupData(),
+                                                                        GetSpeciesManager(), GetSupplyManager()}))
                 m_fleet_blockaded = true;
         }
     }

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -1401,7 +1401,7 @@ void FleetDataPanel::Refresh() {
                 public_fleet_name = public_fleet_name + " (" + std::to_string(m_fleet_id) + ")";
             m_fleet_name_text->SetText(std::move(public_fleet_name));
         }
-        m_fleet_destination_text->SetText(FleetDestinationText(m_fleet_id, ScriptingContext()));
+        m_fleet_destination_text->SetText(FleetDestinationText(m_fleet_id, ScriptingContext{}));
 
         // set icons
         std::vector<std::shared_ptr<GG::Texture>> icons{

--- a/UI/GovernmentWnd.cpp
+++ b/UI/GovernmentWnd.cpp
@@ -1256,7 +1256,8 @@ void GovernmentWnd::MainPanel::SetPolicy(const Policy* policy, unsigned int slot
     // update UI after policy changes
     empire->UpdateInfluenceSpending();
     Populate();
-    GetUniverse().UpdateMeterEstimates(Empires());
+    ScriptingContext context{GetUniverse(), Empires(), GetGalaxySetupData(), GetSpeciesManager(), GetSupplyManager()};
+    GetUniverse().UpdateMeterEstimates(context);
     SidePanel::Refresh();
     FleetUIManager::GetFleetUIManager().RefreshAll();
 }

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -248,10 +248,10 @@ namespace {
 
             item_name = UserString(elem.item.name);
             //available = empire->BuildingTypeAvailable(elem.item.name);
-            location_ok = building_type->ProductionLocation(elem.empire_id, elem.location, ScriptingContext());
+            location_ok = building_type->ProductionLocation(elem.empire_id, elem.location, ScriptingContext{});
             //min_turns = building_type->ProductionTime(elem.empire_id, elem.location);
-            total_cost = building_type->ProductionCost(elem.empire_id, elem.location, ScriptingContext());
-            max_allocation = building_type->PerTurnCost(elem.empire_id, elem.location, ScriptingContext());
+            total_cost = building_type->ProductionCost(elem.empire_id, elem.location, ScriptingContext{});
+            max_allocation = building_type->PerTurnCost(elem.empire_id, elem.location, ScriptingContext{});
             icon = ClientUI::BuildingIcon(elem.item.name);
 
         } else if (elem.item.build_type == BuildType::BT_SHIP) {

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -1358,6 +1358,8 @@ int AutomaticallyChosenColonyShip(int target_planet_id) {
     float best_capacity = -999;
     bool changed_planet = false;
 
+    ScriptingContext context{GetUniverse(), Empires(), GetGalaxySetupData(), GetSpeciesManager(), GetSupplyManager()};
+
     GetUniverse().InhibitUniverseObjectSignals(true);
     for (auto& ship : capable_and_available_colony_ships) {
         if (!ship)
@@ -1392,7 +1394,7 @@ int AutomaticallyChosenColonyShip(int target_planet_id) {
                         target_planet->GetMeter(MeterType::METER_TARGET_POPULATION)->Reset();
 
                         // temporary meter update with currently set species
-                        GetUniverse().UpdateMeterEstimates(target_planet_id, Empires());
+                        GetUniverse().UpdateMeterEstimates(target_planet_id, context);
                         planet_capacity = target_planet->GetMeter(MeterType::METER_TARGET_POPULATION)->Current();  // want value after meter update, so check current, not initial value
                     }
                     species_colony_projections[std::move(spec_pair)] = planet_capacity;
@@ -1411,8 +1413,8 @@ int AutomaticallyChosenColonyShip(int target_planet_id) {
         target_planet->SetOwner(orig_owner);
         target_planet->SetSpecies(orig_species);
         target_planet->GetMeter(MeterType::METER_TARGET_POPULATION)->Set(orig_initial_target_pop,
-                                                              orig_initial_target_pop);
-        GetUniverse().UpdateMeterEstimates(target_planet_id, Empires());
+                                                                         orig_initial_target_pop);
+        GetUniverse().UpdateMeterEstimates(target_planet_id, context);
     }
     GetUniverse().InhibitUniverseObjectSignals(false);
 
@@ -1666,6 +1668,9 @@ void SidePanel::PlanetPanel::Refresh() {
     }
 
     if (can_colonize) {
+        ScriptingContext context{GetUniverse(), Empires(), GetGalaxySetupData(),
+                                 GetSpeciesManager(), GetSupplyManager()};
+
         // show colonize button; in case the chosen colony ship is not actually
         // selected, but has been chosen by AutomaticallyChosenColonyShip,
         // determine what population capacity to put on the conolnize buttone by
@@ -1692,13 +1697,13 @@ void SidePanel::PlanetPanel::Refresh() {
             planet->GetMeter(MeterType::METER_TARGET_POPULATION)->Reset();
 
             // temporary meter updates for curently set species
-            GetUniverse().UpdateMeterEstimates(m_planet_id, Empires());
+            GetUniverse().UpdateMeterEstimates(m_planet_id, context);
             planet_capacity = ((planet_env_for_colony_species == PlanetEnvironment::PE_UNINHABITABLE) ? 0.0 : planet->GetMeter(MeterType::METER_TARGET_POPULATION)->Current());   // want target pop after meter update, so check current value of meter
             planet->SetOwner(orig_owner);
             planet->SetSpecies(orig_species);
             planet->GetMeter(MeterType::METER_TARGET_POPULATION)->Set(
                 orig_initial_target_pop, orig_initial_target_pop);
-            GetUniverse().UpdateMeterEstimates(m_planet_id, Empires());
+            GetUniverse().UpdateMeterEstimates(m_planet_id, context);
 
             colony_projections[this_pair] = planet_capacity;
             GetUniverse().InhibitUniverseObjectSignals(false);

--- a/client/AI/AIWrapper.cpp
+++ b/client/AI/AIWrapper.cpp
@@ -127,8 +127,10 @@ namespace {
     }
 
     void InitMeterEstimatesAndDiscrepancies() {
-        Universe& universe = AIClientApp::GetApp()->GetUniverse();
-        universe.InitMeterEstimatesAndDiscrepancies(AIClientApp::GetApp()->Empires());
+        Universe& universe = GetUniverse();
+        EmpireManager& empires = Empires();
+        ScriptingContext context{universe, empires, GetGalaxySetupData(), GetSpeciesManager(), GetSupplyManager()};
+        universe.InitMeterEstimatesAndDiscrepancies(context);
     }
 
     /** @brief Set ::Universe ::Meter instances to their estimated values as
@@ -169,7 +171,8 @@ namespace {
         }
 
         // update meter estimates with temporary ownership
-        universe.UpdateMeterEstimates(Empires());
+        ScriptingContext context{universe, Empires(), GetGalaxySetupData(), GetSpeciesManager(), GetSupplyManager()};
+        universe.UpdateMeterEstimates(context);
 
         if (pretend_to_own_unowned_planets) {
             // remove temporary ownership added above

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -1,5 +1,3 @@
-
-
 #include "GGHumanClientApp.h"
 #include "../../util/OptionsDB.h"
 #include "../../util/Directories.h"

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -39,7 +39,7 @@ CombatInfo::CombatInfo(int system_id_, int turn_,
                        Universe& universe_mutable_in,
                        const EmpireManager& empires_,
                        const GalaxySetupData& galaxy_setup_data_,
-                       const SpeciesManager& species_,
+                       SpeciesManager& species_,
                        const SupplyManager& supply_) :
     universe(universe_mutable_in),
     empires(empires_.GetEmpires()),

--- a/combat/CombatSystem.h
+++ b/combat/CombatSystem.h
@@ -14,7 +14,7 @@ public:
                Universe& universe_,
                const EmpireManager& empires_,
                const GalaxySetupData& galaxy_setup_data_,
-               const SpeciesManager& species_,
+               SpeciesManager& species_,
                const SupplyManager& supply_);
     // TODO: Constructor taking ObjectMap override?
 
@@ -29,7 +29,7 @@ public:
     const Universe::EmpireObjectVisibilityTurnMap& empire_object_vis_turns{GetUniverse().GetEmpireObjectVisibilityTurnMap()};
     const EmpireManager::DiploStatusMap&           diplo_statuses{Empires().GetDiplomaticStatuses()};
     const GalaxySetupData&                         galaxy_setup_data{GetGalaxySetupData()};
-    const SpeciesManager&                          species{GetSpeciesManager()};
+    SpeciesManager&                                species{GetSpeciesManager()};
     const SupplyManager&                           supply{GetSupplyManager()};
 
     std::unique_ptr<ObjectMap>          objects;                       ///< actual state of objects relevant to combat, filtered and copied for system where combat occurs, not necessarily consistent with contents of universe's ObjectMap

--- a/server/ServerNetworking.cpp
+++ b/server/ServerNetworking.cpp
@@ -97,22 +97,22 @@ private:
         try {
             if (parse::int_free_variable(message)) {
                 auto value_ref = std::make_unique<ValueRef::Variable<int>>(ValueRef::ReferenceType::NON_OBJECT_REFERENCE, message);
-                reply = std::to_string(value_ref->Eval(ScriptingContext()));
+                reply = std::to_string(value_ref->Eval(ScriptingContext{}));
                 DebugLogger(network) << "DiscoveryServer evaluated expression as integer with result: " << reply;
 
             } else if (parse::double_free_variable(message)) {
                 auto value_ref = std::make_unique<ValueRef::Variable<double>>(ValueRef::ReferenceType::NON_OBJECT_REFERENCE, message);
-                reply = std::to_string(value_ref->Eval(ScriptingContext()));
+                reply = std::to_string(value_ref->Eval(ScriptingContext{}));
                 DebugLogger(network) << "DiscoveryServer evaluated expression as double with result: " << reply;
 
             } else if (parse::string_free_variable(message)) {
                 auto value_ref = std::make_unique<ValueRef::Variable<std::string>>(ValueRef::ReferenceType::NON_OBJECT_REFERENCE, message);
-                reply = value_ref->Eval(ScriptingContext());
+                reply = value_ref->Eval(ScriptingContext{});
                 DebugLogger(network) << "DiscoveryServer evaluated expression as string with result: " << reply;
 
             //} else {
             //    auto value_ref = std::make_unique<ValueRef::Variable<std::vector<std::string>>>(ValueRef::ReferenceType::NON_OBJECT_REFERENCE, message);
-            //    auto result = value_ref->Eval(ScriptingContext());
+            //    auto result = value_ref->Eval(ScriptingContext{});
             //    for (auto entry : result)
             //        reply += entry + "\n";
             //    DebugLogger(network) << "DiscoveryServer evaluated expression as string vector with result: " << reply;

--- a/server/ServerWrapper.cpp
+++ b/server/ServerWrapper.cpp
@@ -185,9 +185,12 @@ namespace {
     //Checks the condition against many objects at once.
     //Checking many systems is more efficient because for example monster fleet plans
     //typically uses WithinStarLaneJumps to exclude placement near empires.
-    auto FilterIDsWithCondition(const Condition::Condition* cond, const py::list &obj_ids) -> py::list
+    auto FilterIDsWithCondition(const Condition::Condition* cond, const py::list& obj_ids) -> py::list
     {
         py::list permitted_ids;
+
+        if (!cond)
+            DebugLogger() << "FilterIDsWithCondition passed null condition";
 
         Condition::ObjectSet objs;
         py::stl_input_iterator<int> end;
@@ -207,13 +210,12 @@ namespace {
         // get location condition and evaluate it with the specified universe object
         // if no location condition has been defined, all objects matches
         if (cond && cond->SourceInvariant())
-            cond->Eval(ScriptingContext(), permitted_objs, objs);
+            cond->Eval(ScriptingContext{}, permitted_objs, objs);
         else
             permitted_objs = std::move(objs);
 
-        for (auto &obj : permitted_objs) {
+        for (auto &obj : permitted_objs)
             permitted_ids.append(obj->ID());
-        }
 
         return permitted_ids;
     }

--- a/universe/BuildingType.h
+++ b/universe/BuildingType.h
@@ -66,17 +66,17 @@ public:
     //! Returns the number of production points required to build this building
     //! at this location by this empire
     auto ProductionCost(int empire_id, int location_id,
-                        const ScriptingContext& context = ScriptingContext()) const -> float;
+                        const ScriptingContext& context = ScriptingContext{}) const -> float;
 
     //! Returns the maximum number of production points per turn that can be
     //! spend on this building
     auto PerTurnCost(int empire_id, int location_id,
-                     const ScriptingContext& context = ScriptingContext()) const -> float;
+                     const ScriptingContext& context = ScriptingContext{}) const -> float;
 
     //! Returns the number of turns required to build this building at this
     //! location by this empire
     auto ProductionTime(int empire_id, int location_id,
-                        const ScriptingContext& context = ScriptingContext()) const -> int;
+                        const ScriptingContext& context = ScriptingContext{}) const -> int;
 
     //! Returns the ValueRef that determines ProductionCost()
     auto Cost() const -> const ValueRef::ValueRef<double>*

--- a/universe/Effects.cpp
+++ b/universe/Effects.cpp
@@ -1230,10 +1230,10 @@ void SetSpeciesEmpireOpinion::Execute(ScriptingContext& context) const {
     if (species_name.empty())
         return;
 
-    double initial_opinion = GetSpeciesManager().SpeciesEmpireOpinion(species_name, empire_id); // TODO: get SpeciesManager from ScriptingContext
+    double initial_opinion = context.species.SpeciesEmpireOpinion(species_name, empire_id); // TODO: get SpeciesManager from ScriptingContext
     double opinion = m_opinion->Eval(ScriptingContext(context, initial_opinion));
 
-    GetSpeciesManager().SetSpeciesEmpireOpinion(species_name, empire_id, opinion);
+    context.species.SetSpeciesEmpireOpinion(species_name, empire_id, opinion);
 }
 
 std::string SetSpeciesEmpireOpinion::Dump(unsigned short ntabs) const
@@ -1288,10 +1288,10 @@ void SetSpeciesSpeciesOpinion::Execute(ScriptingContext& context) const {
     if (rated_species_name.empty())
         return;
 
-    float initial_opinion = GetSpeciesManager().SpeciesSpeciesOpinion(opinionated_species_name, rated_species_name);
+    float initial_opinion = context.species.SpeciesSpeciesOpinion(opinionated_species_name, rated_species_name);
     float opinion = m_opinion->Eval(ScriptingContext(context, initial_opinion));
 
-    GetSpeciesManager().SetSpeciesSpeciesOpinion(opinionated_species_name, rated_species_name, opinion);
+    context.species.SetSpeciesSpeciesOpinion(opinionated_species_name, rated_species_name, opinion);
 }
 
 std::string SetSpeciesSpeciesOpinion::Dump(unsigned short ntabs) const

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -884,7 +884,7 @@ void Fleet::MovementPhase(ScriptingContext& context) {
         } catch (const std::exception& e) {
             ErrorLogger() << "Caught exception in Fleet MovementPhase shorentning route: " << e.what();
         }
-        move_path = MovePath(false, ScriptingContext());    // TODO: use passed-in ScriptingContext
+        move_path = MovePath(false, ScriptingContext{});    // TODO: use passed-in ScriptingContext
     }
 
     auto it = move_path.begin();

--- a/universe/Fleet.h
+++ b/universe/Fleet.h
@@ -82,9 +82,9 @@ public:
         specified route.  It is assumed in the calculation that the fleet starts its move path at its actual current
         location, however the fleet's current location will not be on the list, even if it is currently in a system. */
     std::list<MovePathNode> MovePath(const std::list<int>& route, bool flag_blockades = false,
-                                     const ScriptingContext& context = ScriptingContext()) const;
+                                     const ScriptingContext& context = ScriptingContext{}) const;
     std::list<MovePathNode> MovePath(bool flag_blockades = false,
-                                     const ScriptingContext& context = ScriptingContext()) const;   ///< Returns MovePath for fleet's current TravelRoute
+                                     const ScriptingContext& context = ScriptingContext{}) const;   ///< Returns MovePath for fleet's current TravelRoute
 
     std::pair<int, int>     ETA(const ScriptingContext& context) const;         ///< Returns the number of turns which must elapse before the fleet arrives at its current final destination and the turns to the next system, respectively.
     std::pair<int, int>     ETA(const std::list<MovePathNode>& move_path) const;///< Returns the number of turns which must elapse before the fleet arrives at the final destination and next system in the spepcified \a move_path

--- a/universe/ScriptingContext.h
+++ b/universe/ScriptingContext.h
@@ -124,7 +124,7 @@ struct ScriptingContext {
 
     ScriptingContext(Universe& universe, EmpireManager& empires_,
                      const GalaxySetupData& galaxy_setup_data_ = GetGalaxySetupData(),
-                     const SpeciesManager& species_ = GetSpeciesManager(),
+                     SpeciesManager& species_ = GetSpeciesManager(),
                      const SupplyManager& supply_ = GetSupplyManager()) :
         galaxy_setup_data(galaxy_setup_data_),
         species(          species_),
@@ -222,7 +222,7 @@ struct ScriptingContext {
     int                                            combat_bout = 0;
     int                                            current_turn = CurrentTurn();
     const GalaxySetupData&                         galaxy_setup_data{GetGalaxySetupData()};
-    const SpeciesManager&                          species{GetSpeciesManager()};
+    SpeciesManager&                                species{GetSpeciesManager()};
     const SupplyManager&                           supply{GetSupplyManager()};
 private: // Universe and ObjectMap getters select one of these based on constness
     Universe*                                      universe = nullptr;

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -197,12 +197,12 @@ float ShipDesign::ProductionCost(int empire_id, int location_id) const {
 
     float cost_accumulator = 0.0f;
     if (const ShipHull* hull = GetShipHull(m_hull))
-        cost_accumulator += hull->ProductionCost(empire_id, location_id, ScriptingContext(), m_id);
+        cost_accumulator += hull->ProductionCost(empire_id, location_id, ScriptingContext{}, m_id);
 
     int part_count = 0;
     for (const std::string& part_name : m_parts) {
         if (const ShipPart* part = GetShipPart(part_name)) {
-            cost_accumulator += part->ProductionCost(empire_id, location_id, /*ScriptingContext(),*/ m_id);
+            cost_accumulator += part->ProductionCost(empire_id, location_id, /*ScriptingContext{},*/ m_id);
             part_count++;
         }
     }
@@ -765,7 +765,7 @@ namespace {
         if (!design)
             return;
 
-        Universe& universe = GetUniverse();
+        Universe& universe = GetUniverse(); // TODO: pass in
         /* check if there already exists this same design in the universe. */
         for (auto it = universe.beginShipDesigns();
              it != universe.endShipDesigns(); ++it)
@@ -801,7 +801,7 @@ namespace {
     };
 }
 
-void PredefinedShipDesignManager::AddShipDesignsToUniverse() const {
+void PredefinedShipDesignManager::AddShipDesignsToUniverse() const { // TODO: pass in and pass along Universe&
     CheckPendingDesignsTypes();
     m_design_generic_ids.clear();
 

--- a/universe/ShipHull.h
+++ b/universe/ShipHull.h
@@ -97,11 +97,11 @@ public:
     auto ProductionCostTimeLocationInvariant() const -> bool;
 
     //! Returns the number of production points required to produce this hull
-    auto ProductionCost(int empire_id, int location_id, const ScriptingContext& parent_context = ScriptingContext(),
+    auto ProductionCost(int empire_id, int location_id, const ScriptingContext& parent_context = ScriptingContext{},
                         int in_design_id = INVALID_DESIGN_ID) const -> float;
 
     //! Returns the number of turns required to produce this hull
-    auto ProductionTime(int empire_id, int location_id, const ScriptingContext& parent_context = ScriptingContext(),
+    auto ProductionTime(int empire_id, int location_id, const ScriptingContext& parent_context = ScriptingContext{},
                         int in_design_id = INVALID_DESIGN_ID) const -> int;
 
     //! Returns whether this hull type is producible by players and appears on

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -30,6 +30,7 @@ class IDAllocator;
 struct UnlockableItem;
 class FleetPlan;
 class MonsterFleetPlan;
+struct ScriptingContext;
 
 
 namespace Condition {
@@ -185,6 +186,7 @@ public:
       * to vector of EffectAccountInfo for the meter, in order effects
       * were applied to the meter. */
     const Effect::AccountingMap& GetEffectAccountingMap() const { return m_effect_accounting_map; }
+    Effect::AccountingMap& GetEffectAccountingMap() { return m_effect_accounting_map; }
 
     const std::map<std::string, std::map<int, std::map<int, double>>>&
     GetStatRecords() const { return m_stat_records; }
@@ -217,47 +219,47 @@ public:
       * executes all effects on all objects.  Then clamps meter values so
       * target and max meters are within a reasonable range and any current
       * meters with associated max meters are limited by their max. */
-    void ApplyAllEffectsAndUpdateMeters(EmpireManager& empires, bool do_accounting = true);
+    void ApplyAllEffectsAndUpdateMeters(ScriptingContext& context, bool do_accounting = true);
 
     /** Determines all effectsgroups' target sets, then resets meters and
       * executes only SetMeter effects on all objects whose ids are listed in
       * \a object_ids.  Then clamps meter values so target and max meters are
       * within a reasonable range and any current meters with associated max
       * meters are limited by their max. */
-    void ApplyMeterEffectsAndUpdateMeters(const std::vector<int>& object_ids, EmpireManager& empires,
+    void ApplyMeterEffectsAndUpdateMeters(const std::vector<int>& object_ids, ScriptingContext& context,
                                           bool do_accounting = true);
 
     /** Calls above ApplyMeterEffectsAndUpdateMeters() function on all objects.*/
-    void ApplyMeterEffectsAndUpdateMeters(EmpireManager& empires, bool do_accounting = true);
+    void ApplyMeterEffectsAndUpdateMeters(ScriptingContext& context, bool do_accounting = true);
 
     /** Executes effects that modify objects' appearance in the human client. */
-    void ApplyAppearanceEffects(const std::vector<int>& object_ids, EmpireManager& empires);
+    void ApplyAppearanceEffects(const std::vector<int>& object_ids, ScriptingContext& context);
 
     /** Executes effects that modify objects' apperance for all objects. */
-    void ApplyAppearanceEffects(EmpireManager& empires);
+    void ApplyAppearanceEffects(ScriptingContext& context);
 
     /** Executes effects that modify objects' apperance for all objects. */
-    void ApplyGenerateSitRepEffects(EmpireManager& empires);
+    void ApplyGenerateSitRepEffects(ScriptingContext& context);
 
     /** For all objects and meters, determines discrepancies between actual meter
       * maxes and what the known universe should produce, and and stores in
       * m_effect_discrepancy_map. */
-    void InitMeterEstimatesAndDiscrepancies(EmpireManager& empires);
+    void InitMeterEstimatesAndDiscrepancies(ScriptingContext& context);
 
     /** Based on (known subset of, if in a client) universe and any orders
       * given so far this turn, updates estimated meter maxes for next turn
       * for the objects with ids indicated in \a objects_vec. */
-    void UpdateMeterEstimates(const std::vector<int>& objects_vec, EmpireManager& empires);
+    void UpdateMeterEstimates(const std::vector<int>& objects_vec, ScriptingContext& context);
 
     /** Updates indicated object's meters, and if applicable, the
       * meters of objects contained within the indicated object.
       * If \a object_id is INVALID_OBJECT_ID, then all
       * objects' meters are updated. */
-    void UpdateMeterEstimates(int object_id, EmpireManager& empires, bool update_contained_objects = false);
+    void UpdateMeterEstimates(int object_id, ScriptingContext& context, bool update_contained_objects = false);
 
     /** Updates all meters for all (known) objects */
-    void UpdateMeterEstimates(EmpireManager& empires);
-    void UpdateMeterEstimates(EmpireManager& empires, bool do_accounting);
+    void UpdateMeterEstimates(ScriptingContext& context);
+    void UpdateMeterEstimates(ScriptingContext& context, bool do_accounting);
 
     /** Sets all objects' meters' initial values to their current values. */
     void BackPropagateObjectMeters();
@@ -318,7 +320,7 @@ public:
 
     /** Record in statistics that \a object_id was destroyed by species/empire
       * associated with \a source_object_id */
-    void CountDestructionInStats(int object_id, int source_object_id);
+    void CountDestructionInStats(int object_id, int source_object_id, ScriptingContext& context);
 
     /** Removes the object with ID number \a object_id from the universe's map
       * of existing objects, and adds the object's id to the set of destroyed
@@ -455,7 +457,7 @@ private:
     /** Clears \a source_effects_targets_causes, and then populates with all
       * EffectsGroups and their targets in the known universe. */
     void GetEffectsAndTargets(std::map<int, Effect::SourcesEffectsTargetsAndCausesVec>& source_effects_targets_causes,
-                              const EmpireManager& empires,
+                              const ScriptingContext& context,
                               bool only_meter_effects = false) const;
 
     /** Removes entries in \a source_effects_targets_causes about effects groups acting
@@ -464,7 +466,7 @@ private:
       * \a target_objects is empty then default target candidates will be used. */
     void GetEffectsAndTargets(std::map<int, Effect::SourcesEffectsTargetsAndCausesVec>& source_effects_targets_causes,
                               const std::vector<int>& target_objects,
-                              const EmpireManager& empires,
+                              const ScriptingContext& context,
                               bool only_meter_effects = false) const;
 
     void ResetObjectMeters(const std::vector<std::shared_ptr<UniverseObject>>& objects,
@@ -476,7 +478,7 @@ private:
       * values after the rest of effects (including non-meter effects) have
       * been executed. */
     void ExecuteEffects(std::map<int, Effect::SourcesEffectsTargetsAndCausesVec>& source_effects_targets_causes,
-                        EmpireManager& empires,
+                        ScriptingContext& context,
                         bool update_effect_accounting,
                         bool only_meter_effects = false,
                         bool only_appearance_effects = false,
@@ -487,7 +489,7 @@ private:
       * processed objects_vec or whatever they were passed and cleared the
       * relevant effect accounting for those objects and meters. If an empty
       * vector is passed, it will instead update all existing objects. */
-    void UpdateMeterEstimatesImpl(const std::vector<int>& objects_vec, EmpireManager& empires, bool do_accounting);
+    void UpdateMeterEstimatesImpl(const std::vector<int>& objects_vec, ScriptingContext& context, bool do_accounting);
 
     std::unique_ptr<ObjectMap>      m_objects;                          ///< map from object id to UniverseObjects in the universe.  for the server: all of them, up to date and true information about object is stored;  for clients, only limited information based on what the client knows about is sent.
     EmpireObjectMap                 m_empire_latest_known_objects;      ///< map from empire id to (map from object id to latest known information about each object by that empire)

--- a/universe/ValueRef.h
+++ b/universe/ValueRef.h
@@ -74,7 +74,7 @@ struct FO_COMMON_API ValueRef : public ValueRefBase
       * evaluating expressions that do not depend on source, target, or
       * candidate objects. */
     T Eval() const
-    { return Eval(::ScriptingContext()); }
+    { return Eval(::ScriptingContext{}); }
 
     /** Evaluates the expression tree and return the results; \a context
       * is used to fill in any instances of the "Value" variable or references

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -1974,7 +1974,7 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
         std::string opinionated_species_name;
         if (m_string_ref1)
             opinionated_species_name = m_string_ref1->Eval(context);
-        const auto species = GetSpecies(opinionated_species_name);
+        const auto species = context.species.GetSpecies(opinionated_species_name);
         if (!species)
             return 0.0;
 
@@ -2000,7 +2000,7 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
         if (m_string_ref1)
             species_name = m_string_ref1->Eval(context);
 
-        return GetSpeciesManager().SpeciesEmpireOpinion(species_name, empire_id);
+        return context.species.SpeciesEmpireOpinion(species_name, empire_id);
 
     }
     else if (variable_name == "SpeciesSpeciesOpinion") {
@@ -2012,7 +2012,7 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
         if (m_string_ref2)
             rated_species_name = m_string_ref2->Eval(context);
 
-        return GetSpeciesManager().SpeciesSpeciesOpinion(opinionated_species_name, rated_species_name);
+        return context.species.SpeciesSpeciesOpinion(opinionated_species_name, rated_species_name);
 
     }
     else if (variable_name == "SpecialCapacity") {

--- a/universe/ValueRefs.h
+++ b/universe/ValueRefs.h
@@ -1733,7 +1733,7 @@ void Operation<T>::CacheConstValue()
 {
     if (!m_constant_expr)
         return;
-    m_cached_const_value = this->EvalImpl(ScriptingContext());
+    m_cached_const_value = this->EvalImpl(ScriptingContext{});
 }
 
 template <typename T>

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -406,7 +406,7 @@ void FleetMoveOrder::ExecuteImpl() const {
     }
 
     // check destination validity: disallow movement that's out of range
-    auto eta = fleet->ETA(fleet->MovePath(route_list, false, ScriptingContext()));
+    auto eta = fleet->ETA(fleet->MovePath(route_list, false, ScriptingContext{}));
     if (eta.first == Fleet::ETA_NEVER || eta.first == Fleet::ETA_OUT_OF_RANGE) {
         DebugLogger() << "FleetMoveOrder::ExecuteImpl rejected out of range move order";
         return;


### PR DESCRIPTION
This is an incremental step towards replacing accessing gamestate via global getters in Effect, ValueRef, Condition, and similar code, and instead getting it from the passed-in ScriptingContext:
-take and store SpeciesManager by mutable reference in ScriptingContext
-modify ScriptingContext state in Effects
-access and modify ScriptingContext state rather than member state in Universe effect functions
