### PR TITLE
Add unused references check

### DIFF
--- a/check/st-tool.py
+++ b/check/st-tool.py
@@ -845,7 +845,13 @@ def check_action(args):
                 for match in re.finditer(INTERNAL_REFERENCE_PATTERN_TEMPLATE.format('.*?'), entry.value):
                     reference_key = match['key']
                     references.add(reference_key)
-                    if reference_key not in source_st.keys():
+                    # TODO Do not check if key is present in other stringtable
+                    # If reference is not present in the translation it won't be resolved
+                    # Instead just [[...]] will be shown to user.
+                    present_in_reference_st = reference_st and reference_key in reference_st.keys()
+
+                    if not (reference_key in source_st.keys() or present_in_reference_st):
+
                         if match['ref_type'].strip() in OPTIONAL_REF_TYPES:
                             print("{}:{}: Optional referenced key '{}' in value of '{}' was not found. Reference was [[{}{}]].".format(source_st.fpath, entry.keyline, reference_key, entry.key, match['ref_type'], reference_key))
                             continue

--- a/check/st-tool.py
+++ b/check/st-tool.py
@@ -845,7 +845,7 @@ def check_action(args):
                 for match in re.finditer(INTERNAL_REFERENCE_PATTERN_TEMPLATE.format('.*?'), entry.value):
                     reference_key = match['key']
                     references.add(reference_key)
-                    if not (reference_key in source_st.keys() or (reference_st and reference_key in reference_st.keys())):
+                    if reference_key not in source_st.keys():
                         if match['ref_type'].strip() in OPTIONAL_REF_TYPES:
                             print("{}:{}: Optional referenced key '{}' in value of '{}' was not found. Reference was [[{}{}]].".format(source_st.fpath, entry.keyline, reference_key, entry.key, match['ref_type'], reference_key))
                             continue

--- a/default/stringtables/cz.txt
+++ b/default/stringtables/cz.txt
@@ -727,9 +727,6 @@ Spotřeba průmyslu
 RESEARCH_CONSUMPTION
 Spotřeba výzkumu
 
-TRADE_CONSUMPTION
-Spotřeba obchodu
-
 IMPORT_EXPORT_TOOLTIP
 Dovoz / Vývoz
 
@@ -1216,10 +1213,6 @@ Průmysl
 FOCUS_RESEARCH
 Výzkum
 
-# Focus types
-FOCUS_TRADE
-Obchod
-
 # Meter types
 METER_POPULATION
 populace
@@ -1231,10 +1224,6 @@ průmysl
 # Meter types
 METER_RESEARCH
 výzkum
-
-# Meter types
-METER_TRADE
-obchod
 
 # Meter types
 METER_CONSTRUCTION

--- a/default/stringtables/de.txt
+++ b/default/stringtables/de.txt
@@ -2107,12 +2107,6 @@ Imperiumsortung
 MAP_DETECTION_TEXT
 Ortungsreichweite des Imperiums
 
-MAP_TRADE_TITLE
-Handel
-
-MAP_TRADE_TEXT
-Handelsleistung des gesamten Imperiums. (Handel tut nichts)
-
 
 ##
 ## Side panel/System information
@@ -2134,17 +2128,11 @@ Industrieproduktion
 RESEARCH_PRODUCTION
 Forschungsproduktion
 
-TRADE_PRODUCTION
-Handelsproduktion
-
 INDUSTRY_CONSUMPTION
 Industrieverbrauch
 
 RESEARCH_CONSUMPTION
 Forschungsverbrauch
-
-TRADE_CONSUMPTION
-Handelsverbrauch
 
 IMPORT_EXPORT_TOOLTIP
 Einfuhr / Ausfuhr
@@ -3015,9 +3003,6 @@ Industrie
 
 METER_RESEARCH_VALUE_LABEL
 Forschung
-
-METER_TRADE_VALUE_LABEL
-Handel
 
 METER_CONSTRUCTION_VALUE_LABEL
 Infrastruktur
@@ -4234,10 +4219,6 @@ FOCUS_RESEARCH
 Forschung
 
 # Focus types
-FOCUS_TRADE
-Handel
-
-# Focus types
 FOCUS_LOGISTICS
 Logistik
 
@@ -4289,10 +4270,6 @@ METER_TARGET_RESEARCH
 Ziel Forschung
 
 # Meter types
-METER_TARGET_TRADE
-Ziel Handel
-
-# Meter types
 METER_TARGET_CONSTRUCTION
 Ziel Infrastruktur
 
@@ -4335,10 +4312,6 @@ Industrie
 # Meter types
 METER_RESEARCH
 Forschung
-
-# Meter types
-METER_TRADE
-Handel
 
 # Meter types
 METER_CONSTRUCTION
@@ -4400,12 +4373,6 @@ Größe
 #METER_DETECTION_STRENGTH
 #[[encyclopedia DETECTION_TITLE]]
 
-ALIGN_MILITARISM
-Militarismus
-
-ALIGN_ENVIRONMENT_MODIFICATION
-Veränderung der Umgebung
-
 # Empire affiliation types
 AFFIL_SELF
 Eigenes
@@ -4453,10 +4420,6 @@ baue
 # Build types
 BT_SHIP
 Schiff
-
-# Resource types
-RE_TRADE
-Handel
 
 # Resource types
 RE_INDUSTRY
@@ -4645,12 +4608,6 @@ Sternenklasse
 
 #DESC_VAR_SIZE
 #[[METER_SIZE]]
-
-DESC_VAR_TRADESTOCKPILE
-Handelslager
-
-DESC_VAR_TRADEOUTPUT
-Handelsproduktion
 
 DESC_VAR_INDUSTRYOUTPUT
 Industrieproduktion

--- a/default/stringtables/es.txt
+++ b/default/stringtables/es.txt
@@ -3435,12 +3435,6 @@ Diseño
 #*MAP_DETECTION_TEXT
 #* <not translated 1970-01-01 01:00:00>
 
-#*MAP_TRADE_TITLE
-#* <not translated 1970-01-01 01:00:00>
-
-#*MAP_TRADE_TEXT
-#* <not translated 1970-01-01 01:00:00>
-
 #*MAP_FLEET_SHIP_COUNT
 #* <not translated 1970-01-01 01:00:00>
 
@@ -3486,9 +3480,6 @@ Producción Industrial
 RESEARCH_PRODUCTION
 Producción de Investigación
 
-TRADE_PRODUCTION
-Producción de Comercio
-
 #*STOCKPILE_GENERATION
 #* <not translated 1970-01-01 01:00:00>
 
@@ -3497,9 +3488,6 @@ Consumo Industrial
 
 RESEARCH_CONSUMPTION
 Consumo de Investigación
-
-TRADE_CONSUMPTION
-Consumo de Comercio
 
 #*STOCKPILE_USE
 #* <not translated 1970-01-01 01:00:00>
@@ -3945,9 +3933,6 @@ Velocidad de Flota – Equivalente a la velocidad mínima de las naves en la flo
 #* <not translated 1970-01-01 01:00:00>
 
 #*FW_FLEET_RESEARCH_SUMMARY
-#* <not translated 1970-01-01 01:00:00>
-
-#*FW_FLEET_TRADE_SUMMARY
 #* <not translated 1970-01-01 01:00:00>
 
 #*FW_MERGE_SYSTEM_FLEETS
@@ -5598,12 +5583,6 @@ No puede estar en diseños con
 #*METER_TARGET_RESEARCH_VALUE_DESC
 #* <not translated 1970-01-01 01:00:00>
 
-#*METER_TARGET_TRADE_VALUE_LABEL
-#* <not translated 1970-01-01 01:00:00>
-
-#*METER_TARGET_TRADE_VALUE_DESC
-#* <not translated 1970-01-01 01:00:00>
-
 #*METER_TARGET_CONSTRUCTION_VALUE_LABEL
 #* <not translated 1970-01-01 01:00:00>
 
@@ -5705,12 +5684,6 @@ No puede estar en diseños con
 #* <not translated 1970-01-01 01:00:00>
 #* <not translated 1970-01-01 01:00:00>
 #* <not translated 1970-01-01 01:00:00>
-#* <not translated 1970-01-01 01:00:00>
-
-#*METER_TRADE_VALUE_LABEL
-#* <not translated 1970-01-01 01:00:00>
-
-#*METER_TRADE_VALUE_DESC
 #* <not translated 1970-01-01 01:00:00>
 
 #*METER_CONSTRUCTION_VALUE_LABEL
@@ -5907,12 +5880,6 @@ Rango de detección
 #* <not translated 1970-01-01 01:00:00>
 #* <not translated 1970-01-01 01:00:00>
 #* <not translated 1970-01-01 01:00:00>
-#* <not translated 1970-01-01 01:00:00>
-
-#*TRADE_FOCUS_TITLE
-#* <not translated 1970-01-01 01:00:00>
-
-#*TRADE_FOCUS_TEXT
 #* <not translated 1970-01-01 01:00:00>
 
 #*PROTECTION_FOCUS_TITLE
@@ -6448,9 +6415,6 @@ Mensajes
 #* <not translated 1970-01-01 01:00:00>
 
 #*FOCUS
-#* <not translated 1970-01-01 01:00:00>
-
-#*PREFERRED_FOCUS
 #* <not translated 1970-01-01 01:00:00>
 
 #*AVAILABLE_FOCI
@@ -9035,10 +8999,6 @@ FOCUS_RESEARCH
 Investigación
 
 # Focus types
-FOCUS_TRADE
-Comercio
-
-# Focus types
 FOCUS_LOGISTICS
 Logística
 
@@ -9099,10 +9059,6 @@ METER_TARGET_RESEARCH
 Investigación objetivo
 
 # Meter types
-METER_TARGET_TRADE
-Comercio objetivo
-
-# Meter types
 METER_TARGET_CONSTRUCTION
 Infraestructura objetivo
 
@@ -9157,10 +9113,6 @@ Industria
 # Meter types
 METER_RESEARCH
 Investigación
-
-# Meter types
-METER_TRADE
-Comercio
 
 # Meter types
 METER_CONSTRUCTION
@@ -9239,36 +9191,6 @@ Velocidad
 #*METER_TECH_COST_FACTOR
 #* <not translated 1970-01-01 01:00:00>
 
-#*ALIGN_MILITARISM
-#* <not translated 1970-01-01 01:00:00>
-
-#*ALIGN_MILITARY_STRENGTH_DESC
-#* <not translated 1970-01-01 01:00:00>
-
-#*ALIGN_SOCIAL_CONTROL
-#* <not translated 1970-01-01 01:00:00>
-
-#*ALIGN_SOCIAL_CONTROL_DESC
-#* <not translated 1970-01-01 01:00:00>
-
-#*ALIGN_ENVIRONMENT_MODIFICATION
-#* <not translated 1970-01-01 01:00:00>
-
-#*ALIGN_ENVIRONMENT_MODIFICATION_DESC
-#* <not translated 1970-01-01 01:00:00>
-
-#*ALIGN_BIOLOGICAL_ALTERATION
-#* <not translated 1970-01-01 01:00:00>
-
-#*ALIGN_BIOLOGICAL_ALTERATION_DESC
-#* <not translated 1970-01-01 01:00:00>
-
-#*ALIGN_MECHANIZATION
-#* <not translated 1970-01-01 01:00:00>
-
-#*ALIGN_MECHANIZATION_DESC
-#* <not translated 1970-01-01 01:00:00>
-
 # Empire affiliation types
 AFFIL_SELF
 nuestro
@@ -9324,10 +9246,6 @@ nave
 # Resource types
 #*INVALID_RESOURCE_TYPE
 #* <not translated 1970-01-01 01:00:00>
-
-# Resource types
-RE_TRADE
-comercio
 
 # Resource types
 RE_INDUSTRY
@@ -9494,10 +9412,6 @@ Colonización
 #* <not translated 1970-01-01 01:00:00>
 
 #*PC_RESEARCH_DESC
-#* <not translated 1970-01-01 01:00:00>
-
-# Ship part classes
-#*PC_TRADE
 #* <not translated 1970-01-01 01:00:00>
 
 # Ship part classes
@@ -9737,9 +9651,6 @@ valor previo para este medidor
 #*DESC_VAR_TARGETRESEARCH
 #* <not translated 1970-01-01 01:00:00>
 
-#*DESC_VAR_TARGETTRADE
-#* <not translated 1970-01-01 01:00:00>
-
 #*DESC_VAR_TARGETCONSTRUCTION
 #* <not translated 1970-01-01 01:00:00>
 
@@ -9771,9 +9682,6 @@ valor previo para este medidor
 #* <not translated 1970-01-01 01:00:00>
 
 #*DESC_VAR_RESEARCH
-#* <not translated 1970-01-01 01:00:00>
-
-#*DESC_VAR_TRADE
 #* <not translated 1970-01-01 01:00:00>
 
 #*DESC_VAR_CONSTRUCTION
@@ -9814,12 +9722,6 @@ valor previo para este medidor
 
 #*DESC_VAR_SIZE
 #* <not translated 1970-01-01 01:00:00>
-
-DESC_VAR_TRADESTOCKPILE
-existencias de comercio
-
-DESC_VAR_TRADEOUTPUT
-producción de comercio
 
 DESC_VAR_INDUSTRYOUTPUT
 producción industrial
@@ -9905,13 +9807,7 @@ turno actual
 #*DESC_VAR_LASTTURNBATTLEHERE
 #* <not translated 1970-01-01 01:00:00>
 
-#*DESC_COMPLEX
-#* <not translated 1970-01-01 01:00:00>
-
 #*DESC_VAR_JUMPSBETWEEN
-#* <not translated 1970-01-01 01:00:00>
-
-#*DESC_STATISTIC
 #* <not translated 1970-01-01 01:00:00>
 
 #*DESC_VAR_COUNT

--- a/default/stringtables/fi.txt
+++ b/default/stringtables/fi.txt
@@ -948,17 +948,11 @@ Teollisuus
 RESEARCH_PRODUCTION
 Tutkimus
 
-TRADE_PRODUCTION
-Vaihdanta
-
 INDUSTRY_CONSUMPTION
 Teollisuuden käyttö
 
 RESEARCH_CONSUMPTION
 Tutkimuskulutus
-
-TRADE_CONSUMPTION
-Kulutus
 
 IMPORT_EXPORT_TOOLTIP
 Tuonti / Vienti
@@ -1657,10 +1651,6 @@ teollisuus
 FOCUS_RESEARCH
 tutkimus
 
-# Focus types
-FOCUS_TRADE
-vaihdanta
-
 # Meter types
 METER_TARGET_POPULATION
 Tavoite väestö
@@ -1672,10 +1662,6 @@ Tavoite teollisuus
 # Meter types
 METER_TARGET_RESEARCH
 Tavoite tutkimus
-
-# Meter types
-METER_TARGET_TRADE
-Tavoite vaihdanta
 
 # Meter types
 METER_TARGET_CONSTRUCTION
@@ -1708,10 +1694,6 @@ Teollisuus
 # Meter types
 METER_RESEARCH
 Tutkimus
-
-# Meter types
-METER_TRADE
-Vaihdanta
 
 # Meter types
 METER_CONSTRUCTION
@@ -1856,12 +1838,6 @@ objektin tyyppi
 
 DESC_VAR_STARTYPE
 tähden tyyppi
-
-DESC_VAR_TRADESTOCKPILE
-vaihdannan synnyttämä varanto
-
-DESC_VAR_TRADEOUTPUT
-vaihdanta
 
 DESC_VAR_INDUSTRYOUTPUT
 Teollisuus

--- a/default/stringtables/it.txt
+++ b/default/stringtables/it.txt
@@ -1299,12 +1299,6 @@ Rilevamento Impero
 MAP_DETECTION_TEXT
 Forza Rilevamento Impero
 
-MAP_TRADE_TITLE
-Commercio
-
-MAP_TRADE_TEXT
-Commercio totale impero. (Commercio non fa nulla)
-
 
 ##
 ## Side panel/System information
@@ -1326,17 +1320,11 @@ Produzione Industriale
 RESEARCH_PRODUCTION
 Produzione Ricerca
 
-TRADE_PRODUCTION
-Produzione Commercio
-
 INDUSTRY_CONSUMPTION
 Consumo Industriale
 
 RESEARCH_CONSUMPTION
 Consumo Ricerca
-
-TRADE_CONSUMPTION
-Consumo Commercio
 
 IMPORT_EXPORT_TOOLTIP
 Importazione / Esportazione
@@ -2006,9 +1994,6 @@ Industria
 METER_RESEARCH_VALUE_LABEL
 Ricerca
 
-METER_TRADE_VALUE_LABEL
-Commercio
-
 METER_CONSTRUCTION_VALUE_LABEL
 Infrastrutture
 
@@ -2063,12 +2048,6 @@ Gli avamposti sono stazioni non presidiate che possono essere fondate in luoghi 
 
 GROWTH_FOCUS_TITLE
 Focus sulla Crescita
-
-TRADE_FOCUS_TITLE
-Focus sul Commercio
-
-TRADE_FOCUS_TEXT
-Il focus sul commercio non fa nulla, ancora. E' solo un segnaposto per i prossimi aggiornamenti.
 
 PROTECTION_FOCUS_TITLE
 Focus sulla Protezione
@@ -2662,10 +2641,6 @@ industria
 FOCUS_RESEARCH
 ricerca
 
-# Focus types
-FOCUS_TRADE
-commercio
-
 # Empire affiliation types
 AFFIL_SELF
 compagno
@@ -2709,10 +2684,6 @@ edificare
 # Build types
 BT_SHIP
 nave
-
-# Resource types
-RE_TRADE
-commercio
 
 # Resource types
 RE_INDUSTRY

--- a/default/stringtables/nl.txt
+++ b/default/stringtables/nl.txt
@@ -1295,10 +1295,6 @@ industrie
 FOCUS_RESEARCH
 onderzoek
 
-# Focus types
-FOCUS_TRADE
-handel
-
 # Meter types
 METER_POPULATION
 populatie
@@ -1310,10 +1306,6 @@ industrie
 # Meter types
 METER_RESEARCH
 onderzoek
-
-# Meter types
-METER_TRADE
-handel
 
 # Meter types
 METER_CONSTRUCTION
@@ -1424,9 +1416,6 @@ planet omgeving
 
 DESC_VAR_STARTYPE
 ster type
-
-DESC_VAR_TRADESTOCKPILE
-handel voorraad
 
 DESC_VAR_OWNER
 eigenaar

--- a/default/stringtables/pl.txt
+++ b/default/stringtables/pl.txt
@@ -669,9 +669,6 @@ Koncumpcja produkcji przemysłowej
 RESEARCH_CONSUMPTION
 Koncumpcja badań naukowych
 
-TRADE_CONSUMPTION
-Skuteczność handlu
-
 IMPORT_EXPORT_TOOLTIP
 Import / Eksport
 

--- a/default/stringtables/ru.txt
+++ b/default/stringtables/ru.txt
@@ -3013,12 +3013,6 @@ MAP_DETECTION_TITLE
 MAP_DETECTION_TEXT
 Радиус обнаружения
 
-MAP_TRADE_TITLE
-Торговля
-
-MAP_TRADE_TEXT
-Эффективность торговли. (Торговля не реализована)
-
 MAP_FLEET_SHIP_COUNT
 Всего кораблей
 
@@ -3064,9 +3058,6 @@ INDUSTRY_PRODUCTION
 RESEARCH_PRODUCTION
 Наука
 
-TRADE_PRODUCTION
-Торговля
-
 STOCKPILE_GENERATION
 Вместимость резервов
 
@@ -3075,9 +3066,6 @@ INDUSTRY_CONSUMPTION
 
 RESEARCH_CONSUMPTION
 Научные затраты
-
-TRADE_CONSUMPTION
-Торговые расходы
 
 STOCKPILE_USE
 Задействование резервов
@@ -3503,9 +3491,6 @@ FW_FLEET_INDUSTRY_SUMMARY
 
 FW_FLEET_RESEARCH_SUMMARY
 Исследовательская мощь флота - суммарная исследовательская мощь кораблей флота.
-
-FW_FLEET_TRADE_SUMMARY
-Торговые возможности флота - общее количество торговых кораблей флота.
 
 FW_MERGE_SYSTEM_FLEETS
 Объединить все корабли в системе в единый флот
@@ -5045,9 +5030,6 @@ METER_RESEARCH_VALUE_DESC
 
 Для исследования не требуется соединения систем линиями [[metertype METER_SUPPLY]].'''
 
-METER_TRADE_VALUE_LABEL
-Торговля
-
 METER_CONSTRUCTION_VALUE_LABEL
 Инфраструктура
 
@@ -5192,12 +5174,6 @@ GROWTH_FOCUS_TEXT
 Родные планеты, ориентированные на рост населения, только помогают другим планетам, также ориентированным на рост населения. Планета с артефактами, способствующими росту населения и сфокусированные на нем, помогает только соответствующему типу населения, например, некоторые помогают только росту органических видов жизни
 
 [[GROWTH_SPECIALS_ENTRY_LIST]]'''
-
-TRADE_FOCUS_TITLE
-Цель: торговля
-
-TRADE_FOCUS_TEXT
-Торговля пока ничего не делает. Она показывает, где планируется больше ресурсов
 
 PROTECTION_FOCUS_TITLE
 Цель: защита
@@ -5641,9 +5617,6 @@ BUILDING_TYPE
 
 FOCUS
 Цель
-
-PREFERRED_FOCUS
-Предпочтительная цель
 
 AVAILABLE_FOCI
 Доступные цели
@@ -8108,10 +8081,6 @@ FOCUS_RESEARCH
 Исследования
 
 # Focus types
-FOCUS_TRADE
-Торговля
-
-# Focus types
 FOCUS_LOGISTICS
 Снабжение
 
@@ -8172,10 +8141,6 @@ METER_TARGET_RESEARCH
 Цель: наука
 
 # Meter types
-METER_TARGET_TRADE
-Цель: торговля
-
-# Meter types
 METER_TARGET_CONSTRUCTION
 Цель: строительство
 
@@ -8226,10 +8191,6 @@ METER_INDUSTRY
 # Meter types
 METER_RESEARCH
 Исследования
-
-# Meter types
-METER_TRADE
-Торговля
 
 # Meter types
 METER_CONSTRUCTION
@@ -8306,36 +8267,6 @@ METER_SHIP_COST_FACTOR
 METER_TECH_COST_FACTOR
 Фактор стоимости технологии
 
-ALIGN_MILITARISM
-Милитаризм
-
-ALIGN_MILITARY_STRENGTH_DESC
-Сила и размер армии
-
-ALIGN_SOCIAL_CONTROL
-Социальный контроль
-
-ALIGN_SOCIAL_CONTROL_DESC
-Планка, до которой население отслеживается, ограничивается и подвергается воздействиям
-
-ALIGN_ENVIRONMENT_MODIFICATION
-Изменение окружающей среды
-
-ALIGN_ENVIRONMENT_MODIFICATION_DESC
-Использование терраформинга и других широкомасштабных проектов
-
-ALIGN_BIOLOGICAL_ALTERATION
-Биологические модификации
-
-ALIGN_BIOLOGICAL_ALTERATION_DESC
-Использование биоинженеринга и биологических модификаций
-
-ALIGN_MECHANIZATION
-Механизация
-
-ALIGN_MECHANIZATION_DESC
-Использование искусственных организмов и автоматизации
-
 # Empire affiliation types
 AFFIL_SELF
 свой
@@ -8387,10 +8318,6 @@ BT_SHIP
 # Resource types
 INVALID_RESOURCE_TYPE
 Неверный тип ресурса
-
-# Resource types
-RE_TRADE
-торговля
 
 # Resource types
 RE_INDUSTRY
@@ -8557,10 +8484,6 @@ PC_RESEARCH_DESC
 Научные детали увеличивают [[metertype METER_RESEARCH]] генерируемые кораблем. Кораблю может потребоваться [[metertype METER_POPULATION]] чтобы начать производить выходные мощности
 
 # Ship part classes
-PC_TRADE
-Торговля
-
-# Ship part classes
 PC_PRODUCTION_LOCATION
 Производство
 
@@ -8686,9 +8609,6 @@ DESC_VAR_LOCAL_CANDIDATE
 DESC_VAR_ROOT_CANDIDATE
 корневой кандидат состояния
 
-DESC_STATISTIC
-статистика
-
 DESC_STAT_TYPE
 тип отчета
 
@@ -8754,12 +8674,6 @@ DESC_VAR_GALAXYSTARLANEFREQUENCY
 
 DESC_VAR_NON_OBJECT_REFERENCE
 свободная переменная
-
-DESC_VAR_TRADESTOCKPILE
-торговый запас
-
-DESC_VAR_TRADEOUTPUT
-торговая ценность
 
 DESC_VAR_INDUSTRYOUTPUT
 промышленная мощность
@@ -8841,9 +8755,6 @@ DESC_VAR_OWNERTOPPRIORITYENQUEUEDTECH
 
 DESC_VAR_LASTTURNBATTLEHERE
 в последний раз бой был здесь
-
-DESC_COMPLEX
-Совокупность переменных
 
 # FOCS variable reference description text.
 # %1% reference type of the FOCS variable.

--- a/default/stringtables/sv.txt
+++ b/default/stringtables/sv.txt
@@ -1103,10 +1103,6 @@ industri
 FOCUS_RESEARCH
 forskning
 
-# Focus types
-FOCUS_TRADE
-handel
-
 # Meter types
 METER_POPULATION
 population
@@ -1118,10 +1114,6 @@ industri
 # Meter types
 METER_RESEARCH
 forskning
-
-# Meter types
-METER_TRADE
-handel
 
 # Meter types
 METER_CONSTRUCTION
@@ -1224,9 +1216,6 @@ objekttyp
 
 DESC_VAR_STARTYPE
 stjärntyp
-
-DESC_VAR_TRADESTOCKPILE
-handelsreserv
 
 DESC_VAR_OWNER
 ägare


### PR DESCRIPTION
I've started as cleanup of the check script and ended with adding a check.  I don't expect any feedback for the Python part.

Most interesting part of this code is the additional check and ist implementation:
```python
exit_code += _check_key_usage(source_st, reference_st, references)
```

What changes I have done and how they affect the development. 

I've added a check for keys that are not referenced from this file and does not present in en.txt.  This will solve a couple of issues:

- When the developer removes something from en.txt he will be reminded that this key present in other translations.
- When the developer renames some references he will be reminded that there is something else to do.  This is the most important part of this check because this information is shared in a complicated way (git history) and usually is not communicated to the translators.  
