### PR TITLE
cmake: hide PATH-Variables in the advanced section

### DIFF
--- a/cmake/FindFreetype.cmake
+++ b/cmake/FindFreetype.cmake
@@ -176,7 +176,6 @@ find_package_handle_standard_args(
 )
 
 mark_as_advanced(
-  FREETYPE_LIBRARIES
-  FREETYPE_INCLUDE_DIRS
-  FREETYPE_VERSION
+  FREETYPE_LIBRARY
+  FREETYPE_INCLUDE_DIR
 )

--- a/cmake/FindSDL.cmake
+++ b/cmake/FindSDL.cmake
@@ -157,3 +157,8 @@ if(SDL_FOUND)
         add_dependencies(SDL::SDL SDL::main)
     endif()
 endif()
+
+mark_as_advanced(
+  SDL_LIBRARY
+  SDL_INCLUDE_DIR
+)


### PR DESCRIPTION
Maybe you know the cmake-gui or ccmake.
This image is form the cmake-gui:
![cmake-gui](https://user-images.githubusercontent.com/21158813/121788903-a7474000-cbd1-11eb-99a6-ee9cc81f06a4.png)
All the variables for setting paths are hidden behind the switch to the advanced options … except of a few. Changing that.
The removed entries in the diff will still stay hidden after this change.