### PR TITLE
Use OpenGL with GLVND - CMP0072

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,9 @@
-cmake_minimum_required(VERSION 3.6 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 cmake_policy(SET CMP0042 NEW)
+if(POLICY CMP0072)
+  cmake_policy(SET CMP0072 NEW)
+endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_HOME_DIRECTORY}/cmake ${CMAKE_HOME_DIRECTORY}/GG/cmake)
 set(CMAKE_OSX_DEPLOYMENT_TARGET 10.12 CACHE STRING "Set the minimum OSX deployment target version")
@@ -647,7 +650,7 @@ if(BUILD_CLIENT_GG)
         freeorionparse
         GiGi::GiGi
         ${SDL_LIBRARIES}
-        ${OPENGL_gl_LIBRARY}
+        ${OPENGL_opengl_LIBRARY}
         ${OPENAL_LIBRARY}
         ${OGG_LIBRARIES}
         ${VORBIS_LIBRARIES}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
 cmake_policy(SET CMP0042 NEW)
 if(POLICY CMP0072)
@@ -650,7 +650,7 @@ if(BUILD_CLIENT_GG)
         freeorionparse
         GiGi::GiGi
         ${SDL_LIBRARIES}
-        ${OPENGL_opengl_LIBRARY}
+        $<IF:$<BOOL:${OPENGL_opengl_LIBRARY}>,${OPENGL_opengl_LIBRARY},${OPENGL_gl_LIBRARY}>
         ${OPENAL_LIBRARY}
         ${OGG_LIBRARIES}
         ${VORBIS_LIBRARIES}

--- a/GG/CMakeLists.txt
+++ b/GG/CMakeLists.txt
@@ -7,7 +7,11 @@
 # Some Rights Reserved.  See COPYING file or https://www.gnu.org/licenses/lgpl-2.1.txt
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
+
+if(POLICY CMP0072)
+  cmake_policy(SET CMP0072 NEW)
+endif()
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_HOME_DIRECTORY}/cmake)
 
@@ -133,7 +137,7 @@ target_link_libraries(GiGi
         Boost::disable_autolinking
         Boost::dynamic_linking
         GLEW::GLEW
-        ${OPENGL_opengl_LIBRARY}
+        $<IF:$<BOOL:${OPENGL_opengl_LIBRARY}>,${OPENGL_opengl_LIBRARY},${OPENGL_gl_LIBRARY}>
     PRIVATE
         Boost::filesystem
         Boost::regex

--- a/GG/CMakeLists.txt
+++ b/GG/CMakeLists.txt
@@ -7,7 +7,7 @@
 # Some Rights Reserved.  See COPYING file or https://www.gnu.org/licenses/lgpl-2.1.txt
 # SPDX-License-Identifier: LGPL-2.1-or-later
 
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.10 FATAL_ERROR)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_HOME_DIRECTORY}/cmake)
 
@@ -133,7 +133,7 @@ target_link_libraries(GiGi
         Boost::disable_autolinking
         Boost::dynamic_linking
         GLEW::GLEW
-        ${OPENGL_gl_LIBRARY}
+        ${OPENGL_opengl_LIBRARY}
     PRIVATE
         Boost::filesystem
         Boost::regex


### PR DESCRIPTION
Resolves this warning when compiling:
```
CMake Warning (dev) at /usr/share/cmake-3.20/Modules/FindOpenGL.cmake:315 (message):
Policy CMP0072 is not set: FindOpenGL prefers GLVND by default when
available.  Run "cmake --help-policy CMP0072" for policy details.  Use the
cmake_policy command to set the policy and suppress this warning.

FindOpenGL found both a legacy GL library:

OPENGL_gl_LIBRARY: /usr/lib/libGL.so

and GLVND libraries for OpenGL and GLX:

OPENGL_opengl_LIBRARY: /usr/lib/libOpenGL.so
OPENGL_glx_LIBRARY: /usr/lib/libGLX.so

OpenGL_GL_PREFERENCE has not been set to "GLVND" or "LEGACY", so for
compatibility with CMake 3.10 and below the legacy GL library will be used.
Call Stack (most recent call first):
CMakeLists.txt:273 (find_package)
This warning is for project developers.  Use -Wno-dev to suppress it.
```

The policy was added in cmake 3.11, thus checking, if it exists.
The OPENGL_opengl_LIBRARY variable was added in 3.10, and can
be used without the policy being available.

Debian stable has cmake 3.13,
Debian oldstable can get 3.16 from the backports,
Ubuntu 18.04 uses cmake 3.10 (and has no backports).

Older cmake versions could also be supported by using the other method, which would end up with more branching.