### PR TITLE
Send background parsing to separate thread

### DIFF
--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -141,7 +141,10 @@ void AIClientApp::Run() {
                                                  boost::uuids::nil_uuid()));
 
         // Start parsing content
-        StartBackgroundParsing();
+        std::promise<void> barrier;
+        std::future<void> barrier_future = barrier.get_future();
+        StartBackgroundParsing(std::move(barrier));
+        barrier_future.wait();
 
         // respond to messages until disconnected
         while (1) {

--- a/client/human/GGHumanClientApp.cpp
+++ b/client/human/GGHumanClientApp.cpp
@@ -353,7 +353,11 @@ GGHumanClientApp::GGHumanClientApp(int width, int height, bool calculate_fps, st
     // Start parsing content
     std::promise<void> barrier;
     std::future<void> barrier_future = barrier.get_future();
-    StartBackgroundParsing(std::move(barrier));
+    std::thread background([this] (auto b) {
+        DebugLogger() << "Started background parser thread";
+        StartBackgroundParsing(std::move(b));
+    }, std::move(barrier));
+    background.detach();
     barrier_future.wait();
     GetOptionsDB().OptionChangedSignal("resource.path").connect(
         boost::bind(&GGHumanClientApp::HandleResoureDirChange, this));
@@ -1553,7 +1557,11 @@ void GGHumanClientApp::HandleResoureDirChange() {
         DebugLogger() << "Resource directory changed.  Reparsing universe ...";
         std::promise<void> barrier;
         std::future<void> barrier_future = barrier.get_future();
-        StartBackgroundParsing(std::move(barrier));
+        std::thread background([this] (auto b) {
+            DebugLogger() << "Started background parser thread";
+            StartBackgroundParsing(std::move(b));
+        }, std::move(barrier));
+        background.detach();
         barrier_future.wait();
     } else {
         WarnLogger() << "Resource directory changes will take effect on application restart.";

--- a/client/human/GGHumanClientApp.cpp
+++ b/client/human/GGHumanClientApp.cpp
@@ -351,7 +351,10 @@ GGHumanClientApp::GGHumanClientApp(int width, int height, bool calculate_fps, st
     m_fsm->initiate();
 
     // Start parsing content
-    StartBackgroundParsing();
+    std::promise<void> barrier;
+    std::future<void> barrier_future = barrier.get_future();
+    StartBackgroundParsing(std::move(barrier));
+    barrier_future.wait();
     GetOptionsDB().OptionChangedSignal("resource.path").connect(
         boost::bind(&GGHumanClientApp::HandleResoureDirChange, this));
 }
@@ -1548,7 +1551,10 @@ void GGHumanClientApp::UpdateFPSLimit() {
 void GGHumanClientApp::HandleResoureDirChange() {
     if (!m_game_started) {
         DebugLogger() << "Resource directory changed.  Reparsing universe ...";
-        StartBackgroundParsing();
+        std::promise<void> barrier;
+        std::future<void> barrier_future = barrier.get_future();
+        StartBackgroundParsing(std::move(barrier));
+        barrier_future.wait();
     } else {
         WarnLogger() << "Resource directory changes will take effect on application restart.";
     }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -176,27 +176,27 @@ void ServerApp::StartBackgroundParsing(std::promise<void>&& barrier) {
     const auto& rdir = GetResourceDir();
 
     if (fs::exists(rdir / "scripting/starting_unlocks/items.inf"))
-        m_universe.SetInitiallyUnlockedItems(Pending::StartParsing(parse::items, rdir / "scripting/starting_unlocks/items.inf"));
+        m_universe.SetInitiallyUnlockedItems(Pending::StartAsyncParsing(parse::items, rdir / "scripting/starting_unlocks/items.inf"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/starting_unlocks/items.inf").string();
 
     if (fs::exists(rdir / "scripting/starting_unlocks/buildings.inf"))
-        m_universe.SetInitiallyUnlockedBuildings(Pending::StartParsing(parse::starting_buildings, rdir / "scripting/starting_unlocks/buildings.inf"));
+        m_universe.SetInitiallyUnlockedBuildings(Pending::StartAsyncParsing(parse::starting_buildings, rdir / "scripting/starting_unlocks/buildings.inf"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/starting_unlocks/buildings.inf").string();
 
     if (fs::exists(rdir / "scripting/starting_unlocks/fleets.inf"))
-        m_universe.SetInitiallyUnlockedFleetPlans(Pending::StartParsing(parse::fleet_plans, rdir / "scripting/starting_unlocks/fleets.inf"));
+        m_universe.SetInitiallyUnlockedFleetPlans(Pending::StartAsyncParsing(parse::fleet_plans, rdir / "scripting/starting_unlocks/fleets.inf"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/starting_unlocks/fleets.inf").string();
 
     if (fs::exists(rdir / "scripting/monster_fleets.inf"))
-        m_universe.SetMonsterFleetPlans(Pending::StartParsing(parse::monster_fleet_plans, rdir / "scripting/monster_fleets.inf"));
+        m_universe.SetMonsterFleetPlans(Pending::StartAsyncParsing(parse::monster_fleet_plans, rdir / "scripting/monster_fleets.inf"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/monster_fleets.inf").string();
 
     if (fs::exists(rdir / "scripting/empire_statistics"))
-        m_universe.SetEmpireStats(Pending::StartParsing(parse::statistics, rdir / "scripting/empire_statistics"));
+        m_universe.SetEmpireStats(Pending::StartAsyncParsing(parse::statistics, rdir / "scripting/empire_statistics"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/empire_statistics").string();
 }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -119,7 +119,10 @@ ServerApp::ServerApp() :
 
     // Start parsing content before FSM initialization
     // to have data initialized before autostart execution
-    StartBackgroundParsing();
+    std::promise<void> barrier;
+    std::future<void> barrier_future = barrier.get_future();
+    StartBackgroundParsing(std::move(barrier));
+    barrier_future.wait();
 
     m_fsm->initiate();
 
@@ -168,8 +171,8 @@ namespace {
 #include <stdlib.h>
 #endif
 
-void ServerApp::StartBackgroundParsing() {
-    IApp::StartBackgroundParsing();
+void ServerApp::StartBackgroundParsing(std::promise<void>&& barrier) {
+    IApp::StartBackgroundParsing(std::move(barrier));
     const auto& rdir = GetResourceDir();
 
     if (fs::exists(rdir / "scripting/starting_unlocks/items.inf"))

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -92,7 +92,7 @@ public:
 
     void operator()(); ///< external interface to Run()
 
-    void StartBackgroundParsing() override;
+    void StartBackgroundParsing(std::promise<void>&& barrier) override;
 
     /** Returns the galaxy setup data used for the current game */
     GalaxySetupData&    GetGalaxySetupData() { return m_galaxy_setup_data; }

--- a/test/parse/TestScriptParser.cpp
+++ b/test/parse/TestScriptParser.cpp
@@ -20,7 +20,7 @@
 BOOST_FIXTURE_TEST_SUITE(TestScriptParser, ParserAppFixture)
 
 BOOST_AUTO_TEST_CASE(parse_game_rules) {
-    Pending::Pending<GameRules> game_rules_p = Pending::StartParsing(parse::game_rules, m_scripting_dir / "game_rules.focs.txt");
+    Pending::Pending<GameRules> game_rules_p = Pending::StartAsyncParsing(parse::game_rules, m_scripting_dir / "game_rules.focs.txt");
     auto game_rules = *Pending::WaitForPendingUnlocked(std::move(game_rules_p));
     BOOST_REQUIRE(!game_rules.Empty());
     BOOST_REQUIRE(game_rules.RuleExists("RULE_HABITABLE_SIZE_MEDIUM"));
@@ -28,7 +28,7 @@ BOOST_AUTO_TEST_CASE(parse_game_rules) {
 }
 
 BOOST_AUTO_TEST_CASE(parse_techs) {
-    Pending::Pending<TechManager::TechParseTuple> techs_p = Pending::StartParsing(parse::techs<TechManager::TechParseTuple>, m_scripting_dir / "techs");
+    Pending::Pending<TechManager::TechParseTuple> techs_p = Pending::StartAsyncParsing(parse::techs<TechManager::TechParseTuple>, m_scripting_dir / "techs");
     auto [techs, tech_categories, categories_seen] = *Pending::WaitForPendingUnlocked(std::move(techs_p));
     BOOST_REQUIRE(!techs.empty());
     BOOST_REQUIRE(!tech_categories.empty());

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -27,7 +27,10 @@ ClientAppFixture::ClientAppFixture() :
     InfoLogger() << FreeOrionVersionString();
     DebugLogger() << "Test client initialized";
 
-    StartBackgroundParsing();
+    std::promise<void> barrier;
+    std::future<void> barrier_future = barrier.get_future();
+    StartBackgroundParsing(std::move(barrier));
+    barrier_future.wait();
 }
 
 int ClientAppFixture::EffectsProcessingThreads() const

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -29,7 +29,11 @@ ClientAppFixture::ClientAppFixture() :
 
     std::promise<void> barrier;
     std::future<void> barrier_future = barrier.get_future();
-    StartBackgroundParsing(std::move(barrier));
+    std::thread background([this] (auto b) {
+        DebugLogger() << "Started background parser thread";
+        StartBackgroundParsing(std::move(b));
+    }, std::move(barrier));
+    background.detach();
     barrier_future.wait();
 }
 

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -124,7 +124,7 @@ void IApp::StartBackgroundParsing(std::promise<void>&& barrier) {
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/game_rules.focs.txt").string();
 
     if (IsExistingDir(rdir / "scripting/techs"))
-        GetTechManager().SetTechs(Pending::StartParsing(parse::techs<TechManager::TechParseTuple>, rdir / "scripting/techs"));
+        GetTechManager().SetTechs(Pending::Parsed(parse::techs<TechManager::TechParseTuple>, rdir / "scripting/techs"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/techs").string();
 

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -62,69 +62,69 @@ void IApp::StartBackgroundParsing(std::promise<void>&& barrier) {
 
     // named value ref parsing can be done in parallel as the referencing happens after parsing
     if (IsExistingDir(rdir / "scripting/common"))
-        GetNamedValueRefManager().SetNamedValueRefParse(Pending::StartParsing(parse::named_value_refs, rdir / "scripting/common", std::move(barrier)));
+        GetNamedValueRefManager().SetNamedValueRefParse(Pending::StartAsyncParsing(parse::named_value_refs, rdir / "scripting/common", std::move(barrier)));
     else {
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/common").string();
         barrier.set_value();
     }
 
     if (IsExistingDir(rdir / "scripting/buildings"))
-        GetBuildingTypeManager().SetBuildingTypes(Pending::StartParsing(parse::buildings, rdir / "scripting/buildings"));
+        GetBuildingTypeManager().SetBuildingTypes(Pending::StartAsyncParsing(parse::buildings, rdir / "scripting/buildings"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/buildings").string();
 
     if (IsExistingDir(rdir / "scripting/policies"))
-        GetPolicyManager().SetPolicies(Pending::StartParsing(parse::policies, rdir / "scripting/policies"));
+        GetPolicyManager().SetPolicies(Pending::StartAsyncParsing(parse::policies, rdir / "scripting/policies"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/policies").string();
 
     if (IsExistingDir(rdir / "scripting/encyclopedia"))
-        GetEncyclopedia().SetArticles(Pending::StartParsing(parse::encyclopedia_articles, rdir / "scripting/encyclopedia"));
+        GetEncyclopedia().SetArticles(Pending::StartAsyncParsing(parse::encyclopedia_articles, rdir / "scripting/encyclopedia"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/encyclopedia").string();
 
     if (IsExistingDir(rdir / "scripting/fields"))
-        GetFieldTypeManager().SetFieldTypes(Pending::StartParsing(parse::fields, rdir / "scripting/fields"));
+        GetFieldTypeManager().SetFieldTypes(Pending::StartAsyncParsing(parse::fields, rdir / "scripting/fields"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/fields").string();
 
     if (IsExistingDir(rdir / "scripting/specials"))
-        GetSpecialsManager().SetSpecialsTypes(Pending::StartParsing(parse::specials, rdir / "scripting/specials"));
+        GetSpecialsManager().SetSpecialsTypes(Pending::StartAsyncParsing(parse::specials, rdir / "scripting/specials"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/specials").string();
 
     if (IsExistingDir(rdir / "scripting/species"))
-        GetSpeciesManager().SetSpeciesTypes(Pending::StartParsing(parse::species, rdir / "scripting/species"));
+        GetSpeciesManager().SetSpeciesTypes(Pending::StartAsyncParsing(parse::species, rdir / "scripting/species"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/species").string();
 
     if (IsExistingDir(rdir / "scripting/ship_parts"))
-        GetShipPartManager().SetShipParts(Pending::StartParsing(parse::ship_parts, rdir / "scripting/ship_parts"));
+        GetShipPartManager().SetShipParts(Pending::StartAsyncParsing(parse::ship_parts, rdir / "scripting/ship_parts"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/ship_parts").string();
 
     if (IsExistingDir(rdir / "scripting/ship_hulls"))
-        GetShipHullManager().SetShipHulls(Pending::StartParsing(parse::ship_hulls, rdir / "scripting/ship_hulls"));
+        GetShipHullManager().SetShipHulls(Pending::StartAsyncParsing(parse::ship_hulls, rdir / "scripting/ship_hulls"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/ship_hulls").string();
 
     if (IsExistingDir(rdir / "scripting/ship_designs"))
-        GetPredefinedShipDesignManager().SetShipDesignTypes(Pending::StartParsing(parse::ship_designs, rdir / "scripting/ship_designs"));
+        GetPredefinedShipDesignManager().SetShipDesignTypes(Pending::StartAsyncParsing(parse::ship_designs, rdir / "scripting/ship_designs"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/ship_designs").string();
 
     if (IsExistingDir(rdir / "scripting/monster_designs"))
-        GetPredefinedShipDesignManager().SetMonsterDesignTypes(Pending::StartParsing(parse::ship_designs, rdir / "scripting/monster_designs"));
+        GetPredefinedShipDesignManager().SetMonsterDesignTypes(Pending::StartAsyncParsing(parse::ship_designs, rdir / "scripting/monster_designs"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/monster_designs").string();
 
     if (IsExistingFile(rdir / "scripting/game_rules.focs.txt"))
-        GetGameRules().Add(Pending::StartParsing(parse::game_rules, rdir / "scripting/game_rules.focs.txt"));
+        GetGameRules().Add(Pending::StartAsyncParsing(parse::game_rules, rdir / "scripting/game_rules.focs.txt"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/game_rules.focs.txt").string();
 
     if (IsExistingDir(rdir / "scripting/techs"))
-        GetTechManager().SetTechs(Pending::Parsed(parse::techs<TechManager::TechParseTuple>, rdir / "scripting/techs"));
+        GetTechManager().SetTechs(Pending::ParseSynchronously(parse::techs<TechManager::TechParseTuple>, rdir / "scripting/techs"));
     else
         ErrorLogger() << "Background parse path doesn't exist: " << (rdir / "scripting/techs").string();
 

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -13,9 +13,9 @@
 #include "../universe/ShipPart.h"
 #include "../universe/ShipHull.h"
 #include "../universe/Tech.h"
-#include "../util/Directories.h"
-#include "../util/GameRules.h"
-#include "../util/Pending.h"
+#include "Directories.h"
+#include "GameRules.h"
+#include "Pending.h"
 
 #include <boost/filesystem.hpp>
 
@@ -48,8 +48,9 @@ int IApp::MAX_AI_PLAYERS() {
     return max_number_AIs;
 }
 
-void IApp::StartBackgroundParsing() {
+void IApp::StartBackgroundParsing(std::promise<void>&& barrier) {
     namespace fs = boost::filesystem;
+    barrier.set_value();
 
     const auto& rdir = GetResourceDir();
     if (!IsExistingDir(rdir)) {

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -48,8 +48,9 @@ public:
     //! known universe of this application.
     virtual Universe& GetUniverse() = 0;
 
-    /** Start parsing universe object types on a separate thread. */
-    virtual void StartBackgroundParsing();
+    /** Start parsing universe object types on a separate thread.
+      * Uses \a barrier to notify a main thread about completion named values. */
+    virtual void StartBackgroundParsing(std::promise<void>&& barrier);
 
     /** Returns the set of known Empires for this application. */
     virtual EmpireManager& Empires() = 0;

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -48,8 +48,12 @@ public:
     //! known universe of this application.
     virtual Universe& GetUniverse() = 0;
 
-    /** Start parsing universe object types on a separate thread.
-      * Uses \a barrier to notify a main thread about completion named values. */
+    /** Launches asynchronous parsing of game content, then starts
+      * additional content parsing in the calling thread. \a barrier is
+      * unblocked when the asynchronous parsing of named value refs is
+      * completed, but the synchronous parsing of in the calling thread
+      * or the other asynchronous parsing may still be ongoing
+      * at that time. */
     virtual void StartBackgroundParsing(std::promise<void>&& barrier);
 
     /** Returns the set of known Empires for this application. */

--- a/util/Pending.h
+++ b/util/Pending.h
@@ -172,10 +172,9 @@ namespace Pending {
     auto ParseSynchronously(const Func& parser, const boost::filesystem::path& path)
         -> Pending<decltype(parser(path))>
     {
-        auto result = parser(path);
-        auto promise = std::promise<decltype(parser(path))>();
-        promise.set_value(std::move(result));
-        return Pending<decltype(parser(path))>(promise.get_future(), path.filename().string());
+        auto retval = std::async(std::launch::deferred, parser, path);
+        retval.wait();
+        return Pending<decltype(parser(path))>(std::move(retval), path.filename().string());
     }
 
 }

--- a/util/Pending.h
+++ b/util/Pending.h
@@ -162,6 +162,17 @@ namespace Pending {
             path.filename().string());
     }
 
+    /** Return a Pending<T> constructed with \p parser and \p path which parses in same thread. */
+    template <typename Func>
+    auto Parsed(const Func& parser, const boost::filesystem::path& path)
+        -> Pending<decltype(parser(path))>
+    {
+        auto result = parser(path);
+        auto promise = std::promise<decltype(parser(path))>();
+        promise.set_value(std::move(result));
+        return Pending<decltype(parser(path))>(promise.get_future(), path.filename().string());
+    }
+
 }
 
 


### PR DESCRIPTION
Extracted from https://github.com/freeorion/freeorion/pull/3211 without Python things.

Launches background parsing at separate thread for client and uses std::promise to notify the main thread about named values paring completion.