### PR TITLE
Remove old code fromCMakesList

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.8 FATAL_ERROR)
 
-cmake_policy(SET CMP0042 NEW)
 if(POLICY CMP0072)
   cmake_policy(SET CMP0072 NEW)
 endif()


### PR DESCRIPTION
cmake_minimum_required sets implicitly all policies, which were introduced before or with the minimum version, to NEW.