### PR TITLE
Refactored Fleet Aggression Handling

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -2494,7 +2494,7 @@ void Empire::CheckProductionProgress(ScriptingContext& context) {
                     // rename fleet, given its id and the ship that is in it
                     next_fleet->Rename(next_fleet->GenerateFleetName(context.ContextObjects()));
                     FleetAggression new_aggr = next_fleet->HasArmedShips(context.ContextObjects()) ?
-                        FleetAggression::FLEET_AGGRESSIVE : FleetAggression::FLEET_DEFENSIVE;
+                        FleetDefaults::FLEET_DEFAULT_ARMED : FleetDefaults::FLEET_DEFAULT_UNARMED;
                     next_fleet->SetAggression(new_aggr);
 
                     if (rally_point_id != INVALID_OBJECT_ID) {

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -3529,17 +3529,25 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
         auto split_action = [this, &ship_ids_set]() {
             ScopedTimer split_fleet_timer("FleetWnd::SplitFleet", true);
 
+            FleetAggression new_aggression_setting = FleetAggression::INVALID_FLEET_AGGRESSION;
+            if (m_new_fleet_drop_target)
+                new_aggression_setting = m_new_fleet_drop_target->GetFleetAggression();
+
             // assemble container of containers of ids of fleets to create.
             // one ship id per vector
             for (int ship_id : ship_ids_set) {
                 CreateNewFleetFromShips(
                     std::vector<int>{ship_id},
-                    FleetAggression::INVALID_FLEET_AGGRESSION);
+                    new_aggression_setting);
             }
         };
 
         auto split_per_design_action = [this, fleet]() {
-            CreateNewFleetsFromShipsForEachDesign(fleet->ShipIDs(), FleetAggression::INVALID_FLEET_AGGRESSION);
+            FleetAggression new_aggression_setting = FleetAggression::INVALID_FLEET_AGGRESSION;
+            if (m_new_fleet_drop_target)
+                new_aggression_setting = m_new_fleet_drop_target->GetFleetAggression();
+
+            CreateNewFleetsFromShipsForEachDesign(fleet->ShipIDs(), new_aggression_setting);
         };
 
         popup->AddMenuItem(GG::MenuItem(UserString("FW_SPLIT_FLEET"),             false, false, split_action));

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -174,13 +174,13 @@ namespace {
     }
 
     FleetAggression AggressionForFleet(FleetAggression aggression_mode, const std::vector<int>& ship_ids) {
-        if (aggression_mode <= FleetAggression::FLEET_AGGRESSIVE &&
-            aggression_mode >= FleetAggression::FLEET_PASSIVE)
+        if (aggression_mode < FleetAggression::NUM_FLEET_AGGRESSIONS &&
+            aggression_mode > FleetAggression::INVALID_FLEET_AGGRESSION)
         { return aggression_mode; }
         // auto aggression; examine ships to see if any are armed...
         if (ContainsArmedShips(ship_ids))
-            return FleetAggression::FLEET_OBSTRUCTIVE;
-        return FleetAggression::FLEET_PASSIVE;
+            return FleetDefaults::FLEET_DEFAULT_ARMED;
+        return FleetDefaults::FLEET_DEFAULT_UNARMED;
     }
 
     void CreateNewFleetFromShips(const std::vector<int>& ship_ids,
@@ -195,8 +195,6 @@ namespace {
         // TODO: Should probably have the sound effect occur exactly once instead
         //       of not at all.
         Sound::TempUISoundDisabler sound_disabler;
-
-        std::set<int> original_fleet_ids; // ids of fleets from which ships were taken
 
         // validate ships in each group, and generate fleet names for those ships
         const auto ships = Objects().find<const Ship>(ship_ids);
@@ -220,8 +218,6 @@ namespace {
                  ErrorLogger() << "CreateNewFleetFromShips passed ships not owned by this client's empire";
                  return;
              }
-
-             original_fleet_ids.insert(ship->FleetID());
         }
 
         // create new fleet with ships
@@ -302,7 +298,7 @@ namespace {
         std::vector<int> empire_system_fleet_ids;
         empire_system_fleet_ids.reserve(all_system_fleets.size());
         std::vector<int> empire_system_ship_ids;
-        empire_system_ship_ids.reserve(all_system_fleets.size());   // probably an underesitmate
+        empire_system_ship_ids.reserve(all_system_fleets.size());   // probably an underestimate
 
         for (auto& fleet : all_system_fleets) {
             if (!fleet->OwnedBy(client_empire_id))
@@ -3532,29 +3528,18 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
     {
         auto split_action = [this, &ship_ids_set]() {
             ScopedTimer split_fleet_timer("FleetWnd::SplitFleet", true);
-            // remove first ship from set, so it stays in its existing fleet
-            auto ship_id_it = ship_ids_set.begin();
-            ship_ids_set.erase(ship_id_it);
-
-            FleetAggression new_aggression_setting = FleetAggression::INVALID_FLEET_AGGRESSION;
-            if (m_new_fleet_drop_target)
-                new_aggression_setting = m_new_fleet_drop_target->GetFleetAggression();
 
             // assemble container of containers of ids of fleets to create.
             // one ship id per vector
             for (int ship_id : ship_ids_set) {
                 CreateNewFleetFromShips(
                     std::vector<int>{ship_id},
-                    new_aggression_setting);
+                    FleetAggression::INVALID_FLEET_AGGRESSION);
             }
         };
 
         auto split_per_design_action = [this, fleet]() {
-            FleetAggression new_aggression_setting = FleetAggression::INVALID_FLEET_AGGRESSION;
-            if (m_new_fleet_drop_target)
-                new_aggression_setting = m_new_fleet_drop_target->GetFleetAggression();
-
-            CreateNewFleetsFromShipsForEachDesign(fleet->ShipIDs(), new_aggression_setting);
+            CreateNewFleetsFromShipsForEachDesign(fleet->ShipIDs(), FleetAggression::INVALID_FLEET_AGGRESSION);
         };
 
         popup->AddMenuItem(GG::MenuItem(UserString("FW_SPLIT_FLEET"),             false, false, split_action));

--- a/server/ServerWrapper.cpp
+++ b/server/ServerWrapper.cpp
@@ -774,7 +774,7 @@ namespace {
             fleet->Rename(UserString("OBJ_FLEET") + " " + std::to_string(fleet->ID()));
         }
 
-        fleet->SetAggression(aggressive ? FleetAggression::FLEET_AGGRESSIVE : FleetAggression::FLEET_DEFENSIVE);
+        fleet->SetAggression(aggressive ? FleetDefaults::FLEET_DEFAULT_ARMED : FleetDefaults::FLEET_DEFAULT_UNARMED);
 
         // return fleet ID
         return fleet->ID();

--- a/universe/Effects.cpp
+++ b/universe/Effects.cpp
@@ -65,7 +65,7 @@ namespace {
 
         // if aggression specified, use that, otherwise get from whether ship is armed
         FleetAggression new_aggr = aggression == FleetAggression::INVALID_FLEET_AGGRESSION ?
-            (ship->IsArmed() ? FleetAggression::FLEET_AGGRESSIVE : FleetAggression::FLEET_DEFENSIVE) :
+            (ship->IsArmed() ? FleetDefaults::FLEET_DEFAULT_ARMED : FleetDefaults::FLEET_DEFAULT_UNARMED) :
             (aggression);
         fleet->SetAggression(new_aggr);
 

--- a/universe/Fleet.h
+++ b/universe/Fleet.h
@@ -46,6 +46,11 @@ FO_ENUM(
     ((NUM_FLEET_AGGRESSIONS))
 )
 
+namespace FleetDefaults {
+    constexpr auto FLEET_DEFAULT_ARMED = FleetAggression::FLEET_AGGRESSIVE;
+    constexpr auto FLEET_DEFAULT_UNARMED = FleetAggression::FLEET_DEFENSIVE;
+}
+
 /** Encapsulates data for a FreeOrion fleet.  Fleets are basically a group of
   * ships that travel together. */
 class FO_COMMON_API Fleet : public UniverseObject {

--- a/util/SerializeOrderSet.cpp
+++ b/util/SerializeOrderSet.cpp
@@ -68,7 +68,7 @@ void NewFleetOrder::serialize(Archive& ar, const unsigned int version)
     if (version < 2) {
         bool aggressive = false;
         ar  & boost::serialization::make_nvp("m_aggressive", aggressive);
-        m_aggression = aggressive ? FleetAggression::FLEET_AGGRESSIVE : FleetAggression::FLEET_DEFENSIVE;
+        m_aggression = aggressive ? FleetDefaults::FLEET_DEFAULT_ARMED : FleetDefaults::FLEET_DEFAULT_UNARMED;
     } else {
         ar  & BOOST_SERIALIZATION_NVP(m_aggression);
     }

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -367,7 +367,7 @@ void serialize(Archive& ar, Fleet& obj, unsigned int const version)
     if (Archive::is_loading::value && version < 5) {
         bool aggressive = false;
         ar  & make_nvp("m_aggressive", aggressive);
-        obj.m_aggression = aggressive ? FleetDefaults::FLEET_DEFAULT_ARMED : FleetDefaults::FLEET_DEFAULT_UNARMED;
+        obj.m_aggression = aggressive ? FleetAggression::FLEET_AGGRESSIVE : FleetAggression::FLEET_DEFENSIVE;
 
     } else {
         ar  & make_nvp("m_aggression", obj.m_aggression);

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -367,7 +367,7 @@ void serialize(Archive& ar, Fleet& obj, unsigned int const version)
     if (Archive::is_loading::value && version < 5) {
         bool aggressive = false;
         ar  & make_nvp("m_aggressive", aggressive);
-        obj.m_aggression = aggressive ? FleetAggression::FLEET_AGGRESSIVE : FleetAggression::FLEET_DEFENSIVE;
+        obj.m_aggression = aggressive ? FleetDefaults::FLEET_DEFAULT_ARMED : FleetDefaults::FLEET_DEFAULT_UNARMED;
 
     } else {
         ar  & make_nvp("m_aggression", obj.m_aggression);


### PR DESCRIPTION
Default aggression was used inconsistantly. When a fleet was
split, depending on the splitting method split-off battle ships
became aggressive or just obstrusive.
I defined alias values for default aggression of armed
and unarmed ships and used the new values where appropriate.
Also did some further cleanup in those methods.