### PR TITLE
Ignore freshly established colonies for evacuation building effects

### DIFF
--- a/default/scripting/buildings/EVACUATION.focs.txt
+++ b/default/scripting/buildings/EVACUATION.focs.txt
@@ -63,7 +63,7 @@ BuildingType
                 OwnedBy empire = Source.Owner
                 // evacuation building needs to exist one turn for technical reasons.
                 // it should not destroy a new colony
-                (LocalCandidate.TurnsSinceColonization > 1)
+                (LocalCandidate.TurnsSinceColonization > 0)
             ]
             priority = [[CONCENTRATION_CAMP_PRIORITY]]
             effects = [
@@ -85,7 +85,7 @@ BuildingType
                             Population high = 0
                             // evacuation building needs to exist one turn for technical reasons.
                             // it should not destroy a new colony
-                            (LocalCandidate.TurnsSinceColonization < 2)
+                            (LocalCandidate.TurnsSinceColonization < 1)
                         ]
                     ]
                     Contains Building name = "BLD_CONC_CAMP"

--- a/default/scripting/buildings/EVACUATION.focs.txt
+++ b/default/scripting/buildings/EVACUATION.focs.txt
@@ -61,6 +61,9 @@ BuildingType
             activation = ContainedBy And [
                 PopulationCenter
                 OwnedBy empire = Source.Owner
+                // evacuation building needs to exist one turn for technical reasons.
+                // it should not destroy a new colony
+                (LocalCandidate.TurnsSinceColonization > 1)
             ]
             priority = [[CONCENTRATION_CAMP_PRIORITY]]
             effects = [
@@ -78,7 +81,12 @@ BuildingType
                 ContainedBy Or [
                     And [
                         Object id = Source.PlanetID
-                        Population high = 0
+                        Or [
+                            Population high = 0
+                            // evacuation building needs to exist one turn for technical reasons.
+                            // it should not destroy a new colony
+                            (LocalCandidate.TurnsSinceColonization < 2)
+                        ]
                     ]
                     Contains Building name = "BLD_CONC_CAMP"
                     HasSpecial name = "CONC_CAMP_SLAVE_SPECIAL"


### PR DESCRIPTION
Ignoring freshly established colonies on BLD_EVACUATION (i.e. do destroy the building and do not decrease population if the building is on such a colony).

Solves #950 