### PR TITLE
Add analytics

### DIFF
--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -3,6 +3,7 @@ these methods in turn activate other portions of the python AI code."""
 from functools import wraps
 from logging import debug, error, fatal, info
 
+from analytics import Tracker
 from common.configure_logging import redirect_logging_to_freeorion_logger
 
 # Logging is redirected before other imports so that import errors appear in log files.
@@ -20,6 +21,7 @@ from freeorion_tools.fo_chat_handler import configure_debug_chat, process_chat_m
 from freeorion_tools.patch_interface import patch_interface
 
 patch_interface()
+tracker = Tracker()
 
 import ColonisationAI
 import DiplomaticCorp
@@ -362,6 +364,8 @@ def generateOrders():  # pylint: disable=invalid-name
     turn_timer.start("Server_Processing")
 
     aistate.last_turn_played = fo.currentTurn()
+
+    tracker.report_turn()
 
 
 init_handlers(fo.getOptionsDBOptionStr("ai-config"), fo.getAIDir())

--- a/default/python/AI/analytics/__init__.py
+++ b/default/python/AI/analytics/__init__.py
@@ -1,0 +1,1 @@
+from analytics.orders import Tracker

--- a/default/python/AI/analytics/jar.py
+++ b/default/python/AI/analytics/jar.py
@@ -1,35 +1,34 @@
+import freeOrionAIInterface as fo
 from logging import error
 from typing import Dict, List, NamedTuple
 
-import freeOrionAIInterface as fo
-
 
 class CallInfo(NamedTuple):
-  args: tuple
-  result: bool
+    args: tuple
+    result: bool
 
 
 class Jar:
-  def __init__(self, name: str):
-    self.name = name
-    self._jar: Dict[int, List[CallInfo]] = {}
+    def __init__(self, name: str):
+        self.name = name
+        self._jar: Dict[int, List[CallInfo]] = {}
 
-  def set_order(self, args: tuple, result: int):
-    if result == 0:
-      result = False
-    elif result == 1:
-      result = True
-    else:
-      error("Unexpected result from issuing order, expect {0, 1} got " % result, stack_info=True)
-      result = True
+    def set_order(self, args: tuple, result: int):
+        if result == 0:
+            result = False
+        elif result == 1:
+            result = True
+        else:
+            error("Unexpected result from issuing order, expect {0, 1} got " % result, stack_info=True)
+            result = True
 
-    self._jar.setdefault(fo.currentTurn(), []).append(CallInfo(args, result))
+        self._jar.setdefault(fo.currentTurn(), []).append(CallInfo(args, result))
 
-  def get_turn(self, turn: int) -> List[CallInfo]:
-    return self._jar.get(turn, [])
+    def get_turn(self, turn: int) -> List[CallInfo]:
+        return self._jar.get(turn, [])
 
-  def get_total(self):
-    return sum(len(item) for item in self._jar.values())
+    def get_total(self):
+        return sum(len(item) for item in self._jar.values())
 
-  def __repr__(self):
-    return "Jar({})".format(self.name)
+    def __repr__(self):
+        return "Jar({})".format(self.name)

--- a/default/python/AI/analytics/jar.py
+++ b/default/python/AI/analytics/jar.py
@@ -1,0 +1,35 @@
+from logging import error
+from typing import Dict, List, NamedTuple
+
+import freeOrionAIInterface as fo
+
+
+class CallInfo(NamedTuple):
+  args: tuple
+  result: bool
+
+
+class Jar:
+  def __init__(self, name: str):
+    self.name = name
+    self._jar: Dict[int, List[CallInfo]] = {}
+
+  def set_order(self, args: tuple, result: int):
+    if result == 0:
+      result = False
+    elif result == 1:
+      result = True
+    else:
+      error("Unexpected result from issuing order, expect {0, 1} got " % result, stack_info=True)
+      result = True
+
+    self._jar.setdefault(fo.currentTurn(), []).append(CallInfo(args, result))
+
+  def get_turn(self, turn: int) -> List[CallInfo]:
+    return self._jar.get(turn, [])
+
+  def get_total(self):
+    return sum(len(item) for item in self._jar.values())
+
+  def __repr__(self):
+    return "Jar({})".format(self.name)

--- a/default/python/AI/analytics/orders.py
+++ b/default/python/AI/analytics/orders.py
@@ -1,96 +1,64 @@
 from collections import Counter
 from functools import wraps
-from logging import error, info
+from logging import info
 from operator import attrgetter
-from typing import Callable, Dict, Iterator, List, NamedTuple, Tuple
+from typing import Callable, Iterator, List, Tuple
 
 import freeOrionAIInterface as fo
+from analytics.jar import Jar
 from common.print_utils import Number, Table, Text
 
 
-class CallInfo(NamedTuple):
-    args: tuple
-    result: bool
-
-
-class Jar:
-    def __init__(self, name: str):
-        self.name = name
-        self._jar: Dict[int, List[CallInfo]] = {}
-
-    def set_order(self, args: tuple, result: int):
-        if result == 0:
-            result = False
-        elif result == 1:
-            result = True
-        else:
-            error("Unexpected result from issuing order, expect {0, 1} got " % result, stack_info=True)
-            result = True
-
-        self._jar.setdefault(fo.currentTurn(), []).append(CallInfo(args, result))
-
-    def get_turn(self, turn: int) -> List[CallInfo]:
-        return self._jar.get(turn, [])
-
-    def get_total(self):
-        return sum(len(item) for item in self._jar.values())
-
-    def __repr__(self):
-        return "Jar({})".format(self.name)
-
-
 def wrap_order(fun: Callable, call_jar: Jar):
-    @wraps(fun)
-    def wrapper(*args):
-        result = fun(*args)
-        call_jar.set_order(args, result)
-        return result
+  @wraps(fun)
+  def wrapper(*args):
+    result = fun(*args)
+    call_jar.set_order(args, result)
+    return result
 
-    return wrapper
+  return wrapper
 
 
 class CommandTracker:
-    def __init__(self, jar: Jar, fun_name: str):
-        self.fun_name = fun_name
-        self.jar = jar
+  def __init__(self, jar: Jar, fun_name: str):
+    self.fun_name = fun_name
+    self.jar = jar
 
-    def patch(self) -> None:
-        fun = getattr(fo, self.fun_name)
-        wrapped = wrap_order(fun, self.jar)
-        setattr(fo, self.fun_name, wrapped)
+  def patch(self) -> None:
+    fun = getattr(fo, self.fun_name)
+    wrapped = wrap_order(fun, self.jar)
+    setattr(fo, self.fun_name, wrapped)
 
 
 def get_issuers() -> Iterator[Tuple[str, str]]:
-    for attr in dir(fo):
-        if attr.startswith("issue") and attr.endswith("Order"):
-            yield attr[5:-5], attr
+  for attr in dir(fo):
+    if attr.startswith("issue") and attr.endswith("Order"):
+      yield attr[5:-5], attr
 
 
 class Tracker:
-    def __init__(self):
+  def __init__(self):
+    self.jars: List[Jar] = []
+    for name, issuer in get_issuers():
+      jar = Jar(name)
+      self.jars.append(jar)
+      tracker = CommandTracker(jar, issuer)
+      tracker.patch()
+    self.jars.sort(key=attrgetter("name"))
 
-        self.jars: List[Jar] = []
+  def report_turn(self):
+    turn = fo.currentTurn()
+    table = Table(
+      Text('Order'),
+      Number("Issued", precession=0, placeholder=" ", total=True),
+      Number("Failed", precession=0, placeholder=" ", total=True),
+      Number("Total", precession=0, placeholder=" ", total=True),
+      table_name="Issuing orders analytics for turn {}".format(turn),
+    )
 
-        for name, attr in get_issuers():
-            jar = Jar(name)
-            self.jars.append(jar)
-            tracker = CommandTracker(jar, attr)
-            tracker.patch()
-        self.jars.sort(key=attrgetter("name"))
-
-    def report_turn(self):
-        turn = fo.currentTurn()
-        table = Table(
-            Text('Order'),
-            Number("Issued", precession=0, placeholder=" ", total=True),
-            Number("Failed", precession=0, placeholder=" ", total=True),
-            Number("Total", precession=0, placeholder=" ", total=True),
-            table_name="Issuing orders analytics for turn {}".format(turn),
-        )
-
-        for jar in self.jars:
-            results = Counter(item.result for item in jar.get_turn(turn))
-            success = results[True]
-            fail = results[False]
-            table.add_row(jar.name, success, fail, jar.get_total())
-        table.print_table(info)
+    for jar in self.jars:
+      results = Counter(item.result for item in jar.get_turn(turn))
+      success = results[True]
+      fail = results[False]
+      table.add_row(jar.name, success, fail, jar.get_total())
+    table.print_table(info)

--- a/default/python/AI/analytics/orders.py
+++ b/default/python/AI/analytics/orders.py
@@ -82,10 +82,9 @@ class Tracker:
         turn = fo.currentTurn()
         table = Table(
             Text('Order'),
-            Number("I", precession=0, description="Issued orders", placeholder=" ", total=True),
-            Number("F", precession=0, description="Failed orders", placeholder=" ", total=True),
-            Number("Turn", precession=0, description="Total for this turn", placeholder=" ", total=True),
-            Number("Total", precession=0, description="Total for this session", placeholder=" ", total=True),
+            Number("Issued", precession=0, placeholder=" ", total=True),
+            Number("Failed", precession=0, placeholder=" ", total=True),
+            Number("Total", precession=0, placeholder=" ", total=True),
             table_name="Issuing orders analytics for turn {}".format(turn),
         )
 
@@ -93,6 +92,5 @@ class Tracker:
             results = Counter(item.result for item in jar.get_turn(turn))
             success = results[True]
             fail = results[False]
-            total = success + fail
-            table.add_row(jar.name, success, fail, total, jar.get_total())
+            table.add_row(jar.name, success, fail, jar.get_total())
         table.print_table(info)

--- a/default/python/AI/analytics/orders.py
+++ b/default/python/AI/analytics/orders.py
@@ -5,7 +5,7 @@ from operator import attrgetter
 from typing import Callable, Dict, Iterator, List, NamedTuple, Tuple
 
 import freeOrionAIInterface as fo
-from common.print_utils import Float, Table, Text
+from common.print_utils import Number, Table, Text
 
 
 class CallInfo(NamedTuple):
@@ -81,27 +81,20 @@ class Tracker:
     def report_turn(self):
         turn = fo.currentTurn()
         table = Table(
-            [
-                Text('Order'),
-                Float("S", precession=0, description="Issued orders"),
-                Float("F", precession=0, description="Failed orders"),
-                Float("Turn", precession=0, description="Total this turn"),
-                Float("Total", precession=0, description="Grand total"),
-            ],
+            Text('Order'),
+            Number("I", precession=0, description="Issued orders", placeholder=" "),
+            Number("F", precession=0, description="Failed orders", placeholder=" "),
+            Number("Turn", precession=0, description="Total this turn", placeholder=" "),
+            Number("Total", precession=0, description="Grand total", placeholder=" "),
             table_name="Issuing orders analytics for turn {}".format(turn),
-
         )
 
         for jar in self.jars:
-
             results = Counter(item.result for item in jar.get_turn(turn))
-
             success = results[True]
             fail = results[False]
             total = success + fail
             table.add_row(
                 (jar.name, success, fail, total, jar.get_total())
             )
-
-        for row in table.get_table().split("\n"):
-            print(row)
+        table.print_table(info)

--- a/default/python/AI/analytics/orders.py
+++ b/default/python/AI/analytics/orders.py
@@ -1,64 +1,64 @@
+import freeOrionAIInterface as fo
 from collections import Counter
 from functools import wraps
 from logging import info
 from operator import attrgetter
 from typing import Callable, Iterator, List, Tuple
 
-import freeOrionAIInterface as fo
 from analytics.jar import Jar
 from common.print_utils import Number, Table, Text
 
 
 def wrap_order(fun: Callable, call_jar: Jar):
-  @wraps(fun)
-  def wrapper(*args):
-    result = fun(*args)
-    call_jar.set_order(args, result)
-    return result
+    @wraps(fun)
+    def wrapper(*args):
+        result = fun(*args)
+        call_jar.set_order(args, result)
+        return result
 
-  return wrapper
+    return wrapper
 
 
 class CommandTracker:
-  def __init__(self, jar: Jar, fun_name: str):
-    self.fun_name = fun_name
-    self.jar = jar
+    def __init__(self, jar: Jar, fun_name: str):
+        self.fun_name = fun_name
+        self.jar = jar
 
-  def patch(self) -> None:
-    fun = getattr(fo, self.fun_name)
-    wrapped = wrap_order(fun, self.jar)
-    setattr(fo, self.fun_name, wrapped)
+    def patch(self) -> None:
+        fun = getattr(fo, self.fun_name)
+        wrapped = wrap_order(fun, self.jar)
+        setattr(fo, self.fun_name, wrapped)
 
 
 def get_issuers() -> Iterator[Tuple[str, str]]:
-  for attr in dir(fo):
-    if attr.startswith("issue") and attr.endswith("Order"):
-      yield attr[5:-5], attr
+    for attr in dir(fo):
+        if attr.startswith("issue") and attr.endswith("Order"):
+            yield attr[5:-5], attr
 
 
 class Tracker:
-  def __init__(self):
-    self.jars: List[Jar] = []
-    for name, issuer in get_issuers():
-      jar = Jar(name)
-      self.jars.append(jar)
-      tracker = CommandTracker(jar, issuer)
-      tracker.patch()
-    self.jars.sort(key=attrgetter("name"))
+    def __init__(self):
+        self.jars: List[Jar] = []
+        for name, issuer in get_issuers():
+            jar = Jar(name)
+            self.jars.append(jar)
+            tracker = CommandTracker(jar, issuer)
+            tracker.patch()
+        self.jars.sort(key=attrgetter("name"))
 
-  def report_turn(self):
-    turn = fo.currentTurn()
-    table = Table(
-      Text('Order'),
-      Number("Issued", precession=0, placeholder=" ", total=True),
-      Number("Failed", precession=0, placeholder=" ", total=True),
-      Number("Total", precession=0, placeholder=" ", total=True),
-      table_name="Issuing orders analytics for turn {}".format(turn),
-    )
+    def report_turn(self):
+        turn = fo.currentTurn()
+        table = Table(
+            Text('Order'),
+            Number("Issued", precession=0, placeholder=" ", total=True),
+            Number("Failed", precession=0, placeholder=" ", total=True),
+            Number("Total", precession=0, placeholder=" ", total=True),
+            table_name="Issuing orders analytics for turn {}".format(turn),
+        )
 
-    for jar in self.jars:
-      results = Counter(item.result for item in jar.get_turn(turn))
-      success = results[True]
-      fail = results[False]
-      table.add_row(jar.name, success, fail, jar.get_total())
-    table.print_table(info)
+        for jar in self.jars:
+            results = Counter(item.result for item in jar.get_turn(turn))
+            success = results[True]
+            fail = results[False]
+            table.add_row(jar.name, success, fail, jar.get_total())
+        table.print_table(info)

--- a/default/python/AI/analytics/orders.py
+++ b/default/python/AI/analytics/orders.py
@@ -1,0 +1,107 @@
+from collections import Counter
+from functools import wraps
+from logging import error, info
+from operator import attrgetter
+from typing import Callable, Dict, Iterator, List, NamedTuple, Tuple
+
+import freeOrionAIInterface as fo
+from common.print_utils import Float, Table, Text
+
+
+class CallInfo(NamedTuple):
+    args: tuple
+    result: bool
+
+
+class Jar:
+    def __init__(self, name: str):
+        self.name = name
+        self._jar: Dict[int, List[CallInfo]] = {}
+
+    def set_order(self, args: tuple, result: int):
+        if result == 0:
+            result = False
+        elif result == 1:
+            result = True
+        else:
+            error("Unexpected result from issuing order, expect {1, 2} got " % result, stack_info=True)
+            result = True
+
+        self._jar.setdefault(fo.currentTurn(), []).append(CallInfo(args, result))
+
+    def get_turn(self, turn: int) -> List[CallInfo]:
+        return self._jar.get(turn, [])
+
+    def get_total(self):
+        return sum(len(item) for item in self._jar.values())
+
+    def __repr__(self):
+        return "Jar({})".format(self.name)
+
+
+def wrap_order(fun: Callable, call_jar: Jar):
+    @wraps(fun)
+    def wrapper(*args):
+        result = fun(*args)
+        call_jar.set_order(args, result)
+        return result
+
+    return wrapper
+
+
+class CommandTracker:
+    def __init__(self, jar: Jar, fun_name: str):
+        self.fun_name = fun_name
+        self.jar = jar
+
+    def patch(self) -> None:
+        fun = getattr(fo, self.fun_name)
+        wrapped = wrap_order(fun, self.jar)
+        setattr(fo, self.fun_name, wrapped)
+
+
+def get_issuers() -> Iterator[Tuple[str, str]]:
+    for attr in dir(fo):
+        if attr.startswith("issue") and attr.endswith("Order"):
+            yield attr[5:-5], attr
+
+
+class Tracker:
+    def __init__(self):
+
+        self.jars: List[Jar] = []
+
+        for name, attr in get_issuers():
+            jar = Jar(name)
+            self.jars.append(jar)
+            tracker = CommandTracker(jar, attr)
+            tracker.patch()
+        self.jars.sort(key=attrgetter("name"))
+
+    def report_turn(self):
+        turn = fo.currentTurn()
+        table = Table(
+            [
+                Text('Order'),
+                Float("S", precession=0, description="Issued orders"),
+                Float("F", precession=0, description="Failed orders"),
+                Float("Turn", precession=0, description="Total this turn"),
+                Float("Total", precession=0, description="Grand total"),
+            ],
+            table_name="Issuing orders analytics for turn {}".format(turn),
+
+        )
+
+        for jar in self.jars:
+
+            results = Counter(item.result for item in jar.get_turn(turn))
+
+            success = results[True]
+            fail = results[False]
+            total = success + fail
+            table.add_row(
+                (jar.name, success, fail, total, jar.get_total())
+            )
+
+        for row in table.get_table().split("\n"):
+            print(row)

--- a/default/python/AI/analytics/orders.py
+++ b/default/python/AI/analytics/orders.py
@@ -24,7 +24,7 @@ class Jar:
         elif result == 1:
             result = True
         else:
-            error("Unexpected result from issuing order, expect {1, 2} got " % result, stack_info=True)
+            error("Unexpected result from issuing order, expect {0, 1} got " % result, stack_info=True)
             result = True
 
         self._jar.setdefault(fo.currentTurn(), []).append(CallInfo(args, result))

--- a/default/python/AI/analytics/orders.py
+++ b/default/python/AI/analytics/orders.py
@@ -82,10 +82,10 @@ class Tracker:
         turn = fo.currentTurn()
         table = Table(
             Text('Order'),
-            Number("I", precession=0, description="Issued orders", placeholder=" "),
-            Number("F", precession=0, description="Failed orders", placeholder=" "),
-            Number("Turn", precession=0, description="Total this turn", placeholder=" "),
-            Number("Total", precession=0, description="Grand total", placeholder=" "),
+            Number("I", precession=0, description="Issued orders", placeholder=" ", total=True),
+            Number("F", precession=0, description="Failed orders", placeholder=" ", total=True),
+            Number("Turn", precession=0, description="Total for this turn", placeholder=" ", total=True),
+            Number("Total", precession=0, description="Total for this session", placeholder=" ", total=True),
             table_name="Issuing orders analytics for turn {}".format(turn),
         )
 

--- a/default/python/AI/analytics/orders.py
+++ b/default/python/AI/analytics/orders.py
@@ -94,7 +94,5 @@ class Tracker:
             success = results[True]
             fail = results[False]
             total = success + fail
-            table.add_row(
-                (jar.name, success, fail, total, jar.get_total())
-            )
+            table.add_row(jar.name, success, fail, total, jar.get_total())
         table.print_table(info)

--- a/default/python/AI/analytics/report/base_handler.py
+++ b/default/python/AI/analytics/report/base_handler.py
@@ -2,5 +2,5 @@ from analytics.jar import CallInfo
 
 
 def base_reported(call_info: CallInfo) -> str:
-  res = "OK" if call_info.result else "Fail"
-  return f'[{call_info.name}]: {call_info.args}: {res}'
+    res = "OK" if call_info.result else "Fail"
+    return f'[{call_info.name}]: {call_info.args}: {res}'

--- a/default/python/AI/analytics/report/base_handler.py
+++ b/default/python/AI/analytics/report/base_handler.py
@@ -1,0 +1,6 @@
+from analytics.jar import CallInfo
+
+
+def base_reported(call_info: CallInfo) -> str:
+  res = "OK" if call_info.result else "Fail"
+  return f'[{call_info.name}]: {call_info.args}: {res}'

--- a/default/python/AI/analytics/report/reporter.py
+++ b/default/python/AI/analytics/report/reporter.py
@@ -1,19 +1,19 @@
 from collections import Callable
 from typing import Iterator
 
-from analytics.jar import Jar, CallInfo
+from analytics.jar import CallInfo, Jar
 from analytics.report.base_handler import base_reported
 
 
 class Reporter:
-  def __init__(self):
-    self.handlers = {}
-    self.base_handler: Callable[[CallInfo], str] = base_reported
+    def __init__(self):
+        self.handlers = {}
+        self.base_handler: Callable[[CallInfo], str] = base_reported
 
-  def _make_report_for_turn(self, turn: int, jar: Jar) -> Iterator[str]:
-    function = self.handlers.get(jar.name, self.base_handler)
-    for info in jar.get_turn(turn):
-      yield function(info)
+    def _make_report_for_turn(self, turn: int, jar: Jar) -> Iterator[str]:
+        function = self.handlers.get(jar.name, self.base_handler)
+        for info in jar.get_turn(turn):
+            yield function(info)
 
-  def report(self, turn: int, jar: Jar) -> str:
-    return '\n'.join(self._make_report_for_turn(turn, jar))
+    def report(self, turn: int, jar: Jar) -> str:
+        return '\n'.join(self._make_report_for_turn(turn, jar))

--- a/default/python/AI/analytics/report/reporter.py
+++ b/default/python/AI/analytics/report/reporter.py
@@ -1,0 +1,19 @@
+from collections import Callable
+from typing import Iterator
+
+from analytics.jar import Jar, CallInfo
+from analytics.report.base_handler import base_reported
+
+
+class Reporter:
+  def __init__(self):
+    self.handlers = {}
+    self.base_handler: Callable[[CallInfo], str] = base_reported
+
+  def _make_report_for_turn(self, turn: int, jar: Jar) -> Iterator[str]:
+    function = self.handlers.get(jar.name, self.base_handler)
+    for info in jar.get_turn(turn):
+      yield function(info)
+
+  def report(self, turn: int, jar: Jar) -> str:
+    return '\n'.join(self._make_report_for_turn(turn, jar))


### PR DESCRIPTION
Looks like it is easy to measure AI by collecting issued orders.  You don't need to touch actual code.
Here is a sample PR with code. 

Now I print only minimum information (order count).  Later we could build a more sophisticated framework on top of it.  

Here is a sample output.

```
Issuing orders analytics for turn 6
=======================================================
| Order                     | Issued | Failed | Total |
=======================================================
| AdoptPolicy               |        |        |       |
| Aggression                |        |        |     6 |
| AllowStockpileProduction  |      1 |        |     6 |
| Bombard                   |        |        |       |
| ChangeFocus               |      2 |        |    13 |
| ChangeProductionQuantity  |        |        |       |
| Colonize                  |        |        |       |
| CreateShipDesign          |        |        |     1 |
| DeadoptPolicy             |        |        |       |
| DequeueProduction         |        |        |       |
| DequeueTech               |        |        |       |
| EnqueueBuildingProduction |        |        |     1 |
| EnqueueShipProduction     |        |        |     3 |
| EnqueueTech               |        |        |   140 |
| FleetMove                 |      3 |        |    18 |
| FleetTransfer             |        |        |       |
| GiveObjectToEmpire        |        |        |       |
| Invade                    |        |        |       |
| NewFleet                  |        |        |       |
| PauseProduction           |        |        |       |
| Rename                    |        |        |     1 |
| RequeueProduction         |        |        |     1 |
| Scrap                     |        |        |       |
=======================================================
|                           |      6 |      0 |   190 |
=======================================================
```