### PR TITLE
[AI] Use caches to speedup invasion calculations

### DIFF
--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -10,6 +10,7 @@ from common.fo_typing import SystemId
 from EnumsAI import MissionType
 from freeorion_tools import get_fleet_position, get_partial_visibility_turn
 from target import TargetSystem
+from universe.system_network import systems_connected
 
 graph_flags = set()
 border_unexplored_system_ids = set()
@@ -167,7 +168,7 @@ def follow_vis_system_connections(start_system_id, home_system_id):
             status_info = [system_header]
 
         has_been_visible = get_partial_visibility_turn(cur_system_id) > 0
-        is_connected = universe.systemsConnected(cur_system_id, home_system_id, -1)  # self.empire_id)
+        is_connected = systems_connected(cur_system_id, home_system_id)
         status_info.append("    -- is%s partially visible" % ("" if has_been_visible else " not"))
         status_info.append("    -- is%s visibly connected to homesystem" % ("" if is_connected else " not"))
         if has_been_visible:

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -324,7 +324,6 @@ def _get_path_from_capital(planet: "fo.planet") -> Tuple[Sequence[SystemId], int
     Return chain of system from the planet to capital and length.
 
     If there is no path, return empty sequence and default distance.
-
     """
     universe = fo.getUniverse()
     capitol_id = PlanetUtilsAI.get_capital()

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -27,6 +27,7 @@ from turn_state import (
     get_systems_by_supply_tier,
 )
 from turn_state.design import cur_best_military_design_rating
+from universe.system_network import systems_connected
 
 MinThreat = 10  # the minimum threat level that will be ascribed to an unknown threat capable of killing scouts
 _military_allocations = []
@@ -821,7 +822,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
         # border protections
         visible_system_ids = aistate.visInteriorSystemIDs | aistate.visBorderSystemIDs
         accessible_system_ids = (
-            [sys_id for sys_id in visible_system_ids if universe.systemsConnected(sys_id, home_system_id, empire_id)]
+            [sys_id for sys_id in visible_system_ids if systems_connected(sys_id, home_system_id)]
             if home_system_id != INVALID_ID
             else []
         )

--- a/default/python/AI/PlanetUtilsAI.py
+++ b/default/python/AI/PlanetUtilsAI.py
@@ -7,6 +7,7 @@ from common.fo_typing import PlanetId, SystemId
 from empire.colony_builders import get_colony_builders
 from empire.ship_builders import get_ship_builders
 from freeorion_tools import ppstring
+from freeorion_tools.caching import cache_for_current_turn
 
 
 def safe_name(univ_object):
@@ -39,6 +40,7 @@ def planet_string(planet_ids: Union[PlanetId, List[PlanetId]]) -> str:
     return ppstring([_safe_planet_name(pid) for pid in planet_ids])
 
 
+@cache_for_current_turn
 def get_capital() -> PlanetId:
     """
     Return current empire capital id.

--- a/default/python/AI/freeorion_tools/_profile.py
+++ b/default/python/AI/freeorion_tools/_profile.py
@@ -23,6 +23,7 @@ def profile(func: Callable):
         sortby = "cumulative"
         ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
         ps.print_stats()
+        debug(f"Profile stats for {func.__name__}")
         debug(s.getvalue())
         return retval
 

--- a/default/python/AI/universe/system_network.py
+++ b/default/python/AI/universe/system_network.py
@@ -1,0 +1,38 @@
+import freeOrionAIInterface as fo
+from typing import Sequence
+
+from AIDependencies import INVALID_ID
+from common.fo_typing import SystemId
+from freeorion_tools.caching import cache_for_current_turn
+
+
+def _min_max(a, b) -> Sequence:
+    """
+    Return args in sorted order.
+
+    >>> _min_max(1, 2)
+    (1, 2)
+
+    >>> _min_max(2, 1)
+    (1, 2)
+    """
+    return (a, b) if a <= b else (b, a)
+
+
+def systems_connected(system1: SystemId, system2: SystemId) -> bool:
+    """
+    Return True if systems connected.
+
+    Implementation notes: This is expensive operation on server.
+    So we are caching it as much as possible.
+    Sorting planets by ids could increase cache hits.
+    """
+    return _systems_connected(*_min_max(system1, system2))
+
+
+@cache_for_current_turn
+def _systems_connected(system1: SystemId, system2: SystemId) -> bool:
+    if system1 == INVALID_ID:
+        return False
+
+    return fo.getUniverse().systemsConnected(system1, system2, fo.empireID())

--- a/default/python/common/profiling.py
+++ b/default/python/common/profiling.py
@@ -28,7 +28,7 @@ def profile(save_path, sort_by="cumulative"):
             result = function(*args, **kwargs)
             end = time.clock()
             pr.disable()
-            print("Profile %s tooks %f s, saved to %s" % (function.__name__, end - start, save_path))
+            print("Profile %s took %f s, saved to %s" % (function.__name__, end - start, save_path))
             s = StringIO()
             ps = pstats.Stats(pr, stream=s).strip_dirs().sort_stats(sort_by)
             ps.print_stats()


### PR DESCRIPTION
Cache repeating operations related to system network.  This is expensive operations on the server side, so it's easier to deal with them on AI side. 