### PR TITLE
Likes Kraken Nest and Metropoles error in UI

### DIFF
--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4385,7 +4385,7 @@ void MapWnd::SelectSystem(int system_id) {
     if (system && GetOptionsDB().Get<bool>("ui.map.sidepanel.meter-refresh")) {
         // ensure meter estimates are up to date, particularly for which ship is selected
         ScriptingContext context{GetUniverse(), Empires(), GetGalaxySetupData(), GetSpeciesManager(), GetSupplyManager()};
-        GetUniverse().UpdateMeterEstimates(system->ID(), context, true);
+        GetUniverse().UpdateMeterEstimates(context, true);
     }
 
 

--- a/default/scripting/specials/planet/monster_nest/JUGGERNAUT_NEST.focs.txt
+++ b/default/scripting/specials/planet/monster_nest/JUGGERNAUT_NEST.focs.txt
@@ -16,7 +16,9 @@ Special
     ]
     effectsgroups = [
         [[MONSTER_NEST(JUGGERNAUT,juggernaut,0.06)]]
+        [[SPECIAL_LIKES_OR_DISLIKES_SPECIAL_STABILITY_EFFECTS]]
     ]
     graphic = "icons/specials_huge/juggernaut-nest.png"
 
 #include "monster_nest.macros"
+#include "/scripting/specials/specials.macros.txt"

--- a/default/scripting/specials/planet/monster_nest/KRAKEN_NEST.focs.txt
+++ b/default/scripting/specials/planet/monster_nest/KRAKEN_NEST.focs.txt
@@ -16,7 +16,9 @@ Special
     ]
     effectsgroups = [
         [[MONSTER_NEST(KRAKEN,kraken,0.05)]]
+        [[SPECIAL_LIKES_OR_DISLIKES_SPECIAL_STABILITY_EFFECTS]]
     ]
     graphic = "icons/specials_huge/kraken-nest.png"
 
 #include "monster_nest.macros"
+#include "/scripting/specials/specials.macros.txt"

--- a/default/scripting/specials/planet/monster_nest/SNOWFLAKE_NEST.focs.txt
+++ b/default/scripting/specials/planet/monster_nest/SNOWFLAKE_NEST.focs.txt
@@ -15,7 +15,9 @@ Special
     ]
     effectsgroups = [
         [[MONSTER_NEST(SNOWFLAKE,snowflake,0.08)]]
+         [[SPECIAL_LIKES_OR_DISLIKES_SPECIAL_STABILITY_EFFECTS]]
     ]
     graphic = "icons/specials_huge/snowflake-nest.png"
 
 #include "monster_nest.macros"
+#include "/scripting/specials/specials.macros.txt"


### PR DESCRIPTION
LIKE-macros were missing in monster nests specials

MapWnd::SelectSystem called Universe::UpdateMeterEstimates(int object_id... which restricted the context to objects with the system. Metropoles looks for the 6 biggest most populous planets and this only works when the context contains all planets. So when clicking at a system with planets >20, they all showed the Metropoles bonus, even if not amongst the 6 biggest.