### PR TITLE
Remove misleading log entry

### DIFF
--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -550,9 +550,6 @@ void ShipDesign::ForceValidDesignOrThrow(const boost::optional<std::invalid_argu
     if (no_hull_available)
         ss << "ShipDesign has no valid hull and there are no other hulls available.\n";
 
-    ss << "Invalid ShipDesign:\n";
-    ss << Dump() << "\n";
-
     std::tie(m_hull, m_parts) = *force_valid;
 
     ss << "ShipDesign was made valid as:\n";


### PR DESCRIPTION
This entry print the same design as after the words `ShipDesign was made valid`, this produces a kind of confusion.
Having the actual design printed would be nice, but it is not critical, since I could check the FOCS file to see it.

This is a sample from my logs (windows release branch and some [specific save](https://github.com/freeorion/freeorion/pull/3301#issuecomment-776302966))

I have added a comment about the content issue to the corresponding PR https://github.com/freeorion/freeorion/commit/e07b1e54014e8363f4c1d013cd1ad3aad1e54cb3#r49180617

```
23:31:38.686329 {0x0000312c} [info] ai : aiclientapp.cpp:106 : v0.4.10+ [build 2021-04-05.b892319] MSVC 2017
....
23:15:43.991968 {0x00003218} [debug] ai : shipdesign.cpp:524 : Invalid ShipDesign part "SH_PLASMA" can't be mounted in SL_EXTERNAL slot. Removing "SH_PLASMA"
23:15:43.991968 {0x00003218} [warn] ai : shipdesign.cpp:564 : Invalid ShipDesign:
ShipDesign
    name = "SM_BLOATED_JUGGERNAUT"
    uuid = "08a58b08-0929-496d-84fc-fba91424ca22"
    description = "SM_BLOATED_JUGGERNAUT_DESC"
    hull = "SH_BLOATED_JUGGERNAUT_BODY"
    parts = [
        "SP_CHAOS_WAVE"
        "SR_PLASMA_DISCHARGE"
        "SR_SPINES"
        "SR_SPINES"
        "SR_SPINES"
        "SH_PLASMA"
        "ST_CLOAK_2"
        ""
    ]
    icon = "icons/monsters/juggernaut-4.png"
    model = "seed"

ShipDesign was made valid as:
ShipDesign
    name = "SM_BLOATED_JUGGERNAUT"
    uuid = "08a58b08-0929-496d-84fc-fba91424ca22"
    description = "SM_BLOATED_JUGGERNAUT_DESC"
    hull = "SH_BLOATED_JUGGERNAUT_BODY"
    parts = [
        "SP_CHAOS_WAVE"
        "SR_PLASMA_DISCHARGE"
        "SR_SPINES"
        "SR_SPINES"
        "SR_SPINES"
        "SH_PLASMA"
        "ST_CLOAK_2"
        ""
    ]
    icon = "icons/monsters/juggernaut-4.png"
    model = "seed"
```