### PR TITLE
Simplify timers, make better timing for generateOrders

### DIFF
--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -35,7 +35,7 @@ MAX_BASE_TROOPERS_POOR_INVADERS = 10
 _TROOPS_SAFETY_MARGIN = 1  # try to send this amount of additional troops to account for uncertainties in calculation
 MIN_INVASION_SCORE = 20
 
-invasion_timer = AITimer("get_invasion_fleets()", write_log=False)
+invasion_timer = AITimer("get_invasion_fleets()")
 
 
 def get_invasion_fleets():

--- a/default/python/AI/freeorion_tools/timers.py
+++ b/default/python/AI/freeorion_tools/timers.py
@@ -15,6 +15,9 @@ class DummyTimer:
     Dummy timer to be used if timers are disabled.
     """
 
+    def __init__(self, *args, **kwargs):
+        pass
+
     def stop(self, *args, **kwargs):
         pass
 

--- a/default/python/AI/freeorion_tools/timers.py
+++ b/default/python/AI/freeorion_tools/timers.py
@@ -1,15 +1,4 @@
-import freeOrionAIInterface as fo
-import os
-import sys
-
-from common.option_tools import (
-    DEFAULT_SUB_DIR,
-    TIMERS_DUMP_FOLDER,
-    TIMERS_TO_FILE,
-    TIMERS_USE_TIMERS,
-    check_bool,
-    get_option_dict,
-)
+from common.option_tools import TIMERS_USE_TIMERS, check_bool, get_option_dict
 from common.timers import Timer
 
 # setup module
@@ -17,25 +6,8 @@ options = get_option_dict()
 
 try:
     USE_TIMERS = check_bool(options[TIMERS_USE_TIMERS])
-    DUMP_TO_FILE = check_bool(options[TIMERS_TO_FILE])
-    TIMERS_DIR = os.path.join(fo.getUserDataDir(), DEFAULT_SUB_DIR, options[TIMERS_DUMP_FOLDER])
 except KeyError:
     USE_TIMERS = False
-
-
-def make_header(*args):
-    return ["%-8s " % x for x in args]
-
-
-def _get_timers_dir():
-    try:
-        if os.path.isdir(fo.getUserDataDir()) and not os.path.isdir(TIMERS_DIR):
-            os.makedirs(TIMERS_DIR)
-    except OSError:
-        sys.stderr.write("AI Config Error: could not create path %s\n" % TIMERS_DIR)
-        return False
-
-    return TIMERS_DIR
 
 
 class DummyTimer:
@@ -43,79 +15,14 @@ class DummyTimer:
     Dummy timer to be used if timers are disabled.
     """
 
-    def __init__(self, *args, **kwargs):
-        pass
-
     def stop(self, *args, **kwargs):
         pass
 
     def start(self, *args, **kwargs):
         pass
 
-    def stop_and_print(self):
-        pass
-
     def stop_print_and_clear(self):
         pass
 
-    def clear_data(self):
-        pass
 
-    def print_flat(self):
-        pass
-
-    def print_aggregate(self):
-        pass
-
-    def print_statistics(self):
-        pass
-
-
-class AILogTimer(Timer):
-    """A Timer with a FO AI engine dependent extension that logs timer results to a file each turn."""
-
-    def __init__(self, timer_name, write_log=False):
-        """
-        Creates timer. Timer name is name that will be in logs header and part of filename if write_log=True
-        If write_log true and timers logging enabled (DUMP_TO_FILE=True) save timer info to file.
-
-        """
-        Timer.__init__(self, timer_name)
-        self.headers = None
-        self.write_log = write_log
-        self.log_name = None
-
-    def _write(self, text):
-        if not _get_timers_dir():
-            return
-        if not self.log_name:
-            empaire_id = fo.getEmpire().empireID - 1
-            self.log_name = os.path.join(_get_timers_dir(), "%s-%02d.txt" % (self.timer_name, empaire_id))
-            mode = "w"  # empty file
-        else:
-            mode = "a"
-        with open(self.log_name, mode) as f:
-            f.write(text)
-            f.write("\n")
-
-    def stop_print_and_clear(self):
-        """
-        Stop timer, output result, and clear timers.
-        If dumping to file, if headers are not match to prev, new header line will be added.
-        """
-        Timer.stop_and_print(self)
-
-        if self.write_log and DUMP_TO_FILE:
-            turn = fo.currentTurn()
-            headers = make_header("Turn", *[x[0] for x in self.timers])
-            if self.headers != headers:
-                self._write("".join(headers) + "\n" + "".join(["-" * (len(x) - 2) + "  " for x in headers]))
-                self.headers = headers
-
-            row = []
-            for header, val in zip(self.headers, [turn] + [x[1] for x in self.timers]):
-                row.append("%*s " % (len(header) - 2, int(val)))
-            self._write("".join(row))
-
-
-AITimer = AILogTimer if USE_TIMERS else DummyTimer
+AITimer = Timer if USE_TIMERS else DummyTimer

--- a/default/python/common/option_tools.py
+++ b/default/python/common/option_tools.py
@@ -10,8 +10,6 @@ CONFIG_DEFAULT_FILE = "config.ini"
 # CONFIG KEYS
 TIMER_SECTION = "Timers"
 TIMERS_USE_TIMERS = "timers_to_log"
-TIMERS_TO_FILE = "timers_dump"
-TIMERS_DUMP_FOLDER = "timers_dump_folder"
 HANDLERS = "handlers"
 
 
@@ -51,7 +49,7 @@ def _get_preset_default_ai_options():
         [
             (
                 TIMER_SECTION,
-                odict([(TIMERS_USE_TIMERS, False), (TIMERS_TO_FILE, False), (TIMERS_DUMP_FOLDER, "timers")]),
+                odict([(TIMERS_USE_TIMERS, False)]),
             ),
             ("main", odict([(HANDLERS, "")])),  # module names in handler directory, joined by space
         ]

--- a/default/python/common/timers.py
+++ b/default/python/common/timers.py
@@ -52,77 +52,15 @@ class Timer:
         print("-" * line_max_size)
         print(("Total: %8d msec" % sum(x[1] for x in time_table)).rjust(line_max_size))
 
-    def print_flat(self):
+    def stop_print_and_clear(self):
         """
-        Output result.
-        """
-        self._print_timer_table(self.timers)
-
-    def print_aggregate(self):
-        """
-        Print aggregated results for each section.
-        """
-        accumulated_times = {}
-        ordered_names = []
-        for name, val in self.timers:
-            if name not in accumulated_times:
-                ordered_names.append(name)
-                accumulated_times[name] = 0
-            accumulated_times[name] += val
-        time_table = [(name, accumulated_times[name]) for name in ordered_names]
-
-        self._print_timer_table(time_table)
-
-    def print_statistics(self):
-        """
-        Print number of times, average, std, and max statistics for each section.
-        """
-        # TODO: If conversion to python 3 happens, use statistics.pstdev() to compute statistics.
-        number_samples = {}
-        means = {}
-        stds = {}
-        maxes = {}
-        ordered_names = []
-        for name, val in self.timers:
-            if name not in ordered_names:
-                ordered_names.append(name)
-                means[name] = 0
-                stds[name] = 0
-                number_samples[name] = 0
-                maxes[name] = val
-            means[name] += val
-            number_samples[name] += 1
-            maxes[name] = max(val, maxes[name])
-        for name in ordered_names:
-            means[name] = means[name] / number_samples[name]
-        for name, val in self.timers:
-            stds[name] += (val - means[name]) ** 2.0
-        for name in ordered_names:
-            stds[name] = (stds[name] / number_samples[name]) ** 0.5
-
-        max_header = max(len(x) for x in ordered_names)
-        line_max_size = max_header + 70
-        print()
-        print("Timing statistics for %s:" % self.timer_name)
-        print("=" * line_max_size)
-
-        for name in ordered_names:
-            print(
-                ("{:<{name_width}} num: {:>6d}, mean: {:>6.2f} msec, std: {:>6.2f} msec, max: {:>6.2f} msec").format(
-                    name, number_samples[name], means[name], stds[name], maxes[name], name_width=max_header
-                )
-            )
-
-        print("=" * line_max_size)
-
-    def stop_and_print(self):
-        """
-        Stop timer, output flat result.
+        Stop timer, output result and clear state.
         """
         self.stop()
-        self.print_flat()
+        self._print_timer_table(self.timers)
+        self._clear_data()
 
-    def clear_data(self):
+    def _clear_data(self):
         """
         Clear timer data.
         """


### PR DESCRIPTION
If you enable timers in the <logdir>/AI/default/config.ini you can see something like that:

Also I dropped staff that were present in the timers for years.

```
Timing for generate order:
======================================================
Check AI state                                  2 msec
Update states on server                       159 msec
Prepare each turn data                        260 msec
survey_universe                                 6 msec
update_for_new_turn                            16 msec
calculate_priorities                         1467 msec
assign_scouts_to_explore_systems               13 msec
assign_colony_fleets_to_colonise                4 msec
assign_invasion_fleets_to_invade               10 msec
assign_military_fleets_to_systems               2 msec
generate_fleet_orders_for_fleet_missions       36 msec
issue_fleet_orders_for_fleet_missions          84 msec
generate_research_orders                       77 msec
generate_production_orders                     21 msec
generate_resources_orders                     230 msec
------------------------------------------------------
                                  Total:     2393 msec

Timing for full turn:
==================================
Time between AI turn    20424 msec
AI planning              2393 msec
----------------------------------
              Total:    22818 msec
```