### PR TITLE
Didn't kick out current player connection

### DIFF
--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1937,7 +1937,7 @@ int ServerApp::AddPlayerIntoGame(const PlayerConnectionPtr& player_connection, i
     empire->SetAuthenticated(player_connection->IsAuthenticated());
 
     // drop previous connection to that empire
-    if (previous_player_id != Networking::INVALID_PLAYER_ID) {
+    if (previous_player_id != Networking::INVALID_PLAYER_ID && previous_player_id != player_connection->PlayerID()) {
         WarnLogger() << "ServerApp::AddPlayerIntoGame empire " << empire_id
                      << " previous player " << previous_player_id
                      << " was kicked.";


### PR DESCRIPTION
Fixes case when client send multiple Lobby Update messages to join as empire and couldn't issue orders: https://freeorion.org/forum/viewtopic.php?p=107021#p107021