### PR TITLE
Bump CodeQL install Boost version to 1.71

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -44,8 +44,8 @@ jobs:
             libglew-dev \
             libopenal-dev \
             zlibc \
-            libpython3.6 \
-            libpython3.6-dev \
+            python3.8 \
+            python3-dev \
             libfreetype6-dev \
             libpng-dev \
             libogg-dev \

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,7 +40,7 @@ jobs:
       run: |
         # sudo apt-get -qq -y --no-install-recommends install \
         sudo apt-get install --assume-yes \
-            libboost1.62-all-dev \
+            libboost1.71-all-dev \
             libglew-dev \
             libopenal-dev \
             zlibc \


### PR DESCRIPTION
will hopefully fix CodeQL Github action failure due to Boost 1.62 not being found.