### PR TITLE
Destroy on capture and set visibility for abandon outpost and independence

### DIFF
--- a/default/scripting/buildings/ABANDON_OUTPOST.focs.txt
+++ b/default/scripting/buildings/ABANDON_OUTPOST.focs.txt
@@ -1,6 +1,7 @@
 BuildingType
     name = "BLD_ABANDON_OUTPOST"
     description = "BLD_ABANDON_OUTPOST_DESC"
+    captureresult = Destroy
     buildcost = 20
     buildtime = 1
     location = And [
@@ -57,9 +58,9 @@ BuildingType
                     icon = "icons/tech/environmental_encapsulation.png"
                     parameters =  [
                         tag = "planet" data = Target.ID
-                        tag = "rawtext" data = Source.CreationTurn
                     ]
                     empire = Source.Owner
+                SetVisibility empire = Source.Owner visibility = Max(Value, Partial)
             ]
 
         EffectsGroup

--- a/default/scripting/buildings/COLONY_INDEPENDENCE_DECREE.focs.txt
+++ b/default/scripting/buildings/COLONY_INDEPENDENCE_DECREE.focs.txt
@@ -1,6 +1,7 @@
 BuildingType
     name = "BLD_COLONY_INDEPENDENCE_DECREE"
     description = "BLD_COLONY_INDEPENDENCE_DECREE_DESC"
+    captureresult = Destroy
     buildcost = 20
     buildtime = 1
     location = And [
@@ -55,6 +56,7 @@ BuildingType
                         tag = "species" data = Target.Species
                     ]
                     empire = Source.Owner
+                SetVisibility empire = Source.Owner visibility = Max(Value, Partial)
             ]
 
          EffectsGroup


### PR DESCRIPTION
For buildings BLD_ABANDON_OUTPOST, BLD_COLONY_INDEPENDENCE_DECREE

* prevent the effects if invasion happens first
* also give a visibility update after ownership changes