### PR TITLE
Display ValueRef floating points with only 3 digits in UI

### DIFF
--- a/universe/ValueRef.h
+++ b/universe/ValueRef.h
@@ -4,6 +4,7 @@
 #include "ScriptingContext.h"
 #include "../util/Enum.h"
 #include "../util/Export.h"
+#include "../util/i18n.h"
 #include <type_traits>
 
 namespace ValueRef {
@@ -39,7 +40,12 @@ protected:
 
 template<typename T, typename std::enable_if<std::is_arithmetic<T>::value, T>::type* = nullptr>
 std::string FlexibleToString(T&& t)
-{ return std::to_string(t); }
+{
+    if constexpr (std::is_floating_point<T>::value)
+        return DoubleToString(t, 3, false);
+    else
+        return std::to_string(t);
+}
 
 template<typename T, typename std::enable_if<std::is_enum<T>::value, T>::type* = nullptr>
 std::string FlexibleToString(T&& t)

--- a/universe/ValueRef.h
+++ b/universe/ValueRef.h
@@ -38,23 +38,23 @@ protected:
     bool m_source_invariant = false;
 };
 
-template<typename T, typename std::enable_if<std::is_arithmetic<T>::value, T>::type* = nullptr>
+template<typename T, typename std::enable_if_t<std::is_arithmetic_v<T>>* = nullptr>
 std::string FlexibleToString(T&& t)
 {
-    if constexpr (std::is_floating_point<T>::value)
+    if constexpr (std::is_floating_point_v<T>)
         return DoubleToString(t, 3, false);
     else
         return std::to_string(t);
 }
 
-template<typename T, typename std::enable_if<std::is_enum<T>::value, T>::type* = nullptr>
+template<typename T, typename std::enable_if_t<std::is_enum_v<T>>* = nullptr>
 std::string FlexibleToString(T&& t)
-{ return std::to_string(static_cast<typename std::underlying_type<T>::type>(t)); }
+{ return std::to_string(static_cast<std::underlying_type_t<T>>(t)); }
 
 inline std::string FlexibleToString(std::string&& t)
 { return std::move(t); }
 
-template<typename T, typename std::enable_if<std::is_same<T, std::vector<std::string>>::value, T>::type* = nullptr>
+template<typename T, typename std::enable_if_t<std::is_same_v<T, std::vector<std::string>>>* = nullptr>
 std::string FlexibleToString(T&& t)
 {
     std::string s;


### PR DESCRIPTION
Currently, standard ```std::to_string``` format results in excessive number of digits, e.g. ```std::to_string(3.0)``` resulting in 3.000000.

This PR uses existing functionality to return only 3 digits. This number of digits was chosen for consistency with (most) other parts of the UI.

Arguably, ```EvalAsString``` doesn't specify it is only to be used in UI but appears to currently be. Should be trivial to introduce another function reproducing the current behavior if required.