### PR TITLE
Upgrade assertion fails output.

### DIFF
--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -1,5 +1,7 @@
 # This Python file uses the following encoding: utf-8
+import inspect
 import logging
+import pprint
 import re
 import traceback
 from collections.abc import Mapping
@@ -349,28 +351,31 @@ def with_log_level(log_level):
     return decorator
 
 
-def assertion_fails(cond, msg="", logger=logging.error):
+def assertion_fails(cond: bool, msg: str = "") -> bool:
     """
     Check if condition fails and if so, log a traceback but raise no Exception.
 
+    Return False is condition True and True if condition is False.
+
     This is a useful functions for generic sanity checks and may be used to
     replace manual error logging with more context provided by the traceback.
-
-    :param bool cond: condition to be asserted
-    :param str msg: additional info to be logged
-    :param func logger: may be used to override default log level (error)
-    :return: True if assertion failed, otherwise false.
     """
     if cond:
         return False
 
     if msg:
-        header = "Assertion failed: %s." % msg
+        header = "AI raised a warning: %s. See more detailed description in logs." % msg
     else:
-        header = "Assertion failed!"
+        header = "AI raised a warning. See more detailed description in logs."
+
+    warning("\n===")
+    error(header)
     stack = traceback.extract_stack()[:-1]  # do not log this function
-    logger("%s Traceback (most recent call last): %s", header,
-           ''.join(traceback.format_list(stack)))
+    warning("Stack trace (most recent call last): %s", ''.join(traceback.format_list(stack)))
+    frame = inspect.currentframe().f_back
+    local_vars = pprint.pformat(frame.f_locals)
+    warning("Locals inside the {}\n{}".format(frame.f_code.co_name, local_vars))
+    warning("===\n")
     return True
 
 

--- a/default/python/tests/AI/test_assertion_fails.py
+++ b/default/python/tests/AI/test_assertion_fails.py
@@ -14,12 +14,3 @@ def test_message_argument():
     assert assertion_fails(False, "Some message")
     assert not assertion_fails(True, "")
     assert not assertion_fails(True, "Some message")
-
-
-def test_logger_argument():
-    import logging
-    loggers = [logging.debug, logging.info, logging.warning, logging.error]
-    for logger in loggers:
-        assert assertion_fails(False, logger=logger)
-        assert assertion_fails(False, "Some message", logger=logger)
-        assert not assertion_fails(True, logger=logger)


### PR DESCRIPTION
- Rewrite the intro message that it is a warning
- Print traceback only to the console
- Remove unused logger argument
- Add more info to console


See examples in UI and logs:

Also, I have replaced 
```
Traceback (most recent call last):
```
to the 
```
Stack trace (most recent call last):
```
because I usually grep logs for "traceback".  In that case, warnings has fewer chances to be found. 


![image](https://user-images.githubusercontent.com/171597/108772042-8fd63f80-756d-11eb-86c0-15764b0d7405.png)

```
[warn] : ===
[error] : AI raises a warning: Can't split last ship from fleet. Please see more detailed description in logs.
[warn] : Stack trace (most recent call last):   File "i:/projects\freeorion\default\python\AI\FreeOrionAI.py", line 70, in _error_handler
[warn] :     res = func(*args, **kwargs)
[warn] :   File "i:/projects/freeorion/default/python\common\listeners.py", line 42, in wrapper
[warn] :     res = funct(*args)
[warn] :   File "i:/projects\freeorion\default\python\AI\FreeOrionAI.py", line 348, in generateOrders
[warn] :     action()
[warn] :   File "i:/projects\freeorion\default\python\AI\FleetUtilsAI.py", line 594, in issue_fleet_orders_for_fleet_missions
[warn] :     mission.issue_fleet_orders()
[warn] :   File "i:/projects\freeorion\default\python\AI\AIFleetMission.py", line 546, in issue_fleet_orders
[warn] :     new_fleet_id = FleetUtilsAI.split_ship_from_fleet(fleet_id, ship_id)
[warn] :   File "i:/projects\freeorion\default\python\AI\FleetUtilsAI.py", line 237, in split_ship_from_fleet
[warn] :     if assertion_fails(fleet.numShips > 1, "Can't split last ship from fleet"):
[warn] : Locals inside the split_ship_from_fleet
[warn] : {'fleet': F_14922<Fleet 14922>,
[warn] :  'fleet_id': 14922,
[warn] :  'ship_id': 12326,
[warn] :  'universe': <freeOrionAIInterface.universe object at 0x042B9688>}
[warn] : ===
[warn] : 
[warn] : ===
[error] : Assertion failed! Please see more detailed description in logs.
[warn] : Stack trace (most recent call last):   File "i:/projects\freeorion\default\python\AI\FreeOrionAI.py", line 70, in _error_handler
[warn] :     res = func(*args, **kwargs)
[warn] :   File "i:/projects/freeorion/default/python\common\listeners.py", line 42, in wrapper
[warn] :     res = funct(*args)
[warn] :   File "i:/projects\freeorion\default\python\AI\FreeOrionAI.py", line 348, in generateOrders
[warn] :     action()
[warn] :   File "i:/projects\freeorion\default\python\AI\FleetUtilsAI.py", line 594, in issue_fleet_orders_for_fleet_missions
[warn] :     mission.issue_fleet_orders()
[warn] :   File "i:/projects\freeorion\default\python\AI\AIFleetMission.py", line 547, in issue_fleet_orders
[warn] :     if assertion_fails(new_fleet_id and new_fleet_id != INVALID_ID):
[warn] : Locals inside the issue_fleet_orders
[warn] : {'aistate': <AIstate.AIstate object at 0x03AF67D0>,
[warn] :  'allowance': 323172.32813957386,
[warn] :  'clear_all': False,
[warn] :  'fleet_id': 14922,
[warn] :  'fleet_min_rating': 884.3621789483495,
[warn] :  'fleet_order': <fleet_orders.OrderPause object at 0x03B6AED0>,
[warn] :  'fleet_portion_to_remain': 0.0024711964941834287,
[warn] :  'fleet_remaining_rating': 357868.012936209,
[warn] :  'just_issued_move_order': False,
[warn] :  'last_move_target_id': -1,
[warn] :  'last_order': <fleet_orders.OrderPause object at 0x03B6AED0>,
[warn] :  'last_sys_target': 1296,
[warn] :  'new_fleet_id': None,
[warn] :  'new_fleets': [],
[warn] :  'order_completed': True,
[warn] :  'orders': [<fleet_orders.OrderPause object at 0x03B6AED0>],
[warn] :  'potential_threat': 4871.04,
[warn] :  'self': <AIFleetMission.AIFleetMission object at 0x03AF6A70>,
[warn] :  'ship_id': 12326,
[warn] :  'ship_ids': [12326],
[warn] :  'ship_rating': 27072.0,
[warn] :  'status_words': ('', ''),
[warn] :  'target_system': S_1296<Zvaigzne>,
[warn] :  'threat_present': True,
[warn] :  'universe': <freeOrionAIInterface.universe object at 0x042DF4D0>}
[warn] : ===
```