### PR TITLE
Nerf inf. malus of Indoctrination and Checkpoints

### DIFF
--- a/default/scripting/policies/CHECKPOINTS.focs.txt
+++ b/default/scripting/policies/CHECKPOINTS.focs.txt
@@ -14,8 +14,8 @@ Policy
                 OwnedBy empire = Source.Owner
             ]
             effects = [
-                SetTargetInfluence value = Value 
-                   + (NamedReal name = "PLC_CHECKPOINTS_TARGET_INFLUENCE_FLAT" value = -2)
+                SetTargetInfluence value = Value
+                   + (NamedReal name = "PLC_CHECKPOINTS_TARGET_INFLUENCE_FLAT" value = -0.5)
                 SetMaxSupply value = Value 
                    + (NamedReal name = "PLC_CHECKPOINTS_MAX_SUPPLY_FLAT" value = -1)
             ]

--- a/default/scripting/policies/INDOCTRINATION.focs.txt
+++ b/default/scripting/policies/INDOCTRINATION.focs.txt
@@ -9,7 +9,7 @@ Policy
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
 
-        // makes planets more stable over time at cost of influence
+        // makes all planets more stable over time at the cost of influence
         EffectsGroup
         scope = And [
             Planet
@@ -20,8 +20,23 @@ Policy
             SetTargetHappiness value = Value + 
                 min((NamedReal name = "PLC_INDOCTRINATION_STRENGTH_MAX" value = 10.0),
                     (CurrentTurn - TurnPolicyAdopted empire = Source.Owner name = "PLC_INDOCTRINATION") / 4.0)
+            SetTargetInfluence value = Value - 1.0
+        ]
 
-            SetTargetInfluence value = Value - 4.0
+        // boosts influence of influence-focused planets
+        // TODO: Consider restricting this effect to also having the Palace or a Reg. Adm. center.
+        EffectsGroup
+        scope = And [
+            Planet
+            OwnedBy empire = Source.Owner
+            Species
+            Focus type = "FOCUS_INFLUENCE"
+            // Or [Capital Contains Building name = "BLD_REGIONAL_ADMIN"]
+        ]
+        priority = [[TARGET_SCALING_PRIORITY]]
+        effects = [
+            SetTargetInfluence value = Value * 
+                (NamedReal name = "PLC_INDOCTRINATION_INFLUENCE_FACTOR" value = 2.0)
         ]
     ]
     graphic = "icons/policies/indoctrination.png"

--- a/default/scripting/species/common/influence.macros
+++ b/default/scripting/species/common/influence.macros
@@ -9,6 +9,7 @@ BASE_INFLUENCE_COSTS
             ]
             stackinggroup = "IMPERIAL_PALACE_MANY_PLANETS_INFLUENCE_PENALTY"
             accountinglabel = "COLONY_ADMIN_COSTS_LABEL"
+            priority = [[TARGET_LAST_BEFORE_OVERRIDE_PRIORITY]]
             effects = SetTargetInfluence value = Value -
                 (NamedReal name = "COLONY_ADMIN_COSTS_PER_PLANET" value = 0.4) * ((
                     Statistic Count condition = And [
@@ -34,6 +35,7 @@ BASE_INFLUENCE_COSTS
                 Homeworld name = LocalCandidate.Species
             ]
             accountinglabel = "SPECIES_HOMEWORLD_INDEPENDENCE_DESIRE_LABEL"
+            priority = [[TARGET_LAST_BEFORE_OVERRIDE_PRIORITY]]
             effects = SetTargetInfluence value = Value - 1
 
         EffectsGroup      // colonies consume more influence if not supply connected to empire's capital
@@ -48,6 +50,7 @@ BASE_INFLUENCE_COSTS
                 ]
             ]
             accountinglabel = "CAPITAL_DISCONNECTION_LABEL"
+            priority = [[TARGET_LAST_BEFORE_OVERRIDE_PRIORITY]]
             effects = SetTargetInfluence value = Value
                         - NamedReal name = "SUPPLY_DISCONNECTED_INFLUENCE_MALUS"
                                     value = [[SUPPLY_DISCONNECTED_INFLUENCE_MALUS]]
@@ -61,7 +64,7 @@ BASE_INFLUENCE_COSTS
                 (GalaxyMaxAIAggression = 0)
             ]
             accountinglabel = "DIFFICULTY"
-            priority = [[TARGET_AFTER_SCALING_PRIORITY]]
+            priority = [[TARGET_LAST_BEFORE_OVERRIDE_PRIORITY]]
             effects = SetTargetInfluence value = Value + 1
 '''
 
@@ -146,6 +149,7 @@ VERY_BAD_INFLUENCE
                 Focus type = "FOCUS_INFLUENCE"
             ]
             accountinglabel = "VERY_BAD_INFLUENCE_LABEL"
+            priority = [[TARGET_SCALING_PRIORITY]]
             effects = SetTargetInfluence value = Value + ([[VERY_BAD_MULTIPLIER]]-1.0)*abs(Value)
 '''
 
@@ -176,6 +180,7 @@ BAD_INFLUENCE
                 Focus type = "FOCUS_INFLUENCE"
             ]
             accountinglabel = "BAD_INFLUENCE_LABEL"
+            priority = [[TARGET_SCALING_PRIORITY]]
             effects = SetTargetInfluence value = Value + ([[BAD_MULTIPLIER]]-1.0)*abs(Value)
 '''
 
@@ -194,6 +199,7 @@ GOOD_INFLUENCE
                 Focus type = "FOCUS_INFLUENCE"
             ]
             accountinglabel = "GOOD_INFLUENCE_LABEL"
+            priority = [[TARGET_SCALING_PRIORITY]]
             effects = SetTargetInfluence value = Value + ([[GOOD_MULTIPLIER]]-1.0)*abs(Value)
 '''
 
@@ -208,6 +214,7 @@ GREAT_INFLUENCE
                 Focus type = "FOCUS_INFLUENCE"
             ]
             accountinglabel = "GREAT_INFLUENCE_LABEL"
+            priority = [[TARGET_SCALING_PRIORITY]]
             effects = SetTargetInfluence value = Value + ([[GREAT_MULTIPLIER]]-1.0)*abs(Value)
 '''
 
@@ -222,6 +229,7 @@ ULTIMATE_INFLUENCE
                 Focus type = "FOCUS_INFLUENCE"
             ]
             accountinglabel = "ULTIMATE_INFLUENCE_LABEL"
+            priority = [[TARGET_SCALING_PRIORITY]]
             effects = SetTargetInfluence value = Value + ([[ULTIMATE_MULTIPLIER]]-1.0)*abs(Value)
 '''
 


### PR DESCRIPTION
- Reduce influence penalization of Indoctrination (-4 -> -1) and Checkpoints (-2 -> -0.5).
- Indoctrination doubles influence production of influence-focused planets.
- Fixes species trait and influence costs priorities to ensure that upkeeps are not magnified by good species traits.

[Related discussion](https://www.freeorion.org/forum/viewtopic.php?p=106601#p106601).