### PR TITLE
Cache Python API Pathfinder Results

### DIFF
--- a/client/AI/AIFramework.cpp
+++ b/client/AI/AIFramework.cpp
@@ -76,6 +76,8 @@ BOOST_PYTHON_MODULE(freeOrionAIInterface)
     FreeOrionPython::SetWrapper<std::string>::Wrap("StringSet");
 }
 
+void ClearPathfinderCaches();
+
 //////////////////////
 //     PythonAI     //
 //////////////////////
@@ -121,6 +123,7 @@ auto PythonAI::InitModules() -> bool
 void PythonAI::GenerateOrders()
 {
     DebugLogger() << "PythonAI::GenerateOrders : initializing turn";
+    ClearPathfinderCaches();
 
     ScopedTimer order_timer;
     try {


### PR DESCRIPTION
@Cjkjvfnby I noticed with a profiler that the AI sometimes spends a lot of time requesting and thus (in C++) repeatedly calculating least-jump pathes, whether systems are connected, and system immediate neighbours. I'm not sure if / how to speed up the actual calcuations, but I thought adding a cache like this might help.

In some tests, I get quite varied cache hit rates, between nearly 0 and ~99% between clearings of the caches (which happens each time GenerateOrders is called). In another case, it seemed to reduce AI computation time from ~13 s to ~7 s for a turn for the single slow AI in a game.

Does this make sense, or would you prefer to do some caching in Python?

Can you see any similar AI turn generation time speedup with this?