### PR TITLE
Adjust damage output on maintenance ship (nerf)

### DIFF
--- a/default/scripting/monster_designs/SM_GUARD_0.focs.txt
+++ b/default/scripting/monster_designs/SM_GUARD_0.focs.txt
@@ -6,7 +6,7 @@ ShipDesign
     parts = [
         "SR_ARC_DISRUPTOR"
         "AR_PRECURSOR_PLATE"
-        "SR_ARC_DISRUPTOR"
+        ""
         "SH_DEFENSE_GRID"
     ]
     icon = "icons/monsters/maintenance_ship.png"

--- a/default/scripting/ship_hulls/monster/SH_GUARD_0_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_GUARD_0_BODY.focs.txt
@@ -20,9 +20,20 @@ Hull
     effectsgroups = [
         [[MONSTER_SHIELD_REGENERATION]]
         [[UNOWNED_OWNED_VISION_BONUS(WEAK,10,10)]]
+        // weaken damage and distribute shots so it is possible to survive using a half armoured starting level colony ship
+        EffectsGroup
+            scope = Source
+            effects = [
+                SetMaxCapacity      partname = "SR_ARC_DISRUPTOR" value = [[SHIP_WEAPON_DAMAGE_FACTOR]]
+                SetCapacity         partname = "SR_ARC_DISRUPTOR" value = [[SHIP_WEAPON_DAMAGE_FACTOR]]
+                SetMaxSecondaryStat partname = "SR_ARC_DISRUPTOR" value = 5
+                SetSecondaryStat    partname = "SR_ARC_DISRUPTOR" value = 5
+            ]
+
     ]
     icon = ""
     graphic = "icons/monsters/maintenance_ship.png"
 
 #include "../ship_hulls.macros"
 #include "monster.macros"
+#include "/scripting/common/misc.macros"


### PR DESCRIPTION
The last monster revamp by mistake made maintenance ships too strong so that its very costly at the beginning to pass by using colony ships.

Removing one of the two arc disruptors makes fully standard armored medium colony ship pass. Nerfing a bit more relaxes the armor cost.

```
mass driver damage                       72 == 1x3x4 x6
                                        120 == 5x1x4 x 6
arc disruptor damage                    144 == 3x2x4 x 6
medium hull ship with  no basic armour:  80 == 10    x 8
medium hull ship with one basic armour: 128 == 16    x 8
medium hull ship with two basic armour: 176 == 22    x 8
```

https://www.freeorion.org/forum/viewtopic.php?p=106114#p106114