### PR TITLE
Detect boost python library from python library instead of python executable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,6 +231,9 @@ find_package(Threads)
 find_package(PythonInterp ${MINIMUM_PYTHON_VERSION} REQUIRED)
 if(BUILD_AI OR BUILD_SERVER)
     find_package(PythonLibs ${MINIMUM_PYTHON_VERSION} REQUIRED)
+    message(STATUS "Python library version detected ${PYTHONLIBS_VERSION_STRING}")
+    string(REGEX REPLACE "^([0-9]+)\\.([0-9]+)\\..*" "\\1\\2" Boost_PYTHON_SUFFIX "${PYTHONLIBS_VERSION_STRING}")
+    message(STATUS "Boost python version ${Boost_PYTHON_SUFFIX}")
 endif()
 find_package(Boost ${MINIMUM_BOOST_VERSION}
     COMPONENTS
@@ -245,8 +248,12 @@ find_package(Boost ${MINIMUM_BOOST_VERSION}
     REQUIRED)
 
 if(BUILD_AI OR BUILD_SERVER)
-    find_package(Boost COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} REQUIRED)
-    set(Boost_PYTHON_SUFFIX "${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
+    find_package(Boost OPTIONAL_COMPONENTS python${Boost_PYTHON_SUFFIX})
+    if(NOT Boost_PYTHON${Boost_PYTHON_SUFFIX}_FOUND)
+        # try some strange boost installations
+        string(SUBSTRING "${Boost_PYTHON_SUFFIX}" 0 1 Boost_PYTHON_SUFFIX)
+        find_package(Boost COMPONENTS python${Boost_PYTHON_SUFFIX} REQUIRED)
+    endif()
 endif()
 
 find_package(ZLIB REQUIRED)
@@ -321,6 +328,7 @@ add_custom_target(freeorionversion
     "${CMAKE_SOURCE_DIR}/cmake/make_versioncpp.py"
     "${CMAKE_SOURCE_DIR}"
     "CMake"
+    "${Boost_PYTHON_SUFFIX}"
 )
 
 set_source_files_properties(

--- a/cmake/make_versioncpp.py
+++ b/cmake/make_versioncpp.py
@@ -13,22 +13,6 @@ from glob import glob
 
 INVALID_BUILD_NO = "???"
 
-required_boost_libraries = [
-    "boost_chrono",
-    "boost_date_time",
-    "boost_filesystem",
-    "boost_iostreams",
-    "boost_locale",
-    "boost_log",
-    "boost_log_setup",
-    "boost_python%d%d" % (sys.version_info.major, sys.version_info.minor),
-    "boost_regex",
-    "boost_serialization",
-    "boost_signals",
-    "boost_system",
-    "boost_thread",
-]
-
 
 class Generator(object):
     def __init__(self, infile, outfile):
@@ -105,13 +89,34 @@ class NsisInstScriptGenerator(Generator):
                 FreeOrion_PYTHON_VERSION="")
 
 
-if 3 != len(sys.argv):
+if len(sys.argv) not in (3, 4):
     print("ERROR: invalid parameters.")
-    print("make_versioncpp.py <project rootdir> <build system name>")
+    print("make_versioncpp.py <project rootdir> <build system name> [<boost python suffix>]")
     quit()
 
 os.chdir(sys.argv[1])
 build_sys = sys.argv[2]
+if 4 == len(sys.argv):
+    boost_python_suffix = sys.argv[3]
+else:
+    boost_python_suffix = "%d%d" % (sys.version_info.major, sys.version_info.minor)
+
+required_boost_libraries = [
+    "boost_chrono",
+    "boost_date_time",
+    "boost_filesystem",
+    "boost_iostreams",
+    "boost_locale",
+    "boost_log",
+    "boost_log_setup",
+    "boost_python%s" % boost_python_suffix,
+    "boost_regex",
+    "boost_serialization",
+    "boost_signals",
+    "boost_system",
+    "boost_thread",
+]
+
 
 # A list of tuples containing generators
 generators = [


### PR DESCRIPTION
Fix #3334 

Allows to have different python library and python executable in case of cross-compilation.