### PR TITLE
Round values to avoid saving too many digist after point

### DIFF
--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -1057,8 +1057,9 @@ def get_tot_mil_rating() -> float:
 
     :return: a military rating value
     """
-    return sum(
-        get_fleet_rating(fleet_id) for fleet_id in FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.MILITARY)
+    return round(
+        sum(get_fleet_rating(fleet_id) for fleet_id in FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.MILITARY)),
+        0,
     )
 
 
@@ -1069,8 +1070,11 @@ def get_concentrated_tot_mil_rating() -> float:
 
     :return: a military rating value
     """
-    return combine_ratings(
-        get_fleet_rating(fleet_id) for fleet_id in FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.MILITARY)
+    return round(
+        combine_ratings(
+            get_fleet_rating(fleet_id) for fleet_id in FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.MILITARY)
+        ),
+        0,
     )
 
 

--- a/default/python/AI/colonization/calculate_planet_colonization_rating.py
+++ b/default/python/AI/colonization/calculate_planet_colonization_rating.py
@@ -664,7 +664,7 @@ def _get_base_colony_defense_value():
 
     # for now, just combing these for rough composite factor
     result = 4 * (0.1 + net_count) * (1 + regen_count / 2.0) * (1 + garrison_count / 4.0) * (1 + shield_count / 2.0)
-    return result
+    return round(result, 2)
 
 
 def _revise_threat_factor(
@@ -717,7 +717,7 @@ def _get_base_outpost_defense_value() -> float:
     # than for colonies
     result = 3 * (0.1 + net_count) * (1 + regen_count / 3.0) * (1 + garrison_count / 6.0) * (1 + shield_count / 3.0)
 
-    return result
+    return round(result, 2)
 
 
 @cache_for_session


### PR DESCRIPTION
JSON in save string might look like that,  so we could round it to save some bytes.
```
"__INT__69": "__FLOAT__34848.0",
"__INT__70": "__FLOAT__36576.0",
"__INT__71": "__FLOAT__36576.0",
"__INT__72": "__FLOAT__38304.0",
"__INT__73": "__FLOAT__345455.99999999994",
"__INT__74": "__FLOAT__347183.99999999994",
"__INT__75": "__FLOAT__348047.99999999994",
"__INT__76": "__FLOAT__349775.99999999994",
```

Starting values:
```
"get_concentrated_tot_mil_rating": {
                "__INT__1": "__FLOAT__2304.0",
"get_tot_mil_rating": {
                "__INT__1": "__FLOAT__2304.0"
"_get_base_outpost_defense_value": {
                "__INT__1": "__FLOAT__0.30000000000000004",
"_get_base_colony_defense_value": {
                "__INT__4": "__FLOAT__0.4",
```


