### PR TITLE
Add totalFighterDamage and totalShipDamage calculations

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1168,9 +1168,9 @@ void Empire::UpdateSupplyUnobstructedSystems(const ScriptingContext& context,
         TraceLogger(supply) << "Fleet " << fleet->ID() << " is in system " << system_id
                             << " with next system " << fleet->NextSystemID()
                             << " and is owned by " << fleet->Owner()
-                            << " armed: " << fleet->HasArmedShips(context.ContextObjects())
+                            << " can damage ships: " << fleet->CanDamageShips(context.ContextObjects())
                             << " and obstructive: " << fleet->Obstructive();
-        if (fleet->HasArmedShips(context.ContextObjects()) && fleet->Obstructive()) {
+        if (fleet->CanDamageShips(context.ContextObjects()) && fleet->Obstructive()) {
             if (fleet->OwnedBy(m_id)) {
                 if (fleet->NextSystemID() == INVALID_OBJECT_ID || fleet->NextSystemID() == fleet->SystemID()) {
                     systems_containing_friendly_fleets.insert(system_id);

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -372,7 +372,7 @@ void SupplyManager::Update() {
             if (system_id == INVALID_OBJECT_ID || known_destroyed_objects.count(fleet->ID()))
                 continue;
 
-            if (fleet->HasArmedShips(objects) && fleet->Obstructive() && fleet->OwnedBy(empire_id)) {
+            if (fleet->CanDamageShips(Objects()) && fleet->Obstructive() && fleet->OwnedBy(empire_id)) {
                 if (fleet->NextSystemID() == INVALID_OBJECT_ID ||
                     fleet->NextSystemID() == fleet->SystemID())
                 { systems_containing_friendly_fleets.insert(system_id); }

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2486,10 +2486,10 @@ namespace {
         auto& species = ship->SpeciesName().empty() ? "Generic" : UserString(ship->SpeciesName());
         float structure = ship->GetMeter(MeterType::METER_MAX_STRUCTURE)->Current();
         float shield = ship->GetMeter(MeterType::METER_MAX_SHIELD)->Current();
-        float attack = ship->TotalWeaponsDamage();
+        float attack = ship->TotalWeaponsShipDamage(); // FIXME TotalWeaponsFighterDamage 
         float strength = std::pow(attack * structure, 0.6f);
         float typical_shot = *std::max_element(enemy_shots.begin(), enemy_shots.end());
-        float typical_strength = std::pow(ship->TotalWeaponsDamage(enemy_DR) * structure * typical_shot / std::max(typical_shot - shield, 0.001f), 0.6f);
+        float typical_strength = std::pow(ship->TotalWeaponsShipDamage(enemy_DR) * structure * typical_shot / std::max(typical_shot - shield, 0.001f), 0.6f); // FIXME TotalWeaponsFighterDamage 
         return (FlexibleFormat(UserString("ENC_SHIP_DESIGN_DESCRIPTION_STATS_STR"))
             % species
             % attack
@@ -2503,7 +2503,7 @@ namespace {
             % ship->SumCurrentPartMeterValuesForPartClass(MeterType::METER_CAPACITY, ShipPartClass::PC_COLONY)
             % ship->SumCurrentPartMeterValuesForPartClass(MeterType::METER_CAPACITY, ShipPartClass::PC_TROOPS)
             % ship->FighterMax()
-            % (attack - ship->TotalWeaponsDamage(0.0f, false))
+            % (attack - ship->TotalWeaponsShipDamage(0.0f, false)) // FIXME TotalWeaponsFighterDamage 
             % ship->SumCurrentPartMeterValuesForPartClass(MeterType::METER_MAX_CAPACITY, ShipPartClass::PC_FIGHTER_BAY)
             % strength
             % (strength / cost)
@@ -2599,7 +2599,7 @@ namespace {
                     enemy_DR = this_ship->GetMeter(MeterType::METER_MAX_SHIELD)->Initial();
                     DebugLogger() << "Using selected ship for enemy values, DR: " << enemy_DR;
                     enemy_shots.clear();
-                    auto this_damage = this_ship->AllWeaponsMaxDamage();
+                    auto this_damage = this_ship->AllWeaponsMaxShipDamage(); // FIXME FighterDamage
                     for (float shot : this_damage)
                         DebugLogger() << "Weapons Dmg " << shot;
                     enemy_shots.insert(this_damage.begin(), this_damage.end());
@@ -2734,7 +2734,7 @@ namespace {
                     enemy_DR = this_ship->GetMeter(MeterType::METER_MAX_SHIELD)->Initial();
                     DebugLogger() << "Using selected ship for enemy values, DR: " << enemy_DR;
                     enemy_shots.clear();
-                    auto this_damage = this_ship->AllWeaponsMaxDamage();
+                    auto this_damage = this_ship->AllWeaponsMaxShipDamage(); // FIXME MaxFighterDamage
                     for (float shot : this_damage)
                         DebugLogger() << "Weapons Dmg " << shot;
                     enemy_shots.insert(this_damage.begin(), this_damage.end());

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2486,14 +2486,15 @@ namespace {
         auto& species = ship->SpeciesName().empty() ? "Generic" : UserString(ship->SpeciesName());
         float structure = ship->GetMeter(MeterType::METER_MAX_STRUCTURE)->Current();
         float shield = ship->GetMeter(MeterType::METER_MAX_SHIELD)->Current();
-        float attack = ship->TotalWeaponsShipDamage(); // FIXME TotalWeaponsFighterDamage 
+        float attack = ship->TotalWeaponsShipDamage();
+        float destruction = ship->TotalWeaponsFighterDamage();
         float strength = std::pow(attack * structure, 0.6f);
         float typical_shot = *std::max_element(enemy_shots.begin(), enemy_shots.end());
         float typical_strength = std::pow(ship->TotalWeaponsShipDamage(enemy_DR) * structure * typical_shot / std::max(typical_shot - shield, 0.001f), 0.6f); // FIXME TotalWeaponsFighterDamage 
         return (FlexibleFormat(UserString("ENC_SHIP_DESIGN_DESCRIPTION_STATS_STR"))
             % species
             % attack
-            % ship->SumCurrentPartMeterValuesForPartClass(MeterType::METER_MAX_SECONDARY_STAT, ShipPartClass::PC_DIRECT_WEAPON)
+            % destruction
             % structure
             % shield
             % ship->GetMeter(MeterType::METER_DETECTION)->Current()

--- a/UI/FleetButton.cpp
+++ b/UI/FleetButton.cpp
@@ -437,7 +437,7 @@ std::vector<std::shared_ptr<GG::Texture>> FleetHeadIcons(
     bool hasOutpostShips = false;
     bool hasTroopShips = false;
     bool hasMonsters = false;
-    bool hasArmedShips = false;
+    bool canDamageShips = false;
 
     for (auto* fleet : fleets) {
         if (!fleet)
@@ -447,7 +447,7 @@ std::vector<std::shared_ptr<GG::Texture>> FleetHeadIcons(
         hasOutpostShips = hasOutpostShips || fleet->HasOutpostShips(Objects());
         hasTroopShips   = hasTroopShips   || fleet->HasTroopShips(Objects());
         hasMonsters     = hasMonsters     || fleet->HasMonsters(Objects());
-        hasArmedShips   = hasArmedShips   || fleet->HasArmedShips(Objects()) || fleet->HasFighterShips(Objects());
+        canDamageShips   = canDamageShips   || fleet->CanDamageShips(Objects());
     }
 
     // get file name main part depending on type of fleet
@@ -455,10 +455,10 @@ std::vector<std::shared_ptr<GG::Texture>> FleetHeadIcons(
     std::vector<std::string> main_filenames;
     main_filenames.reserve(4);
     if (hasMonsters) {
-        if (hasArmedShips)   { main_filenames.emplace_back(size_prefix + "head-monster.png"); }
+        if (canDamageShips)   { main_filenames.emplace_back(size_prefix + "head-monster.png"); }
         else                 { main_filenames.emplace_back(size_prefix + "head-monster-harmless.png"); }
     } else {
-        if (hasArmedShips)   { main_filenames.emplace_back(size_prefix + "head-warship.png"); }
+        if (canDamageShips)   { main_filenames.emplace_back(size_prefix + "head-warship.png"); }
         if (hasColonyShips)  { main_filenames.emplace_back(size_prefix + "head-colony.png");  }
         if (hasOutpostShips) { main_filenames.emplace_back(size_prefix + "head-outpost.png"); }
         if (hasTroopShips)   { main_filenames.emplace_back(size_prefix + "head-lander.png");  }

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -860,9 +860,9 @@ namespace {
     double ShipDataPanel::StatValue(MeterType stat_name) const {
         if (auto ship = Objects().get<Ship>(m_ship_id)) {
             if (stat_name == MeterType::METER_CAPACITY)
-                return ship->TotalWeaponsShipDamage(0.0f, false);
+                return ship->TotalWeaponsShipDamage(0.0f, true);
             else if (stat_name == MeterType::METER_MAX_CAPACITY) // number of fighters shot down
-                return ship->TotalWeaponsFighterDamage(false); // XXX include fighters?
+                return ship->TotalWeaponsFighterDamage(true);
             else if (stat_name == MeterType::METER_TROOPS)
                 return ship->TroopCapacity();
             else if (stat_name == MeterType::METER_SECONDARY_STAT)
@@ -1546,8 +1546,8 @@ void FleetDataPanel::SetStatIconValues() {
 
         if (ship->Design()) {
             ship_count++;
-            damage_tally += ship->TotalWeaponsShipDamage(0.0f, false);
-            destroy_tally += ship->TotalWeaponsFighterDamage(false);// XXX include fighters?
+            damage_tally += ship->TotalWeaponsShipDamage(0.0f, true);
+            destroy_tally += ship->TotalWeaponsFighterDamage(true);
             fighters_tally += ship->FighterCount();
             troops_tally += ship->TroopCapacity();
             colony_tally += ship->ColonyCapacity();

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -166,11 +166,11 @@ namespace {
     bool ClientPlayerIsModerator()
     { return GGHumanClientApp::GetApp()->GetClientType() == Networking::ClientType::CLIENT_TYPE_HUMAN_MODERATOR; }
 
-    bool ContainsArmedShips(const std::vector<int>& ship_ids) {
+    bool CanDamageShips(const std::vector<int>& ship_ids) {
         for (const auto& ship : Objects().find<Ship>(ship_ids)) {
             if (!ship)
                 continue;
-            if (ship->IsArmed() || ship->HasFighters())
+            if (ship->CanDamageShips())
                 return true;
         }
         return false;
@@ -181,7 +181,7 @@ namespace {
             aggression_mode > FleetAggression::INVALID_FLEET_AGGRESSION)
         { return aggression_mode; }
         // auto aggression; examine ships to see if any are armed...
-        if (ContainsArmedShips(ship_ids))
+        if (CanDamageShips(ship_ids))
             return FleetDefaults::FLEET_DEFAULT_ARMED;
         return FleetDefaults::FLEET_DEFAULT_UNARMED;
     }
@@ -1571,12 +1571,12 @@ void FleetDataPanel::SetStatIconValues() {
             break;
         case MeterType::METER_CAPACITY:
             icon->SetValue(damage_tally);
-            if (fleet->HasArmedShips(objects))
+            if (fleet->CanDamageShips(objects))
                 AttachChild(icon);
             break;
         case MeterType::METER_MAX_CAPACITY:
             icon->SetValue(destroy_tally);
-            if (fleet->HasArmedShips(objects))
+            if (fleet->CanDestroyFighters(objects))
                 AttachChild(icon);
             break;
         case MeterType::METER_SECONDARY_STAT:

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -856,7 +856,7 @@ namespace {
     double ShipDataPanel::StatValue(MeterType stat_name) const {
         if (auto ship = Objects().get<Ship>(m_ship_id)) {
             if (stat_name == MeterType::METER_CAPACITY)
-                return ship->TotalWeaponsDamage(0.0f, false);
+                return ship->TotalWeaponsShipDamage(0.0f, false); // FIXME TotalWeaponsFighterDamage
             else if (stat_name == MeterType::METER_TROOPS)
                 return ship->TroopCapacity();
             else if (stat_name == MeterType::METER_SECONDARY_STAT)
@@ -1537,7 +1537,7 @@ void FleetDataPanel::SetStatIconValues() {
 
         if (ship->Design()) {
             ship_count++;
-            damage_tally += ship->TotalWeaponsDamage(0.0f, false);
+            damage_tally += ship->TotalWeaponsShipDamage(0.0f, false); // FIXME TotalWeaponsFighterDamage 
             fighters_tally += ship->FighterCount();
             troops_tally += ship->TroopCapacity();
             colony_tally += ship->ColonyCapacity();
@@ -2902,7 +2902,7 @@ void FleetWnd::SetStatIconValues() {
 
             if (ship->Design()) {
                 ship_count++;
-                damage_tally += ship->TotalWeaponsDamage(0.0f, false);
+                damage_tally += ship->TotalWeaponsShipDamage(0.0f, false); // FIXME TotalWeaponsFighterDamage 
                 fighters_tally += ship->FighterCount();
                 structure_tally += ship->GetMeter(MeterType::METER_STRUCTURE)->Initial();
                 shield_tally += ship->GetMeter(MeterType::METER_SHIELD)->Initial();

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -504,14 +504,16 @@ void ShipDamageBrowseWnd::UpdateSummary() {
     float breakdown_total = ship->TotalWeaponsShipDamage(0.0f, false);
     float breakdown_total_augmentation = ship->TotalWeaponsFighterDamage(false);
     std::string breakdown_meter_name = UserString("SHIP_DAMAGE_STAT_TITLE");
-
+    std::string breakdown_meter_augmentation_name = UserString("SHIP_DESTRUCTION_STAT_TITLE");
+    
 
     // set accounting breakdown total / summary
     if (m_meter_title)
         m_meter_title->SetText(boost::io::str(FlexibleFormat(UserString("TT_BREAKDOWN_AUGMENTED_SUMMARY")) %
                                               breakdown_meter_name %
                                               DoubleToString(breakdown_total, 3, false) %
-                                              DoubleToString(breakdown_total_augmentation, 1, false)));
+                                              breakdown_meter_augmentation_name %
+                                              (int)breakdown_total_augmentation));
 }
 
 void ShipDamageBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -501,7 +501,7 @@ void ShipDamageBrowseWnd::UpdateSummary() {
         return;
 
     // unpaired meter total for breakdown summary
-    float breakdown_total = ship->TotalWeaponsDamage(0.0f, false);
+    float breakdown_total = ship->TotalWeaponsShipDamage(0.0f, false); // FIXME do something with ship->TotalWeaponsFighterDamage
     std::string breakdown_meter_name = UserString("SHIP_DAMAGE_STAT_TITLE");
 
 

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -1,6 +1,7 @@
 #include "MeterBrowseWnd.h"
 
 #include "../util/i18n.h"
+#include "../util/GameRules.h"
 #include "../util/Logger.h"
 #include "../universe/Building.h"
 #include "../universe/Effect.h"
@@ -501,19 +502,15 @@ void ShipDamageBrowseWnd::UpdateSummary() {
         return;
 
     // unpaired meter total for breakdown summary
-    float breakdown_total = ship->TotalWeaponsShipDamage(0.0f, false);
-    float breakdown_total_augmentation = ship->TotalWeaponsFighterDamage(false);
-    std::string breakdown_meter_name = UserString("SHIP_DAMAGE_STAT_TITLE");
-    std::string breakdown_meter_augmentation_name = UserString("SHIP_DESTRUCTION_STAT_TITLE");
-    
-
+    float total_structure_damage = ship->TotalWeaponsShipDamage(0.0f, false);
+    float total_fighters_destroyed = ship->TotalWeaponsFighterDamage(false);
+    int num_bouts = GetGameRules().Get<int>("RULE_NUM_COMBAT_ROUNDS");
     // set accounting breakdown total / summary
     if (m_meter_title)
-        m_meter_title->SetText(boost::io::str(FlexibleFormat(UserString("TT_BREAKDOWN_AUGMENTED_SUMMARY")) %
-                                              breakdown_meter_name %
-                                              DoubleToString(breakdown_total, 3, false) %
-                                              breakdown_meter_augmentation_name %
-                                              (int)breakdown_total_augmentation));
+        m_meter_title->SetText(boost::io::str(FlexibleFormat(UserString("TT_DAMAGE_BREAKDOWN_SUMMARY")) %
+                                              num_bouts %
+                                              DoubleToString(total_structure_damage, 3, false) %
+                                              (int)total_fighters_destroyed));
 }
 
 void ShipDamageBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -546,7 +546,7 @@ void ShipDamageBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
             continue;
 
         // get the attack power for each weapon part
-        const ScriptingContext context(ship);
+        const ScriptingContext context{ship};
         float part_attack = ship->WeaponPartShipDamage(part, context);
         float part_fighters_shot = ship->WeaponPartFighterDamage(part, context);
 

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -817,8 +817,8 @@ void ShipFightersBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
         std::map<int, Combat::FighterBoutInfo> bout_info = Combat::ResolveFighterBouts(
             std::static_pointer_cast<const Ship>(ship), combat_targets, bay_total_capacity, hangar_current_fighters, fighter_damage, 2);
         Combat::FighterBoutInfo first_wave = bout_info.rbegin()->second;
-        GG::Clr highlight_clr = bout_info[1].qty.launched < bay_total_capacity ? HANGAR_COLOR : BAY_COLOR;
-        std::string launch_text = ColouredInt(first_wave.qty.attacking, false, highlight_clr);
+        GG::Clr highlight_clr = bout_info[1].launched < bay_total_capacity ? HANGAR_COLOR : BAY_COLOR;
+        std::string launch_text = ColouredInt(first_wave.attacking, false, highlight_clr);
         std::string damage_label_text = boost::io::str(FlexibleFormat(UserString("TT_FIGHTER_DAMAGE"))
                                                        % launch_text % fighter_damage_text);
         // damage formula label
@@ -919,7 +919,7 @@ void ShipFightersBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
 
             // damage formula label
             std::string formula_label_text = boost::io::str(FlexibleFormat(UserString("TT_FIGHTER_DAMAGE"))
-                                                            % IntToString(bout.qty.attacking)
+                                                            % IntToString(bout.attacking)
                                                             % fighter_damage_text);
             auto formula_label = GG::Wnd::Create<CUILabel>(std::move(formula_label_text), GG::FORMAT_RIGHT);
             formula_label->MoveTo(GG::Pt(left, top));
@@ -945,9 +945,9 @@ void ShipFightersBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
             AttachChild(launch_label);
             left += (LABEL_WIDTH / 2) + EDGE_PAD + EDGE_PAD;
 
-            GG::Clr launch_clr = bout.qty.launched < bay_total_capacity ? HANGAR_COLOR : BAY_COLOR;
+            GG::Clr launch_clr = bout.launched < bay_total_capacity ? HANGAR_COLOR : BAY_COLOR;
             std::string launch_text = boost::io::str(FlexibleFormat(UserString("TT_N_OF_N"))
-                                                     % ColouredInt(bout.qty.launched, false, launch_clr)
+                                                     % ColouredInt(bout.launched, false, launch_clr)
                                                      % ColouredInt(previous_docked, false, HANGAR_COLOR));
             auto launch_value = GG::Wnd::Create<CUILabel>(std::move(launch_text), GG::FORMAT_RIGHT);
             launch_value->MoveTo(GG::Pt(left, top));
@@ -957,7 +957,7 @@ void ShipFightersBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
 
             top += m_row_height;
             left = GG::X0;
-            previous_docked = bout.qty.docked;
+            previous_docked = bout.docked;
         }
     }
 }

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -276,7 +276,8 @@ namespace {
             col_types[{UserStringNop("NEAREST_SYSTEM"),             UserStringNop("FLEETS_SUBMENU")}] = ObjectNameValueRef("NearestSystemID");
             col_types[{UserStringNop("HULL"),                       UserStringNop("FLEETS_SUBMENU")}] = UserStringValueRef("Hull");
             col_types[{UserStringNop("PARTS"),                      UserStringNop("FLEETS_SUBMENU")}] = UserStringVecValueRef("Parts");
-            col_types[{UserStringNop("ATTACK"),                     UserStringNop("FLEETS_SUBMENU")}] = StringCastedValueRef<double>("Attack");
+            col_types[{UserStringNop("DAMAGE_STRUCTURE_PER_BATTLE"), UserStringNop("FLEETS_SUBMENU")}] = StringCastedValueRef<double>("DamageStructurePerBattleMax");
+            col_types[{UserStringNop("DESTROY_FIGHTERS_PER_BATTLE"), UserStringNop("FLEETS_SUBMENU")}] = StringCastedValueRef<double>("DestroyFightersPerBattleMax");
             col_types[{UserStringNop("PRODUCTION_COST"),            UserStringNop("FLEETS_SUBMENU")}] = DesignCostValueRef();
 
             // planet environments species

--- a/combat/CMakeLists.txt
+++ b/combat/CMakeLists.txt
@@ -1,10 +1,12 @@
 target_sources(freeorioncommon
     PUBLIC
+        ${CMAKE_CURRENT_LIST_DIR}/CombatDamage.h
         ${CMAKE_CURRENT_LIST_DIR}/CombatEvent.h
         ${CMAKE_CURRENT_LIST_DIR}/CombatEvents.h
         ${CMAKE_CURRENT_LIST_DIR}/CombatLogManager.h
         ${CMAKE_CURRENT_LIST_DIR}/CombatSystem.h
     PRIVATE
+        ${CMAKE_CURRENT_LIST_DIR}/CombatDamage.cpp
         ${CMAKE_CURRENT_LIST_DIR}/CombatEvent.cpp
         ${CMAKE_CURRENT_LIST_DIR}/CombatEvents.cpp
         ${CMAKE_CURRENT_LIST_DIR}/CombatLogManager.cpp

--- a/combat/CombatDamage.cpp
+++ b/combat/CombatDamage.cpp
@@ -15,12 +15,8 @@
 
 namespace {
     ScriptingContext CombatContextWithShipTarget(std::shared_ptr<const Ship> source, float shields = 0.0f) {
-        // FIXME find default enemy - i use the given design as that at least exists (but might be non-targetable because of stealth)
-        //ErrorLogger() << "DESIGN " << GetPredefinedShipDesignManager().GetDesignID("08a58b08-0929-496d-84fc-faa91424ca21");
-        //auto target = std::make_shared<Ship>(ALL_EMPIRES, GetPredefinedShipDesignManager().GetDesignID("SD_MARK_1"), "SP_HUMAN");
-        //auto target = std::make_shared<Fighter>();
-        // XXX DesignID valid?
-        auto target = std::make_shared<Ship>(ALL_EMPIRES, source->DesignID(), "SP_HUMAN");
+        // use the given design and species as default enemy. at least those least exists
+        auto target = std::make_shared<Ship>(ALL_EMPIRES, source->DesignID(), source->SpeciesName());
         // target needs to have an ID != -1 to be visible, stealth should be low enough
         // structure must be higher than zero to be valid target
         target->SetID(-1000000); // XXX magic number AutoresolveInfo.next_fighter_id starts at -1000001 counting down

--- a/combat/CombatDamage.cpp
+++ b/combat/CombatDamage.cpp
@@ -1,0 +1,211 @@
+#include "CombatDamage.h"
+
+#include "../util/Logger.h"
+#include "../util/GameRules.h"
+#include "../universe/Condition.h"
+#include "../universe/Enums.h"
+#include "../universe/Fighter.h"
+#include "../universe/Ship.h"
+#include "../universe/ShipDesign.h"
+#include "../universe/ShipPart.h"
+#include "../universe/ValueRef.h"
+
+// This knows about combat bouts, fighter launches, combatTargets conditions,
+// damage calculation (shortrange, fighters, shields)
+
+namespace {
+    ScriptingContext CombatContextWithShipTarget(std::shared_ptr<const Ship> source, float shields = 0.0f) {
+        // FIXME find default enemy - i use the given design as that at least exists (but might be non-targetable because of stealth)
+        //ErrorLogger() << "DESIGN " << GetPredefinedShipDesignManager().GetDesignID("08a58b08-0929-496d-84fc-faa91424ca21");
+        //auto target = std::make_shared<Ship>(ALL_EMPIRES, GetPredefinedShipDesignManager().GetDesignID("SD_MARK_1"), "SP_HUMAN");
+        //auto target = std::make_shared<Fighter>();
+        // XXX DesignID valid?
+        auto target = std::make_shared<Ship>(ALL_EMPIRES, source->DesignID(), "SP_HUMAN");
+        // target needs to have an ID != -1 to be visible, stealth should be low enough
+        // structure must be higher than zero to be valid target
+        target->SetID(-1000000); // XXX magic number AutoresolveInfo.next_fighter_id starts at -1000001 counting down
+        target->GetMeter(MeterType::METER_STRUCTURE)->Set(100.0f, 100.0f);
+        target->GetMeter(MeterType::METER_MAX_STRUCTURE)->Set(100.0f, 100.0f);
+        // Shield value is used for structural damage estimation
+        target->GetMeter(MeterType::METER_SHIELD)->Set(shields,shields);
+        GetUniverse().SetEmpireObjectVisibility(source->Owner(), target->ID(), Visibility::VIS_FULL_VISIBILITY);
+        return ScriptingContext(source, target);
+    }
+
+    ScriptingContext CombatContextWithFighterTarget(std::shared_ptr<const Ship> source) {
+        auto target = std::make_shared<Fighter>();
+        target->SetID(-1000000); // XXX magic number AutoresolveInfo.next_fighter_id starts at -1000001 counting down
+        GetUniverse().SetEmpireObjectVisibility(source->Owner(), target->ID(), Visibility::VIS_FULL_VISIBILITY);
+        return ScriptingContext(source, target);
+    }
+
+    std::vector<float> WeaponDamageCalcImpl(std::shared_ptr<const Ship> ship, const ShipDesign* design,
+                                            bool max, bool include_fighters, bool target_ships, const ScriptingContext&& context) {
+        std::vector<float> retval;
+        if (!ship || !design)
+            return retval;
+        const std::vector<std::string>& parts = design->Parts();
+        if (parts.empty())
+            return retval;
+
+        MeterType METER = max ? MeterType::METER_MAX_CAPACITY : MeterType::METER_CAPACITY;
+        MeterType SECONDARY_METER = max ? MeterType::METER_MAX_SECONDARY_STAT : MeterType::METER_SECONDARY_STAT;
+
+        float fighter_damage = 0.0f;
+        int fighter_launch_capacity = 0;
+        int available_fighters = 0;
+
+        retval.reserve(parts.size() + 1);
+        int num_bouts = GetGameRules().Get<int>("RULE_NUM_COMBAT_ROUNDS");
+        // for each weapon part, get its damage meter value
+        for (const auto& part_name : parts) {
+            const ShipPart* part = GetShipPart(part_name);
+            if (!part)
+                continue;
+            ShipPartClass part_class = part->Class();
+
+            // get the attack power for each weapon part.
+            if (part_class == ShipPartClass::PC_DIRECT_WEAPON) {
+                if (target_ships)
+                    retval.emplace_back(ship->WeaponPartShipDamage(part, context));
+                else
+                    retval.emplace_back(ship->WeaponPartFighterDamage(part, context));
+            } else if (part_class == ShipPartClass::PC_FIGHTER_BAY && include_fighters) {
+                // launch capacity determined by capacity of bay
+                fighter_launch_capacity += static_cast<int>(ship->CurrentPartMeterValue(METER, part_name));
+
+            } else if (part_class == ShipPartClass::PC_FIGHTER_HANGAR && include_fighters) {
+                // attack strength of a ship's fighters per bout determined by the hangar...
+                // assuming all hangars on a ship are the same part type...
+                if (target_ships && part->TotalShipDamage()) {
+                    retval.emplace_back(part->TotalShipDamage()->Eval(context));
+                    // as TotalShipDamage contains the damage from all fighters, do not further include fighter
+                    include_fighters = false;
+                } else if (part->TotalFighterDamage() && !target_ships) {
+                    retval.emplace_back(part->TotalFighterDamage()->Eval(context));
+                    // as TotalFighterDamage contains the damage from all fighters, do not further include fighter
+                    include_fighters = false;
+                } else if (part->CombatTargets() && context.effect_target && part->CombatTargets()->Eval(context, context.effect_target)) {
+                    fighter_damage = ship->CurrentPartMeterValue(SECONDARY_METER, part_name);
+                    available_fighters = std::max(0, static_cast<int>(ship->CurrentPartMeterValue(METER, part_name)));  // stacked meter
+                } else {
+                    std::vector<const Condition::Condition*> target_conditions;
+                    target_conditions.push_back(part->CombatTargets());
+                    // target is not of the right type
+                    fighter_damage = 0.0f;
+                    include_fighters = false;
+                }
+            }
+        }
+
+        if (!include_fighters || fighter_damage <= 0.0f || available_fighters <= 0 || fighter_launch_capacity <= 0)
+            return retval;
+
+        // Calculate fighter damage manually if not
+        int fighter_shots = std::min(available_fighters, fighter_launch_capacity);  // how many fighters launched in bout 1
+        available_fighters -= fighter_shots;
+        int launched_fighters = fighter_shots;
+        int remaining_bouts = num_bouts - 2;  // no attack for first round, second round already added
+        while (remaining_bouts > 0) {
+            int fighters_launched_this_bout = std::min(available_fighters, fighter_launch_capacity);
+            available_fighters -= fighters_launched_this_bout;
+            launched_fighters += fighters_launched_this_bout;
+            fighter_shots += launched_fighters;
+            --remaining_bouts;
+        }
+
+        // how much damage does a fighter shot do?
+        fighter_damage = std::max(0.0f, fighter_damage);
+
+        if (target_ships)
+            retval.emplace_back(fighter_damage * fighter_shots);
+        else
+            retval.emplace_back((float)fighter_shots);
+        return retval;
+    }
+}
+
+std::vector<float> Combat::WeaponDamageImpl(std::shared_ptr<const Ship> ship, const ShipDesign* design,
+                                            float shields, bool max, bool include_fighters, bool target_ships)
+{
+    if (target_ships)
+        return WeaponDamageCalcImpl(ship, design, max, include_fighters, target_ships, CombatContextWithShipTarget(ship, shields));
+    else
+        return WeaponDamageCalcImpl(ship, design, max, include_fighters, target_ships, CombatContextWithFighterTarget(ship));
+}
+
+
+/** Populate fighter state quantities and damages for each combat round until @p limit_to_bout */
+std::map<int, Combat::FighterBoutInfo> Combat::ResolveFighterBouts(std::shared_ptr<const Ship> ship,
+                                                           const Condition::Condition* combat_targets,
+                                                   int bay_capacity, int current_docked,
+                                                   float fighter_damage, int limit_to_bout)
+{
+        // FIXME this should be moved to combat probably
+        std::map<int, FighterBoutInfo> retval;
+        const int NUM_BOUTS = GetGameRules().Get<int>("RULE_NUM_COMBAT_ROUNDS");
+        int target_bout = limit_to_bout < 1 ? NUM_BOUTS : limit_to_bout;
+
+        ScriptingContext context = CombatContextWithShipTarget(ship);
+
+        for (int bout = 1; bout <= target_bout; ++bout) {
+            context.combat_bout = bout;
+            // init current fighters
+            if (bout == 1) {
+                retval[bout].qty.docked = current_docked;
+                retval[bout].qty.attacking = 0;
+                retval[bout].qty.launched = 0;
+            } else {
+                retval[bout].qty = retval[bout - 1].qty;
+                retval[bout].qty.attacking += retval[bout].qty.launched;
+                retval[bout].qty.launched = 0;
+                retval[bout].total_damage = retval[bout - 1].total_damage;
+            }
+            // calc damage this bout, apply to total
+            int shots_this_bout = retval[bout].qty.attacking;
+            if (combat_targets && !combat_targets->Eval(context, context.effect_target)) {
+                shots_this_bout = 0;
+            }
+            retval[bout].damage = shots_this_bout * fighter_damage;
+            retval[bout].total_damage += retval[bout].damage;
+            // launch fighters
+            if (bout < NUM_BOUTS) {
+                retval[bout].qty.launched = std::min(bay_capacity, retval[bout].qty.docked);
+                retval[bout].qty.docked -= retval[bout].qty.launched;
+            }
+        }
+        return retval;
+}
+
+int Combat::TotalFighterShots(const ScriptingContext& context, const Ship& ship, const Condition::Condition* sampling_condition)
+{
+
+    // Iterate over context, but change bout number
+    // XXX probably should rather take ship ID as argument as well
+    // XXX else i get a fighter and have to fetch me the launching ship from that
+    ScriptingContext mut_context(context);
+    int launch_capacity = ship.SumCurrentPartMeterValuesForPartClass(MeterType::METER_CAPACITY, ShipPartClass::PC_FIGHTER_BAY);
+    int hangar_fighters = ship.SumCurrentPartMeterValuesForPartClass(MeterType::METER_CAPACITY, ShipPartClass::PC_FIGHTER_HANGAR);
+    int launched_fighters = 0;
+    int shots_total = 0;
+    Condition::ObjectSet condition_matches;
+
+    for (int bout = 1; bout <= GetGameRules().Get<int>("RULE_NUM_COMBAT_ROUNDS"); ++bout) {
+        mut_context.combat_bout = bout;
+        int launch_this_bout = std::min(launch_capacity,hangar_fighters);
+        int shots_this_bout = launched_fighters;
+        if (sampling_condition && launched_fighters > 0) {
+            // check if not shooting
+            condition_matches.clear();
+            sampling_condition->Eval(mut_context, condition_matches);
+            if (condition_matches.size() == 0) {
+                shots_this_bout = 0;
+            }
+        }
+        shots_total += shots_this_bout;
+        launched_fighters += launch_this_bout;
+        hangar_fighters -= launch_this_bout;
+    }
+
+    return shots_total;
+}

--- a/combat/CombatDamage.cpp
+++ b/combat/CombatDamage.cpp
@@ -35,11 +35,16 @@ namespace {
         return ScriptingContext{source, target};
     }
 
-    std::vector<float> WeaponDamageCalcImpl(std::shared_ptr<const Ship> ship, const ShipDesign* design,
-                                            bool max, bool include_fighters, bool target_ships, const ScriptingContext&& context) {
+    std::vector<float> WeaponDamageCalcImpl(std::shared_ptr<const Ship> ship, bool max, bool include_fighters,
+                                            bool target_ships, const ScriptingContext&& context) {
         std::vector<float> retval;
-        if (!ship || !design)
+        if (!ship)
             return retval;
+
+        const ShipDesign* design = ship->Design();
+        if (!design)
+            return retval;
+
         const std::vector<std::string>& parts = design->Parts();
         if (parts.empty())
             return retval;
@@ -121,13 +126,13 @@ namespace {
     }
 }
 
-std::vector<float> Combat::WeaponDamageImpl(std::shared_ptr<const Ship> ship, const ShipDesign* design,
-                                            float shields, bool max, bool include_fighters, bool target_ships)
+std::vector<float> Combat::WeaponDamageImpl(std::shared_ptr<const Ship> source, float shields,
+                                            bool max, bool launch_fighters, bool target_ships)
 {
     if (target_ships)
-        return WeaponDamageCalcImpl(ship, design, max, include_fighters, target_ships, CombatContextWithShipTarget(ship, shields));
+        return WeaponDamageCalcImpl(source, max, launch_fighters, target_ships, CombatContextWithShipTarget(source, shields));
     else
-        return WeaponDamageCalcImpl(ship, design, max, include_fighters, target_ships, CombatContextWithFighterTarget(ship));
+        return WeaponDamageCalcImpl(source, max, launch_fighters, target_ships, CombatContextWithFighterTarget(source));
 }
 
 

--- a/combat/CombatDamage.cpp
+++ b/combat/CombatDamage.cpp
@@ -139,11 +139,10 @@ std::vector<float> Combat::WeaponDamageImpl(std::shared_ptr<const Ship> source, 
 
 /** Populate fighter state quantities and damages for each combat round until @p limit_to_bout */
 std::map<int, Combat::FighterBoutInfo> Combat::ResolveFighterBouts(std::shared_ptr<const Ship> ship,
-                                                           const Condition::Condition* combat_targets,
-                                                   int bay_capacity, int current_docked,
-                                                   float fighter_damage, int limit_to_bout)
+                                                                   const Condition::Condition* combat_targets,
+                                                                   int bay_capacity, int current_docked,
+                                                                   float fighter_damage, int limit_to_bout)
 {
-        // FIXME this should be moved to combat probably
         std::map<int, FighterBoutInfo> retval;
         const int NUM_BOUTS = GetGameRules().Get<int>("RULE_NUM_COMBAT_ROUNDS");
         int target_bout = limit_to_bout < 1 ? NUM_BOUTS : limit_to_bout;
@@ -183,8 +182,6 @@ int Combat::TotalFighterShots(const ScriptingContext& context, const Ship& ship,
 {
 
     // Iterate over context, but change bout number
-    // XXX probably should rather take ship ID as argument as well
-    // XXX else i get a fighter and have to fetch me the launching ship from that
     ScriptingContext mut_context(context);
     int launch_capacity = ship.SumCurrentPartMeterValuesForPartClass(MeterType::METER_CAPACITY, ShipPartClass::PC_FIGHTER_BAY);
     int hangar_fighters = ship.SumCurrentPartMeterValuesForPartClass(MeterType::METER_CAPACITY, ShipPartClass::PC_FIGHTER_HANGAR);

--- a/combat/CombatDamage.cpp
+++ b/combat/CombatDamage.cpp
@@ -20,7 +20,7 @@ namespace {
         auto target = std::make_shared<Ship>(ALL_EMPIRES, source->DesignID(), source->SpeciesName());
         // target needs to have an ID != -1 to be visible, stealth should be low enough
         // structure must be higher than zero to be valid target
-        target->SetID(-1000000); // XXX magic number AutoresolveInfo.next_fighter_id starts at -1000001 counting down
+        target->SetID(TEMPORARY_OBJECT_ID); // also see InsertTemp function usage
         target->GetMeter(MeterType::METER_STRUCTURE)->Set(100.0f, 100.0f);
         target->GetMeter(MeterType::METER_MAX_STRUCTURE)->Set(100.0f, 100.0f);
         // Shield value is used for structural damage estimation
@@ -32,7 +32,7 @@ namespace {
     ScriptingContext CombatContextWithFighterTarget(std::shared_ptr<const Ship> source)
     {
         auto target = std::make_shared<Fighter>();
-        target->SetID(-1000000); // XXX magic number AutoresolveInfo.next_fighter_id starts at -1000001 counting down
+        target->SetID(TEMPORARY_OBJECT_ID);
         GetUniverse().SetEmpireObjectVisibility(source->Owner(), target->ID(), Visibility::VIS_FULL_VISIBILITY);
         return ScriptingContext{source, target};
     }

--- a/combat/CombatDamage.cpp
+++ b/combat/CombatDamage.cpp
@@ -71,9 +71,9 @@ namespace {
             // get the attack power for each weapon part.
             if (part_class == ShipPartClass::PC_DIRECT_WEAPON) {
                 if (target_ships)
-                    retval.emplace_back(ship->WeaponPartShipDamage(part, context));
+                    retval.push_back(ship->WeaponPartShipDamage(part, context));
                 else
-                    retval.emplace_back(ship->WeaponPartFighterDamage(part, context));
+                    retval.push_back(ship->WeaponPartFighterDamage(part, context));
             } else if (part_class == ShipPartClass::PC_FIGHTER_BAY && include_fighters) {
                 // launch capacity determined by capacity of bay
                 fighter_launch_capacity += static_cast<int>(ship->CurrentPartMeterValue(METER, part_name));
@@ -82,11 +82,11 @@ namespace {
                 // attack strength of a ship's fighters per bout determined by the hangar...
                 // assuming all hangars on a ship are the same part type...
                 if (target_ships && part->TotalShipDamage()) {
-                    retval.emplace_back(part->TotalShipDamage()->Eval(context));
+                    retval.push_back(part->TotalShipDamage()->Eval(context));
                     // as TotalShipDamage contains the damage from all fighters, do not further include fighter
                     include_fighters = false;
                 } else if (part->TotalFighterDamage() && !target_ships) {
-                    retval.emplace_back(part->TotalFighterDamage()->Eval(context));
+                    retval.push_back(part->TotalFighterDamage()->Eval(context));
                     // as TotalFighterDamage contains the damage from all fighters, do not further include fighter
                     include_fighters = false;
                 } else if (part->CombatTargets() && context.effect_target && part->CombatTargets()->Eval(context, context.effect_target)) {
@@ -122,9 +122,9 @@ namespace {
         fighter_damage = std::max(0.0f, fighter_damage);
 
         if (target_ships)
-            retval.emplace_back(fighter_damage * fighter_shots);
+            retval.push_back(fighter_damage * fighter_shots);
         else
-            retval.emplace_back((float)fighter_shots);
+            retval.push_back((float)fighter_shots);
         return retval;
     }
 }

--- a/combat/CombatDamage.cpp
+++ b/combat/CombatDamage.cpp
@@ -153,17 +153,18 @@ std::map<int, Combat::FighterBoutInfo> Combat::ResolveFighterBouts(std::shared_p
             context.combat_bout = bout;
             // init current fighters
             if (bout == 1) {
-                retval[bout].qty.docked = current_docked;
-                retval[bout].qty.attacking = 0;
-                retval[bout].qty.launched = 0;
+                retval[bout].docked = current_docked;
+                retval[bout].attacking = 0;
+                retval[bout].launched = 0;
             } else {
-                retval[bout].qty = retval[bout - 1].qty;
-                retval[bout].qty.attacking += retval[bout].qty.launched;
-                retval[bout].qty.launched = 0;
+                retval[bout] = retval[bout - 1];
+                retval[bout].docked = retval[bout - 1].docked;
+                retval[bout].attacking = retval[bout - 1].attacking + retval[bout].launched;
+                retval[bout].launched = 0;
                 retval[bout].total_damage = retval[bout - 1].total_damage;
             }
             // calc damage this bout, apply to total
-            int shots_this_bout = retval[bout].qty.attacking;
+            int shots_this_bout = retval[bout].attacking;
             if (combat_targets && !combat_targets->Eval(context, context.effect_target)) {
                 shots_this_bout = 0;
             }
@@ -171,8 +172,8 @@ std::map<int, Combat::FighterBoutInfo> Combat::ResolveFighterBouts(std::shared_p
             retval[bout].total_damage += retval[bout].damage;
             // launch fighters
             if (bout < NUM_BOUTS) {
-                retval[bout].qty.launched = std::min(bay_capacity, retval[bout].qty.docked);
-                retval[bout].qty.docked -= retval[bout].qty.launched;
+                retval[bout].launched = std::min(bay_capacity, retval[bout].docked);
+                retval[bout].docked -= retval[bout].launched;
             }
         }
         return retval;

--- a/combat/CombatDamage.cpp
+++ b/combat/CombatDamage.cpp
@@ -93,9 +93,7 @@ namespace {
                     fighter_damage = ship->CurrentPartMeterValue(SECONDARY_METER, part_name);
                     available_fighters = std::max(0, static_cast<int>(ship->CurrentPartMeterValue(METER, part_name)));  // stacked meter
                 } else {
-                    std::vector<const Condition::Condition*> target_conditions;
-                    target_conditions.push_back(part->CombatTargets());
-                    // target is not of the right type
+                    // target is not of the right type; no damage; stop checking hangars/launch bays
                     fighter_damage = 0.0f;
                     include_fighters = false;
                 }

--- a/combat/CombatDamage.cpp
+++ b/combat/CombatDamage.cpp
@@ -122,7 +122,7 @@ namespace {
         if (target_ships)
             retval.push_back(fighter_damage * fighter_shots);
         else
-            retval.push_back((float)fighter_shots);
+            retval.push_back(fighter_shots);
         return retval;
     }
 }

--- a/combat/CombatDamage.cpp
+++ b/combat/CombatDamage.cpp
@@ -14,7 +14,8 @@
 // damage calculation (shortrange, fighters, shields)
 
 namespace {
-    ScriptingContext CombatContextWithShipTarget(std::shared_ptr<const Ship> source, float shields = 0.0f) {
+    ScriptingContext CombatContextWithShipTarget(std::shared_ptr<const Ship> source, float shields = 0.0f)
+    {
         // use the given design and species as default enemy. at least those least exists
         auto target = std::make_shared<Ship>(ALL_EMPIRES, source->DesignID(), source->SpeciesName());
         // target needs to have an ID != -1 to be visible, stealth should be low enough
@@ -28,7 +29,8 @@ namespace {
         return ScriptingContext{source, target};
     }
 
-    ScriptingContext CombatContextWithFighterTarget(std::shared_ptr<const Ship> source) {
+    ScriptingContext CombatContextWithFighterTarget(std::shared_ptr<const Ship> source)
+    {
         auto target = std::make_shared<Fighter>();
         target->SetID(-1000000); // XXX magic number AutoresolveInfo.next_fighter_id starts at -1000001 counting down
         GetUniverse().SetEmpireObjectVisibility(source->Owner(), target->ID(), Visibility::VIS_FULL_VISIBILITY);
@@ -36,7 +38,8 @@ namespace {
     }
 
     std::vector<float> WeaponDamageCalcImpl(std::shared_ptr<const Ship> ship, bool max, bool include_fighters,
-                                            bool target_ships, const ScriptingContext&& context) {
+                                            bool target_ships, const ScriptingContext&& context)
+    {
         std::vector<float> retval;
         if (!ship)
             return retval;

--- a/combat/CombatDamage.cpp
+++ b/combat/CombatDamage.cpp
@@ -29,14 +29,14 @@ namespace {
         // Shield value is used for structural damage estimation
         target->GetMeter(MeterType::METER_SHIELD)->Set(shields,shields);
         GetUniverse().SetEmpireObjectVisibility(source->Owner(), target->ID(), Visibility::VIS_FULL_VISIBILITY);
-        return ScriptingContext(source, target);
+        return ScriptingContext{source, target};
     }
 
     ScriptingContext CombatContextWithFighterTarget(std::shared_ptr<const Ship> source) {
         auto target = std::make_shared<Fighter>();
         target->SetID(-1000000); // XXX magic number AutoresolveInfo.next_fighter_id starts at -1000001 counting down
         GetUniverse().SetEmpireObjectVisibility(source->Owner(), target->ID(), Visibility::VIS_FULL_VISIBILITY);
-        return ScriptingContext(source, target);
+        return ScriptingContext{source, target};
     }
 
     std::vector<float> WeaponDamageCalcImpl(std::shared_ptr<const Ship> ship, const ShipDesign* design,

--- a/combat/CombatDamage.cpp
+++ b/combat/CombatDamage.cpp
@@ -178,6 +178,7 @@ std::map<int, Combat::FighterBoutInfo> Combat::ResolveFighterBouts(std::shared_p
         return retval;
 }
 
+/** Returns max number of shots a carrier's fighters in a battle. Evals @p sampling_condition for each bout vs @p context */
 int Combat::TotalFighterShots(const ScriptingContext& context, const Ship& ship, const Condition::Condition* sampling_condition)
 {
 

--- a/combat/CombatDamage.cpp
+++ b/combat/CombatDamage.cpp
@@ -23,7 +23,7 @@ namespace {
         target->GetMeter(MeterType::METER_STRUCTURE)->Set(100.0f, 100.0f);
         target->GetMeter(MeterType::METER_MAX_STRUCTURE)->Set(100.0f, 100.0f);
         // Shield value is used for structural damage estimation
-        target->GetMeter(MeterType::METER_SHIELD)->Set(shields,shields);
+        target->GetMeter(MeterType::METER_SHIELD)->Set(shields, shields);
         GetUniverse().SetEmpireObjectVisibility(source->Owner(), target->ID(), Visibility::VIS_FULL_VISIBILITY);
         return ScriptingContext{source, target};
     }

--- a/combat/CombatDamage.h
+++ b/combat/CombatDamage.h
@@ -8,14 +8,11 @@
 namespace Combat {
     /** Container for return values of ResolveFighterBouts */
     struct FighterBoutInfo {
-        struct StateQty {
-            int         docked;
-            int         attacking;
-            int         launched;       // transitioning between docked and attacking
-        };
-        float           damage;
-        float           total_damage;   // damage from all previous bouts, including this bout
-        StateQty        qty;
+        float damage       = 0;
+        float total_damage = 0;  // damage from all previous bouts, including this bout
+        int docked    = 0;
+        int attacking = 0;
+        int launched  = 0;       // transitioning between docked and attacking
     };
 
     /** Populate fighter state quantities and damages for each combat round until @p limit_to_bout */

--- a/combat/CombatDamage.h
+++ b/combat/CombatDamage.h
@@ -1,0 +1,35 @@
+#ifndef _CombatDamage_h_
+#define _CombatDamage_h_
+
+#include "../universe/Condition.h"
+#include "../universe/EnumsFwd.h"
+#include "../universe/Ship.h"
+
+namespace Combat {
+    /** Container for return values of ResolveFighterBouts */
+    struct FighterBoutInfo {
+        struct StateQty {
+            int         docked;
+            int         attacking;
+            int         launched;       // transitioning between docked and attacking
+        };
+        float           damage;
+        float           total_damage;   // damage from all previous bouts, including this bout
+        StateQty        qty;
+    };
+
+    /** Populate fighter state quantities and damages for each combat round until @p limit_to_bout */
+    FO_COMMON_API std::map<int, FighterBoutInfo> ResolveFighterBouts(std::shared_ptr<const Ship> ship,
+                                                               const Condition::Condition* combat_targets,
+                                                               int bay_capacity, int current_docked,
+                                                               float fighter_damage, int limit_to_bout = -1);
+
+    FO_COMMON_API int TotalFighterShots(const ScriptingContext& context, const Ship& ship, const Condition::Condition* sampling_condition);
+
+    FO_COMMON_API std::vector<float> WeaponDamageImpl(std::shared_ptr<const Ship> ship, const ShipDesign* design,
+                                                      float DR, bool max, bool include_fighters, bool target_ships = true);
+
+
+}
+
+#endif

--- a/combat/CombatDamage.h
+++ b/combat/CombatDamage.h
@@ -20,9 +20,9 @@ namespace Combat {
 
     /** Populate fighter state quantities and damages for each combat round until @p limit_to_bout */
     FO_COMMON_API std::map<int, FighterBoutInfo> ResolveFighterBouts(std::shared_ptr<const Ship> ship,
-                                                               const Condition::Condition* combat_targets,
-                                                               int bay_capacity, int current_docked,
-                                                               float fighter_damage, int limit_to_bout = -1);
+                                                                     const Condition::Condition* combat_targets,
+                                                                     int bay_capacity, int current_docked,
+                                                                     float fighter_damage, int limit_to_bout = -1);
 
     FO_COMMON_API int TotalFighterShots(const ScriptingContext& context, const Ship& ship, const Condition::Condition* sampling_condition);
 

--- a/combat/CombatDamage.h
+++ b/combat/CombatDamage.h
@@ -24,6 +24,10 @@ namespace Combat {
                                                                      int bay_capacity, int current_docked,
                                                                      float fighter_damage, int limit_to_bout = -1);
 
+    /** Returns the maximum number of shots the fighters launched by carrier @p ship shoot in a battle.
+     * If a @p sampling_condition is given, shots are counted for a bout iff the @p sampling_condition evals to true
+     * in the given @p context.
+     * Note that a copy of the context modified with current combat bout is used so the @p sampling_condition can consider the bout */
     FO_COMMON_API int TotalFighterShots(const ScriptingContext& context, const Ship& ship, const Condition::Condition* sampling_condition);
 
     FO_COMMON_API std::vector<float> WeaponDamageImpl(std::shared_ptr<const Ship> ship, float target_shields, bool use_max_meters,

--- a/combat/CombatDamage.h
+++ b/combat/CombatDamage.h
@@ -26,8 +26,8 @@ namespace Combat {
 
     FO_COMMON_API int TotalFighterShots(const ScriptingContext& context, const Ship& ship, const Condition::Condition* sampling_condition);
 
-    FO_COMMON_API std::vector<float> WeaponDamageImpl(std::shared_ptr<const Ship> ship, const ShipDesign* design,
-                                                      float DR, bool max, bool include_fighters, bool target_ships = true);
+    FO_COMMON_API std::vector<float> WeaponDamageImpl(std::shared_ptr<const Ship> ship, float target_shields, bool use_max_meters,
+                                                      bool launch_fighters, bool target_ships = true);
 
 
 }

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -586,7 +586,7 @@ namespace {
     {
         float power = weapon.part_attack;
 
-        if (attacker->TotalWeaponsDamage(0.0f, false) > 0.0f) {
+        if (power > 0.0f) {
             // any damage is enough to kill any fighter
             DebugLogger(combat) << "COMBAT: " << attacker->Name() << " of empire " << attacker->Owner()
                                 << " (" << attacker->ID() << ") does " << power

--- a/default/scripting/common/named_values.focs.txt
+++ b/default/scripting/common/named_values.focs.txt
@@ -18,6 +18,9 @@ NamedInteger name = "FIRST_COMBAT_ROUND_IN_CLOSE_TARGETING_RANGE" value = (GameR
 
 NamedReal name = "AUGMENTATION_FULL_GROWTH_INFRASTRUCTURE_REQUIREMENT" value = 40.0
 
+// For calculation we mostly need a real value
+NamedReal name = "NUM_REAL_COMBAT_ROUNDS_IN_CLOSE_TARGETING_RANGE" value = (GameRule name = "RULE_NUM_COMBAT_ROUNDS") - (GameRule name = "RULE_FIRST_COMBAT_ROUND_IN_CLOSE_TARGETING_RANGE") + 1
+
 NamedInteger name = "MIN_COLONY_SIZE" value = [[MIN_RECOLONIZING_SIZE]]
 
 NamedInteger name = "MIN_COLONY_HAPPINESS" value = [[MIN_RECOLONIZING_HAPPINESS]]

--- a/default/scripting/empire_statistics/MILITARY_STRENGTH.focs.txt
+++ b/default/scripting/empire_statistics/MILITARY_STRENGTH.focs.txt
@@ -1,12 +1,21 @@
 Statistic name = "MILITARY_STRENGTH_STAT" value =
     // Damage prevention by shields: each shield is hit twice and a half times by non-shield-piercing weapons.
-    //   as a shield usefulness scales with structure, we "split" the effect and put part of it on the damage side
+    //   Or often it prevents a third of the damage (going against similar tech level direct weapons)
+    //   as a shield usefulness scales with structure, we "split" the effect into a relative and an absolute part
     // Damage prevention by shooting down fighters: each part shot prevents 2/3 of a hit by a laser fighter (4+2 base damage) in bout two.
     //     With four bouts a bomber destructed in bout two prevents 2 bomber shots, but flak and interceptors are usually idle 2/3 of their total destruction estimation so that evens out
     //     Usefulness of most anti-fighter weapons scales with the number of enemy fighters
     // Note that weapons targeting fighters and ships will be counted twice (once for doing structural damage, once for preventing fighter damage)
-    Statistic Sum value = ((LocalCandidate.DamageStructurePerBattleMax + 1.5 * LocalCandidate.MaxShield)
-                         * (LocalCandidate.Structure + LocalCandidate.MaxShield + ([[FIGHTER_DAMAGE_FACTOR]] * 4 * LocalCandidate.DestroyFightersPerBattleMax)))
+    Statistic Sum value = LocalCandidate.DamageStructurePerBattleMax
+        condition = And [
+            Ship
+            OwnedBy empire = Source.Owner
+        ]
+    *
+    Statistic Sum value = (LocalCandidate.Structure
+                          + ([[FIGHTER_DAMAGE_FACTOR]] * 4 * LocalCandidate.DestroyFightersPerBattleMax)
+                          + (1.5 * LocalCandidate.MaxShield)
+                          + (max(LocalCandidate.MaxShield,0.0) * LocalCandidate.Structure / 4))
         condition = And [
             Ship
             OwnedBy empire = Source.Owner

--- a/default/scripting/empire_statistics/MILITARY_STRENGTH.focs.txt
+++ b/default/scripting/empire_statistics/MILITARY_STRENGTH.focs.txt
@@ -1,6 +1,15 @@
 Statistic name = "MILITARY_STRENGTH_STAT" value =
-    Statistic Sum value = (LocalCandidate.Attack * (LocalCandidate.Structure + 2 * LocalCandidate.MaxShield))
+    // Damage prevention by shields: each shield is hit twice and a half times by non-shield-piercing weapons.
+    //   as a shield usefulness scales with structure, we "split" the effect and put part of it on the damage side
+    // Damage prevention by shooting down fighters: each part shot prevents 2/3 of a hit by a laser fighter (4+2 base damage) in bout two.
+    //     With four bouts a bomber destructed in bout two prevents 2 bomber shots, but flak and interceptors are usually idle 2/3 of their total destruction estimation so that evens out
+    //     Usefulness of most anti-fighter weapons scales with the number of enemy fighters
+    // Note that weapons targeting fighters and ships will be counted twice (once for doing structural damage, once for preventing fighter damage)
+    Statistic Sum value = ((LocalCandidate.TotalShipDamageEstimation + 1.5 * LocalCandidate.MaxShield)
+                         * (LocalCandidate.Structure + LocalCandidate.MaxShield + ([[FIGHTER_DAMAGE_FACTOR]] * 4 * LocalCandidate.TotalFighterDamageEstimation)))
         condition = And [
             Ship
             OwnedBy empire = Source.Owner
         ]
+
+#include "/scripting/common/misc.macros"

--- a/default/scripting/empire_statistics/MILITARY_STRENGTH.focs.txt
+++ b/default/scripting/empire_statistics/MILITARY_STRENGTH.focs.txt
@@ -5,8 +5,8 @@ Statistic name = "MILITARY_STRENGTH_STAT" value =
     //     With four bouts a bomber destructed in bout two prevents 2 bomber shots, but flak and interceptors are usually idle 2/3 of their total destruction estimation so that evens out
     //     Usefulness of most anti-fighter weapons scales with the number of enemy fighters
     // Note that weapons targeting fighters and ships will be counted twice (once for doing structural damage, once for preventing fighter damage)
-    Statistic Sum value = ((LocalCandidate.TotalShipDamageEstimation + 1.5 * LocalCandidate.MaxShield)
-                         * (LocalCandidate.Structure + LocalCandidate.MaxShield + ([[FIGHTER_DAMAGE_FACTOR]] * 4 * LocalCandidate.TotalFighterDamageEstimation)))
+    Statistic Sum value = ((LocalCandidate.DamageStructurePerBattleMax + 1.5 * LocalCandidate.MaxShield)
+                         * (LocalCandidate.Structure + LocalCandidate.MaxShield + ([[FIGHTER_DAMAGE_FACTOR]] * 4 * LocalCandidate.DestroyFightersPerBattleMax)))
         condition = And [
             Ship
             OwnedBy empire = Source.Owner

--- a/default/scripting/ship_parts/ShortRange/SR_GRAV_PULSE.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_GRAV_PULSE.focs.txt
@@ -4,6 +4,10 @@ Part
     class = ShortRange
     damage = 1
     shots = 12
+    totalFighterDamageEstimation = ShipPartMeter part = "SR_GRAV_PULSE" meter = SecondaryStat object = Source.ID
+    totalShipDamageEstimation    =
+        max(0,ShipPartMeter part = "SR_GRAV_PULSE" meter = Capacity object = Source.ID - Value(Target.Shield))
+        * ShipPartMeter part = "SR_GRAV_PULSE" meter = SecondaryStat object = Source.ID
     combatTargets = And [
         (CombatBout = 2)
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]

--- a/default/scripting/ship_parts/ShortRange/SR_GRAV_PULSE.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_GRAV_PULSE.focs.txt
@@ -4,8 +4,8 @@ Part
     class = ShortRange
     damage = 1
     shots = 12
-    totalFighterDamageEstimation = ShipPartMeter part = "SR_GRAV_PULSE" meter = SecondaryStat object = Source.ID
-    totalShipDamageEstimation    =
+    destroyFightersPerBattleMax = ShipPartMeter part = "SR_GRAV_PULSE" meter = SecondaryStat object = Source.ID
+    damageStructurePerBattleMax =
         max(0,ShipPartMeter part = "SR_GRAV_PULSE" meter = Capacity object = Source.ID - Value(Target.Shield))
         * ShipPartMeter part = "SR_GRAV_PULSE" meter = SecondaryStat object = Source.ID
     combatTargets = And [

--- a/default/scripting/ship_parts/ShortRange/SR_JAWS.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_JAWS.focs.txt
@@ -3,8 +3,8 @@ Part
     description = "SR_JAWS_DESC"
     class = ShortRange
     damage = 10
-    totalFighterDamageEstimation = 0
-    totalShipDamageEstimation =
+    destroyFightersPerBattleMax = 0
+    damageStructurePerBattleMax =
         max(0,ShipPartMeter part = "SR_JAWS" meter = Capacity object = Source.ID - Value(Target.Shield))
         * ShipPartMeter part = "SR_JAWS" meter = SecondaryStat object = Source.ID
         * NamedRealLookup name = "NUM_REAL_COMBAT_ROUNDS_IN_CLOSE_TARGETING_RANGE"

--- a/default/scripting/ship_parts/ShortRange/SR_JAWS.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_JAWS.focs.txt
@@ -3,6 +3,11 @@ Part
     description = "SR_JAWS_DESC"
     class = ShortRange
     damage = 10
+    totalFighterDamageEstimation = 0
+    totalShipDamageEstimation =
+        max(0,ShipPartMeter part = "SR_JAWS" meter = Capacity object = Source.ID - Value(Target.Shield))
+        * ShipPartMeter part = "SR_JAWS" meter = SecondaryStat object = Source.ID
+        * NamedRealLookup name = "NUM_REAL_COMBAT_ROUNDS_IN_CLOSE_TARGETING_RANGE"
     combatTargets = And [
         (CombatBout >= NamedIntegerLookup name = "FIRST_COMBAT_ROUND_IN_CLOSE_TARGETING_RANGE")
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
@@ -20,5 +25,6 @@ Part
 
 #include "shortrange.macros"
 
+#include "/scripting/common/misc.macros"
 #include "/scripting/common/upkeep.macros"
 #include "/scripting/ship_parts/targeting.macros"

--- a/default/scripting/ship_parts/ShortRange/SR_SPINAL_ANTIMATTER.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_SPINAL_ANTIMATTER.focs.txt
@@ -3,6 +3,7 @@ Part
     description = "SR_SPINAL_ANTIMATTER_DESC"
     class = ShortRange
     damage = 100
+    totalFighterDamageEstimation = 0
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
         Or [

--- a/default/scripting/ship_parts/ShortRange/SR_SPINAL_ANTIMATTER.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_SPINAL_ANTIMATTER.focs.txt
@@ -3,7 +3,7 @@ Part
     description = "SR_SPINAL_ANTIMATTER_DESC"
     class = ShortRange
     damage = 100
-    totalFighterDamageEstimation = 0
+    destroyFightersPerBattleMax = 0
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
         Or [

--- a/default/scripting/ship_parts/ShortRange/SR_SPINES.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_SPINES.focs.txt
@@ -3,8 +3,8 @@ Part
     description = "SR_SPINES_DESC"
     class = ShortRange
     damage = 40
-    totalFighterDamageEstimation = 0
-    totalShipDamageEstimation =
+    destroyFightersPerBattleMax = 0
+    damageStructurePerBattleMax =
         max(0,ShipPartMeter part = "SR_SPINES" meter = Capacity object = Source.ID - Value(Target.Shield))
         * ShipPartMeter part = "SR_SPINES" meter = SecondaryStat object = Source.ID
         * NamedRealLookup name = "NUM_REAL_COMBAT_ROUNDS_IN_CLOSE_TARGETING_RANGE"

--- a/default/scripting/ship_parts/ShortRange/SR_SPINES.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_SPINES.focs.txt
@@ -3,6 +3,11 @@ Part
     description = "SR_SPINES_DESC"
     class = ShortRange
     damage = 40
+    totalFighterDamageEstimation = 0
+    totalShipDamageEstimation =
+        max(0,ShipPartMeter part = "SR_SPINES" meter = Capacity object = Source.ID - Value(Target.Shield))
+        * ShipPartMeter part = "SR_SPINES" meter = SecondaryStat object = Source.ID
+        * NamedRealLookup name = "NUM_REAL_COMBAT_ROUNDS_IN_CLOSE_TARGETING_RANGE"
     combatTargets = And [
         (CombatBout >= NamedIntegerLookup name = "FIRST_COMBAT_ROUND_IN_CLOSE_TARGETING_RANGE")
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]

--- a/default/scripting/ship_parts/ShortRange/SR_TENTACLE.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_TENTACLE.focs.txt
@@ -4,8 +4,8 @@ Part
     class = ShortRange
     damage = 5
     shots = 2
-    // totalFighterDamageEstimation = default, can shoot fighters starting from bout 2
-    totalShipDamageEstimation =
+    // destroyFightersPerBattleMax = default, can shoot fighters starting from bout 2
+    damageStructurePerBattleMax =
         max(0,ShipPartMeter part = "SR_TENTACLE" meter = Capacity object = Source.ID - Value(Target.Shield))
         * ShipPartMeter part = "SR_TENTACLE" meter = SecondaryStat object = Source.ID
         * NamedRealLookup name = "NUM_REAL_COMBAT_ROUNDS_IN_CLOSE_TARGETING_RANGE"

--- a/default/scripting/ship_parts/ShortRange/SR_TENTACLE.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_TENTACLE.focs.txt
@@ -4,6 +4,12 @@ Part
     class = ShortRange
     damage = 5
     shots = 2
+    // totalFighterDamageEstimation = default, can shoot fighters starting from bout 2
+    totalShipDamageEstimation =
+        max(0,ShipPartMeter part = "SR_TENTACLE" meter = Capacity object = Source.ID - Value(Target.Shield))
+        * ShipPartMeter part = "SR_TENTACLE" meter = SecondaryStat object = Source.ID
+        * NamedRealLookup name = "NUM_REAL_COMBAT_ROUNDS_IN_CLOSE_TARGETING_RANGE"
+
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
         OrderedAlternativesOf [
@@ -22,8 +28,8 @@ Part
                ]
            ]
            And [
-               // Attack fighters in bout 2
-               (CombatBout = 2)
+               // Attack fighters starting from bout 2 until FIRST_COMBAT_ROUND_IN_CLOSE_TARGETING_RANGE
+               (CombatBout >= 2)
                [[COMBAT_TARGETS_VISIBLE_ENEMY]] Fighter
            ]
         ]

--- a/default/scripting/ship_parts/ShortRange/SR_THRASHING_BODY.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_THRASHING_BODY.focs.txt
@@ -4,10 +4,10 @@ Part
     class = ShortRange
     damage = 1
     shots = 10
-    totalFighterDamageEstimation =
+    destroyFightersPerBattleMax =
         ShipPartMeter part = "SR_THRASHING_BODY" meter = SecondaryStat object = Source.ID
         * NamedRealLookup name = "NUM_REAL_COMBAT_ROUNDS_IN_CLOSE_TARGETING_RANGE"
-    totalShipDamageEstimation =
+    damageStructurePerBattleMax =
         max(0,ShipPartMeter part = "SR_THRASHING_BODY" meter = Capacity object = Source.ID - Value(Target.Shield))
         * ShipPartMeter part = "SR_THRASHING_BODY" meter = SecondaryStat object = Source.ID
         * NamedRealLookup name = "NUM_REAL_COMBAT_ROUNDS_IN_CLOSE_TARGETING_RANGE"

--- a/default/scripting/ship_parts/ShortRange/SR_THRASHING_BODY.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_THRASHING_BODY.focs.txt
@@ -4,6 +4,13 @@ Part
     class = ShortRange
     damage = 1
     shots = 10
+    totalFighterDamageEstimation =
+        ShipPartMeter part = "SR_THRASHING_BODY" meter = SecondaryStat object = Source.ID
+        * NamedRealLookup name = "NUM_REAL_COMBAT_ROUNDS_IN_CLOSE_TARGETING_RANGE"
+    totalShipDamageEstimation =
+        max(0,ShipPartMeter part = "SR_THRASHING_BODY" meter = Capacity object = Source.ID - Value(Target.Shield))
+        * ShipPartMeter part = "SR_THRASHING_BODY" meter = SecondaryStat object = Source.ID
+        * NamedRealLookup name = "NUM_REAL_COMBAT_ROUNDS_IN_CLOSE_TARGETING_RANGE"
     combatTargets = And [
         (CombatBout >= NamedIntegerLookup name = "FIRST_COMBAT_ROUND_IN_CLOSE_TARGETING_RANGE")
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_0_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_0_1.focs.txt
@@ -5,7 +5,7 @@ Part
     damage = 1
     shots = 3
     NoDefaultCapacityEffect
-    totalShipDamageEstimation = 0
+    damageStructurePerBattleMax = 0
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
         Fighter

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_0_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_0_1.focs.txt
@@ -5,6 +5,7 @@ Part
     damage = 1
     shots = 3
     NoDefaultCapacityEffect
+    totalShipDamageEstimation = 0
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
         Fighter

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_1_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_1_1.focs.txt
@@ -4,6 +4,7 @@ Part
     class = ShortRange
     damage = 3
     NoDefaultCapacityEffect
+    totalFighterDamageEstimation = 0
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
         Or [

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_1_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_1_1.focs.txt
@@ -4,7 +4,7 @@ Part
     class = ShortRange
     damage = 3
     NoDefaultCapacityEffect
-    totalFighterDamageEstimation = 0
+    destroyFightersPerBattleMax = 0
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
         Or [

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_2_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_2_1.focs.txt
@@ -4,7 +4,7 @@ Part
     class = ShortRange
     damage = 5
     NoDefaultCapacityEffect
-    totalFighterDamageEstimation = 0
+    destroyFightersPerBattleMax = 0
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
         Or [

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_2_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_2_1.focs.txt
@@ -4,6 +4,7 @@ Part
     class = ShortRange
     damage = 5
     NoDefaultCapacityEffect
+    totalFighterDamageEstimation = 0
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
         Or [

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_3_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_3_1.focs.txt
@@ -4,6 +4,7 @@ Part
     class = ShortRange
     damage = 9
     NoDefaultCapacityEffect
+    totalFighterDamageEstimation = 0
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
         Or [

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_3_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_3_1.focs.txt
@@ -4,7 +4,7 @@ Part
     class = ShortRange
     damage = 9
     NoDefaultCapacityEffect
-    totalFighterDamageEstimation = 0
+    destroyFightersPerBattleMax = 0
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
         Or [

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_4_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_4_1.focs.txt
@@ -4,6 +4,7 @@ Part
     class = ShortRange
     damage = 15
     NoDefaultCapacityEffect
+    totalFighterDamageEstimation = 0
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
         Or [

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_4_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_4_1.focs.txt
@@ -4,7 +4,7 @@ Part
     class = ShortRange
     damage = 15
     NoDefaultCapacityEffect
-    totalFighterDamageEstimation = 0
+    destroyFightersPerBattleMax = 0
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
         Or [

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3822,6 +3822,12 @@ Change
 TT_BREAKDOWN_SUMMARY
 %1%: %2%
 
+# %1% the meter name displayed.
+# %2% the meter value. (E.g. max damage against ships)
+# %3% the augmenting meter value. (E.g. max number of destroyed fighters)
+TT_BREAKDOWN_AUGMENTED_SUMMARY
+%1%: %2% / %3%
+
 TT_INHERENT
 Inherent
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5522,7 +5522,6 @@ Estimated combat strength   (<i>ignoring shields</i>):  %15$.f   (%16$.2f per PP
             (<i>enemy with attack %17$.1f and shields %18$.1f</i>):  %19$.f   (%20$.2f per PP)
 '''
 
-
 ENC_SDD_HANGAR
 [[encyclopedia PC_FIGHTER_HANGAR]] [[METER_CAPACITY]]
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6884,6 +6884,12 @@ Hull
 ATTACK
 Total Weapon Damage
 
+DAMAGE_STRUCTURE_PER_BATTLE
+Total Structure Damage per Battle
+
+DESTROY_FIGHTERS_PER_BATTLE
+Number of Destroyed Fighters per Battle
+
 PRODUCTION_COST
 Production Cost
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -4105,7 +4105,10 @@ FW_FLEET_STRUCTURE_SUMMARY
 Fleet Structure - Equal to the total structure of ships in the fleet.
 
 FW_FLEET_DAMAGE_SUMMARY
-Fleet Damage - Equal to the total direct fire damage of ships in the fleet.
+Fleet Damage - Equal to the total maximum structural damage of ships and fighters in the fleet.
+
+FW_FLEET_DESTROY_SUMMARY
+Fleet Destruction - Equal to the total maximum fighter destruction of ships and fighters in the fleet.
 
 FW_FLEET_FIGHTER_SUMMARY
 Fleet Fighters - Equal to the total fighters in the fleet.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -4108,10 +4108,10 @@ FW_FLEET_STRUCTURE_SUMMARY
 Fleet Structure - Equal to the total structure of ships in the fleet.
 
 FW_FLEET_DAMAGE_SUMMARY
-Fleet Damage - Equal to the total maximum structural damage of ships and fighters in the fleet.
+Structural Damage by Fleet - Equal to the total maximum structural damage done by ships and fighters in the fleet.
 
 FW_FLEET_DESTROY_SUMMARY
-Fleet Destruction - Equal to the total maximum fighter destruction of ships and fighters in the fleet.
+Fighter Destruction by Fleet - Equal to the total maximum of fighters destroyed by ships and fighters in the fleet.
 
 FW_FLEET_FIGHTER_SUMMARY
 Fleet Fighters - Equal to the total fighters in the fleet.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3822,12 +3822,11 @@ Change
 TT_BREAKDOWN_SUMMARY
 %1%: %2%
 
-# %1% the meter name displayed. (E.g. 'Damage')
-# %2% the meter value. (E.g. max damage against ships)
-# %3% the augmenting meter name displayed. (E.g. 'Destruction')
-# %3% the augmenting meter value. (E.g. max number of destroyed fighters)
-TT_BREAKDOWN_AUGMENTED_SUMMARY
-%1%: %2% / %3%: %4%
+# %1% the number bouts per battle
+# %2% the total estimate of structure damage
+# %3% the total estimate of destroyed fighters
+TT_DAMAGE_BREAKDOWN_SUMMARY
+Totals for %1% bout battle, Structure Damage: %2% / Fighters Destroyed: %3%
 
 TT_INHERENT
 Inherent

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3822,11 +3822,12 @@ Change
 TT_BREAKDOWN_SUMMARY
 %1%: %2%
 
-# %1% the meter name displayed.
+# %1% the meter name displayed. (E.g. 'Damage')
 # %2% the meter value. (E.g. max damage against ships)
+# %3% the augmenting meter name displayed. (E.g. 'Destruction')
 # %3% the augmenting meter value. (E.g. max number of destroyed fighters)
 TT_BREAKDOWN_AUGMENTED_SUMMARY
-%1%: %2% / %3%
+%1%: %2% / %3%: %4%
 
 TT_INHERENT
 Inherent
@@ -4063,7 +4064,10 @@ FW_ROGUE_SHIP
 Rogue Ship
 
 SHIP_DAMAGE_STAT_TITLE
-Damage
+Structural Damage
+
+SHIP_DESTRUCTION_STAT_TITLE
+Destroyed Fighters
 
 SHIP_TROOPS_TITLE
 Troops

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5512,7 +5512,7 @@ Parts: %3%
 ENC_SHIP_DESIGN_DESCRIPTION_STATS_STR
 '''
 For [[encyclopedia ENC_SPECIES]]: %1%
-Total [[encyclopedia DAMAGE_TITLE]]: %2%    [[PC_DIRECT_WEAPON]] Shots: %3%
+Total Structure [[encyclopedia DAMAGE_TITLE]]: %2%    Total Fighter Destruction: %3%
 [[metertype METER_STRUCTURE]]: %4%    [[metertype METER_SHIELD]]: %5%
 [[metertype METER_DETECTION]]: %6%    [[metertype METER_STEALTH]]: %7%
 [[metertype METER_SPEED]]: %8%    [[metertype METER_FUEL]] [[METER_CAPACITY]]: %9%
@@ -5521,6 +5521,7 @@ Colonization [[METER_CAPACITY]]: %10%    [[metertype METER_TROOPS]]: %11%
 Estimated combat strength   (<i>ignoring shields</i>):  %15$.f   (%16$.2f per PP)
             (<i>enemy with attack %17$.1f and shields %18$.1f</i>):  %19$.f   (%20$.2f per PP)
 '''
+
 
 ENC_SDD_HANGAR
 [[encyclopedia PC_FIGHTER_HANGAR]] [[METER_CAPACITY]]

--- a/msvc2017/Common/Common.vcxproj
+++ b/msvc2017/Common/Common.vcxproj
@@ -181,6 +181,7 @@
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\combat\CombatDamage.h" />
     <ClInclude Include="..\..\combat\CombatEvent.h" />
     <ClInclude Include="..\..\combat\CombatEvents.h" />
     <ClInclude Include="..\..\combat\CombatLogManager.h" />
@@ -269,6 +270,7 @@
     <ClInclude Include="StdAfx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\combat\CombatDamage.cpp" />
     <ClCompile Include="..\..\combat\CombatEvent.cpp" />
     <ClCompile Include="..\..\combat\CombatEvents.cpp" />
     <ClCompile Include="..\..\combat\CombatLogManager.cpp" />

--- a/msvc2017/Common/Common.vcxproj.filters
+++ b/msvc2017/Common/Common.vcxproj.filters
@@ -244,6 +244,9 @@
     <ClInclude Include="..\..\util\ScopedTimer.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\combat\CombatDamage.h">
+      <Filter>Header Files\combat</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\combat\CombatEvent.h">
       <Filter>Header Files\combat</Filter>
     </ClInclude>
@@ -501,6 +504,9 @@
     </ClCompile>
     <ClCompile Include="..\..\util\SaveGamePreviewUtils.cpp">
       <Filter>Source Files\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\combat\CombatDamage.cpp">
+      <Filter>Source Files\combat</Filter>
     </ClCompile>
     <ClCompile Include="..\..\combat\CombatEvents.cpp">
       <Filter>Source Files\combat</Filter>

--- a/msvc2019/Common/Common.vcxproj
+++ b/msvc2019/Common/Common.vcxproj
@@ -181,6 +181,7 @@
     </CustomBuild>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\combat\CombatDamage.h" />
     <ClInclude Include="..\..\combat\CombatEvent.h" />
     <ClInclude Include="..\..\combat\CombatEvents.h" />
     <ClInclude Include="..\..\combat\CombatLogManager.h" />
@@ -269,6 +270,7 @@
     <ClInclude Include="StdAfx.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\combat\CombatDamage.cpp" />
     <ClCompile Include="..\..\combat\CombatEvent.cpp" />
     <ClCompile Include="..\..\combat\CombatEvents.cpp" />
     <ClCompile Include="..\..\combat\CombatLogManager.cpp" />

--- a/msvc2019/Common/Common.vcxproj.filters
+++ b/msvc2019/Common/Common.vcxproj.filters
@@ -244,6 +244,9 @@
     <ClInclude Include="..\..\util\ScopedTimer.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\combat\CombatDamage.h">
+      <Filter>Header Files\combat</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\combat\CombatEvent.h">
       <Filter>Header Files\combat</Filter>
     </ClInclude>
@@ -501,6 +504,9 @@
     </ClCompile>
     <ClCompile Include="..\..\util\SaveGamePreviewUtils.cpp">
       <Filter>Source Files\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\combat\CombatDamage.cpp">
+      <Filter>Source Files\combat</Filter>
     </ClCompile>
     <ClCompile Include="..\..\combat\CombatEvents.cpp">
       <Filter>Source Files\combat</Filter>

--- a/parse/DoubleValueRefParser.cpp
+++ b/parse/DoubleValueRefParser.cpp
@@ -140,6 +140,11 @@ parse::double_parser_rules::double_parser_rules(
           ]
         ;
 
+    named_int_valueref_cast
+        =   int_rules.named_int_valueref [ _val = construct_movable_(new_<ValueRef::StaticCast<int, double>>(deconstruct_movable_(_1, _pass))) ]
+        ;
+
+
     statistic_value_ref_expr
         = primary_expr.alias();
 
@@ -156,6 +161,7 @@ parse::double_parser_rules::double_parser_rules(
         |    int_complex_variable_cast
         |    int_total_fighter_shots_cast
         |    named_real_valueref
+        |    named_int_valueref_cast
         ;
 
     int_free_variable_cast.name("integer free variable");
@@ -164,6 +170,7 @@ parse::double_parser_rules::double_parser_rules(
     int_complex_variable_cast.name("integer complex variable");
     int_total_fighter_shots_cast.name("integer TotalFighterShots");
     named_real_valueref.name("named real valueref");
+    named_int_valueref_cast.name("named integer valueref");
 
 #if DEBUG_VALUEREF_PARSERS
     debug(int_constant_cast);
@@ -174,6 +181,7 @@ parse::double_parser_rules::double_parser_rules(
     debug(int_total_fighter_shots_cast);
     debug(double_complex_variable);
     debug(named_real_valueref);
+    debug(named_int_valueref_cast);
 #endif
 }
 

--- a/parse/DoubleValueRefParser.cpp
+++ b/parse/DoubleValueRefParser.cpp
@@ -56,8 +56,8 @@ parse::detail::simple_double_parser_rules::simple_double_parser_rules(const pars
         |   tok.HabitableSize_
         |   tok.Size_
         |   tok.DistanceFromOriginalType_
-        |   tok.TotalFighterDamageEstimation_
-        |   tok.TotalShipDamageEstimation_
+        |   tok.DestroyFightersPerBattleMax_
+        |   tok.DamageStructurePerBattleMax_
         |   tok.PropagatedSupplyRange_
         ;
 

--- a/parse/DoubleValueRefParser.cpp
+++ b/parse/DoubleValueRefParser.cpp
@@ -56,7 +56,8 @@ parse::detail::simple_double_parser_rules::simple_double_parser_rules(const pars
         |   tok.HabitableSize_
         |   tok.Size_
         |   tok.DistanceFromOriginalType_
-        |   tok.Attack_
+        |   tok.TotalFighterDamageEstimation_
+        |   tok.TotalShipDamageEstimation_
         |   tok.PropagatedSupplyRange_
         ;
 

--- a/parse/DoubleValueRefParser.cpp
+++ b/parse/DoubleValueRefParser.cpp
@@ -116,6 +116,10 @@ parse::double_parser_rules::double_parser_rules(
         =   int_rules.statistic_expr [ _val = construct_movable_(new_<ValueRef::StaticCast<int, double>>(deconstruct_movable_(_1, _pass))) ]
         ;
 
+    int_total_fighter_shots_cast
+        =   int_rules.total_fighter_shots [ _val = construct_movable_(new_<ValueRef::StaticCast<int, double>>(deconstruct_movable_(_1, _pass))) ]
+        ;
+
     int_complex_variable_cast
         =   int_complex_grammar [ _val = construct_movable_(new_<ValueRef::StaticCast<int, double>>(deconstruct_movable_(_1, _pass))) ]
         ;
@@ -150,6 +154,7 @@ parse::double_parser_rules::double_parser_rules(
         |    int_free_variable_cast
         |    int_bound_variable_cast
         |    int_complex_variable_cast
+        |    int_total_fighter_shots_cast
         |    named_real_valueref
         ;
 
@@ -157,6 +162,7 @@ parse::double_parser_rules::double_parser_rules(
     int_bound_variable_cast.name("integer bound variable");
     int_statistic_cast.name("integer statistic");
     int_complex_variable_cast.name("integer complex variable");
+    int_total_fighter_shots_cast.name("integer TotalFighterShots");
     named_real_valueref.name("named real valueref");
 
 #if DEBUG_VALUEREF_PARSERS
@@ -165,6 +171,7 @@ parse::double_parser_rules::double_parser_rules(
     debug(int_bound_variable_cast);
     debug(int_statistic_cast);
     debug(int_complex_variable_cast);
+    debug(int_total_fighter_shots_cast);
     debug(double_complex_variable);
     debug(named_real_valueref);
 #endif

--- a/parse/IntValueRefParser.cpp
+++ b/parse/IntValueRefParser.cpp
@@ -152,9 +152,11 @@ parse::int_arithmetic_rules::int_arithmetic_rules(
         ;
 
     total_fighter_shots
-        = ( tok.TotalFighterShots_ >> label(tok.condition_) > condition_parser
+        = ( tok.TotalFighterShots_
+            > -( label(tok.carrier_) > primary_expr )
+            > -( label(tok.condition_) > condition_parser )
           ) [
-            _val =  construct_movable_(new_<ValueRef::TotalFighterShots>(deconstruct_movable_(_2, _pass)))
+            _val =  construct_movable_(new_<ValueRef::TotalFighterShots>(deconstruct_movable_(_2, _pass), deconstruct_movable_(_3, _pass)))
           ]
         ;
 

--- a/parse/IntValueRefParser.cpp
+++ b/parse/IntValueRefParser.cpp
@@ -129,6 +129,7 @@ parse::int_arithmetic_rules::int_arithmetic_rules(
     qi::_val_type _val;
     qi::_pass_type _pass;
     const boost::phoenix::function<detail::construct_movable> construct_movable_;
+    const boost::phoenix::function<detail::deconstruct_movable> deconstruct_movable_;
     const parse::detail::value_ref_rule<int>& simple = simple_int_rules.simple;
 
     statistic_value_ref_expr
@@ -150,6 +151,13 @@ parse::int_arithmetic_rules::int_arithmetic_rules(
           ]
         ;
 
+    total_fighter_shots
+        = ( tok.TotalFighterShots_ >> label(tok.condition_) > condition_parser
+          ) [
+            _val =  construct_movable_(new_<ValueRef::TotalFighterShots>(deconstruct_movable_(_2, _pass)))
+          ]
+        ;
+
     primary_expr
         =   '(' >> expr >> ')'
         |   simple
@@ -157,9 +165,11 @@ parse::int_arithmetic_rules::int_arithmetic_rules(
         |   named_lookup_expr
         |   int_complex_grammar
         |   named_int_valueref
+        |   total_fighter_shots
         ;
 
     named_int_valueref.name("named int valueref");
+    total_fighter_shots.name("TotalFighterShots valueref");
 }
 
 namespace parse {

--- a/parse/ShipPartsParser.cpp
+++ b/parse/ShipPartsParser.cpp
@@ -133,8 +133,8 @@ namespace {
                    )
                 > matches_[tok.NoDefaultCapacityEffect_]                // _6
 //                > -(label(tok.value_)       > qi::as<parse::detail::MovableEnvelope<ValueRef::ValueRef<double>>>()[double_rules.expr]) // _7
-                > -(label(tok.totalFighterDamageEstimation_) > double_rules.expr) // _7
-                > -(label(tok.totalShipDamageEstimation_)    > double_rules.expr) // _8
+                > -(label(tok.destroyFightersPerBattleMax_) > double_rules.expr) // _7
+                > -(label(tok.damageStructurePerBattleMax_) > double_rules.expr) // _8
                 > -(label(tok.combatTargets_)       > condition_parser) // _9
                 > -(label(tok.mountableSlotTypes_)  > one_or_more_slots)// _10
                 >   common_rules.common                                 // _11

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -28,7 +28,6 @@
     (Article)                                   \
     (Application)                               \
     (Asteroids)                                 \
-    (Attack)                                    \
     (Barren)                                    \
     (Basic)                                     \
     (BlackHole)                                 \
@@ -576,8 +575,10 @@
     (TopPriorityResearchableTech)               \
     (TopPriorityTransferrableTech)              \
     (totalFighterDamageEstimation)              \
+    (TotalFighterDamageEstimation)              \
     (TotalFighterShots)                         \
     (totalShipDamageEstimation)                 \
+    (TotalShipDamageEstimation)                 \
     (Toxic)                                     \
     (Trade)
 

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -70,6 +70,7 @@
     (Core)                                      \
     (cos)                                       \
     (Count)                                     \
+    (countIf)                                   \
     (CountUnique)                               \
     (CounterClockwiseNextPlanetType)            \
     (CreateBuilding)                            \
@@ -575,6 +576,7 @@
     (TopPriorityResearchableTech)               \
     (TopPriorityTransferrableTech)              \
     (totalFighterDamageEstimation)              \
+    (TotalFighterShots)                         \
     (totalShipDamageEstimation)                 \
     (Toxic)                                     \
     (Trade)

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -51,6 +51,7 @@
     (Capacity)                                  \
     (Capital)                                   \
     (Capture)                                   \
+    (carrier)                                   \
     (captureresult)                             \
     (category)                                  \
     (ceil)                                      \

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -87,6 +87,8 @@
 #define TOKEN_SEQ_3                             \
     (damage)                                    \
     (Damage)                                    \
+    (damageStructurePerBattleMax)               \
+    (DamageStructurePerBattleMax)               \
     (data)                                      \
     (default)                                   \
     (defaultfocus)                              \
@@ -105,6 +107,8 @@
     (designname)                                \
     (destination)                               \
     (Destroy)                                   \
+    (destroyFightersPerBattleMax)               \
+    (DestroyFightersPerBattleMax)               \
     (Detection)                                 \
     (DirectDistanceBetween)                     \
     (Disabled)                                  \
@@ -575,11 +579,7 @@
     (TopPriorityEnqueuedTech)                   \
     (TopPriorityResearchableTech)               \
     (TopPriorityTransferrableTech)              \
-    (totalFighterDamageEstimation)              \
-    (TotalFighterDamageEstimation)              \
     (TotalFighterShots)                         \
-    (totalShipDamageEstimation)                 \
-    (TotalShipDamageEstimation)                 \
     (Toxic)                                     \
     (Trade)
 

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -574,6 +574,8 @@
     (TopPriorityEnqueuedTech)                   \
     (TopPriorityResearchableTech)               \
     (TopPriorityTransferrableTech)              \
+    (totalFighterDamageEstimation)              \
+    (totalShipDamageEstimation)                 \
     (Toxic)                                     \
     (Trade)
 

--- a/parse/ValueRefParser.h
+++ b/parse/ValueRefParser.h
@@ -268,6 +268,7 @@ namespace parse {
         detail::simple_int_parser_rules simple_int_rules;
         int_complex_parser_grammar      int_complex_grammar;
         detail::value_ref_rule<int>     named_int_valueref;
+        detail::value_ref_rule<int>     total_fighter_shots;
     };
 
     struct double_complex_parser_grammar : public detail::complex_variable_grammar<double> {
@@ -310,6 +311,7 @@ namespace parse {
         detail::value_ref_rule<double>      int_free_variable_cast;
         detail::value_ref_rule<double>      int_statistic_cast;
         detail::value_ref_rule<double>      int_complex_variable_cast;
+        detail::value_ref_rule<double>      int_total_fighter_shots_cast;
         detail::value_ref_rule<double>      named_real_valueref;
     };
 

--- a/parse/ValueRefParser.h
+++ b/parse/ValueRefParser.h
@@ -313,6 +313,7 @@ namespace parse {
         detail::value_ref_rule<double>      int_complex_variable_cast;
         detail::value_ref_rule<double>      int_total_fighter_shots_cast;
         detail::value_ref_rule<double>      named_real_valueref;
+        detail::value_ref_rule<double>      named_int_valueref_cast;
     };
 
     struct castable_as_int_parser_rules {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -2341,7 +2341,7 @@ namespace {
                     continue;
                 // an unarmed Monster will not trigger combat
                 if (  (fleet->Aggressive() || fleet->Unowned())  &&
-                      (fleet->HasArmedShips(objects) || !fleet->Unowned())  )
+                      (fleet->CanDamageShips(objects) || !fleet->Unowned())  )
                 {
                     if (!empires_with_aggressive_fleets_here.count(empire_id))
                         DebugLogger(combat) << "\t Empire " << empire_id << " has at least one aggressive fleet present";
@@ -2846,7 +2846,7 @@ namespace {
             // find which empires have obstructive armed ships in system
             std::set<int> empires_with_armed_ships_in_system;
             for (auto& fleet : objects.find<const Fleet>(system->FleetIDs())) {
-                if (fleet->Obstructive() && fleet->HasArmedShips(objects))
+                if (fleet->Obstructive() && fleet->CanDamageShips(objects))
                     empires_with_armed_ships_in_system.insert(fleet->Owner());  // may include ALL_EMPIRES, which is fine; this makes monsters prevent colonization
             }
 
@@ -3464,7 +3464,7 @@ void ServerApp::UpdateMonsterTravelRestrictions() {
             // before you, or be in cahoots with someone who did.
             bool unrestricted = ((fleet->ArrivalStarlane() == system->ID())
                                  && fleet->Obstructive()
-                                 && fleet->HasArmedShips(m_universe.Objects()));
+                                 && fleet->CanDamageShips(m_universe.Objects()));
             if (fleet->Unowned()) {
                 monsters.push_back(std::move(fleet));
                 if (unrestricted)

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -655,6 +655,16 @@ namespace {
     }
 }
 
+bool Fleet::CanDamageShips(const ObjectMap& objects, float target_shields) const {
+    auto isX = [target_shields](const std::shared_ptr<const Ship>& ship){ return ship->CanDamageShips(target_shields); };
+    return HasXShips(isX, m_ships, objects);
+}
+
+bool Fleet::CanDestroyFighters(const ObjectMap& objects) const {
+    auto isX = [](const std::shared_ptr<const Ship>& ship){ return ship->CanDestroyFighters(); };
+    return HasXShips(isX, m_ships, objects);
+}
+
 bool Fleet::HasMonsters(const ObjectMap& objects) const {
     auto isX = [](const std::shared_ptr<const Ship>& ship){ return ship->IsMonster(); };
     return HasXShips(isX, m_ships, objects);
@@ -1301,7 +1311,7 @@ bool Fleet::BlockadedAtSystem(int start_system_id, int dest_system_id,
         if (fleet->MaxShipAgeInTurns() <= 1)
             continue;
         // These are the most costly checks.  Do them last
-        if (!fleet->HasArmedShips(objects))
+        if (!fleet->CanDamageShips(objects))
             continue;
 
         // don't exit early here, because blockade may yet be thwarted by ownership & presence check above

--- a/universe/Fleet.h
+++ b/universe/Fleet.h
@@ -106,6 +106,8 @@ public:
     bool    BlockadedAtSystem(int start_system_id, int dest_system_id, const ScriptingContext& context) const; ///< returns true iff this fleet's movement would be blockaded at system.
     float   Speed(const ObjectMap& objects) const;                      ///< Returns speed of fleet. (Should be equal to speed of slowest ship in fleet, unless in future the calculation of fleet speed changes.)
     bool    CanChangeDirectionEnRoute() const   { return false; }       ///< Returns true iff this fleet can change its direction while in interstellar space.
+    bool    CanDamageShips(const ObjectMap& objects, float target_shields = 0.0f) const;              ///< Returns true if there is at least one ship in the fleet which is currently able to damage a ship using direct weapons or fighters
+    bool    CanDestroyFighters(const ObjectMap& objects) const;              ///< Returns true if there is at least one ship in the fleet which is currently able to destroy fighters using direct weapons or fighters
     bool    HasMonsters(const ObjectMap& objects) const;                ///< returns true iff this fleet contains monster ships.
     bool    HasArmedShips(const ObjectMap& objects) const;              ///< Returns true if there is at least one armed ship in the fleet, meaning it has direct fire weapons or fighters that can be launched and that do damage
     bool    HasFighterShips(const ObjectMap& objects) const;            ///< Returns true if there is at least one ship with fighters in the fleet.

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -1,5 +1,8 @@
 #include "Ship.h"
 
+#include "Condition.h"
+#include "Conditions.h"
+#include "Fighter.h"
 #include "Fleet.h"
 #include "ScriptingContext.h"
 #include "ShipDesign.h"
@@ -492,11 +495,9 @@ float Ship::TotalWeaponsShipDamage(float shield_DR, bool include_fighters) const
 }
 
 namespace {
-    std::vector<float> WeaponDamageImpl(std::shared_ptr<const Ship> ship, const ShipDesign* design,
-                                            float DR, bool max, bool include_fighters, bool target_ships = true)
-    {
+    std::vector<float> WeaponDamageCalcImpl(std::shared_ptr<const Ship> ship, const ShipDesign* design,
+                                            bool max, bool include_fighters, bool target_ships, const ScriptingContext context) {
         std::vector<float> retval;
-
         if (!ship || !design)
             return retval;
         const std::vector<std::string>& parts = design->Parts();
@@ -511,7 +512,6 @@ namespace {
         int available_fighters = 0;
 
         retval.reserve(parts.size() + 1);
-        const ScriptingContext context(ship);
         int num_bouts = GetGameRules().Get<int>("RULE_NUM_COMBAT_ROUNDS");
         // for each weapon part, get its damage meter value
         for (const auto& part_name : parts) {
@@ -520,7 +520,6 @@ namespace {
                 continue;
             ShipPartClass part_class = part->Class();
 
-            const ScriptingContext context(ship);
             // get the attack power for each weapon part.
             if (part_class == ShipPartClass::PC_DIRECT_WEAPON) {
                 if (target_ships)
@@ -532,8 +531,19 @@ namespace {
                 fighter_launch_capacity += static_cast<int>(ship->CurrentPartMeterValue(METER, part_name));
 
             } else if (part_class == ShipPartClass::PC_FIGHTER_HANGAR && include_fighters) {
-                // attack strength of a ship's fighters determined by the hangar...
-                fighter_damage = ship->CurrentPartMeterValue(SECONDARY_METER, part_name);  // assuming all hangars have the same damage...
+                // attack strength of a ship's fighters per bout determined by the hangar...
+                // assuming all hangars on a ship are the same part type...
+                if (part->CombatTargets() && context.effect_target && part->CombatTargets()->Eval(context, context.effect_target)) {
+                    fighter_damage = ship->CurrentPartMeterValue(SECONDARY_METER, part_name);
+                } else {
+                    ErrorLogger() << "does not match combatTargets condition";
+                    ErrorLogger() << "source: " << context.source->Owner() << "  target: " << context.effect_target->Owner();
+                    std::vector<const Condition::Condition*> target_conditions;
+                    target_conditions.push_back(part->CombatTargets());
+                    // target is not of the right type
+                    fighter_damage = 0.0f;
+                    include_fighters = true; // FIXME should be false
+                }
                 available_fighters = std::max(0, static_cast<int>(ship->CurrentPartMeterValue(METER, part_name)));  // stacked meter
             }
         }
@@ -556,9 +566,39 @@ namespace {
         // how much damage does a fighter shot do?
         fighter_damage = std::max(0.0f, fighter_damage);
 
-        retval.emplace_back(fighter_damage * fighter_shots / num_bouts); // divide by bouts because fighter calculation is for a full combat, but direct fire for one attack
-
+        if (target_ships)
+            retval.emplace_back(fighter_damage * fighter_shots / num_bouts); // divide by bouts because fighter calculation is for a full combat, but direct fire for one attack
+        else
+            retval.emplace_back((float)fighter_shots / num_bouts); // divide by bouts because fighter calculation is for a full combat, but direct fire for one attack
         return retval;
+    }
+
+    std::vector<float> WeaponDamageImpl(std::shared_ptr<const Ship> ship, const ShipDesign* design,
+                                        float DR, bool max, bool include_fighters, bool target_ships = true)
+    {
+        if (target_ships) {
+            // FIXME find default enemy - i use the given design as that at least exists (but might be non-targetable because of stealth)
+            //ErrorLogger() << "DESIGN " << GetPredefinedShipDesignManager().GetDesignID("08a58b08-0929-496d-84fc-faa91424ca21");
+            //auto target = std::make_shared<Ship>(ALL_EMPIRES, GetPredefinedShipDesignManager().GetDesignID("SD_MARK_1"), "SP_HUMAN");
+            auto target = std::make_shared<Ship>(ALL_EMPIRES, design->ID(), "SP_HUMAN");
+            // target needs to have an ID != -1 to be visible, stealth should be low enough
+            // structure must be higher than zero to be valid target
+            target->SetID(-1000000); // XXX magic number AutoresolveInfo.next_fighter_id starts at -1000001 counting down
+            target->GetMeter(MeterType::METER_STRUCTURE)->Set(100.0f, 100.0f);
+            target->GetMeter(MeterType::METER_MAX_STRUCTURE)->Set(100.0f, 100.0f);
+            // Shield value is used for structural damage estimation
+            target->GetMeter(MeterType::METER_SHIELD)->Set(DR,DR);
+            GetUniverse().SetEmpireObjectVisibility(ship->Owner(), target->ID(), Visibility::VIS_FULL_VISIBILITY);
+            ScriptingContext context(ship, target);
+            // XXX maybe always put, maybe remove afterwards
+            return WeaponDamageCalcImpl(ship, design, max, include_fighters, target_ships, context);
+        } else {
+            auto target = std::make_shared<Fighter>();
+            target->SetID(-1000000); // XXX magic number AutoresolveInfo.next_fighter_id starts at -1000001 counting down
+            GetUniverse().SetEmpireObjectVisibility(ship->Owner(), target->ID(), Visibility::VIS_FULL_VISIBILITY);
+            ScriptingContext context(ship, target);
+            return WeaponDamageCalcImpl(ship, design, max, include_fighters, target_ships, context);
+        }
     }
 }
 

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -238,12 +238,10 @@ bool Ship::IsMonster() const { // TODO: pass in ScriptingContext
 }
 
 bool Ship::IsArmed() const {
-    ErrorLogger() << "IsArmed?";
     if ((TotalWeaponsShipDamage(0.0f, false) > 0.0f) || (TotalWeaponsFighterDamage(false) > 0.0f))
         return true;    // has non-fighter weapons damaging ships or fighters
     if (HasFighters() && ((TotalWeaponsShipDamage(0.0f, true) > 0.0f) || (TotalWeaponsFighterDamage(false) > 0.0f)))
         return true;    // has no non-fighter weapons but has launchable fighters that do damage
-    ErrorLogger() << "IsArmed - no";
     return false;
 }
 
@@ -440,7 +438,6 @@ float Ship::WeaponPartFighterDamage(const ShipPart* part, const ScriptingContext
 
     // usually a weapon part destroys one fighter per shot, but that can be overridden
     if (part->TotalFighterDamage()) {
-        ErrorLogger() << "WeaponPartFighterDamage PC_DIRECT_WEAPON TotalFighterDamage " << part->TotalFighterDamage()->Eval(context);
         return part->TotalFighterDamage()->Eval(context);
     } else {
         int num_bouts_with_fighter_targets = GetGameRules().Get<int>("RULE_NUM_COMBAT_ROUNDS") - 1;
@@ -449,13 +446,11 @@ float Ship::WeaponPartFighterDamage(const ShipPart* part, const ScriptingContext
 }
 
 float Ship::WeaponPartShipDamage(const ShipPart* part, const ScriptingContext& context) const {
-    ErrorLogger() << "WeaponPartShipDamage";
     if (!part || (part->Class() != ShipPartClass::PC_DIRECT_WEAPON))
         return 0.0f;
 
     // usually a weapon part does damage*shots ship damage, but that can be overridden
     if (part->TotalShipDamage()) {
-        ErrorLogger() << "WeaponPartShipDamage TotalShipDamage " << part->TotalShipDamage()->Eval(context);
         return part->TotalShipDamage()->Eval(context);
     } else {
         float part_attack = CurrentPartMeterValue(MeterType::METER_CAPACITY, part->Name());  // used within loop that updates meters, so need current, not initial values
@@ -466,7 +461,6 @@ float Ship::WeaponPartShipDamage(const ShipPart* part, const ScriptingContext& c
             if (target) 
                 target_shield = target->GetMeter(MeterType::METER_SHIELD)->Current();
         }
-        ErrorLogger() << "WeaponPartShipDamage target.Shield " << part_attack << " - " << target_shield << "  *" << part_shots;
         if (part_attack > target_shield) {
             int num_bouts = GetGameRules().Get<int>("RULE_NUM_COMBAT_ROUNDS");
             return (part_attack - target_shield) * part_shots * num_bouts;
@@ -534,12 +528,10 @@ namespace {
                 // attack strength of a ship's fighters per bout determined by the hangar...
                 // assuming all hangars on a ship are the same part type...
                 if (target_ships && part->TotalShipDamage()) {
-                    ErrorLogger() << "WeaponDamageCalcImpl PC_FIGHTER_HANGAR add part->TotalShipDamage";
                     retval.emplace_back(part->TotalShipDamage()->Eval(context));
                     // as TotalShipDamage contains the damage from all fighters, do not further include fighter
                     include_fighters = false;
                 } else if (part->TotalFighterDamage() && !target_ships) {
-                    ErrorLogger() << "WeaponDamageCalcImpl PC_FIGHTER_HANGAR add part->TotalFighterDamage";
                     retval.emplace_back(part->TotalFighterDamage()->Eval(context));
                     // as TotalFighterDamage contains the damage from all fighters, do not further include fighter
                     include_fighters = false;
@@ -547,8 +539,6 @@ namespace {
                     fighter_damage = ship->CurrentPartMeterValue(SECONDARY_METER, part_name);
                     available_fighters = std::max(0, static_cast<int>(ship->CurrentPartMeterValue(METER, part_name)));  // stacked meter
                 } else {
-                    ErrorLogger() << "WeaponDamageCalcImpl PC_FIGHTER_HANGAR does not match combatTargets condition";
-                    ErrorLogger() << "WeaponDamageCalcImpl PC_FIGHTER_HANGAR source: " << context.source->Owner() << "  target: " << context.effect_target->Owner();
                     std::vector<const Condition::Condition*> target_conditions;
                     target_conditions.push_back(part->CombatTargets());
                     // target is not of the right type
@@ -616,7 +606,7 @@ namespace {
 std::vector<float> Ship::AllWeaponsFighterDamage(bool include_fighters) const {
     std::vector<float> retval;
 
-    const ShipDesign* design = GetShipDesign(m_design_id);
+    const ShipDesign* design = GetUniverse().GetShipDesign(m_design_id);
     if (!design)
         return retval;
 

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -237,12 +237,19 @@ bool Ship::IsMonster() const { // TODO: pass in ScriptingContext
         return false;
 }
 
+bool Ship::CanDamageShips(float target_shields) const {
+    return TotalWeaponsShipDamage(target_shields, true) > 0.0f;
+}
+
+bool Ship::CanDestroyFighters() const {
+    return TotalWeaponsFighterDamage(true) > 0.0f;
+}
+
 bool Ship::IsArmed() const {
-    if ((TotalWeaponsShipDamage(0.0f, false) > 0.0f) || (TotalWeaponsFighterDamage(false) > 0.0f))
-        return true;    // has non-fighter weapons damaging ships or fighters
     if (HasFighters() && ((TotalWeaponsShipDamage(0.0f, true) > 0.0f) || (TotalWeaponsFighterDamage(true) > 0.0f)))
-        return true;    // has no non-fighter weapons but has launchable fighters that do damage
-    return false;
+        return true;
+    else
+        return ((TotalWeaponsShipDamage(0.0f, false) > 0.0f) || (TotalWeaponsFighterDamage(false) > 0.0f));
 }
 
 bool Ship::HasFighters() const {

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -498,23 +498,11 @@ float Ship::TotalWeaponsShipDamage(float shield_DR, bool include_fighters) const
 }
 
 std::vector<float> Ship::AllWeaponsFighterDamage(bool include_fighters) const {
-    std::vector<float> retval;
-
-    const ShipDesign* design = GetUniverse().GetShipDesign(m_design_id);
-    if (!design)
-        return retval;
-
-    return Combat::WeaponDamageImpl(std::static_pointer_cast<const Ship>(shared_from_this()), design, /*target_shield_DR*/0, /*max meters*/false, include_fighters, /*target_ships*/false);
+    return Combat::WeaponDamageImpl(std::static_pointer_cast<const Ship>(shared_from_this()), /*target_shield_DR*/0, /*max meters*/false, include_fighters, /*target_ships*/false);
 }
 
 std::vector<float> Ship::AllWeaponsShipDamage(float shield_DR, bool include_fighters) const {
-    std::vector<float> retval;
-
-    const ShipDesign* design = GetUniverse().GetShipDesign(m_design_id); // TODO: pass in ScriptingContext
-    if (!design)
-        return retval;
-
-    return Combat::WeaponDamageImpl(std::static_pointer_cast<const Ship>(shared_from_this()), design, shield_DR, false, include_fighters);
+    return Combat::WeaponDamageImpl(std::static_pointer_cast<const Ship>(shared_from_this()), shield_DR, false, include_fighters, true);
 }
 
 std::vector<float> Ship::AllWeaponsMaxShipDamage(float shield_DR , bool include_fighters) const {
@@ -524,7 +512,7 @@ std::vector<float> Ship::AllWeaponsMaxShipDamage(float shield_DR , bool include_
     if (!design)
         return retval;
 
-    return Combat::WeaponDamageImpl(std::static_pointer_cast<const Ship>(shared_from_this()), design, shield_DR, true, include_fighters);
+    return Combat::WeaponDamageImpl(std::static_pointer_cast<const Ship>(shared_from_this()), shield_DR, true, include_fighters);
 }
 
 void Ship::SetFleetID(int fleet_id) {

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -240,7 +240,7 @@ bool Ship::IsMonster() const { // TODO: pass in ScriptingContext
 bool Ship::IsArmed() const {
     if ((TotalWeaponsShipDamage(0.0f, false) > 0.0f) || (TotalWeaponsFighterDamage(false) > 0.0f))
         return true;    // has non-fighter weapons damaging ships or fighters
-    if (HasFighters() && ((TotalWeaponsShipDamage(0.0f, true) > 0.0f) || (TotalWeaponsFighterDamage(false) > 0.0f)))
+    if (HasFighters() && ((TotalWeaponsShipDamage(0.0f, true) > 0.0f) || (TotalWeaponsFighterDamage(true) > 0.0f)))
         return true;    // has no non-fighter weapons but has launchable fighters that do damage
     return false;
 }

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -238,13 +238,11 @@ bool Ship::IsMonster() const { // TODO: pass in ScriptingContext
         return false;
 }
 
-bool Ship::CanDamageShips(float target_shields) const {
-    return TotalWeaponsShipDamage(target_shields, true) > 0.0f;
-}
+bool Ship::CanDamageShips(float target_shields) const
+{ return TotalWeaponsShipDamage(target_shields, true) > 0.0f; }
 
-bool Ship::CanDestroyFighters() const {
-    return TotalWeaponsFighterDamage(true) > 0.0f;
-}
+bool Ship::CanDestroyFighters() const
+{ return TotalWeaponsFighterDamage(true) > 0.0f; }
 
 bool Ship::IsArmed() const {
     if (HasFighters() && ((TotalWeaponsShipDamage(0.0f, true) > 0.0f) || (TotalWeaponsFighterDamage(true) > 0.0f)))
@@ -479,40 +477,38 @@ float Ship::WeaponPartShipDamage(const ShipPart* part, const ScriptingContext& c
 }
 
 
-float Ship::TotalWeaponsFighterDamage(bool include_fighters) const {
+float Ship::TotalWeaponsFighterDamage(bool launch_fighters) const {
     // sum up all individual weapons' attack strengths
     float total_shots = 0.0f;
-    auto all_weapons_shots = AllWeaponsFighterDamage(include_fighters);
+    auto all_weapons_shots = AllWeaponsFighterDamage(launch_fighters);
     for (float shots : all_weapons_shots)
         total_shots += shots;
     return total_shots;
 }
 
-float Ship::TotalWeaponsShipDamage(float shield_DR, bool include_fighters) const {
+float Ship::TotalWeaponsShipDamage(float shield_DR, bool launch_fighters) const {
     // sum up all individual weapons' attack strengths
     float total_attack = 0.0f;
-    auto all_weapons_damage = AllWeaponsShipDamage(shield_DR, include_fighters);
+    auto all_weapons_damage = AllWeaponsShipDamage(shield_DR, launch_fighters);
     for (float attack : all_weapons_damage)
         total_attack += attack;
     return total_attack;
 }
 
-std::vector<float> Ship::AllWeaponsFighterDamage(bool include_fighters) const {
-    return Combat::WeaponDamageImpl(std::static_pointer_cast<const Ship>(shared_from_this()), /*target_shield_DR*/0, /*max meters*/false, include_fighters, /*target_ships*/false);
-}
+std::vector<float> Ship::AllWeaponsFighterDamage(bool launch_fighters) const
+{ return Combat::WeaponDamageImpl(std::static_pointer_cast<const Ship>(shared_from_this()), /*target_shield_DR*/0, /*max meters*/false, launch_fighters, /*target_ships*/false); }
 
-std::vector<float> Ship::AllWeaponsShipDamage(float shield_DR, bool include_fighters) const {
-    return Combat::WeaponDamageImpl(std::static_pointer_cast<const Ship>(shared_from_this()), shield_DR, false, include_fighters, true);
-}
+std::vector<float> Ship::AllWeaponsShipDamage(float shield_DR, bool launch_fighters) const
+{ return Combat::WeaponDamageImpl(std::static_pointer_cast<const Ship>(shared_from_this()), shield_DR, false, launch_fighters, true); }
 
-std::vector<float> Ship::AllWeaponsMaxShipDamage(float shield_DR , bool include_fighters) const {
+std::vector<float> Ship::AllWeaponsMaxShipDamage(float shield_DR, bool launch_fighters) const {
     std::vector<float> retval;
 
     const ShipDesign* design = GetUniverse().GetShipDesign(m_design_id); // TODO: pass in Scriptingcontext
     if (!design)
         return retval;
 
-    return Combat::WeaponDamageImpl(std::static_pointer_cast<const Ship>(shared_from_this()), shield_DR, true, include_fighters);
+    return Combat::WeaponDamageImpl(std::static_pointer_cast<const Ship>(shared_from_this()), shield_DR, true, launch_fighters);
 }
 
 void Ship::SetFleetID(int fleet_id) {

--- a/universe/Ship.h
+++ b/universe/Ship.h
@@ -4,6 +4,7 @@
 
 #include "Meter.h"
 #include "ConstantsFwd.h"
+#include "ScriptingContext.h"
 #include "UniverseObject.h"
 #include "../util/Export.h"
 
@@ -74,11 +75,11 @@ public:
     /** Returns sum of current value for part meter @p type of all parts with ShipPartClass @p part_class */
     float                       SumCurrentPartMeterValuesForPartClass(MeterType type, ShipPartClass part_class) const;
 
-    float                       TotalWeaponsDamage(float shield_DR = 0.0f, bool include_fighters = true) const; ///< versus an enemy with a given shields DR
+    float                       TotalWeaponsShipDamage(float shield_DR = 0.0f, bool include_fighters = true) const; ///< versus an enemy with a given shields DR
     float                       FighterCount() const;
     float                       FighterMax() const;
-    std::vector<float>          AllWeaponsDamage(float shield_DR = 0.0f, bool include_fighters = true) const;   ///< any nonzero weapons strengths after adjustment versus an enemy with a given shields DR
-    std::vector<float>          AllWeaponsMaxDamage(float shield_DR = 0.0f, bool include_fighters = true) const;///< any nonzero weapons strengths, assuming the ship has been refueled recently, after adjustment versus an enemy with a given shields DR
+    std::vector<float>          AllWeaponsShipDamage(float shield_DR = 0.0f, bool include_fighters = true) const;   ///< any nonzero weapons strengths after adjustment versus an enemy with a given shields DR
+    std::vector<float>          AllWeaponsMaxShipDamage(float shield_DR = 0.0f, bool include_fighters = true) const;///< any nonzero weapons strengths, assuming the ship has been refueled recently, after adjustment versus an enemy with a given shields DR
 
     void            SetFleetID(int fleet_id);                                   ///< sets the ID of the fleet the ship resides in
     void            SetArrivedOnTurn(int turn);

--- a/universe/Ship.h
+++ b/universe/Ship.h
@@ -86,7 +86,7 @@ public:
     float                       FighterMax() const;
     std::vector<float>          AllWeaponsFighterDamage(bool include_fighters = true) const;   ///< any shots against enemy fighters
     std::vector<float>          AllWeaponsShipDamage(float shield_DR = 0.0f, bool include_fighters = true) const;   ///< any nonzero weapons strengths after adjustment versus an enemy with a given shields DR
-    std::vector<float>          AllWeaponsMaxShipDamage(float shield_DR = 0.0f, bool include_fighters = true) const;///< any nonzero weapons strengths, assuming the ship has been refueled recently, after adjustment versus an enemy with a given shields DR
+    std::vector<float>          AllWeaponsMaxShipDamage(float shield_DR = 0.0f, bool include_fighters = true) const;///< any nonzero weapons strengths, assuming the ship has been resupplied recently, after adjustment versus an enemy with a given shields DR
 
     void            SetFleetID(int fleet_id);                                   ///< sets the ID of the fleet the ship resides in
     void            SetArrivedOnTurn(int turn);

--- a/universe/Ship.h
+++ b/universe/Ship.h
@@ -51,6 +51,8 @@ public:
     int                         LastResuppliedOnTurn() const{ return m_last_resupplied_on_turn;}///< returns the turn on which this ship was last resupplied / upgraded
 
     bool                        IsMonster() const;
+    bool                        CanDamageShips(float target_shields = 0.0f) const;
+    bool                        CanDestroyFighters() const;
     bool                        IsArmed() const;
     bool                        HasFighters() const;
     bool                        CanColonize() const;

--- a/universe/Ship.h
+++ b/universe/Ship.h
@@ -85,8 +85,13 @@ public:
     float                       FighterCount() const;
     float                       FighterMax() const;
     std::vector<float>          AllWeaponsFighterDamage(bool include_fighters = true) const;   ///< any shots against enemy fighters
-    std::vector<float>          AllWeaponsShipDamage(float shield_DR = 0.0f, bool include_fighters = true) const;   ///< any nonzero weapons strengths after adjustment versus an enemy with a given shields DR
-    std::vector<float>          AllWeaponsMaxShipDamage(float shield_DR = 0.0f, bool include_fighters = true) const;///< any nonzero weapons strengths, assuming the ship has been resupplied recently, after adjustment versus an enemy with a given shields DR
+    /** returns any nonzero weapons strengths after adjustment versus an enemy with a given @p shield_DR shield rating,
+      * uses the normal meters so it might be lower than AllWeaponsMaxShipDamage
+      * if e.g. the ship has less than a full complement of fighters */
+    std::vector<float>          AllWeaponsShipDamage(float shield_DR = 0.0f, bool include_fighters = true) const;
+    /** returns any nonzero weapons strengths after adjustment versus an enemy with a given @p shield_DR shield rating,
+      * assuming the ship has been resupplied recently (i.e. this uses Max*Meters) */
+    std::vector<float>          AllWeaponsMaxShipDamage(float shield_DR = 0.0f, bool include_fighters = true) const;
 
     void            SetFleetID(int fleet_id);                                   ///< sets the ID of the fleet the ship resides in
     void            SetArrivedOnTurn(int turn);

--- a/universe/Ship.h
+++ b/universe/Ship.h
@@ -9,6 +9,7 @@
 #include "../util/Export.h"
 
 class ShipDesign;
+class ShipPart;
 
 /** a class representing a single FreeOrion ship */
 class FO_COMMON_API Ship : public UniverseObject {
@@ -75,9 +76,13 @@ public:
     /** Returns sum of current value for part meter @p type of all parts with ShipPartClass @p part_class */
     float                       SumCurrentPartMeterValuesForPartClass(MeterType type, ShipPartClass part_class) const;
 
-    float                       TotalWeaponsShipDamage(float shield_DR = 0.0f, bool include_fighters = true) const; ///< versus an enemy with a given shields DR
+    float                       WeaponPartFighterDamage(const ShipPart* part, const ScriptingContext& context) const; ///< versus fighter enemies
+    float                       WeaponPartShipDamage(const ShipPart* part, const ScriptingContext& context) const; ///< versus an enemy context.effect_target ship with a given shields meter
+    float                       TotalWeaponsFighterDamage(bool include_fighters = true) const; ///< versus an fighter enemy
+    float                       TotalWeaponsShipDamage(float shield_DR = 0.0f, bool include_fighters = true) const; ///< versus an enemy ship with a given shields DR
     float                       FighterCount() const;
     float                       FighterMax() const;
+    std::vector<float>          AllWeaponsFighterDamage(bool include_fighters = true) const;   ///< any shots against enemy fighters
     std::vector<float>          AllWeaponsShipDamage(float shield_DR = 0.0f, bool include_fighters = true) const;   ///< any nonzero weapons strengths after adjustment versus an enemy with a given shields DR
     std::vector<float>          AllWeaponsMaxShipDamage(float shield_DR = 0.0f, bool include_fighters = true) const;///< any nonzero weapons strengths, assuming the ship has been refueled recently, after adjustment versus an enemy with a given shields DR
 

--- a/universe/ShipPart.cpp
+++ b/universe/ShipPart.cpp
@@ -371,7 +371,7 @@ float ShipPart::Capacity() const {
 float ShipPart::SecondaryStat() const {
     switch (m_class) {
     case ShipPartClass::PC_FIGHTER_HANGAR:
-        return m_capacity * GetGameRules().Get<double>("RULE_FIGHTER_DAMAGE_FACTOR");
+        return m_secondary_stat * GetGameRules().Get<double>("RULE_FIGHTER_DAMAGE_FACTOR");
         break;
     default:
         return m_secondary_stat;

--- a/universe/ShipPart.cpp
+++ b/universe/ShipPart.cpp
@@ -148,7 +148,9 @@ ShipPart::ShipPart(ShipPartClass part_class, double capacity, double stat2,
                    std::string&& description, std::set<std::string>&& exclusions,
                    std::vector<ShipSlotType> mountable_slot_types,
                    std::string&& icon, bool add_standard_capacity_effect,
-                   std::unique_ptr<Condition::Condition>&& combat_targets) :
+                   std::unique_ptr<Condition::Condition>&& combat_targets,
+                   std::unique_ptr<ValueRef::ValueRef<double>>&& total_fighter_damage,
+                   std::unique_ptr<ValueRef::ValueRef<double>>&& total_ship_damage) :
     m_name(std::move(name)),
     m_description(std::move(description)),
     m_class(part_class),
@@ -164,7 +166,9 @@ ShipPart::ShipPart(ShipPartClass part_class, double capacity, double stat2,
     m_exclusions(std::move(exclusions)),
     m_icon(std::move(icon)),
     m_add_standard_capacity_effect(add_standard_capacity_effect),
-    m_combat_targets(std::move(combat_targets))
+    m_combat_targets(std::move(combat_targets)),
+    m_total_fighter_damage(std::move(total_fighter_damage)),
+    m_total_ship_damage(std::move(total_ship_damage))
 {
     Init(std::move(common_params.effects));
 
@@ -282,6 +286,8 @@ bool ShipPart::operator==(const ShipPart& rhs) const {
     CHECK_COND_VREF_MEMBER(m_production_cost)
     CHECK_COND_VREF_MEMBER(m_production_time)
     CHECK_COND_VREF_MEMBER(m_location)
+    CHECK_COND_VREF_MEMBER(m_total_fighter_damage)
+    CHECK_COND_VREF_MEMBER(m_total_ship_damage)
     CHECK_COND_VREF_MEMBER(m_combat_targets)
 
     if (m_effects.size() != rhs.m_effects.size())
@@ -493,7 +499,10 @@ unsigned int ShipPart::GetCheckSum() const {
     CheckSums::CheckSumCombine(retval, m_exclusions);
     CheckSums::CheckSumCombine(retval, m_effects);
     CheckSums::CheckSumCombine(retval, m_icon);
-    CheckSums::CheckSumCombine(retval, m_add_standard_capacity_effect);
+    CheckSums::CheckSumCombine(retval, m_add_standard_capacity_effect),
+    CheckSums::CheckSumCombine(retval, m_combat_targets),
+    CheckSums::CheckSumCombine(retval, m_total_fighter_damage);
+    CheckSums::CheckSumCombine(retval, m_total_ship_damage);
 
     return retval;
 }

--- a/universe/ShipPart.h
+++ b/universe/ShipPart.h
@@ -43,7 +43,9 @@ public:
              std::string&& description, std::set<std::string>&& exclusions,
              std::vector<ShipSlotType> mountable_slot_types,
              std::string&& icon, bool add_standard_capacity_effect = true,
-             std::unique_ptr<Condition::Condition>&& combat_targets = nullptr);
+             std::unique_ptr<Condition::Condition>&& combat_targets = nullptr,
+             std::unique_ptr<ValueRef::ValueRef<double>>&& total_fighter_damage = nullptr,
+             std::unique_ptr<ValueRef::ValueRef<double>>&& total_ship_damage = nullptr);
 
     ~ShipPart();
 
@@ -73,6 +75,16 @@ public:
 
     //! Returns true if this part can be placed in a slot of the indicated type
     auto CanMountInSlotType(ShipSlotType slot_type) const -> bool;
+
+    //! Returns the value ref estimating maximum damage against fighters in a combat.
+    //! may be nullptr if no value ref was specified
+    auto TotalFighterDamage() const -> const ValueRef::ValueRef<double>*
+    { return m_total_fighter_damage.get(); }
+
+    //! Returns the value ref estimating maximum damage against ships in a combat.
+    //! may be nullptr if no value ref was specified
+    auto TotalShipDamage() const -> const ValueRef::ValueRef<double>*
+    { return m_total_ship_damage.get(); }
 
     //! Returns the condition for possible targets. may be nullptr if no
     //! condition was specified.
@@ -156,6 +168,8 @@ private:
     std::string                                         m_icon;
     bool                                                m_add_standard_capacity_effect = false;
     std::unique_ptr<Condition::Condition>               m_combat_targets;
+    std::unique_ptr<ValueRef::ValueRef<double>>         m_total_fighter_damage;
+    std::unique_ptr<ValueRef::ValueRef<double>>         m_total_ship_damage;
 };
 
 

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -874,18 +874,18 @@ double Variable<double>::Eval(const ScriptingContext& context) const
     } else if (property_name == "CurrentTurn") {
         return context.current_turn;
 
-    } else if (property_name == "TotalFighterDamageEstimation") {
+    } else if (property_name == "DestroyFightersPerBattleMax") {
         if (auto ship = std::dynamic_pointer_cast<const Ship>(object)) {
-            InfoLogger() << "TotalFighterDamageEstimation" <<  ship->TotalWeaponsFighterDamage();
-            // FIXME prevent recursion; disallowing the ValueRef inside totalWeaponsFighterDamage via parsers would be best.
+            InfoLogger() << "DestroyFightersPerBattleMax" <<  ship->TotalWeaponsFighterDamage();
+            // FIXME prevent recursion; disallowing the ValueRef inside of destroyFightersPerBattleMax via parsers would be best.
             return ship->TotalWeaponsFighterDamage();
         }
         return 0.0;
 
-    } else if (property_name == "TotalShipDamageEstimation") {
+    } else if (property_name == "DamageStructurePerBattleMax") {
         if (auto ship = std::dynamic_pointer_cast<const Ship>(object)) {
-            // FIXME prevent recursion; disallowing the ValueRef inside of totalWeaponsShipDamage via parsers would be best.
-            InfoLogger() << "TotalShipDamageEstimation" <<  ship->TotalWeaponsShipDamage();
+            // FIXME prevent recursion; disallowing the ValueRef inside of damageStructurePerBattleMax via parsers would be best.
+            InfoLogger() << "DamageStructurePerBattleMax" <<  ship->TotalWeaponsShipDamage();
             return ship->TotalWeaponsShipDamage();
         }
         return 0.0;

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -839,7 +839,6 @@ double Variable<double>::Eval(const ScriptingContext& context) const
     MeterType meter_type = NameToMeter(property_name);
     if (object && meter_type != MeterType::INVALID_METER_TYPE) {
         if (auto* m = object->GetMeter(meter_type)) {
-            ErrorLogger() << "GetMeter " << property_name << " " << m->Current() << " " << m->Initial() ;
             return m_return_immediate_value ? m->Current() : m->Initial();
         }
         return 0.0;
@@ -877,8 +876,10 @@ double Variable<double>::Eval(const ScriptingContext& context) const
     } else if (property_name == "Attack") {
         if (auto fleet = std::dynamic_pointer_cast<const Fleet>(object))
             return fleet->Damage(context.ContextObjects());
-        if (auto ship = std::dynamic_pointer_cast<const Ship>(object))
+        if (auto ship = std::dynamic_pointer_cast<const Ship>(object)) {
+            // FIXME need something to prevent recursion ; actually disallowing using Attack inside of combat estimation condition via parsers would be best.
             return ship->TotalWeaponsShipDamage(); // FIXME + ship-> TotalWeaponsFighterDamage()
+        }
         if (auto fighter = std::dynamic_pointer_cast<const Fighter>(object))
             return fighter->Damage();
         return 0.0;
@@ -1328,6 +1329,114 @@ std::string Statistic<std::string, std::string>::Eval(const ScriptingContext& co
                                 [](auto p1, auto p2) { return p1.second < p2.second; });
 
     return max->first;
+}
+
+///////////////////////////////////////////////////////////
+// TotalFighterShots (of a carrier during one battle)    //
+///////////////////////////////////////////////////////////
+TotalFighterShots::TotalFighterShots(std::unique_ptr<Condition::Condition>&& sampling_condition) :
+    Variable<int>(ReferenceType::SOURCE_REFERENCE),
+    m_sampling_condition(std::move(sampling_condition))
+{
+    this->m_root_candidate_invariant = (!m_sampling_condition || m_sampling_condition->RootCandidateInvariant());
+
+    // don't need to check if sampling condition is LocalCandidateInvariant, as
+    // all conditions aren't, but that refers to their own local candidate.  no
+    // condition is explicitly dependent on the parent context's local candidate.
+    // FIXME not sure what that above means (stolen from Statistic constructor), so i claim it is not invariant
+    this->m_local_candidate_invariant = false;
+
+    this->m_target_invariant = (!m_sampling_condition || m_sampling_condition->TargetInvariant());
+
+    this->m_source_invariant = (!m_sampling_condition || m_sampling_condition->SourceInvariant());
+}
+
+bool TotalFighterShots::operator==(const ValueRef<int>& rhs) const
+{
+    if (&rhs == this)
+        return true;
+    if (typeid(rhs) != typeid(*this))
+        return false;
+    const TotalFighterShots& rhs_ = static_cast<const TotalFighterShots&>(rhs);
+
+    if (m_sampling_condition == rhs_.m_sampling_condition) {
+        return true;
+    }
+    return false;
+}
+
+std::string TotalFighterShots::Description() const
+{
+    std::string retval = "TotalFighterShots(";
+    if (m_sampling_condition) {
+        retval += m_sampling_condition->Description();
+    }
+    retval += ")";
+    return retval;
+}
+
+std::string TotalFighterShots::Dump(unsigned short ntabs) const
+{
+    std::string retval = "TotalFighterShots";
+    if (m_sampling_condition)
+        retval += " condition = " + m_sampling_condition->Dump();
+    return retval;
+}
+
+void TotalFighterShots::SetTopLevelContent(const std::string& content_name)
+{
+    if (m_sampling_condition)
+        m_sampling_condition->SetTopLevelContent(content_name);
+}
+
+unsigned int TotalFighterShots::GetCheckSum() const
+{
+    unsigned int retval{0};
+
+    CheckSums::CheckSumCombine(retval, "ValueRef::TotalFighterShots");
+    CheckSums::CheckSumCombine(retval, m_sampling_condition);
+    TraceLogger() << "GetCheckSum(Statisic<T>): " << typeid(*this).name() << " retval: " << retval;
+    return retval;
+}
+
+int TotalFighterShots::Eval(const ScriptingContext& context) const
+{
+    Condition::ObjectSet condition_matches;
+
+    // Iterate over context, but change bout number
+    // XXX probably should rather take ship ID as argument as well
+    // XXX else i get a fighter and have to fetch me the launching ship from that
+    std::shared_ptr<const Ship> ship = std::static_pointer_cast<const Ship>(context.source);
+    if (!ship) {
+        ErrorLogger() << "TotalFighterShots condition used in context where the Source is not a ship";
+        return 0;
+    }
+
+    //XXX actually part of combat system, defined in AutoResolveCombat, maybe reuse
+    ScriptingContext mut_context(context);
+    int launch_capacity = ship->SumCurrentPartMeterValuesForPartClass(MeterType::METER_CAPACITY, ShipPartClass::PC_FIGHTER_BAY);
+    int hangar_fighters = ship->SumCurrentPartMeterValuesForPartClass(MeterType::METER_CAPACITY, ShipPartClass::PC_FIGHTER_HANGAR);
+    int launched_fighters = 0;
+    int shots_total = 0;
+
+    for (int bout = 1; bout <= GetGameRules().Get<int>("RULE_NUM_COMBAT_ROUNDS"); ++bout) {
+        mut_context.combat_bout = bout;
+        int launch_this_bout = std::min(launch_capacity,hangar_fighters);
+        int shots_this_bout = launched_fighters;
+        if (m_sampling_condition && launched_fighters > 0) {
+            // check if not shooting
+            condition_matches.clear();
+            m_sampling_condition->Eval(mut_context, condition_matches);
+            if (condition_matches.size() == 0) {
+                shots_this_bout = 0;
+            }
+        }
+        shots_total += shots_this_bout;
+        launched_fighters += launch_this_bout;
+        hangar_fighters -= launch_this_bout;
+    }
+
+    return shots_total;
 }
 
 ///////////////////////////////////////////////////////////

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -1340,7 +1340,7 @@ std::string Statistic<std::string, std::string>::Eval(const ScriptingContext& co
 ///////////////////////////////////////////////////////////
 // TotalFighterShots (of a carrier during one battle)    //
 ///////////////////////////////////////////////////////////
-TotalFighterShots::TotalFighterShots(std::unique_ptr<ValueRef<int>>&& carrier_id = nullptr, std::unique_ptr<Condition::Condition>&& sampling_condition = nullptr) :
+TotalFighterShots::TotalFighterShots(std::unique_ptr<ValueRef<int>>&& carrier_id, std::unique_ptr<Condition::Condition>&& sampling_condition) :
     Variable<int>(ReferenceType::NON_OBJECT_REFERENCE),
     m_carrier_id(std::move(carrier_id)),
     m_sampling_condition(std::move(sampling_condition))

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -1341,11 +1341,9 @@ TotalFighterShots::TotalFighterShots(std::unique_ptr<Condition::Condition>&& sam
 {
     this->m_root_candidate_invariant = (!m_sampling_condition || m_sampling_condition->RootCandidateInvariant());
 
-    // don't need to check if sampling condition is LocalCandidateInvariant, as
-    // all conditions aren't, but that refers to their own local candidate.  no
-    // condition is explicitly dependent on the parent context's local candidate.
-    // FIXME not sure what that above means (stolen from Statistic constructor), so i claim it is not invariant
-    this->m_local_candidate_invariant = false;
+    // no condition can explicitly reference the parent context's local candidate.
+    // so local candidate invariance does not depend on the sampling condition
+    this->m_local_candidate_invariant = true;
 
     this->m_target_invariant = (!m_sampling_condition || m_sampling_condition->TargetInvariant());
 

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -874,15 +874,20 @@ double Variable<double>::Eval(const ScriptingContext& context) const
     } else if (property_name == "CurrentTurn") {
         return context.current_turn;
 
-    } else if (property_name == "Attack") {
-        if (auto fleet = std::dynamic_pointer_cast<const Fleet>(object))
-            return fleet->Damage(context.ContextObjects());
+    } else if (property_name == "TotalFighterDamageEstimation") {
         if (auto ship = std::dynamic_pointer_cast<const Ship>(object)) {
-            // FIXME need something to prevent recursion ; actually disallowing using Attack inside of combat estimation condition via parsers would be best.
-            return ship->TotalWeaponsShipDamage(); // FIXME + ship-> TotalWeaponsFighterDamage()
+            ErrorLogger() << "TotalFighterDamageEstimation" <<  ship->TotalWeaponsFighterDamage();
+            // FIXME prevent recursion; disallowing the ValueRef inside totalWeaponsFighterDamage via parsers would be best.
+            return ship->TotalWeaponsFighterDamage();
         }
-        if (auto fighter = std::dynamic_pointer_cast<const Fighter>(object))
-            return fighter->Damage();
+        return 0.0;
+
+    } else if (property_name == "TotalShipDamageEstimation") {
+        if (auto ship = std::dynamic_pointer_cast<const Ship>(object)) {
+            // FIXME prevent recursion; disallowing the ValueRef inside of totalWeaponsShipDamage via parsers would be best.
+            ErrorLogger() << "TotalShipDamageEstimation" <<  ship->TotalWeaponsShipDamage();
+            return ship->TotalWeaponsShipDamage();
+        }
         return 0.0;
 
     } else if (property_name == "PropagatedSupplyRange") {

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -838,8 +838,10 @@ double Variable<double>::Eval(const ScriptingContext& context) const
 
     MeterType meter_type = NameToMeter(property_name);
     if (object && meter_type != MeterType::INVALID_METER_TYPE) {
-        if (auto* m = object->GetMeter(meter_type))
+        if (auto* m = object->GetMeter(meter_type)) {
+            ErrorLogger() << "GetMeter " << property_name << " " << m->Current() << " " << m->Initial() ;
             return m_return_immediate_value ? m->Current() : m->Initial();
+        }
         return 0.0;
 
     } else if (property_name == "X") {

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -26,6 +26,7 @@
 #include "UniverseObjectVisitors.h"
 #include "UniverseObject.h"
 #include "Universe.h"
+#include "../combat/CombatDamage.h"
 #include "../Empire/Empire.h"
 #include "../Empire/Supply.h"
 #include "../util/GameRules.h"
@@ -1395,48 +1396,19 @@ unsigned int TotalFighterShots::GetCheckSum() const
 
     CheckSums::CheckSumCombine(retval, "ValueRef::TotalFighterShots");
     CheckSums::CheckSumCombine(retval, m_sampling_condition);
-    TraceLogger() << "GetCheckSum(Statisic<T>): " << typeid(*this).name() << " retval: " << retval;
+    TraceLogger() << "GetCheckSum(TotalFighterShots):  retval: " << retval;
     return retval;
 }
 
 int TotalFighterShots::Eval(const ScriptingContext& context) const
 {
-    Condition::ObjectSet condition_matches;
-
-    // Iterate over context, but change bout number
-    // XXX probably should rather take ship ID as argument as well
-    // XXX else i get a fighter and have to fetch me the launching ship from that
     std::shared_ptr<const Ship> ship = std::static_pointer_cast<const Ship>(context.source);
     if (!ship) {
         ErrorLogger() << "TotalFighterShots condition used in context where the Source is not a ship";
         return 0;
     }
 
-    //XXX actually part of combat system, defined in AutoResolveCombat, maybe reuse
-    ScriptingContext mut_context(context);
-    int launch_capacity = ship->SumCurrentPartMeterValuesForPartClass(MeterType::METER_CAPACITY, ShipPartClass::PC_FIGHTER_BAY);
-    int hangar_fighters = ship->SumCurrentPartMeterValuesForPartClass(MeterType::METER_CAPACITY, ShipPartClass::PC_FIGHTER_HANGAR);
-    int launched_fighters = 0;
-    int shots_total = 0;
-
-    for (int bout = 1; bout <= GetGameRules().Get<int>("RULE_NUM_COMBAT_ROUNDS"); ++bout) {
-        mut_context.combat_bout = bout;
-        int launch_this_bout = std::min(launch_capacity,hangar_fighters);
-        int shots_this_bout = launched_fighters;
-        if (m_sampling_condition && launched_fighters > 0) {
-            // check if not shooting
-            condition_matches.clear();
-            m_sampling_condition->Eval(mut_context, condition_matches);
-            if (condition_matches.size() == 0) {
-                shots_this_bout = 0;
-            }
-        }
-        shots_total += shots_this_bout;
-        launched_fighters += launch_this_bout;
-        hangar_fighters -= launch_this_bout;
-    }
-
-    return shots_total;
+    return Combat::TotalFighterShots(context, *ship, m_sampling_condition.get());
 }
 
 ///////////////////////////////////////////////////////////

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -876,7 +876,7 @@ double Variable<double>::Eval(const ScriptingContext& context) const
         if (auto fleet = std::dynamic_pointer_cast<const Fleet>(object))
             return fleet->Damage(context.ContextObjects());
         if (auto ship = std::dynamic_pointer_cast<const Ship>(object))
-            return ship->TotalWeaponsDamage();
+            return ship->TotalWeaponsShipDamage(); // FIXME + ship-> TotalWeaponsFighterDamage()
         if (auto fighter = std::dynamic_pointer_cast<const Fighter>(object))
             return fighter->Damage();
         return 0.0;

--- a/universe/ValueRefs.h
+++ b/universe/ValueRefs.h
@@ -176,13 +176,13 @@ private:
     std::unique_ptr<ValueRef<V>>          m_value_ref;
 };
 
-/** The variable TotalFighterShots class.   The value returned by this node is
+/** The variable TotalFighterShots class. The value returned by this node is
   * computed from the gamestate; the number of shots of a launched fighters
-  * of the source carrier is counted (and added up) for all combat bouts
+  * of the given \a carrier_id is counted (and added up) for all combat bouts
   * in which the given \a sampling_condition matches. */
 struct FO_COMMON_API TotalFighterShots final : public Variable<int>
 {
-    TotalFighterShots(std::unique_ptr<ValueRef<int>>&& carrier_id, std::unique_ptr<Condition::Condition>&& sampling_condition);
+    TotalFighterShots(std::unique_ptr<ValueRef<int>>&& carrier_id, std::unique_ptr<Condition::Condition>&& sampling_condition = nullptr);
 
     bool        operator==(const ValueRef<int>& rhs) const override;
     int         Eval(const ScriptingContext& context) const override;

--- a/universe/ValueRefs.h
+++ b/universe/ValueRefs.h
@@ -176,6 +176,33 @@ private:
     std::unique_ptr<ValueRef<V>>          m_value_ref;
 };
 
+/** The variable TotalFighterShots class.   The value returned by this node is
+  * computed from the gamestate; the number of shots of a launched fighters
+  * of the source carrier is counted (and added up) for all combat bouts
+  * in which the given \a sampling_condition matches. */
+struct FO_COMMON_API TotalFighterShots final : public Variable<int>
+{
+    TotalFighterShots(std::unique_ptr<Condition::Condition>&& sampling_condition);
+
+    bool        operator==(const ValueRef<int>& rhs) const override;
+    int         Eval(const ScriptingContext& context) const override;
+    std::string Description() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
+    void        SetTopLevelContent(const std::string& content_name) override;
+
+    const Condition::Condition* GetSamplingCondition() const
+    { return m_sampling_condition.get(); }
+
+    unsigned int GetCheckSum() const override;
+
+    std::unique_ptr<ValueRef<int>> Clone() const override {
+        return std::make_unique<TotalFighterShots>(CloneUnique(m_sampling_condition));
+    }
+
+private:
+    std::unique_ptr<Condition::Condition> m_sampling_condition;
+};
+
 /** The complex variable ValueRef class. The value returned by this node
   * is taken from the gamestate. */
 template <typename T>
@@ -1187,6 +1214,12 @@ template struct Statistic<double, double>;
 template struct Statistic<double, std::string>;
 template struct Statistic<int, int>;
 template struct Statistic<int, std::string>;
+
+///////////////////////////////////////////////////////////
+// TotalFighterShots (of a carrier during one battle)    //
+///////////////////////////////////////////////////////////
+
+// Definig implementation here leads to ODR-hell
 
 ///////////////////////////////////////////////////////////
 // ComplexVariable                                       //

--- a/universe/ValueRefs.h
+++ b/universe/ValueRefs.h
@@ -182,7 +182,7 @@ private:
   * in which the given \a sampling_condition matches. */
 struct FO_COMMON_API TotalFighterShots final : public Variable<int>
 {
-    TotalFighterShots(std::unique_ptr<Condition::Condition>&& sampling_condition);
+    TotalFighterShots(std::unique_ptr<ValueRef<int>>&& carrier_id, std::unique_ptr<Condition::Condition>&& sampling_condition);
 
     bool        operator==(const ValueRef<int>& rhs) const override;
     int         Eval(const ScriptingContext& context) const override;
@@ -196,10 +196,11 @@ struct FO_COMMON_API TotalFighterShots final : public Variable<int>
     unsigned int GetCheckSum() const override;
 
     std::unique_ptr<ValueRef<int>> Clone() const override {
-        return std::make_unique<TotalFighterShots>(CloneUnique(m_sampling_condition));
+        return std::make_unique<TotalFighterShots>(CloneUnique(m_carrier_id), CloneUnique(m_sampling_condition));
     }
 
 private:
+    std::unique_ptr<ValueRef<int>>        m_carrier_id;
     std::unique_ptr<Condition::Condition> m_sampling_condition;
 };
 


### PR DESCRIPTION
I am working on combat damage estimation based on valuerefs. 

In the end I want to have two numbers shown in the UI. 
One is the maximum damage a ship can do against a ship in a combat. The other is the maximum count of fighters a ship can destroy in a combat.

In some places we currently show the per-bout damage, but in many cases I think it makes more sense to give the damage per combat as that is directly comparable to enemy structure for a turn-advance.

Implementation is based on providing two optional fields in weapon and hangar definitions: totalFighterDamage and totalShipDamage. There you can override the default implementation.
Note the backend implementation drifts towards using the term "destroy" capacity for the number of fighters an attacker can shoot as opposed to "damage" (used in its most specific sense) meaning the amount of damage to structure against ship targets.

Currently implemented as examples are the SR_WEAPON_0_1 (Flak) which has totalShipDamage = 0, SR_WEAPON_1_1 (mass driver) which has totalFighterDamage = 0 and SR_JAWS which only shoots in close range bouts (usually 2 out of 4 bouts -> half the normal damage).

- [ ] add to documentation: need to use immediate values (e.g. `Value(Source.MaxStructure)`), else the info in the design window is wrong (as the initial values are zero)
- [ ] add to documentation: dont use ThisPart here, but the part name instead (maybe open an issue?)
- [x] use the totalFighterDamage in the UI
- [x] check has weapon/blockade implications (weapons able to shoot down only fighters should also count for blockade?)
- [x] (my) decision: blockade should only be possible by ships which are able to damage ships (so destroying fighters is not enough), it doesnt matter if that damage comes from fighters (strikers,(heavy)bombers) are direct weapons. If a blockade is enforced by a fighter force, eliminating that fighter force (e.g. using flak) can break the blockade.
- [x] UI decision: should fighter caused damage be included in "destroy tally"? min/max issue? - yes, including it seems the better default
- [x] UI decision: should the fleet window show whole-combat damage? min/max issue with fighters? - whole-combat damage. min/max damage is out of scope for this PR, so showing only max damage.
- [x] decision: should the lower level backend functions calculate combat-damage or bout-damage as default (those are convertible on ship level/knowing the targeting)? the targeting can turn damage for a bout on/off. fighter damage depends also on launch behaviour (which needs launch bay and hangar capacities).
- [x] adapt all the weapons
- [x] maybe switch in all that backend-code to full combat damage instead of per-bout
- [x] also check for shields (target-dependent ShipDamage) (currently half implemented/not working)
- [x] see followups... ~~also check for Attack property, it currently triggers an endless recursion. using it should currently produce a warning at least (so the game crashes and you can easily see that using the Attack valueref was the cause).~~ Will crash for scope of this PR.
- [x] https://www.freeorion.org/forum/viewtopic.php?f=6&t=11985 IsArmed/HasArmedShips discussion and implementation -> going for CanDamageShips for supply and blockade

Primary test cases
- Strikers against shields (design screen), ARC_DISRUPTOR (design screen), Capital against shields, Starting frigate ship&fleet,

Secondary test cases
- SR Jaws (design screen), Mass Driver, Flak, Bomber, Interceptor, shields yes/no, CR weapon (ship)

Followups/Out of scope for this PR
- [ ] adapt planet defense UI to show full combat damage(?) - problem is defense dual role - one might want to know both the "shield equivalent" and the "total structural damage!
- [ ] show total fighter hangar(?) damage in ship damage popup - it may make sense to group multiple weapons of a kind
- [ ] find a good UI to give a feeling for real combat strength. Max total damage assumes that you loose no ships nor fighters, which is far from what is usually happening, so a span would be nice but hard to do nicely in UI
- [ ] using METER_CAPACITY and METER_MAX_CAPACITY for structural damage and fighter destruction leads to "strange" labels in the UI (as the meter descriptions are used) - I think that happens in MeterBrowseWnd
- [ ] asteroid snail should not have a SR_WEAPON_3_1, it blows the cover. Maybe some close range arc disruption instead or/and a jaws upgrade?
- [ ] per bout damage info on fleet (and maybe system) level as a mouse-over
- [ ] preventing/warning scripters not to use TotalFighterDamageEstimation in totalFighterDamageEstimation
- [ ] preventing/warning scripters not to use TotalShipDamageEstimation in totalShipDamageEstimation
- [ ] rename FighterDamage -> FighterDestruction (in backend and FOCS)
- [ ] maybe rename ShipDamage -> StructuralDamage (in backend and FOCS)
- [ ] AI interface 

[developer chat notes](https://www.freeorion.org/forum/viewtopic.php?p=105197#p105197)