### PR TITLE
Fix bad_alloc crash when fighters shoot

### DIFF
--- a/universe/Fighter.h
+++ b/universe/Fighter.h
@@ -37,7 +37,7 @@ private:
     float               m_damage = 0.0f;                        // strength of fighter's attack
     bool                m_destroyed = false;                    // was attacked by anything -> destroyed
     int                 m_launched_from_id = INVALID_OBJECT_ID; // from what object (ship?) was this fighter launched
-    const std::string&  m_species_name;
+    std::string  m_species_name;
     const ::Condition::Condition* m_combat_targets = nullptr;
 };
 


### PR DESCRIPTION
On my fedora build system since a31333b the game crashes with bad_alloc.
Making the m_species_name a string instead of a reference to a const string fixes this. 

Not sure why this does not seem to occur on my snap build (which is based on ubuntu 18.4).

Maybe something else should be done.