### PR TITLE
Add clone method to value ref and condition

### DIFF
--- a/universe/Condition.h
+++ b/universe/Condition.h
@@ -93,6 +93,9 @@ struct FO_COMMON_API Condition {
     virtual unsigned int GetCheckSum() const
     { return 0; }
 
+    //! Makes a clone of this Condition in a new owning pointer. Required for Boost.Python, which
+    //! doesn't supports move semantics for returned values.
+    [[nodiscard]] virtual std::unique_ptr<Condition> Clone() const = 0;
 protected:
     bool m_root_candidate_invariant = false;
     bool m_target_invariant = false;

--- a/universe/Condition.h
+++ b/universe/Condition.h
@@ -97,6 +97,9 @@ struct FO_COMMON_API Condition {
     //! doesn't supports move semantics for returned values.
     [[nodiscard]] virtual std::unique_ptr<Condition> Clone() const = 0;
 protected:
+    //! Copies invariants from other Condition
+    Condition(const Condition& rhs) = default;
+
     bool m_root_candidate_invariant = false;
     bool m_target_invariant = false;
     bool m_source_invariant = false;

--- a/universe/ConditionAll.h
+++ b/universe/ConditionAll.h
@@ -22,6 +22,8 @@ struct FO_COMMON_API All final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override
     {}
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 };
 
 }

--- a/universe/ConditionSource.h
+++ b/universe/ConditionSource.h
@@ -23,6 +23,8 @@ struct FO_COMMON_API Source final : public Condition {
     {}
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 };

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -2164,7 +2164,7 @@ void Type::GetDefaultInitialCandidateObjects(const ScriptingContext& parent_cont
                 AddSystemSet(parent_context.ContextObjects(), condition_non_targets);
                 break;
             case UniverseObjectType::OBJ_FIGHTER:   // shouldn't exist outside of combat as a separate object
-            default: 
+            default:
                 found_type = false;
                 break;
         }
@@ -2418,6 +2418,19 @@ HasSpecial::HasSpecial(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name,
     m_source_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
 }
 
+HasSpecial::HasSpecial(const HasSpecial& rhs) :
+    Condition(),
+    m_name(ValueRef::CloneUnique(rhs.m_name)),
+    m_capacity_low(ValueRef::CloneUnique(rhs.m_capacity_low)),
+    m_capacity_high(ValueRef::CloneUnique(rhs.m_capacity_high)),
+    m_since_turn_low(ValueRef::CloneUnique(rhs.m_since_turn_low)),
+    m_since_turn_high(ValueRef::CloneUnique(rhs.m_since_turn_high))
+{
+    m_root_candidate_invariant = rhs.m_root_candidate_invariant;
+    m_target_invariant = rhs.m_target_invariant;
+    m_source_invariant = rhs.m_source_invariant;
+}
+
 bool HasSpecial::operator==(const Condition& rhs) const {
     if (this == &rhs)
         return true;
@@ -2608,15 +2621,7 @@ unsigned int HasSpecial::GetCheckSum() const {
 }
 
 std::unique_ptr<Condition> HasSpecial::Clone() const {
-    auto retval = std::make_unique<HasSpecial>(ValueRef::CloneUnique(m_name),
-                                               ValueRef::CloneUnique(m_since_turn_low),
-                                               ValueRef::CloneUnique(m_since_turn_high));
-    retval->m_capacity_low = ValueRef::CloneUnique(m_capacity_low);
-    retval->m_capacity_high = ValueRef::CloneUnique(m_capacity_high);
-    retval->m_root_candidate_invariant = m_root_candidate_invariant;
-    retval->m_target_invariant = m_target_invariant;
-    retval->m_source_invariant = m_source_invariant;
-    return retval;
+    return std::make_unique<HasSpecial>(*this);
 }
 
 ///////////////////////////////////////////////////////////
@@ -2908,13 +2913,13 @@ namespace {
         ContainsSimpleMatch(const ObjectSet& subcondition_matches) :
             m_subcondition_matches_ids()
         {
-            // We need a sorted container for efficiently intersecting 
+            // We need a sorted container for efficiently intersecting
             // subcondition_matches with the set of objects contained in some
             // candidate object.
             // We only need ids, not objects, so we can do that conversion
             // here as well, simplifying later code.
-            // Note that this constructor is called only once per 
-            // Contains::Eval(), its work cannot help performance when executed 
+            // Note that this constructor is called only once per
+            // Contains::Eval(), its work cannot help performance when executed
             // for each candidate.
             m_subcondition_matches_ids.reserve(subcondition_matches.size());
             // gather the ids
@@ -4532,6 +4537,20 @@ Enqueued::Enqueued(BuildType build_type,
     m_source_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
 }
 
+Enqueued::Enqueued(const Enqueued& rhs) :
+    Condition(),
+    m_build_type(rhs.m_build_type),
+    m_name(ValueRef::CloneUnique(rhs.m_name)),
+    m_design_id(ValueRef::CloneUnique(rhs.m_design_id)),
+    m_empire_id(ValueRef::CloneUnique(rhs.m_empire_id)),
+    m_low(ValueRef::CloneUnique(rhs.m_low)),
+    m_high(ValueRef::CloneUnique(rhs.m_high))
+{
+    m_root_candidate_invariant = rhs.m_root_candidate_invariant;
+    m_source_invariant = rhs.m_source_invariant;
+    m_target_invariant = rhs.m_target_invariant;
+}
+
 bool Enqueued::operator==(const Condition& rhs) const {
     if (this == &rhs)
         return true;
@@ -4798,16 +4817,7 @@ unsigned int Enqueued::GetCheckSum() const {
 }
 
 std::unique_ptr<Condition> Enqueued::Clone() const {
-    auto retval = std::make_unique<Enqueued>(m_build_type,
-                                             ValueRef::CloneUnique(m_name),
-                                             ValueRef::CloneUnique(m_empire_id),
-                                             ValueRef::CloneUnique(m_low),
-                                             ValueRef::CloneUnique(m_high));
-    retval->m_design_id = ValueRef::CloneUnique(m_design_id);
-    retval->m_root_candidate_invariant = m_root_candidate_invariant;
-    retval->m_target_invariant = m_target_invariant;
-    retval->m_source_invariant = m_source_invariant;
-    return retval;
+    return std::make_unique<Enqueued>(*this);
 }
 
 ///////////////////////////////////////////////////////////
@@ -9445,6 +9455,25 @@ ValueTest::ValueTest(std::unique_ptr<ValueRef::ValueRef<int>>&& value_ref1,
     m_source_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
 }
 
+ValueTest::ValueTest(const ValueTest& rhs) :
+    Condition(),
+    m_value_ref1(ValueRef::CloneUnique(rhs.m_value_ref1)),
+    m_value_ref2(ValueRef::CloneUnique(rhs.m_value_ref2)),
+    m_value_ref3(ValueRef::CloneUnique(rhs.m_value_ref3)),
+    m_string_value_ref1(ValueRef::CloneUnique(rhs.m_string_value_ref1)),
+    m_string_value_ref2(ValueRef::CloneUnique(rhs.m_string_value_ref2)),
+    m_string_value_ref3(ValueRef::CloneUnique(rhs.m_string_value_ref3)),
+    m_int_value_ref1(ValueRef::CloneUnique(rhs.m_int_value_ref1)),
+    m_int_value_ref2(ValueRef::CloneUnique(rhs.m_int_value_ref2)),
+    m_int_value_ref3(ValueRef::CloneUnique(rhs.m_int_value_ref3)),
+    m_compare_type1(rhs.m_compare_type1),
+    m_compare_type2(rhs.m_compare_type2)
+{
+    m_root_candidate_invariant = rhs.m_root_candidate_invariant;
+    m_target_invariant = rhs.m_target_invariant;
+    m_source_invariant = rhs.m_source_invariant;
+}
+
 bool ValueTest::operator==(const Condition& rhs) const {
     if (this == &rhs)
         return true;
@@ -9676,21 +9705,7 @@ unsigned int ValueTest::GetCheckSum() const {
 }
 
 std::unique_ptr<Condition> ValueTest::Clone() const {
-    auto retval = std::make_unique<ValueTest>(ValueRef::CloneUnique(m_value_ref1),
-                                              m_compare_type1,
-                                              ValueRef::CloneUnique(m_value_ref2),
-                                              m_compare_type2,
-                                              ValueRef::CloneUnique(m_value_ref3));
-    retval->m_string_value_ref1 = CloneUnique(m_string_value_ref1);
-    retval->m_string_value_ref2 = CloneUnique(m_string_value_ref2);
-    retval->m_string_value_ref3 = CloneUnique(m_string_value_ref3);
-    retval->m_int_value_ref1 = CloneUnique(m_int_value_ref1);
-    retval->m_int_value_ref2 = CloneUnique(m_int_value_ref2);
-    retval->m_int_value_ref3 = CloneUnique(m_int_value_ref3);
-    retval->m_root_candidate_invariant = m_root_candidate_invariant;
-    retval->m_target_invariant = m_target_invariant;
-    retval->m_source_invariant = m_source_invariant;
-    return retval;
+    return std::make_unique<ValueTest>(*this);
 }
 
 ///////////////////////////////////////////////////////////
@@ -10343,7 +10358,7 @@ void Or::Eval(const ScriptingContext& parent_context, ObjectSet& matches,
         ObjectSet partly_checked_matches;
         partly_checked_matches.reserve(matches.size());
 
-        // move items in matches set the fail the first operand condition into 
+        // move items in matches set the fail the first operand condition into
         // partly_checked_matches set
         m_operands[0]->Eval(parent_context, matches, partly_checked_matches, SearchDomain::MATCHES);
 
@@ -10357,7 +10372,7 @@ void Or::Eval(const ScriptingContext& parent_context, ObjectSet& matches,
         non_matches.insert(non_matches.end(), partly_checked_matches.begin(), partly_checked_matches.end());
 
         // items already in non_matches set are not checked and remain in
-        // non_matches set even if they pass one or more of the operand 
+        // non_matches set even if they pass one or more of the operand
         // conditions
     }
 }

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -524,6 +524,13 @@ unsigned int Number::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> Number::Clone() const {
+    return std::make_unique<Number>(ValueRef::CloneUnique(m_low),
+                                    ValueRef::CloneUnique(m_high),
+                                    ValueRef::CloneUnique(m_condition));
+}
+
+
 ///////////////////////////////////////////////////////////
 // Turn                                                  //
 ///////////////////////////////////////////////////////////
@@ -664,6 +671,11 @@ unsigned int Turn::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(Turn): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> Turn::Clone() const {
+    return std::make_unique<Turn>(ValueRef::CloneUnique(m_low),
+                                  ValueRef::CloneUnique(m_high));
 }
 
 ///////////////////////////////////////////////////////////
@@ -1078,6 +1090,13 @@ unsigned int SortedNumberOf::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> SortedNumberOf::Clone() const {
+    return std::make_unique<SortedNumberOf>(ValueRef::CloneUnique(m_number),
+                                            ValueRef::CloneUnique(m_sort_key),
+                                            m_sorting_method,
+                                            ValueRef::CloneUnique(m_condition));
+}
+
 ///////////////////////////////////////////////////////////
 // All                                                   //
 ///////////////////////////////////////////////////////////
@@ -1123,6 +1142,11 @@ unsigned int All::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> All::Clone() const {
+    return std::make_unique<All>();
+}
+
+
 ///////////////////////////////////////////////////////////
 // None                                                  //
 ///////////////////////////////////////////////////////////
@@ -1167,6 +1191,10 @@ unsigned int None::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> None::Clone() const {
+    return std::make_unique<None>();
+}
+
 ///////////////////////////////////////////////////////////
 // NoOp                                                  //
 ///////////////////////////////////////////////////////////
@@ -1202,6 +1230,10 @@ unsigned int NoOp::GetCheckSum() const {
 
     TraceLogger(conditions) << "GetCheckSum(NoOp): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> NoOp::Clone() const {
+    return std::make_unique<NoOp>();
 }
 
 ///////////////////////////////////////////////////////////
@@ -1445,6 +1477,11 @@ unsigned int EmpireAffiliation::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> EmpireAffiliation::Clone() const {
+    return std::make_unique<EmpireAffiliation>(ValueRef::CloneUnique(m_empire_id),
+                                               m_affiliation);
+}
+
 ///////////////////////////////////////////////////////////
 // Source                                                //
 ///////////////////////////////////////////////////////////
@@ -1489,6 +1526,11 @@ unsigned int Source::GetCheckSum() const {
     TraceLogger() << "GetCheckSum(Source): retval: " << retval;
     return retval;
 }
+
+std::unique_ptr<Condition> Source::Clone() const {
+    return std::make_unique<Source>();
+}
+
 
 ///////////////////////////////////////////////////////////
 // RootCandidate                                         //
@@ -1535,6 +1577,10 @@ unsigned int RootCandidate::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> RootCandidate::Clone() const {
+    return std::make_unique<RootCandidate>();
+}
+
 ///////////////////////////////////////////////////////////
 // Target                                                //
 ///////////////////////////////////////////////////////////
@@ -1578,6 +1624,10 @@ unsigned int Target::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(Target): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> Target::Clone() const {
+    return std::unique_ptr<Target>();
 }
 
 ///////////////////////////////////////////////////////////
@@ -1788,6 +1838,10 @@ unsigned int Homeworld::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> Homeworld::Clone() const {
+    return std::make_unique<Homeworld>(ValueRef::CloneUnique(m_names));
+}
+
 ///////////////////////////////////////////////////////////
 // Capital                                               //
 ///////////////////////////////////////////////////////////
@@ -1842,6 +1896,10 @@ unsigned int Capital::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> Capital::Clone() const {
+    return std::make_unique<Capital>();
+}
+
 ///////////////////////////////////////////////////////////
 // Monster                                               //
 ///////////////////////////////////////////////////////////
@@ -1894,6 +1952,10 @@ unsigned int Monster::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> Monster::Clone() const {
+    return std::make_unique<Monster>();
+}
+
 ///////////////////////////////////////////////////////////
 // Armed                                                 //
 ///////////////////////////////////////////////////////////
@@ -1940,6 +2002,10 @@ unsigned int Armed::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(Armed): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> Armed::Clone() const {
+    return std::make_unique<Armed>();
 }
 
 ///////////////////////////////////////////////////////////
@@ -2129,6 +2195,10 @@ unsigned int Type::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> Type::Clone() const {
+    return std::make_unique<Type>(ValueRef::CloneUnique(m_type));
+}
+
 ///////////////////////////////////////////////////////////
 // Building                                              //
 ///////////////////////////////////////////////////////////
@@ -2291,6 +2361,10 @@ unsigned int Building::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(Building): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> Building::Clone() const {
+    return std::make_unique<Building>(ValueRef::CloneUnique(m_names));
 }
 
 ///////////////////////////////////////////////////////////
@@ -2533,6 +2607,18 @@ unsigned int HasSpecial::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> HasSpecial::Clone() const {
+    auto retval = std::make_unique<HasSpecial>(ValueRef::CloneUnique(m_name),
+                                               ValueRef::CloneUnique(m_since_turn_low),
+                                               ValueRef::CloneUnique(m_since_turn_high));
+    retval->m_capacity_low = ValueRef::CloneUnique(m_capacity_low);
+    retval->m_capacity_high = ValueRef::CloneUnique(m_capacity_high);
+    retval->m_root_candidate_invariant = m_root_candidate_invariant;
+    retval->m_target_invariant = m_target_invariant;
+    retval->m_source_invariant = m_source_invariant;
+    return retval;
+}
+
 ///////////////////////////////////////////////////////////
 // HasTag                                                //
 ///////////////////////////////////////////////////////////
@@ -2663,6 +2749,10 @@ unsigned int HasTag::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> HasTag::Clone() const {
+    return std::make_unique<HasTag>(ValueRef::CloneUnique(m_name));
+}
+
 ///////////////////////////////////////////////////////////
 // CreatedOnTurn                                         //
 ///////////////////////////////////////////////////////////
@@ -2781,6 +2871,11 @@ unsigned int CreatedOnTurn::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(CreatedOnTurn): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> CreatedOnTurn::Clone() const {
+    return std::make_unique<CreatedOnTurn>(ValueRef::CloneUnique(m_low),
+                                           ValueRef::CloneUnique(m_high));
 }
 
 ///////////////////////////////////////////////////////////
@@ -2981,6 +3076,10 @@ unsigned int Contains::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(Contains): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> Contains::Clone() const {
+    return std::make_unique<Contains>(ValueRef::CloneUnique(m_condition));
 }
 
 ///////////////////////////////////////////////////////////
@@ -3200,6 +3299,10 @@ unsigned int ContainedBy::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> ContainedBy::Clone() const {
+    return std::make_unique<ContainedBy>(ValueRef::CloneUnique(m_condition));
+}
+
 ///////////////////////////////////////////////////////////
 // InOrIsSystem                                          //
 ///////////////////////////////////////////////////////////
@@ -3354,6 +3457,10 @@ unsigned int InOrIsSystem::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> InOrIsSystem::Clone() const {
+    return std::make_unique<InOrIsSystem>(ValueRef::CloneUnique(m_system_id));
+}
+
 ///////////////////////////////////////////////////////////
 // OnPlanet                                              //
 ///////////////////////////////////////////////////////////
@@ -3504,6 +3611,10 @@ unsigned int OnPlanet::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> OnPlanet::Clone() const {
+    return std::make_unique<OnPlanet>(ValueRef::CloneUnique(m_planet_id));
+}
+
 ///////////////////////////////////////////////////////////
 // ObjectID                                              //
 ///////////////////////////////////////////////////////////
@@ -3630,6 +3741,10 @@ unsigned int ObjectID::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(ObjectID): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> ObjectID::Clone() const {
+    return std::make_unique<ObjectID>(ValueRef::CloneUnique(m_object_id));
 }
 
 ///////////////////////////////////////////////////////////
@@ -3795,6 +3910,10 @@ unsigned int PlanetType::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(PlanetType): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> PlanetType::Clone() const {
+    return std::make_unique<PlanetType>(ValueRef::CloneUnique(m_types));
 }
 
 ///////////////////////////////////////////////////////////
@@ -3963,6 +4082,10 @@ unsigned int PlanetSize::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(PlanetSize): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> PlanetSize::Clone() const {
+    return std::make_unique<PlanetSize>(ValueRef::CloneUnique(m_sizes));
 }
 
 ///////////////////////////////////////////////////////////
@@ -4170,6 +4293,11 @@ unsigned int PlanetEnvironment::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> PlanetEnvironment::Clone() const {
+    return std::make_unique<PlanetEnvironment>(ValueRef::CloneUnique(m_environments),
+                                               ValueRef::CloneUnique(m_species_name));
+}
+
 ///////////////////////////////////////////////////////////
 // Species                                               //
 ///////////////////////////////////////////////////////////
@@ -4354,6 +4482,10 @@ unsigned int Species::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(Species): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> Species::Clone() const {
+    return std::make_unique<Species>(ValueRef::CloneUnique(m_names));
 }
 
 ///////////////////////////////////////////////////////////
@@ -4665,6 +4797,19 @@ unsigned int Enqueued::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> Enqueued::Clone() const {
+    auto retval = std::make_unique<Enqueued>(m_build_type,
+                                             ValueRef::CloneUnique(m_name),
+                                             ValueRef::CloneUnique(m_empire_id),
+                                             ValueRef::CloneUnique(m_low),
+                                             ValueRef::CloneUnique(m_high));
+    retval->m_design_id = ValueRef::CloneUnique(m_design_id);
+    retval->m_root_candidate_invariant = m_root_candidate_invariant;
+    retval->m_target_invariant = m_target_invariant;
+    retval->m_source_invariant = m_source_invariant;
+    return retval;
+}
+
 ///////////////////////////////////////////////////////////
 // FocusType                                             //
 ///////////////////////////////////////////////////////////
@@ -4840,6 +4985,10 @@ unsigned int FocusType::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> FocusType::Clone() const {
+    return std::make_unique<FocusType>(ValueRef::CloneUnique(m_names));
+}
+
 ///////////////////////////////////////////////////////////
 // StarType                                              //
 ///////////////////////////////////////////////////////////
@@ -5000,6 +5149,10 @@ unsigned int StarType::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> StarType::Clone() const {
+    return std::make_unique<StarType>(ValueRef::CloneUnique(m_types));
+}
+
 ///////////////////////////////////////////////////////////
 // DesignHasHull                                         //
 ///////////////////////////////////////////////////////////
@@ -5123,6 +5276,10 @@ unsigned int DesignHasHull::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(DesignHasHull): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> DesignHasHull::Clone() const {
+    return std::make_unique<DesignHasHull>(ValueRef::CloneUnique(m_name));
 }
 
 ///////////////////////////////////////////////////////////
@@ -5305,6 +5462,12 @@ unsigned int DesignHasPart::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> DesignHasPart::Clone() const {
+    return std::make_unique<DesignHasPart>(ValueRef::CloneUnique(m_name),
+                                           ValueRef::CloneUnique(m_low),
+                                           ValueRef::CloneUnique(m_high));
+}
+
 ///////////////////////////////////////////////////////////
 // DesignHasPartClass                                    //
 ///////////////////////////////////////////////////////////
@@ -5467,6 +5630,12 @@ unsigned int DesignHasPartClass::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> DesignHasPartClass::Clone() const {
+    return std::make_unique<DesignHasPartClass>(m_class,
+                                                ValueRef::CloneUnique(m_low),
+                                                ValueRef::CloneUnique(m_high));
+}
+
 ///////////////////////////////////////////////////////////
 // PredefinedShipDesign                                  //
 ///////////////////////////////////////////////////////////
@@ -5601,6 +5770,10 @@ unsigned int PredefinedShipDesign::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> PredefinedShipDesign::Clone() const {
+    return std::make_unique<PredefinedShipDesign>(ValueRef::CloneUnique(m_name));
+}
+
 ///////////////////////////////////////////////////////////
 // NumberedShipDesign                                    //
 ///////////////////////////////////////////////////////////
@@ -5702,6 +5875,10 @@ unsigned int NumberedShipDesign::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(NumberedShipDesign): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> NumberedShipDesign::Clone() const {
+    return std::make_unique<NumberedShipDesign>(ValueRef::CloneUnique(m_design_id));
 }
 
 ///////////////////////////////////////////////////////////
@@ -5813,6 +5990,10 @@ unsigned int ProducedByEmpire::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> ProducedByEmpire::Clone() const {
+    return std::make_unique<ProducedByEmpire>(ValueRef::CloneUnique(m_empire_id));
+}
+
 ///////////////////////////////////////////////////////////
 // Chance                                                //
 ///////////////////////////////////////////////////////////
@@ -5904,6 +6085,10 @@ unsigned int Chance::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(Chance): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> Chance::Clone() const {
+    return std::make_unique<Chance>(ValueRef::CloneUnique(m_chance));
 }
 
 ///////////////////////////////////////////////////////////
@@ -6099,6 +6284,12 @@ unsigned int MeterValue::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> MeterValue::Clone() const {
+    return std::make_unique<MeterValue>(m_meter,
+                                        ValueRef::CloneUnique(m_low),
+                                        ValueRef::CloneUnique(m_high));
+}
+
 ///////////////////////////////////////////////////////////
 // ShipPartMeterValue                                    //
 ///////////////////////////////////////////////////////////
@@ -6260,6 +6451,13 @@ unsigned int ShipPartMeterValue::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(ShipPartMeterValue): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> ShipPartMeterValue::Clone() const {
+    return std::make_unique<ShipPartMeterValue>(ValueRef::CloneUnique(m_part_name),
+                                                m_meter,
+                                                ValueRef::CloneUnique(m_low),
+                                                ValueRef::CloneUnique(m_high));
 }
 
 ///////////////////////////////////////////////////////////
@@ -6443,6 +6641,13 @@ unsigned int EmpireMeterValue::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> EmpireMeterValue::Clone() const {
+    return std::make_unique<EmpireMeterValue>(ValueRef::CloneUnique(m_empire_id),
+                                              m_meter,
+                                              ValueRef::CloneUnique(m_low),
+                                              ValueRef::CloneUnique(m_high));
+}
+
 ///////////////////////////////////////////////////////////
 // EmpireStockpileValue                                  //
 ///////////////////////////////////////////////////////////
@@ -6617,6 +6822,13 @@ unsigned int EmpireStockpileValue::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> EmpireStockpileValue::Clone() const {
+    return std::make_unique<EmpireStockpileValue>(ValueRef::CloneUnique(m_empire_id),
+                                                  m_stockpile,
+                                                  ValueRef::CloneUnique(m_low),
+                                                  ValueRef::CloneUnique(m_high));
+}
+
 ///////////////////////////////////////////////////////////
 // EmpireHasAdoptedPolicy                                //
 ///////////////////////////////////////////////////////////
@@ -6760,6 +6972,11 @@ unsigned int EmpireHasAdoptedPolicy::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> EmpireHasAdoptedPolicy::Clone() const {
+    return std::make_unique<EmpireHasAdoptedPolicy>(ValueRef::CloneUnique(m_empire_id),
+                                                    ValueRef::CloneUnique(m_name));
+}
+
 ///////////////////////////////////////////////////////////
 // OwnerHasTech                                          //
 ///////////////////////////////////////////////////////////
@@ -6898,6 +7115,11 @@ unsigned int OwnerHasTech::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(OwnerHasTech): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> OwnerHasTech::Clone() const {
+    return std::make_unique<OwnerHasTech>(ValueRef::CloneUnique(m_empire_id),
+                                          ValueRef::CloneUnique(m_name));
 }
 
 ///////////////////////////////////////////////////////////
@@ -7041,6 +7263,11 @@ unsigned int OwnerHasBuildingTypeAvailable::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> OwnerHasBuildingTypeAvailable::Clone() const {
+    return std::make_unique<OwnerHasBuildingTypeAvailable>(ValueRef::CloneUnique(m_empire_id),
+                                                           ValueRef::CloneUnique(m_name));
+}
+
 ///////////////////////////////////////////////////////////
 // OwnerHasShipDesignAvailable                           //
 ///////////////////////////////////////////////////////////
@@ -7181,6 +7408,11 @@ unsigned int OwnerHasShipDesignAvailable::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> OwnerHasShipDesignAvailable::Clone() const {
+    return std::make_unique<OwnerHasShipDesignAvailable>(ValueRef::CloneUnique(m_empire_id),
+                                                         ValueRef::CloneUnique(m_id));
+}
+
 ///////////////////////////////////////////////////////////
 // OwnerHasShipPartAvailable                             //
 ///////////////////////////////////////////////////////////
@@ -7317,6 +7549,11 @@ unsigned int OwnerHasShipPartAvailable::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(OwnerHasShipPartAvailable): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> OwnerHasShipPartAvailable::Clone() const {
+    return std::make_unique<OwnerHasShipPartAvailable>(ValueRef::CloneUnique(m_empire_id),
+                                                       ValueRef::CloneUnique(m_name));
 }
 
 ///////////////////////////////////////////////////////////
@@ -7535,6 +7772,12 @@ unsigned int VisibleToEmpire::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> VisibleToEmpire::Clone() const {
+    return std::make_unique<VisibleToEmpire>(ValueRef::CloneUnique(m_empire_id),
+                                             ValueRef::CloneUnique(m_since_turn),
+                                             ValueRef::CloneUnique(m_vis));
+}
+
 ///////////////////////////////////////////////////////////
 // WithinDistance                                        //
 ///////////////////////////////////////////////////////////
@@ -7671,6 +7914,11 @@ unsigned int WithinDistance::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> WithinDistance::Clone() const {
+    return std::make_unique<WithinDistance>(ValueRef::CloneUnique(m_distance),
+                                            ValueRef::CloneUnique(m_condition));
+}
+
 ///////////////////////////////////////////////////////////
 // WithinStarlaneJumps                                   //
 ///////////////////////////////////////////////////////////
@@ -7788,6 +8036,11 @@ unsigned int WithinStarlaneJumps::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(WithinStarlaneJumps): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> WithinStarlaneJumps::Clone() const {
+    return std::make_unique<WithinStarlaneJumps>(ValueRef::CloneUnique(m_jumps),
+                                                 ValueRef::CloneUnique(m_condition));
 }
 
 ///////////////////////////////////////////////////////////
@@ -8237,6 +8490,10 @@ unsigned int CanAddStarlaneConnection::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> CanAddStarlaneConnection::Clone() const {
+    return std::make_unique<CanAddStarlaneConnection>(ValueRef::CloneUnique(m_condition));
+}
+
 ///////////////////////////////////////////////////////////
 // ExploredByEmpire                                      //
 ///////////////////////////////////////////////////////////
@@ -8349,6 +8606,10 @@ unsigned int ExploredByEmpire::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> ExploredByEmpire::Clone() const {
+    return std::make_unique<ExploredByEmpire>(ValueRef::CloneUnique(m_empire_id));
+}
+
 ///////////////////////////////////////////////////////////
 // Stationary                                            //
 ///////////////////////////////////////////////////////////
@@ -8408,6 +8669,10 @@ unsigned int Stationary::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(Stationary): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> Stationary::Clone() const {
+    return std::make_unique<Stationary>();
 }
 
 ///////////////////////////////////////////////////////////
@@ -8475,6 +8740,10 @@ unsigned int Aggressive::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(Aggressive): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> Aggressive::Clone() const {
+    return std::make_unique<Aggressive>(m_aggressive);
 }
 
 ///////////////////////////////////////////////////////////
@@ -8587,6 +8856,10 @@ unsigned int FleetSupplyableByEmpire::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(FleetSupplyableByEmpire): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> FleetSupplyableByEmpire::Clone() const {
+    return std::make_unique<FleetSupplyableByEmpire>(ValueRef::CloneUnique(m_empire_id));
 }
 
 ///////////////////////////////////////////////////////////
@@ -8778,6 +9051,11 @@ unsigned int ResourceSupplyConnectedByEmpire::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> ResourceSupplyConnectedByEmpire::Clone() const {
+    return std::make_unique<ResourceSupplyConnectedByEmpire>(ValueRef::CloneUnique(m_empire_id),
+                                                             ValueRef::CloneUnique(m_condition));
+}
+
 ///////////////////////////////////////////////////////////
 // CanColonize                                           //
 ///////////////////////////////////////////////////////////
@@ -8859,6 +9137,10 @@ unsigned int CanColonize::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> CanColonize::Clone() const {
+    return std::make_unique<CanColonize>();
+}
+
 ///////////////////////////////////////////////////////////
 // CanProduceShips                                       //
 ///////////////////////////////////////////////////////////
@@ -8938,6 +9220,10 @@ unsigned int CanProduceShips::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(CanProduceShips): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> CanProduceShips::Clone() const {
+    return std::make_unique<CanProduceShips>();
 }
 
 ///////////////////////////////////////////////////////////
@@ -9058,6 +9344,10 @@ unsigned int OrderedBombarded::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(OrderedBombarded): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> OrderedBombarded::Clone() const {
+    return std::make_unique<OrderedBombarded>(ValueRef::CloneUnique(m_by_object_condition));
 }
 
 ///////////////////////////////////////////////////////////
@@ -9385,6 +9675,24 @@ unsigned int ValueTest::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> ValueTest::Clone() const {
+    auto retval = std::make_unique<ValueTest>(ValueRef::CloneUnique(m_value_ref1),
+                                              m_compare_type1,
+                                              ValueRef::CloneUnique(m_value_ref2),
+                                              m_compare_type2,
+                                              ValueRef::CloneUnique(m_value_ref3));
+    retval->m_string_value_ref1 = CloneUnique(m_string_value_ref1);
+    retval->m_string_value_ref2 = CloneUnique(m_string_value_ref2);
+    retval->m_string_value_ref3 = CloneUnique(m_string_value_ref3);
+    retval->m_int_value_ref1 = CloneUnique(m_int_value_ref1);
+    retval->m_int_value_ref2 = CloneUnique(m_int_value_ref2);
+    retval->m_int_value_ref3 = CloneUnique(m_int_value_ref3);
+    retval->m_root_candidate_invariant = m_root_candidate_invariant;
+    retval->m_target_invariant = m_target_invariant;
+    retval->m_source_invariant = m_source_invariant;
+    return retval;
+}
+
 ///////////////////////////////////////////////////////////
 // Location                                              //
 ///////////////////////////////////////////////////////////
@@ -9595,6 +9903,12 @@ unsigned int Location::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> Location::Clone() const {
+    return std::make_unique<Location>(m_content_type,
+                                      CloneUnique(m_name1),
+                                      CloneUnique(m_name2));
+}
+
 ///////////////////////////////////////////////////////////
 // CombatTarget                                          //
 ///////////////////////////////////////////////////////////
@@ -9750,6 +10064,11 @@ unsigned int CombatTarget::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(CombatTarget): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> CombatTarget::Clone() const {
+    return std::make_unique<CombatTarget>(m_content_type,
+                                          CloneUnique(m_name));
 }
 
 ///////////////////////////////////////////////////////////
@@ -9937,6 +10256,10 @@ std::vector<const Condition*> And::Operands() const {
     std::transform(m_operands.begin(), m_operands.end(), std::back_inserter(retval),
                    [](const std::unique_ptr<Condition>& xx) {return xx.get();});
     return retval;
+}
+
+std::unique_ptr<Condition> And::Clone() const {
+    return std::make_unique<And>(ValueRef::CloneUnique(m_operands));
 }
 
 ///////////////////////////////////////////////////////////
@@ -10134,6 +10457,10 @@ unsigned int Or::GetCheckSum() const {
     return retval;
 }
 
+std::unique_ptr<Condition> Or::Clone() const {
+    return std::make_unique<Or>(ValueRef::CloneUnique(m_operands));
+}
+
 ///////////////////////////////////////////////////////////
 // Not                                                   //
 ///////////////////////////////////////////////////////////
@@ -10200,6 +10527,10 @@ unsigned int Not::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(Not): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> Not::Clone() const {
+    return std::make_unique<Not>(ValueRef::CloneUnique(m_operand));
 }
 
 ///////////////////////////////////////////////////////////
@@ -10403,6 +10734,10 @@ std::vector<const Condition*> OrderedAlternativesOf::Operands() const {
     return retval;
 }
 
+std::unique_ptr<Condition> OrderedAlternativesOf::Clone() const {
+    return std::make_unique<OrderedAlternativesOf>(ValueRef::CloneUnique(m_operands));
+}
+
 ///////////////////////////////////////////////////////////
 // Described                                             //
 ///////////////////////////////////////////////////////////
@@ -10464,5 +10799,10 @@ unsigned int Described::GetCheckSum() const {
 
     TraceLogger() << "GetCheckSum(Described): retval: " << retval;
     return retval;
+}
+
+std::unique_ptr<Condition> Described::Clone() const {
+    return std::make_unique<Described>(ValueRef::CloneUnique(m_condition),
+                                       m_desc_stringtable_key);
 }
 }

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -2419,16 +2419,13 @@ HasSpecial::HasSpecial(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name,
 }
 
 HasSpecial::HasSpecial(const HasSpecial& rhs) :
-    Condition(),
+    Condition(rhs),
     m_name(ValueRef::CloneUnique(rhs.m_name)),
     m_capacity_low(ValueRef::CloneUnique(rhs.m_capacity_low)),
     m_capacity_high(ValueRef::CloneUnique(rhs.m_capacity_high)),
     m_since_turn_low(ValueRef::CloneUnique(rhs.m_since_turn_low)),
     m_since_turn_high(ValueRef::CloneUnique(rhs.m_since_turn_high))
 {
-    m_root_candidate_invariant = rhs.m_root_candidate_invariant;
-    m_target_invariant = rhs.m_target_invariant;
-    m_source_invariant = rhs.m_source_invariant;
 }
 
 bool HasSpecial::operator==(const Condition& rhs) const {
@@ -4538,7 +4535,7 @@ Enqueued::Enqueued(BuildType build_type,
 }
 
 Enqueued::Enqueued(const Enqueued& rhs) :
-    Condition(),
+    Condition(rhs),
     m_build_type(rhs.m_build_type),
     m_name(ValueRef::CloneUnique(rhs.m_name)),
     m_design_id(ValueRef::CloneUnique(rhs.m_design_id)),
@@ -4546,9 +4543,6 @@ Enqueued::Enqueued(const Enqueued& rhs) :
     m_low(ValueRef::CloneUnique(rhs.m_low)),
     m_high(ValueRef::CloneUnique(rhs.m_high))
 {
-    m_root_candidate_invariant = rhs.m_root_candidate_invariant;
-    m_source_invariant = rhs.m_source_invariant;
-    m_target_invariant = rhs.m_target_invariant;
 }
 
 bool Enqueued::operator==(const Condition& rhs) const {
@@ -9456,7 +9450,7 @@ ValueTest::ValueTest(std::unique_ptr<ValueRef::ValueRef<int>>&& value_ref1,
 }
 
 ValueTest::ValueTest(const ValueTest& rhs) :
-    Condition(),
+    Condition(rhs),
     m_value_ref1(ValueRef::CloneUnique(rhs.m_value_ref1)),
     m_value_ref2(ValueRef::CloneUnique(rhs.m_value_ref2)),
     m_value_ref3(ValueRef::CloneUnique(rhs.m_value_ref3)),
@@ -9469,9 +9463,6 @@ ValueTest::ValueTest(const ValueTest& rhs) :
     m_compare_type1(rhs.m_compare_type1),
     m_compare_type2(rhs.m_compare_type2)
 {
-    m_root_candidate_invariant = rhs.m_root_candidate_invariant;
-    m_target_invariant = rhs.m_target_invariant;
-    m_source_invariant = rhs.m_source_invariant;
 }
 
 bool ValueTest::operator==(const Condition& rhs) const {

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -84,6 +84,8 @@ struct FO_COMMON_API Number final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -104,6 +106,8 @@ struct FO_COMMON_API Turn final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -142,6 +146,8 @@ struct FO_COMMON_API SortedNumberOf final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_number;
     std::unique_ptr<ValueRef::ValueRef<double>> m_sort_key;
@@ -164,6 +170,8 @@ struct FO_COMMON_API None final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override
     {}
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 };
 
 /** Does not modify the input ObjectSets. */
@@ -177,6 +185,8 @@ struct FO_COMMON_API NoOp final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override
     {}
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 };
 
 /** Matches all objects that are owned (if \a exclusive == false) or only owned
@@ -195,6 +205,8 @@ struct FO_COMMON_API EmpireAffiliation final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -218,6 +230,8 @@ struct FO_COMMON_API RootCandidate final : public Condition {
     {}
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 };
@@ -236,6 +250,8 @@ struct FO_COMMON_API Target final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override
     {}
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -258,6 +274,8 @@ struct FO_COMMON_API Homeworld final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -276,6 +294,8 @@ struct FO_COMMON_API Capital final : public Condition {
     {}
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 };
@@ -292,6 +312,8 @@ struct FO_COMMON_API Monster final : public Condition {
     {}
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 };
@@ -305,6 +327,8 @@ struct FO_COMMON_API Armed final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override
     {}
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -324,6 +348,8 @@ struct FO_COMMON_API Type final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -345,6 +371,8 @@ struct FO_COMMON_API Building final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -372,6 +400,8 @@ struct FO_COMMON_API HasSpecial final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -396,6 +426,8 @@ struct FO_COMMON_API HasTag final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -414,6 +446,8 @@ struct FO_COMMON_API CreatedOnTurn final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -437,6 +471,8 @@ struct FO_COMMON_API Contains final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -457,6 +493,8 @@ struct FO_COMMON_API ContainedBy final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -480,6 +518,8 @@ struct FO_COMMON_API InOrIsSystem final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -502,6 +542,8 @@ struct FO_COMMON_API OnPlanet final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -521,6 +563,8 @@ struct FO_COMMON_API ObjectID final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -544,6 +588,8 @@ struct FO_COMMON_API PlanetType final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -565,6 +611,8 @@ struct FO_COMMON_API PlanetSize final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -589,6 +637,8 @@ struct FO_COMMON_API PlanetEnvironment final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -612,6 +662,8 @@ struct FO_COMMON_API Species final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -643,6 +695,8 @@ struct FO_COMMON_API Enqueued final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -668,6 +722,8 @@ struct FO_COMMON_API FocusType final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -686,6 +742,8 @@ struct FO_COMMON_API StarType final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -706,6 +764,8 @@ struct FO_COMMON_API DesignHasHull final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -729,6 +789,8 @@ struct FO_COMMON_API DesignHasPart final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -755,6 +817,8 @@ struct FO_COMMON_API DesignHasPartClass final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -776,6 +840,8 @@ struct FO_COMMON_API PredefinedShipDesign final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -793,6 +859,8 @@ struct FO_COMMON_API NumberedShipDesign final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -812,6 +880,8 @@ struct FO_COMMON_API ProducedByEmpire final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -829,6 +899,8 @@ struct FO_COMMON_API Chance final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -850,6 +922,8 @@ struct FO_COMMON_API MeterValue final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -874,6 +948,8 @@ struct FO_COMMON_API ShipPartMeterValue final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -903,6 +979,8 @@ struct FO_COMMON_API EmpireMeterValue final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -930,6 +1008,8 @@ struct FO_COMMON_API EmpireStockpileValue final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -959,6 +1039,8 @@ struct FO_COMMON_API EmpireHasAdoptedPolicy final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -979,6 +1061,8 @@ struct FO_COMMON_API OwnerHasTech final : public Condition {
     std::string     Dump(unsigned short ntabs = 0) const override;
     void            SetTopLevelContent(const std::string& content_name) override;
     unsigned int    GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -1002,6 +1086,8 @@ struct FO_COMMON_API OwnerHasBuildingTypeAvailable final : public Condition {
     void            SetTopLevelContent(const std::string& content_name) override;
     unsigned int    GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -1023,6 +1109,8 @@ struct FO_COMMON_API OwnerHasShipDesignAvailable final : public Condition {
     std::string     Dump(unsigned short ntabs = 0) const override;
     void            SetTopLevelContent(const std::string& content_name) override;
     unsigned int    GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -1046,6 +1134,8 @@ struct FO_COMMON_API OwnerHasShipPartAvailable final : public Condition {
     void            SetTopLevelContent(const std::string& content_name) override;
     unsigned int    GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -1067,6 +1157,8 @@ struct FO_COMMON_API VisibleToEmpire final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -1092,6 +1184,8 @@ struct FO_COMMON_API WithinDistance final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -1114,6 +1208,8 @@ struct FO_COMMON_API WithinStarlaneJumps final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -1139,6 +1235,8 @@ struct FO_COMMON_API CanAddStarlaneConnection : Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -1158,6 +1256,8 @@ struct FO_COMMON_API ExploredByEmpire final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -1176,6 +1276,8 @@ struct FO_COMMON_API Stationary final : public Condition {
     {}
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 };
@@ -1191,6 +1293,8 @@ struct FO_COMMON_API Aggressive final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override {}
     bool GetAggressive() const { return m_aggressive; }
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -1210,6 +1314,8 @@ struct FO_COMMON_API FleetSupplyableByEmpire final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -1232,6 +1338,8 @@ struct FO_COMMON_API ResourceSupplyConnectedByEmpire final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -1250,6 +1358,8 @@ struct FO_COMMON_API CanColonize final : public Condition {
     {}
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 };
@@ -1264,6 +1374,8 @@ struct FO_COMMON_API CanProduceShips final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override
     {}
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -1281,6 +1393,8 @@ struct FO_COMMON_API OrderedBombarded final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     virtual void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -1317,6 +1431,8 @@ struct FO_COMMON_API ValueTest final : public Condition {
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -1350,6 +1466,8 @@ public:
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     bool Match(const ScriptingContext& local_context) const override;
 
@@ -1372,6 +1490,8 @@ public:
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     bool Match(const ScriptingContext& local_context) const override;
@@ -1399,6 +1519,8 @@ struct FO_COMMON_API And final : public Condition {
     std::vector<const Condition*> Operands() const;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     std::vector<std::unique_ptr<Condition>> m_operands;
 };
@@ -1421,6 +1543,8 @@ struct FO_COMMON_API Or final : public Condition {
     virtual void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     std::vector<std::unique_ptr<Condition>> m_operands;
 };
@@ -1436,6 +1560,8 @@ struct FO_COMMON_API Not final : public Condition {
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     std::unique_ptr<Condition> m_operand;
@@ -1457,6 +1583,8 @@ struct FO_COMMON_API OrderedAlternativesOf final : public Condition {
     std::vector<const Condition*> Operands() const;
     unsigned int GetCheckSum() const override;
 
+    std::unique_ptr<Condition> Clone() const override;
+
 private:
     std::vector<std::unique_ptr<Condition>> m_operands;
 };
@@ -1474,6 +1602,8 @@ struct FO_COMMON_API Described final : public Condition {
     { return m_condition ? m_condition->Dump(ntabs) : ""; }
     void SetTopLevelContent(const std::string& content_name) override;
     unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<Condition> Clone() const override;
 
 private:
     std::unique_ptr<Condition> m_condition;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -391,6 +391,7 @@ struct FO_COMMON_API HasSpecial final : public Condition {
     HasSpecial(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name,
                std::unique_ptr<ValueRef::ValueRef<double>>&& capacity_low,
                std::unique_ptr<ValueRef::ValueRef<double>>&& capacity_high = nullptr);
+    explicit HasSpecial(const HasSpecial& rhs);
 
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
@@ -684,6 +685,7 @@ struct FO_COMMON_API Enqueued final : public Condition {
                       std::unique_ptr<ValueRef::ValueRef<int>>&& low = nullptr,
                       std::unique_ptr<ValueRef::ValueRef<int>>&& high = nullptr);
     Enqueued();
+    Enqueued(const Enqueued& rhs);
 
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
@@ -1422,6 +1424,7 @@ struct FO_COMMON_API ValueTest final : public Condition {
               std::unique_ptr<ValueRef::ValueRef<int>>&& value_ref2,
               ComparisonType comp2 = ComparisonType::INVALID_COMPARISON,
               std::unique_ptr<ValueRef::ValueRef<int>>&& value_ref3 = nullptr);
+    explicit ValueTest(const ValueTest& rhs);
 
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,

--- a/universe/NamedValueRefManager.h
+++ b/universe/NamedValueRefManager.h
@@ -109,6 +109,9 @@ struct FO_COMMON_API NamedRef final : public ValueRef<T>
         return retval;
     }
 
+    std::unique_ptr<ValueRef<T>> Clone() const override {
+        return std::make_unique<NamedRef<T>>(m_value_ref_name, m_is_lookup_only);
+    }
 
 private:
     //! initialises invariants from registered valueref, waits a bit for registration, use on first access

--- a/universe/ValueRef.h
+++ b/universe/ValueRef.h
@@ -88,6 +88,10 @@ struct FO_COMMON_API ValueRef : public ValueRefBase
       * See ValueRefs.cpp for specialisation implementations. */
     std::string EvalAsString() const final
     { return FlexibleToString(Eval()); }
+
+    /** Makes a clone of this ValueRef in a new owning pointer. Required for Boost.Python, which
+      * doesn't supports move semantics for returned values. */
+    [[nodiscard]] virtual std::unique_ptr<ValueRef<T>> Clone() const = 0;
 };
 
 FO_ENUM(
@@ -112,6 +116,21 @@ FO_ENUM(
     ((STDEV))       // returns the standard deviation of the property values of all objects matching the condition
     ((PRODUCT))     // returns the product of the property values of all objects matching the condition
 )
+
+template<typename T>
+[[nodiscard]] inline std::unique_ptr<T> CloneUnique(const std::unique_ptr<T>& ptr) {
+    return ptr ? ptr->Clone() : nullptr;
+}
+
+template<typename T>
+[[nodiscard]] inline std::vector<std::unique_ptr<T>> CloneUnique(const std::vector<std::unique_ptr<T>>& vec) {
+    std::vector<std::unique_ptr<T>> retval;
+    retval.reserve(vec.size());
+    for (const auto& val : vec) {
+        retval.push_back(CloneUnique(val));
+    }
+    return retval;
+}
 
 }
 


### PR DESCRIPTION
Follows up #3265. Requirement for #3309 .

Workaround for missing `std::unique_ptr` support in Boost.Python https://github.com/boostorg/python/issues/202