### PR TITLE
Add PolicyManager to Universe Checksum

### DIFF
--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -3175,6 +3175,7 @@ std::map<std::string, unsigned int> CheckSumContent() {
     checksums["BuildingTypeManager"] = GetBuildingTypeManager().GetCheckSum();
     checksums["Encyclopedia"] = GetEncyclopedia().GetCheckSum();
     checksums["FieldTypeManager"] = GetFieldTypeManager().GetCheckSum();
+    checksums["PolicyManager"] = GetPolicyManager().GetCheckSum();
     checksums["ShipHullManager"] = GetShipHullManager().GetCheckSum();
     checksums["ShipPartManager"] = GetShipPartManager().GetCheckSum();
     checksums["PredefinedShipDesignManager"] = GetPredefinedShipDesignManager().GetCheckSum();


### PR DESCRIPTION
PolicyManager was not included in universe checksumming.

As policies register named valuerefs, the checksum of the NamedValueManager depends on the policy content and should wait until policies are parsed. The easiest way to ensure that is to call PolicyManager::GetCheckSum before  NamedValueRefManager::GetCheckSum is called when calculating CheckSumContent.

Also policy content being game-relevant should be included in content checksumming anyway.