### PR TITLE
Avoid linking against libvorbisenc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -276,7 +276,7 @@ if(BUILD_CLIENT_GG)
     find_package(OpenGL REQUIRED)
     find_package(OpenAL REQUIRED)
     find_package(Ogg REQUIRED)
-    find_package(Vorbis REQUIRED)
+    find_package(Vorbis COMPONENTS Vorbis VorbisFile REQUIRED)
 endif()
 
 if(APPLE)
@@ -641,7 +641,6 @@ if(BUILD_CLIENT_GG)
             ${OPENGL_INCLUDE_DIR}
             ${OPENAL_INCLUDE_DIR}
             ${OGG_INCLUDE_DIRS}
-            ${VORBIS_INCLUDE_DIRS}
             ${FREETYPE_INCLUDE_DIRS}
     )
 
@@ -653,7 +652,8 @@ if(BUILD_CLIENT_GG)
         $<IF:$<BOOL:${OPENGL_opengl_LIBRARY}>,${OPENGL_opengl_LIBRARY},${OPENGL_gl_LIBRARY}>
         ${OPENAL_LIBRARY}
         ${OGG_LIBRARIES}
-        ${VORBIS_LIBRARIES}
+        Vorbis::Vorbis
+        Vorbis::VorbisFile
         ${ICONV_LIBRARY}
     )
 


### PR DESCRIPTION
Due to ${VORBIS_LIBRARIES} it was also linking against libvorbisenc.

As for how to easily see if it's needed or not:
libvorbisenc.dll is not in the list for packaging at the end of the file, only libvorbis.dll and libvorbisfile.dll. So, if it would be needed, you would have had problems and noticed it already.