### PR TITLE
Avoid negative effect from Industrialism

### DIFF
--- a/default/scripting/policies/INDUSTRIALISM.focs.txt
+++ b/default/scripting/policies/INDUSTRIALISM.focs.txt
@@ -19,8 +19,8 @@ Policy
             ]
             priority = [[TARGET_2ND_SCALING_PRIORITY]]
             effects =
-                SetTargetIndustry value = Value + abs(Value)
-                    * ((NamedReal name = "PLC_INDUSTRIALISM_TARGET_INDUSTRY_SCALING" value = 1.25) - 1)
+                SetTargetIndustry value = Value
+                    + abs(Value * (NamedReal name = "PLC_INDUSTRIALISM_TARGET_INDUSTRY_PERCENT" value = 25) / 100)
 
         EffectsGroup
             scope = And [

--- a/default/scripting/policies/INDUSTRIALISM.focs.txt
+++ b/default/scripting/policies/INDUSTRIALISM.focs.txt
@@ -19,8 +19,8 @@ Policy
             ]
             priority = [[TARGET_2ND_SCALING_PRIORITY]]
             effects =
-                SetTargetIndustry value = Value
-                    * (NamedReal name = "PLC_INDUSTRIALISM_TARGET_INDUSTRY_SCALING" value = 1.25)
+                SetTargetIndustry value = Value + abs(Value)
+                    * ((NamedReal name = "PLC_INDUSTRIALISM_TARGET_INDUSTRY_SCALING" value = 1.25) - 1)
 
         EffectsGroup
             scope = And [

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -11529,7 +11529,7 @@ PLC_INDUSTRIALISM
 Industrialism
 
 PLC_INDUSTRIALISM_DESC
-'''Industry-focused planets get a boost to [[metertype METER_TARGET_INDUSTRY]] (x[[value PLC_INDUSTRIALISM_TARGET_INDUSTRY_SCALING]]) and a bonus of [[value PLC_INDUSTRIALISM_TARGET_HAPPINESS_FLAT]] to [[metertype METER_HAPPINESS]].
+'''Industry-focused planets get a boost to [[metertype METER_TARGET_INDUSTRY]] of [[value PLC_INDUSTRIALISM_TARGET_INDUSTRY_PERCENT]]% and a bonus of [[value PLC_INDUSTRIALISM_TARGET_HAPPINESS_FLAT]] to [[metertype METER_HAPPINESS]].
 
 Also makes some production-boosting generation techs cheaper to research.'''
 

--- a/default/stringtables/fr.txt
+++ b/default/stringtables/fr.txt
@@ -11529,7 +11529,7 @@ PLC_INDUSTRIALISM
 Industrialisme
 
 PLC_INDUSTRIALISM_DESC
-'''Les planètes en Focus Industrie améliorent leur [[metertype METER_TARGET_INDUSTRY]] (x[[value PLC_INDUSTRIALISM_TARGET_INDUSTRY_SCALING]]) et leur [[metertype METER_HAPPINESS]] augmente de [[value PLC_INDUSTRIALISM_TARGET_HAPPINESS_FLAT]].
+'''Les planètes en Focus Industrie améliorent leur [[metertype METER_TARGET_INDUSTRY]] de [[value PLC_INDUSTRIALISM_TARGET_INDUSTRY_PERCENT]]% et leur [[metertype METER_HAPPINESS]] augmente de [[value PLC_INDUSTRIALISM_TARGET_HAPPINESS_FLAT]].
 
 Diminue le coût de recherche de certaines technologies de Génération améliorant la production.'''
 


### PR DESCRIPTION
Industrialism bonus is calculated after -5 from Environmentalism,
so the value can be negative at that point and simply multiplying
it with 1.25 can result in making it worse.