### PR TITLE
Make policy adoption costs based on #planets or #population use square root

### DIFF
--- a/default/scripting/policies/ALLIED_REPAIR.focs.txt
+++ b/default/scripting/policies/ALLIED_REPAIR.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_ALLIED_REPAIR_DESC"
     short_description = "PLC_ALLIED_REPAIR_SHORT_DESC"
     category = "MILITARY_CATEGORY"
-    adoptioncost = floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
     ]

--- a/default/scripting/policies/ARTISAN_WORKSHOPS.focs.txt
+++ b/default/scripting/policies/ARTISAN_WORKSHOPS.focs.txt
@@ -3,8 +3,7 @@ Policy
     description = "PLC_ARTISAN_WORKSHOPS_DESC"
     short_description = "PLC_ARTISAN_WORKSHOPS_SHORT_DESC"
     category = "SOCIAL_CATEGORY"
-    adoptioncost = 1.0 * floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population
-                                           condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_INDOCTRINATION" "PLC_CONFORMANCE" "PLC_TERROR_SUPPRESSION" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]

--- a/default/scripting/policies/AUGMENTATION.focs.txt
+++ b/default/scripting/policies/AUGMENTATION.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_AUGMENTATION_DESC"
     short_description = "PLC_AUGMENTATION_SHORT_DESC"
     category = "SOCIAL_CATEGORY"
-    adoptioncost = 100.0
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_RACIAL_PURITY" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]

--- a/default/scripting/policies/AUTOMATED_RESEARCH.focs.txt
+++ b/default/scripting/policies/AUTOMATED_RESEARCH.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_ALGORITHMIC_RESEARCH_DESC"
     short_description = "PLC_ALGORITHMIC_RESEARCH_SHORT_DESC"
     category = "SOCIAL_CATEGORY"
-    adoptioncost = 1.0*floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
     

--- a/default/scripting/policies/BALANCE.focs.txt
+++ b/default/scripting/policies/BALANCE.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_BALANCE_DESC"
     short_description = "PLC_BALANCE_SHORT_DESC"
     category = "ECONOMIC_CATEGORY"
-    adoptioncost = 1.0*floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_TECHNOCRACY" "PLC_INDUSTRIALISM" "PLC_STOCKPILE_LIQUIDATION" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]

--- a/default/scripting/policies/BOOTSTRAPPING.focs.txt
+++ b/default/scripting/policies/BOOTSTRAPPING.focs.txt
@@ -3,8 +3,7 @@ Policy
     description = "PLC_BOOTSTRAPPING_DESC"
     short_description = "PLC_BOOTSTRAPPING_SHORT_DESC"
     category = "ECONOMIC_CATEGORY"
-    adoptioncost = 1.0 * floor(2 + 2 * Statistic Count
-                                           condition = And [ Planet Species OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(5.0 * [[PLANETS_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_ISOLATION" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]

--- a/default/scripting/policies/BUREAUCRACY.focs.txt
+++ b/default/scripting/policies/BUREAUCRACY.focs.txt
@@ -3,8 +3,7 @@ Policy
     description = "PLC_BUREAUCRACY_DESC"
     short_description = "PLC_BUREAUCRACY_SHORT_DESC"
     category = "ECONOMIC_CATEGORY"
-    adoptioncost = 1.0 * floor(2 + 2 * Statistic Count
-                                           condition = And [ Planet Species OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     prerequisites = [ "PLC_CENTRALIZATION" ]
     unlock = Item type = Policy name = "PLC_TECHNOCRACY"
     effectsgroups = [

--- a/default/scripting/policies/CAPITAL_MARKETS.focs.txt
+++ b/default/scripting/policies/CAPITAL_MARKETS.focs.txt
@@ -3,9 +3,7 @@ Policy
     description = "PLC_CAPITAL_MARKETS_DESC"
     short_description = "PLC_CAPITAL_MARKETS_SHORT_DESC"
     category = "ECONOMIC_CATEGORY"
-    adoptioncost = 1.0 * floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population
-                                          condition = And [ Planet OwnedBy empire = Source.Owner ])
-    effectsgroups = [
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)    effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
     ]
     graphic = "icons/policies/capital_markets.png"

--- a/default/scripting/policies/CENTRALIZATION.focs.txt
+++ b/default/scripting/policies/CENTRALIZATION.focs.txt
@@ -3,8 +3,7 @@ Policy
     description = "PLC_CENTRALIZATION_DESC"
     short_description = "PLC_CENTRALIZATION_SHORT_DESC"
     category = "ECONOMIC_CATEGORY"
-    adoptioncost = 1.0 * floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population
-                                          condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_CONFEDERATION" "PLC_COLONIZATION" "PLC_ISOLATION" ]
     unlock = Item type = Building name = "BLD_REGIONAL_ADMIN"
     effectsgroups = [

--- a/default/scripting/policies/CHECKPOINTS.focs.txt
+++ b/default/scripting/policies/CHECKPOINTS.focs.txt
@@ -3,8 +3,7 @@ Policy
     description = "PLC_CHECKPOINTS_DESC"
     short_description = "PLC_CHECKPOINTS_SHORT_DESC"
     category = "ECONOMIC_CATEGORY"
-    adoptioncost = 5 + floor(Statistic Sum value = LocalCandidate.Population
-                                           condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = 5 + floor(5.0 * [[PLANETS_OWNED_BY_EMPIRE]]^0.5)
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
 

--- a/default/scripting/policies/COLONIZATION.focs.txt
+++ b/default/scripting/policies/COLONIZATION.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_COLONIZATION_DESC"
     short_description = "PLC_COLONIZATION_SHORT_DESC"
     category = "SOCIAL_CATEGORY"
-    adoptioncost = floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_EXPLORATION" "PLC_CENTRALIZATION" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]

--- a/default/scripting/policies/CONFEDERATION.focs.txt
+++ b/default/scripting/policies/CONFEDERATION.focs.txt
@@ -3,8 +3,7 @@ Policy
     description = "PLC_CONFEDERATION_DESC"
     short_description = "PLC_CONFEDERATION_SHORT_DESC"
     category = "SOCIAL_CATEGORY"
-    adoptioncost = 1.0 * floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population
-                                           condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_CENTRALIZATION" ]
     unlock = [
         Item type = Policy name = "PLC_VASSALIZATION"

--- a/default/scripting/policies/CONFORMANCE.focs.txt
+++ b/default/scripting/policies/CONFORMANCE.focs.txt
@@ -3,8 +3,7 @@ Policy
     description = "PLC_CONFORMANCE_DESC"
     short_description = "PLC_CONFORMANCE_SHORT_DESC"
     category = "SOCIAL_CATEGORY"
-    adoptioncost = 5 + floor(Statistic Sum value = LocalCandidate.Population
-                                           condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_LIBERTY" "PLC_DIVERSITY" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]

--- a/default/scripting/policies/CONTINUOUS_SCANNING.focs.txt
+++ b/default/scripting/policies/CONTINUOUS_SCANNING.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_CONTINUOUS_SCANNING_DESC"
     short_description = "PLC_CONTINUOUS_SCANNING_SHORT_DESC"
     category = "MILITARY_CATEGORY"
-    adoptioncost = 5 + floor(Statistic Count condition = And [Ship OwnedBy empire = Source.Owner])
+    adoptioncost = 5 + [[SHIPS_OWNED_BY_EMPIRE]]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
 

--- a/default/scripting/policies/DESIGN_SIMPLICITY.focs.txt
+++ b/default/scripting/policies/DESIGN_SIMPLICITY.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_DESIGN_SIMPLICITY_DESC"
     short_description = "PLC_DESIGN_SIMPLICITY_SHORT_DESC"
     category = "MILITARY_CATEGORY"
-    adoptioncost = floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = 5 + [[SHIPS_OWNED_BY_EMPIRE]]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
     ]

--- a/default/scripting/policies/DIVERSITY.focs.txt
+++ b/default/scripting/policies/DIVERSITY.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_DIVERSITY_DESC"
     short_description = "PLC_DIVERSITY_SHORT_DESC"
     category = "SOCIAL_CATEGORY"
-    adoptioncost = 1.0*floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_RACIAL_PURITY" ]
     unlock = Item type = Policy name = "PLC_ARTISAN_WORKSHOPS"
     effectsgroups = [

--- a/default/scripting/policies/DIVINE_AUTHORITY.focs.txt
+++ b/default/scripting/policies/DIVINE_AUTHORITY.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_DIVINE_AUTHORITY_DESC"
     short_description = "PLC_DIVINE_AUTHORITY_SHORT_DESC"
     category = "SOCIAL_CATEGORY"
-    adoptioncost = 1.0*floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     prerequisites = [ "PLC_INDOCTRINATION" ]
     exclusions = [ "PLC_LIBERTY" "PLC_ALGORITHMIC_RESEARCH" ]
     unlock = Item type = Policy name = "PLC_FEUDALISM"

--- a/default/scripting/policies/ENGINEERING.focs.txt
+++ b/default/scripting/policies/ENGINEERING.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_ENGINEERING_DESC"
     short_description = "PLC_ENGINEERING_SHORT_DESC"
     category = "MILITARY_CATEGORY"
-    adoptioncost = 5 + Statistic Count condition = And [Ship OwnedBy empire = Source.Owner]
+    adoptioncost = 5 + [[SHIPS_OWNED_BY_EMPIRE]]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
     

--- a/default/scripting/policies/ENVIRONMENTALISM.focs.txt
+++ b/default/scripting/policies/ENVIRONMENTALISM.focs.txt
@@ -3,8 +3,7 @@ Policy
     description = "PLC_ENVIRONMENTALISM_DESC"
     short_description = "PLC_ENVIRONMENTALISM_SHORT_DESC"
     category = "ECONOMIC_CATEGORY"
-    adoptioncost = 1.0 * floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population
-                                          condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_TERRAFORMING" "PLC_INDUSTRIALISM" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]

--- a/default/scripting/policies/EXPLORATION.focs.txt
+++ b/default/scripting/policies/EXPLORATION.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_EXPLORATION_DESC"
     short_description = "PLC_EXPLORATION_SHORT_DESC"
     category = "MILITARY_CATEGORY"
-    adoptioncost = 5 + Statistic Count condition = And [Ship OwnedBy empire = Source.Owner]
+    adoptioncost = 5 + [[SHIPS_OWNED_BY_EMPIRE]]
     exclusions = [ "PLC_COLONIZATION" "PLC_ISOLATION" ]
     unlock = Item type = Policy name = "PLC_EXPLORATION_RESEARCH"
     effectsgroups = [

--- a/default/scripting/policies/FLANKING.focs.txt
+++ b/default/scripting/policies/FLANKING.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_FLANKING_DESC"
     short_description = "PLC_FLANKING_SHORT_DESC"
     category = "MILITARY_CATEGORY"
-    adoptioncost = 5 + floor(Statistic Count condition = And [Ship OwnedBy empire = Source.Owner])
+    adoptioncost = 5 + [[SHIPS_OWNED_BY_EMPIRE]]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
 

--- a/default/scripting/policies/INDOCTRINATION.focs.txt
+++ b/default/scripting/policies/INDOCTRINATION.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_INDOCTRINATION_DESC"
     short_description = "PLC_INDOCTRINATION_SHORT_DESC"
     category = "SOCIAL_CATEGORY"
-    adoptioncost = 10
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     prerequisites = [ "PLC_PROPAGANDA" "PLC_CONFORMANCE" ]
     exclusions = [ "PLC_LIBERTY" "PLC_DIVERSITY" ]
     effectsgroups = [

--- a/default/scripting/policies/INDUSTRIALISM.focs.txt
+++ b/default/scripting/policies/INDUSTRIALISM.focs.txt
@@ -3,8 +3,7 @@ Policy
     description = "PLC_INDUSTRIALISM_DESC"
     short_description = "PLC_INDUSTRIALISM_SHORT_DESC"
     category = "ECONOMIC_CATEGORY"
-    adoptioncost = 1.0 * floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population
-                                          condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_BALANCE" "PLC_TECHNOCRACY" "PLC_ENVIRONMENTALISM" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]

--- a/default/scripting/policies/ISOLATION.focs.txt
+++ b/default/scripting/policies/ISOLATION.focs.txt
@@ -3,8 +3,7 @@ Policy
     description = "PLC_ISOLATION_DESC"
     short_description = "PLC_ISOLATION_SHORT_DESC"
     category = "SOCIAL_CATEGORY"
-    adoptioncost = 1.0 * floor(2 + 2 * Statistic Count
-                                           condition = And [ Planet Species OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(5.0 * [[PLANETS_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_BOOTSTRAPPING" "PLC_CENTRALIZATION" "PLC_EXPLORATION"]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]

--- a/default/scripting/policies/LIBERTY.focs.txt
+++ b/default/scripting/policies/LIBERTY.focs.txt
@@ -3,8 +3,7 @@ Policy
     description = "PLC_LIBERTY_DESC"
     short_description = "PLC_LIBERTY_SHORT_DESC"
     category = "SOCIAL_CATEGORY"
-    adoptioncost = 5 + floor(Statistic Sum value = LocalCandidate.Population
-                                           condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(3.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_MARTIAL_LAW" "PLC_TERROR_SUPPRESSION" "PLC_INDOCTRINATION" "PLC_CONFORMANCE" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]

--- a/default/scripting/policies/MARINE_RECRUITMENT.focs.txt
+++ b/default/scripting/policies/MARINE_RECRUITMENT.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_MARINE_RECRUITMENT_DESC"
     short_description = "PLC_MARINE_RECRUITMENT_SHORT_DESC"
     category = "MILITARY_CATEGORY"
-    adoptioncost = floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
     ]

--- a/default/scripting/policies/MARTIAL_LAW.focs.txt
+++ b/default/scripting/policies/MARTIAL_LAW.focs.txt
@@ -3,13 +3,13 @@ Policy
     description = "PLC_MARTIAL_LAW_DESC"
     short_description = "PLC_MARTIAL_LAW_SHORT_DESC"
     category = "MILITARY_CATEGORY"
-    adoptioncost = 10
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     prerequisites = [ "PLC_CHECKPOINTS" ]
     exclusions = [ "PLC_LIBERTY" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
 
-        // makes planets more stable and at cost of research and supply range
+        // makes planets more stable at cost of research and supply range
         EffectsGroup
         scope = And [
             Planet

--- a/default/scripting/policies/NATIVE_APPROPRIATION.focs.txt
+++ b/default/scripting/policies/NATIVE_APPROPRIATION.focs.txt
@@ -3,8 +3,7 @@ Policy
     description = "PLC_NATIVE_APPROPRIATION_DESC"
     short_description = "PLC_NATIVE_APPROPRIATION_SHORT_DESC"
     category = "SOCIAL_CATEGORY"
-    adoptioncost = 5 + floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population
-                                        condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     prerequisites = [ "PLC_DIVERSITY" ]
     exclusions = [ "PLC_RACIAL_PURITY" ]
     unlock = Item type = Policy name = "PLC_THE_HUNT"

--- a/default/scripting/policies/NO_GROWTH.focs.txt
+++ b/default/scripting/policies/NO_GROWTH.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_NO_GROWTH_DESC"
     short_description = "PLC_NO_GROWTH_SHORT_DESC"
     category = "SOCIAL_CATEGORY"
-    adoptioncost = floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_POPULATION" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]

--- a/default/scripting/policies/NO_SUPPLY.focs.txt
+++ b/default/scripting/policies/NO_SUPPLY.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_NO_SUPPLY_DESC"
     short_description = "PLC_NO_SUPPLY_SHORT_DESC"
     category = "ECONOMIC_CATEGORY"
-    adoptioncost = 5 + floor(Statistic Sum value = LocalCandidate.Population condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
     

--- a/default/scripting/policies/POPULATION.focs.txt
+++ b/default/scripting/policies/POPULATION.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_POPULATION_DESC"
     short_description = "PLC_POPULATION_SHORT_DESC"
     category = "SOCIAL_CATEGORY"
-    adoptioncost = floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_NO_GROWTH" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]

--- a/default/scripting/policies/RACIAL_PURITY.focs.txt
+++ b/default/scripting/policies/RACIAL_PURITY.focs.txt
@@ -3,8 +3,7 @@ Policy
     description = "PLC_RACIAL_PURITY_DESC"
     short_description = "PLC_RACIAL_PURITY_SHORT_DESC"
     category = "SOCIAL_CATEGORY"
-    adoptioncost = 1.0 * floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population
-                                          condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     prerequisites = [ "PLC_CHECKPOINTS" ]
     exclusions = [ "PLC_DIVERSITY" "PLC_NATIVE_APPROPRIATION" ]
     unlock = Item type = Policy name = "PLC_THE_HUNT"

--- a/default/scripting/policies/RESERVE_TANKS.focs.txt
+++ b/default/scripting/policies/RESERVE_TANKS.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_RESERVE_TANKS_DESC"
     short_description = "PLC_RESERVE_TANKS_SHORT_DESC"
     category = "MILITARY_CATEGORY"
-    adoptioncost = ceil(0.2 * Statistic Count condition = And [Ship OwnedBy empire = Source.Owner])
+    adoptioncost = ceil(0.2 * [[SHIPS_OWNED_BY_EMPIRE]])
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
 

--- a/default/scripting/policies/STOCKPILE_LIQUIDATION.focs.txt
+++ b/default/scripting/policies/STOCKPILE_LIQUIDATION.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_STOCKPILE_LIQUIDATION_DESC"
     short_description = "PLC_STOCKPILE_LIQUIDATION_SHORT_DESC"
     category = "ECONOMIC_CATEGORY"
-    adoptioncost = 5 + floor(Statistic Sum value = LocalCandidate.Population condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor([[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_BALANCE" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]

--- a/default/scripting/policies/TECHNOCRACY.focs.txt
+++ b/default/scripting/policies/TECHNOCRACY.focs.txt
@@ -3,8 +3,7 @@ Policy
     description = "PLC_TECHNOCRACY_DESC"
     short_description = "PLC_TECHNOCRACY_SHORT_DESC"
     category = "ECONOMIC_CATEGORY"
-    adoptioncost = 1.0 * floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population
-                                          condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_BALANCE" "PLC_INDUSTRIALISM" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]

--- a/default/scripting/policies/TERRAFORMING.focs.txt
+++ b/default/scripting/policies/TERRAFORMING.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_TERRAFORMING_DESC"
     short_description = "PLC_TERRAFORMING_SHORT_DESC"
     category = "ECONOMIC_CATEGORY"
-    adoptioncost = 1.0*floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_ENVIRONMENTALISM" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]

--- a/default/scripting/policies/THE_HUNT.focs.txt
+++ b/default/scripting/policies/THE_HUNT.focs.txt
@@ -3,8 +3,7 @@ Policy
     description = "PLC_THE_HUNT_DESC"
     short_description = "PLC_THE_HUNT_SHORT_DESC"
     category = "SOCIAL_CATEGORY"
-    adoptioncost = 1.0 * floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population
-                                          condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = floor(2.0 * [[POPULATION_OWNED_BY_EMPIRE]]^0.5)
     exclusions = [ "PLC_DIVERSITY" "PLC_NATIVE_APPROPRIATION" "PLC_LIBERTY" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]

--- a/default/scripting/policies/TRAFFIC_CONTROL.focs.txt
+++ b/default/scripting/policies/TRAFFIC_CONTROL.focs.txt
@@ -3,7 +3,7 @@ Policy
     description = "PLC_TRAFFIC_CONTROL_DESC"
     short_description = "PLC_TRAFFIC_CONTROL_SHORT_DESC"
     category = "ECONOMIC_CATEGORY"
-    adoptioncost = 10
+    adoptioncost = 5 + [[SHIPS_OWNED_BY_EMPIRE]]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
     

--- a/default/scripting/policies/policies.macros
+++ b/default/scripting/policies/policies.macros
@@ -27,3 +27,14 @@ SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS
             effects =
                 SetTargetHappiness value = Value + [[STABILITY_PER_LIKED_OR_DISLIKED_POLICY]] * SpeciesContentOpinion species = Target.Species name = ThisPolicy
 '''
+
+POPULATION_OWNED_BY_EMPIRE
+'''(Statistic Sum value = LocalCandidate.Population condition = And [ Planet OwnedBy empire = Source.Owner ])'''
+
+PLANETS_OWNED_BY_EMPIRE
+'''(Statistic Count condition = And [ Planet Species OwnedBy empire = Source.Owner ])'''
+
+SHIPS_OWNED_BY_EMPIRE
+'''(Statistic Count condition = And [Ship OwnedBy empire = Source.Owner])'''
+
+


### PR DESCRIPTION
Due to scarcity of influence points for bigger empires, using absolute values of planets or populations (even with a constant factor reducing it) makes it too expensive to adopt most of the policies once a certain empire size has been reached. This PR deals with that by using the square root of such magnitudes. Costs for starting empires remain very close to what they were.

Also add macros for #ships, #planets and #population in policies.macros and change base costs in a few policies:
- Augmentation: #population instead of 100 -> make it easier for smaller empires, harder for bigger ones
- Bureaucracy: #population instead of #planets -> better for fluff
- Checkpoints: #planets instead of #population -> better for fluff
- Design Simplicity: #ships instead of #population -> better for fluff, also rewards getting it earlier in army-growth process instead of earlier in empire-growth process
- Indoctrination: #population instead of 10 -> better for fluff
- Martial Law: #population instead of 10 -> better for fluff