### PR TITLE
Add new building: Abandon Outpost System

### DIFF
--- a/default/scripting/buildings/ABANDON_OUTPOST.focs.txt
+++ b/default/scripting/buildings/ABANDON_OUTPOST.focs.txt
@@ -1,0 +1,76 @@
+BuildingType
+    name = "BLD_ABANDON_OUTPOST"
+    description = "BLD_ABANDON_OUTPOST_DESC"
+    buildcost = 20
+    buildtime = 1
+    location = And [
+        Planet
+        OwnedBy empire = Source.Owner
+        Population high = 0
+    ]
+
+    effectsgroups = [
+         // PREPARE FOR TWO TURNS
+         EffectsGroup
+            scope = Source
+            activation = Turn high = Source.CreationTurn + 2
+            stackinggroup = "ABANDON_OUTPOST_STACK"
+            effects = GenerateSitRepMessage
+                message = "SITREP_OUTPOST_ABANDONED_PREPARATION"
+                label = "SITREP_OUTPOST_ABANDONED_PREPARATION_LABEL"
+                icon = "icons/tech/environmental_encapsulation.png"
+                parameters = [
+                    tag = "planet" data = Source.PlanetID
+                    tag = "rawtext" data = Source.CreationTurn + 4
+                ]
+                empire = Source.Owner
+
+         // THEN CANT ABANDON IF BATTLE
+         EffectsGroup
+            scope = Source
+            activation = Turn  low = 3 + Source.CreationTurn  high = Source.System.LastTurnBattleHere
+            stackinggroup = "ABANDON_OUTPOST_STACK"
+            effects = GenerateSitRepMessage
+                message = "SITREP_OUTPOST_ABANDONED_PREVENTED_BY_BATTLE"
+                label = "SITREP_OUTPOST_ABANDONED_LABEL"
+                icon = "icons/tech/environmental_encapsulation.png"
+                parameters = [
+                    tag = "planet" data = Target.PlanetID
+                    tag = "system" data = Target.SystemID
+                ]
+                empire = Source.Owner
+
+         // ELSE ABANDON OUTPOST
+         EffectsGroup
+            scope = And [
+                Object id = Source.PlanetID
+                Planet
+            ]
+            activation = Turn low = max(1 + Source.System.LastTurnBattleHere, 3 + Source.CreationTurn)
+            stackinggroup = "ABANDON_OUTPOST_STACK"
+            priority = [[POPULATION_OVERRIDE_PRIORITY]]
+            effects = [
+                SetOwner empire = [[UNOWNED_EMPIRE_ID]]
+                GenerateSitRepMessage
+                    message = "SITREP_OUTPOST_ABANDONED"
+                    label = "SITREP_OUTPOST_ABANDONED_LABEL"
+                    icon = "icons/tech/environmental_encapsulation.png"
+                    parameters =  [
+                        tag = "planet" data = Target.ID
+                        tag = "rawtext" data = Source.CreationTurn
+                    ]
+                    empire = Source.Owner
+            ]
+
+        EffectsGroup
+            scope = Source
+            activation = Turn low = max(1 + Source.System.LastTurnBattleHere, 3 + Source.CreationTurn)
+            effects = Destroy
+    ]
+    icon = "icons/tech/environmental_encapsulation.png"
+
+#include "/scripting/common/enqueue.macros"
+#include "/scripting/common/upkeep.macros"
+#include "/scripting/common/priorities.macros"
+#include "/scripting/common/base_prod.macros"
+#include "/scripting/common/misc.macros"

--- a/default/scripting/common/misc.macros
+++ b/default/scripting/common/misc.macros
@@ -39,3 +39,7 @@ SYSTEM_MINES_DAMAGE_FACTOR
 
 SUPPLY_DISCONNECTED_INFLUENCE_MALUS
 '''1'''
+
+// empire id used for unowned planets/ships - as defined in Universe.cpp(?)
+UNOWNED_EMPIRE_ID
+'''-1'''

--- a/default/scripting/techs/construction/OUTPOST.focs.txt
+++ b/default/scripting/techs/construction/OUTPOST.focs.txt
@@ -5,6 +5,7 @@ Tech
     category = "CONSTRUCTION_CATEGORY"
     researchcost = 1
     researchturns = 1
+    unlock = Item type = Building name = "BLD_ABANDON_OUTPOST"
     tags = [ "PEDIA_CONSTRUCTION_CATEGORY" ]
 
     // Effects for outposts

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -13431,10 +13431,10 @@ BLD_EVACUATION_DESC
 Remove [[metertype METER_POPULATION]] from this planet over several turns according to an [[encyclopedia EVACUATION_TITLE]]. If a suitable alternate planets are available, with the same species and sufficient extra capacity, Population will move there.
 
 BLD_ABANDON_OUTPOST
-Abandon System
+Abandon
 
 BLD_ABANDON_OUTPOST_DESC
-Abandon the outpost on this planet. The Abandon System building needs two turns to prepare dismantling the outpost. If it is prepared, it needs an uninterupted turn without battles happening to completely abandon the outpost. The building gets used up in the process and the planet will be unowned afterwards.
+Abandon the outpost on this planet. The building needs two turns to prepare dismantling the outpost. If dismantling is prepared, it takes an uninterupted turn without battles happening to completely abandon the outpost. The building gets used up in the process and the planet will be unowned afterwards.
 
 BLD_OBSERVATORY
 Observatory

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6149,7 +6149,7 @@ OUTPOSTS_TITLE
 Outpost
 
 OUTPOSTS_TEXT
-Outposts are unmanned stations, which can be founded in places too hostile for a colony to survive. They have no [[metertype METER_POPULATION]], and normally produce no resources. But they create [[metertype METER_SUPPLY]] (with the right tech) and provide fuel and vision. Colonies can be founded on planets that already have an Outpost. Building an Outpost requires a ship with an [[shippart CO_OUTPOST_POD]]. Outposts are also formed when the Population of a colony drops to zero for any reason. You can abandon an outpost by building a [[building BLD_ABANDON_OUTPOST]].
+Outposts are unmanned stations, which can be founded in places too hostile for a colony to survive. They have no [[metertype METER_POPULATION]], and normally produce no resources. But they create [[metertype METER_SUPPLY]] (with the right tech) and provide fuel and vision. Colonies can be founded on planets that already have an Outpost. Building an Outpost requires a ship with an [[shippart CO_OUTPOST_POD]]. Outposts are also formed when the Population of a colony drops to zero for any reason. You can abandon an outpost by building a [[buildingtype BLD_ABANDON_OUTPOST]] building.
 
 HOMEWORLDS_TITLE
 Homeworld
@@ -6348,8 +6348,8 @@ EVACUATION_TITLE
 Evacuation Plan
 
 EVACUATION_TEXT
-'''The [[buildingtype BLD_EVACUATION]] when built will remove the [[metertype METER_POPULATION]] of a planet. Each turn, some of the Population will be removed. If there are planets colonized by the same species with free space, and connected by [[metertype METER_SUPPLY]] lines, one will be randomly chosen and the Population will move there. If there are no appropriate planets available, the Population disappears into the vastness of space.
-During an evacuation, production drops to nothing. When the colony is empty, it reverts to an [[encyclopedia OUTPOSTS_TITLE]]. It still belongs to the same empire, and may be re-colonized once the [[buildingtype BLD_EVACUATION]] deletes itself.'''
+'''The [[buildingtype BLD_EVACUATION]] building when built will remove the [[metertype METER_POPULATION]] of a planet. Each turn, some of the Population will be removed. If there are planets colonized by the same species with free space, and connected by [[metertype METER_SUPPLY]] lines, one will be randomly chosen and the Population will move there. If there are no appropriate planets available, the Population disappears into the vastness of space.
+During an evacuation, production drops to nothing. When the colony is empty, it reverts to an [[encyclopedia OUTPOSTS_TITLE]]. It still belongs to the same empire, and may be re-colonized once the [[buildingtype BLD_EVACUATION]] building deletes itself.'''
 
 AI_LEVELS_TITLE
 AI Aggression Levels
@@ -13425,13 +13425,13 @@ Additional experience and facilities improvements further extend the size of ind
 ##
 
 BLD_EVACUATION
-Evacuation
+Evacuate Planet
 
 BLD_EVACUATION_DESC
 Remove [[metertype METER_POPULATION]] from this planet over several turns according to an [[encyclopedia EVACUATION_TITLE]]. If a suitable alternate planets are available, with the same species and sufficient extra capacity, Population will move there.
 
 BLD_ABANDON_OUTPOST
-Abandon
+Abandon Outpost
 
 BLD_ABANDON_OUTPOST_DESC
 Abandon the outpost on this planet. The building needs two turns to prepare dismantling the outpost. If dismantling is prepared, it takes an uninterupted turn without battles happening to completely abandon the outpost. The building gets used up in the process and the planet will be unowned afterwards.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -13425,7 +13425,7 @@ Additional experience and facilities improvements further extend the size of ind
 ##
 
 BLD_EVACUATION
-Evacuation System
+Evacuation
 
 BLD_EVACUATION_DESC
 Remove [[metertype METER_POPULATION]] from this planet over several turns according to an [[encyclopedia EVACUATION_TITLE]]. If a suitable alternate planets are available, with the same species and sufficient extra capacity, Population will move there.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6149,7 +6149,7 @@ OUTPOSTS_TITLE
 Outpost
 
 OUTPOSTS_TEXT
-Outposts are unmanned stations, which can be founded in places too hostile for a colony to survive. They have no [[metertype METER_POPULATION]], and normally produce no resources. But they create [[metertype METER_SUPPLY]] (with the right tech) and provide fuel and vision. Colonies can be founded on planets that already have an Outpost. Building an Outpost requires a ship with an [[shippart CO_OUTPOST_POD]]. Outposts are also formed when the Population of a colony drops to zero for any reason.
+Outposts are unmanned stations, which can be founded in places too hostile for a colony to survive. They have no [[metertype METER_POPULATION]], and normally produce no resources. But they create [[metertype METER_SUPPLY]] (with the right tech) and provide fuel and vision. Colonies can be founded on planets that already have an Outpost. Building an Outpost requires a ship with an [[shippart CO_OUTPOST_POD]]. Outposts are also formed when the Population of a colony drops to zero for any reason. You can abandon an outpost by building a [[building BLD_ABANDON_OUTPOST]].
 
 HOMEWORLDS_TITLE
 Homeworld
@@ -7238,6 +7238,21 @@ SITREP_PLANET_OUTPOSTED
 
 SITREP_PLANET_OUTPOSTED_LABEL
 Planet Outposted
+
+SITREP_OUTPOST_ABANDONED_PREPARATION
+Outpost on %planet% prepares to be abandoned in turn %rawtext%.
+
+SITREP_OUTPOST_ABADONED_PREPARATION_LABEL
+Outpost Prepare Abandon
+
+SITREP_OUTPOST_ABANDONED_PREVENTED_BY_BATTLE
+Outpost on %planet% can't be abandoned as long as there is battle in the system %system%.
+
+SITREP_OUTPOST_ABANDONED
+Outpost on %planet% was abandoned.  %rawtext%.
+
+SITREP_OUTPOST_ABADONED_LABEL
+Outpost Abandoned
 
 SITREP_NEW_COLONY_ESTABLISHED
 On %planet%: A new %species% colony has been established.
@@ -13414,6 +13429,12 @@ Evacuation System
 
 BLD_EVACUATION_DESC
 Remove [[metertype METER_POPULATION]] from this planet over several turns according to an [[encyclopedia EVACUATION_TITLE]]. If a suitable alternate planets are available, with the same species and sufficient extra capacity, Population will move there.
+
+BLD_ABANDON_OUTPOST
+Abandon System
+
+BLD_ABANDON_OUTPOST_DESC
+Abandon the outpost on this planet. The Abandon System building needs two turns to prepare dismantling the outpost. If it is prepared, it needs an uninterupted turn without battles happening to completely abandon the outpost. The building gets used up in the process and the planet will be unowned afterwards.
 
 BLD_OBSERVATORY
 Observatory


### PR DESCRIPTION
this PR adds a building which can be used to make an outpost unowned again

it has a timer built in, cant abandon the outpost if there is battle in the system and gives useful feedback using sitrep messages

it could maybe be improved by adding a special to carry the timer (because that cant be removed), but i think this is good enough and the implementation with the special would be way more ugly

[forum discussion](https://www.freeorion.org/forum/viewtopic.php?f=6&t=11933)