### PR TITLE
Fix multiplayer issues

### DIFF
--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1926,12 +1926,13 @@ int ServerApp::AddPlayerIntoGame(const PlayerConnectionPtr& player_connection, i
         return ALL_EMPIRES;
     }
 
+    int previous_player_id = EmpirePlayerID(empire_id);
+
     // make a link to new connection
     m_player_empire_ids[player_connection->PlayerID()] = empire_id;
     empire->SetAuthenticated(player_connection->IsAuthenticated());
 
     // drop previous connection to that empire
-    int previous_player_id = EmpirePlayerID(empire_id);
     if (previous_player_id != Networking::INVALID_PLAYER_ID) {
         WarnLogger() << "ServerApp::AddPlayerIntoGame empire " << empire_id
                      << " previous player " << previous_player_id

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -2991,7 +2991,7 @@ sc::result PlayingGame::react(const LobbyUpdate& msg) {
         if (player.first == sender->PlayerID() && player.second.save_game_empire_id != ALL_EMPIRES) {
             int empire_id = server.AddPlayerIntoGame(sender, player.second.save_game_empire_id);
             if (empire_id != ALL_EMPIRES) {
-                context<ServerFSM>().UpdateIngameLobby();
+                server.m_fsm->UpdateIngameLobby();
                 return discard_event();
             }
         }


### PR DESCRIPTION
Correctly get revious player id. Before could get same player just connected.

Fix crash if connection to the game could cause switch to lobby.