### PR TITLE
Remove transitive dependency in Techs

### DIFF
--- a/default/scripting/techs/learning/GATEWAY_VOID.focs.txt
+++ b/default/scripting/techs/learning/GATEWAY_VOID.focs.txt
@@ -8,7 +8,6 @@ Tech
     tags = [ "PEDIA_LEARNING_CATEGORY" ]
     prerequisites = [
         "CON_STARGATE"
-        "LRN_NDIM_SUBSPACE"
     ]
     unlock = Item type = Building name = "BLD_GATEWAY_VOID"
     graphic = "icons/tech/monument_to_exodus.png"


### PR DESCRIPTION
We have two tech paths to LRN_GATEWAY_VOID from LRN_NDIM_SUBSPACE

1) LRN_NDIM_SUBSPACE opens LRN_GATEWAY_VOID 
2) LRN_NDIM_SUBSPACE opens LRN_SPATIAL_DISTORT_GEN opens CON_STARGATE opens LRN_GATEWAY_VOID 

```
┌─────────────────────────┐
│    LRN_NDIM_SUBSPACE    │ ─┐
└─────────────────────────┘  │
  │                          │
  ▼                          │
┌─────────────────────────┐  │
│ LRN_SPATIAL_DISTORT_GEN │  │
└─────────────────────────┘  │
  │                          │
  ▼                          │
┌─────────────────────────┐  │
│      CON_STARGATE       │  │
└─────────────────────────┘  │
  │                          │
  ▼                          │
┌─────────────────────────┐  │
│    LRN_GATEWAY_VOID     │ ◀┘
└─────────────────────────┘
```

We would like to break one of the paths to simplify code.

Log error suggests breaking somewhere in the second path
(it's a bit confusing and takes me some time to build a real picture in my head).

```
tech.cpp:529 : ERROR: Redundant tech dependency found (A <-- B means A is a prerequisite of B):
LRN_SPATIAL_DISTORT_GEN <-- CON_STARGATE,
CON_STARGATE <-- LRN_GATEWAY_VOID,
LRN_SPATIAL_DISTORT_GEN <-- LRN_GATEWAY_VOID;
remove the LRN_SPATIAL_DISTORT_GEN <-- LRN_GATEWAY_VOID dependency.
```

In my opinion we should break the first path since this will not affect the research process.