### PR TITLE
Two more min stability case and a fix

### DIFF
--- a/default/scripting/common/named_values.focs.txt
+++ b/default/scripting/common/named_values.focs.txt
@@ -6,6 +6,8 @@
 
 NamedReal name = "ANCIENT_RUINS_TARGET_RESEARCH_PERPOP" value = (5 * [[RESEARCH_PER_POP]])
 
+NamedReal name = "ANCIENT_RUINS_MIN_STABILITY" value = 12
+
 NamedReal name = "IMPERIAL_GARRISON_MAX_TROOPS_FLAT" value = 6
 
 NamedReal name = "SHP_REINFORCED_HULL_BONUS" value = (5 * [[SHIP_STRUCTURE_FACTOR]]) 

--- a/default/scripting/policies/DIVINE_AUTHORITY.focs.txt
+++ b/default/scripting/policies/DIVINE_AUTHORITY.focs.txt
@@ -15,16 +15,23 @@ Policy
             Planet
             OwnedBy empire = Source.Owner
             Population low = 0.001
-            Happiness low = 10
         ]
         effects = [
             SetTargetHappiness value = Value
                 + (NamedReal name = "PLC_DIVINE_AUTHORITY_TARGET_HAPPINESS_FLAT" value = 4)
             SetTargetResearch value = Value
                 + (NamedReal name = "PLC_DIVINE_AUTHORITY_TARGET_RESEARCH_FLAT" value = -5)
+        ]
+        EffectsGroup
+        scope = And [
+            Planet
+            OwnedBy empire = Source.Owner
+            Population low = 0.001
+            Happiness low = (NamedReal name = "PLC_DIVINE_AUTHORITY_MIN_STABILITY" value = 10)
+        ]
+        effects =
             SetTargetInfluence value = Value
                 + (NamedReal name = "PLC_DIVINE_AUTHORITY_TARGET_INFLUENCE_FLAT" value = 1)
-        ]
     ]
     graphic = "icons/policies/divine_authority.png"
 

--- a/default/scripting/specials/planet/ANCIENT_RUINS.focs.txt
+++ b/default/scripting/specials/planet/ANCIENT_RUINS.focs.txt
@@ -45,7 +45,7 @@ Special
             scope = And [
                 Source
                 Focus type = "FOCUS_RESEARCH"
-                Happiness low = 10
+                Happiness low = NamedRealLookup name = "ANCIENT_RUINS_MIN_STABILITY"
             ]
             effects = SetTargetResearch value = Value + Target.Population
                         * NamedRealLookup name = "ANCIENT_RUINS_TARGET_RESEARCH_PERPOP"

--- a/default/scripting/specials/planet/ANCIENT_RUINS_DEPLETED.focs.txt
+++ b/default/scripting/specials/planet/ANCIENT_RUINS_DEPLETED.focs.txt
@@ -11,7 +11,7 @@ Special
             scope = And [
                 Source
                 Focus type = "FOCUS_RESEARCH"
-                Happiness low = 15
+                Happiness low = NamedRealLookup name = "ANCIENT_RUINS_MIN_STABILITY"
             ]
             effects = SetTargetResearch value = Value + Target.Population
                         * NamedRealLookup name = "ANCIENT_RUINS_TARGET_RESEARCH_PERPOP"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -13996,7 +13996,7 @@ Species InterDesign Academy
 
 BLD_INTERSPECIES_ACADEMY_DESC
 '''Increases the imperial stockpile use limit by increasing the stockpile use capacity on this planet by [[value BLD_INTERSPECIES_ACADEMY_MAX_STOCKPILE_FLAT]] when it has [[encyclopedia STOCKPILE_FOCUS_TITLE]], [[metertype METER_TARGET_RESEARCH]] by [[value BLD_INTERSPECIES_ACADEMY_TARGET_RESEARCH_FLAT]] when it has [[encyclopedia RESEARCH_FOCUS_TITLE]], or [[metertype METER_TARGET_INFLUENCE]] by [[value BLD_INTERSPECIES_ACADEMY_TARGET_INFLUENCE_FLAT]] when it has [[encyclopedia INFLUENCE_FOCUS_TITLE]]
-The research bonus requires a stability of [[value BLD_INTERSPECIES_ACADEMY_MIN_STABILITY]].
+The research bonus requires a stability of [[value BLD_INTERSPECIES_ACADEMY_MIN_STABILITY_RESEARCH]].
 
 Learning to design devices for use by different species is crucial for developing universally usable tools.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -9004,6 +9004,7 @@ Ancient Ruins (Excavated)
 
 ANCIENT_RUINS_DEPLETED_SPECIAL_DESC
 '''Increases [[metertype METER_TARGET_RESEARCH]] on this planet by [[value ANCIENT_RUINS_TARGET_RESEARCH_PERPOP]] per [[metertype METER_POPULATION]] when Focus is set to Research.
+The effect requires a stability of [[value ANCIENT_RUINS_MIN_STABILITY]].
 
 This planet holds the ruins of an unknown, advanced ancient race. A valuable discovery has already been made here.'''
 
@@ -9011,7 +9012,8 @@ ANCIENT_RUINS_SPECIAL
 Ancient Ruins
 
 ANCIENT_RUINS_SPECIAL_DESCRIPTION
-'''Increases [[metertype METER_TARGET_RESEARCH]] on this planet by 1 per [[metertype METER_POPULATION]] when Focus is set to Research.
+'''Increases [[metertype METER_TARGET_RESEARCH]] on this planet by [[value ANCIENT_RUINS_TARGET_RESEARCH_PERPOP]] per [[metertype METER_POPULATION]] when Focus is set to Research.
+The effect requires a stability of [[value ANCIENT_RUINS_MIN_STABILITY]].
 
 This planet holds the ruins of an unknown, advanced ancient race. The first empire with the tech [[tech LRN_XENOARCH]] to possess this planet receives one free advanced tech or uncovers a powerful building or ship. There's also a good chance that well preserved bodies of an extinct species will be found.'''
 
@@ -11619,7 +11621,7 @@ PLC_DIVERSITY_DESC
 '''Gives bonuses or penalties to research, stability, and capital influence, dependent on the number of species in the empire.
 The research bonus requires a stability of [[value PLC_DIVERSITY_MIN_STABILITY]].
 
-All bonuses or penalties are [value PLC_DIVERSITY_SCALING]] per species above or below 4 species that are present.'''
+All bonuses or penalties are [[value PLC_DIVERSITY_SCALING]] per species above or below 4 species that are present.'''
 
 PLC_DIVERSITY_SHORT_DESC
 Improves research, stability, and Influence
@@ -11683,6 +11685,7 @@ Divine Authority
 
 PLC_DIVINE_AUTHORITY_DESC
 '''Increases [[metertype METER_TARGET_HAPPINESS]] by [[value PLC_DIVINE_AUTHORITY_TARGET_HAPPINESS_FLAT]] and [[metertype METER_TARGET_INFLUENCE]] by [[value PLC_DIVINE_AUTHORITY_TARGET_INFLUENCE_FLAT]], but reduces [[metertype METER_TARGET_RESEARCH]] ([[value PLC_DIVINE_AUTHORITY_TARGET_RESEARCH_FLAT]]).
+The influence bonus requires a stability of [[value PLC_DIVINE_AUTHORITY_MIN_STABILITY]].
 
 The empire is ruled by a theocracy which claims deific authority. They assert omnipotence and infallibility, and inspire the empire with the belief that they are the chosen people. Religious extremism is promoted in the population, boosting confidence in government decree and stabilizing society, but critical thinking and evidence-based science is hampered.'''
 


### PR DESCRIPTION
I've changed divine authotity as discussed.
Ancient ruins now use 12 as a minimum instead of 10 or 15.
Depleted is the natural state of ancient ruins, they get depleted
as soon as an owner has Xenoarchaeology. Of course with the common
definitions its now easier to change, too.
Two more errors en.txt, argh :-(