### PR TITLE
Use f string instead of format

### DIFF
--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -140,7 +140,7 @@ class AIFleetMission:
 
         :param context: Context of the function call for logging purposes
         """
-        debug("Considering to merge %s", self.__str__())
+        debug(f"Considering to merge {self}")
         if self.type not in MERGEABLE_MISSION_TYPES:
             debug("Mission type does not allow merging.")
             return

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -459,7 +459,7 @@ class AIstate:
         self.empire_standard_enemy_rating = self.get_standard_enemy().get_rating()
 
     def __update_system_status(self):
-        debug('{0} Updating System Threats {0}'.format(10 * "="))
+        debug('=== Updating System Threats ===')
         universe = fo.getUniverse()
         empire = fo.getEmpire()
         empire_id = fo.empireID()

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -287,12 +287,24 @@ def generateOrders():  # pylint: disable=invalid-name
     debug("***************************************************************************")
     debug("*******  Log info for AI progress chart script. Do not modify.   **********")
     debug("Generating Orders")
-    debug("EmpireID: {empire.empireID}"
-          " Name: {empire.name}_{empire.empireID}_pid:{p_id}_{p_name}RIdx_{res_idx}_{aggression}"
-          " Turn: {turn}".format(empire=empire, p_id=fo.playerID(), p_name=fo.playerName(),
-                                 res_idx=ResearchAI.get_research_index(), turn=turn,
-                                 aggression=aggression_name.capitalize()))
-    debug("EmpireColors: {0.colour[0]} {0.colour[1]} {0.colour[2]} {0.colour[3]}".format(empire))
+
+    name_parts = (
+        empire.name,
+        empire.empireID,
+        "pid",
+        fo.playerID(),
+        fo.playerName(),
+        "RIdx",
+        ResearchAI.get_research_index(),
+        aggression_name.capitalize(),
+    )
+    empire_name = '_'.join(
+        str(part) for part in name_parts
+    )
+
+    debug(f"EmpireID: {empire.empireID} Name: {empire_name} Turn: {turn}")
+
+    debug(f"EmpireColors: {empire.colour}")
     if planet:
         debug("CapitalID: " + str(planet_id) + " Name: " + planet.name + " Species: " + planet.speciesName)
     else:

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -40,7 +40,7 @@ unmetThreat = 0
 
 def calculate_priorities():
     """Calculates the priorities of the AI player."""
-    debug("\n{0}Preparing to Calculate Priorities{0}".format(10 * "="))
+    debug("\n=== Preparing to Calculate Priorities ===")
     prioritiees_timer.start('setting Production Priority')
     aistate = get_aistate()
     aistate.set_priority(PriorityType.RESOURCE_PRODUCTION, 50)  # let this one stay fixed & just adjust Research

--- a/default/python/AI/freeorion_tools/chat_handler/debug_chat_handler.py
+++ b/default/python/AI/freeorion_tools/chat_handler/debug_chat_handler.py
@@ -148,7 +148,7 @@ class DebugChatHandler(ChatHandlerBase):
 
     def _handle_shell_input(self, message):
         """Handle message and prints it to chat and logs."""
-        self.send_notification(log_message=">>> {}".format(message))
+        self.send_notification(log_message=f">>> {message}")
         out, err = self._interpreter.eval(message)
         if out:
             self.send_notification(

--- a/default/python/AI/freeorion_tools/patch_interface.py
+++ b/default/python/AI/freeorion_tools/patch_interface.py
@@ -70,7 +70,7 @@ def to_dict_recursive(method):
 
 
 def to_str(prefix, id, name):
-    return '{}_{}<{}>'.format(prefix, id, name)
+    return f'{prefix}_{id}<{name}>'
 
 
 def patch_interface():

--- a/default/python/common/print_utils/_base_field.py
+++ b/default/python/common/print_utils/_base_field.py
@@ -29,13 +29,13 @@ class Field(ABC):
         self.total = total
 
     def __repr__(self):
-        return '%s(%s)' % (self.__class__.__name__, self.name)
+        return f'{self.__class__.__name__}({self.name})'
 
     def format_cell(self, item, width):
-        return '{:{align}{width}}'.format(item, width=width, align=self.align)
+        return f'{item:{self.align}{width}}'
 
     def format_header(self, width):
-        return '{: <{width}}'.format(self.name, width=width)
+        return f'{self.name:<{width}}'
 
     def make_cell_string(self, val):
         if self.placeholder and not val:


### PR DESCRIPTION
f-string is one of the cool features which became available after migration to Python 3.6
https://docs.python.org/3/tutorial/inputoutput.html#fancier-output-formatting

In most cases, we don't need to use `.format` and `%` anymore.

I have updated `format` usages, since the f-string reduces the number of characters.  As for `%` let it be.