### PR TITLE
Fix use of boost placeholders

### DIFF
--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -373,7 +373,7 @@ void TechTreeWnd::TechTreeControls::RefreshCategoryButtons() {
         AttachChild(m_cat_buttons[category]);
 
         m_cat_buttons[category]->CheckedSignal.connect(
-            boost::bind(&TechTreeControls::CategoryButtonCheckedSlot, this, category, _1));
+            boost::bind(&TechTreeControls::CategoryButtonCheckedSlot, this, category, boost::placeholders::_1));
     }
 
     DoButtonLayout();


### PR DESCRIPTION
Fixes build error:
```
[ 62%] Building CXX object CMakeFiles/freeorion.dir/UI/TechTreeWnd.cpp.o
freeorion/UI/TechTreeWnd.cpp: In member function ‘void TechTreeWnd::TechTreeControls::RefreshCategoryButtons()’:
freeorion/UI/TechTreeWnd.cpp:376:87: error: ‘_1’ was not declared in this scope
  376 |             boost::bind(&TechTreeControls::CategoryButtonCheckedSlot, this, category, _1));
```