### PR TITLE
Colonize after conquer

### DIFF
--- a/default/scripting/policies/INDOCTRINATION.focs.txt
+++ b/default/scripting/policies/INDOCTRINATION.focs.txt
@@ -10,25 +10,45 @@ Policy
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
 
         // makes all planets more stable over time at the cost of influence
+        // First variant: Current population was colonized.
+        // Planet was never conquered or it was conquered, emptied and re-colonised.
+        // Bonus is based on only how long indoctrination has been adapted.
         EffectsGroup
         scope = And [
             Planet
             OwnedBy empire = Source.Owner
             Species
+            Or [(LocalCandidate.TurnsSinceLastConquered == 0)
+                (LocalCandidate.TurnsSinceLastConquered > LocalCandidate.TurnsSinceColonization)]
         ]
         effects = [
             SetTargetHappiness value = Value + 
                 min((NamedReal name = "PLC_INDOCTRINATION_STRENGTH_MAX" value = 10.0),
-                    (Target.TurnsSinceLastConquered != 0 ?
-                     min(Target.TurnsSinceLastConquered,
-                         TurnsSincePolicyAdopted empire = Source.Owner name = ThisPolicy) :
-                     TurnsSincePolicyAdopted empire = Source.Owner name = ThisPolicy) *
-                     (NamedReal name = "PLC_INDOCTRINATION_PER_TURN" value = 0.25))
+                    (TurnsSincePolicyAdopted empire = Source.Owner name = ThisPolicy) *
+                    (NamedReal name = "PLC_INDOCTRINATION_PER_TURN" value = 0.25))
+            SetTargetInfluence value = Value - 1.0
+        ]
+        // Second variant: Current population was conquered.
+        // Bonus is additonally limited to turns since conquered.
+        EffectsGroup
+        scope = And [
+            Planet
+            OwnedBy empire = Source.Owner
+            Species
+            (LocalCandidate.TurnsSinceLastConquered != 0)
+            // Note: TurnsSinceColonization cannot be equal to TurnsSinceLastConquered
+            (LocalCandidate.TurnsSinceLastConquered < LocalCandidate.TurnsSinceColonization)
+        ]
+        effects = [
+            SetTargetHappiness value = Value +
+                min((NamedRealLookup name = "PLC_INDOCTRINATION_STRENGTH_MAX"),
+                    min(Target.TurnsSinceLastConquered,
+                        TurnsSincePolicyAdopted empire = Source.Owner name = ThisPolicy) *
+                    (NamedRealLookup name = "PLC_INDOCTRINATION_PER_TURN"))
             SetTargetInfluence value = Value - 1.0
         ]
 
-        // boosts influence of influence-focused planets
-        // TODO: Consider restricting this effect to also having the Palace or a Reg. Adm. center.
+        // boosts influence of influence-focused capitals or regional administrations
         EffectsGroup
         scope = And [
             Planet

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -16468,10 +16468,10 @@ GOOD_PLANETARY_DEFENSE_DESC
 +	Good planetary [[metertype METER_DEFENSE]]: +5
 
 BROAD_EP_DESC
-++	Broad Planet Tolerance: can tolerate more types.
++	Broad Planet Tolerance: can tolerate more types.
 
 NARROW_EP_DESC
-−	Narrow Planet Tolerance: flourishes on fewer types.
+−−	Narrow Planet Tolerance: flourishes on fewer types.
 
 FAST_COLONIZATION_DESC
 +	Fast Colonization: -25% time to build colonies


### PR DESCRIPTION
As discussed in the forum, these two should not require much discussion.

Note that the ? : operator in FOCS does not work as expected, that's why I had to turn it into two effects separated by scope conditions.
When I tried to replace the simple condition (Target.TurnsSinceLastConquered != 0) by a boolean expression using "And", I get a parse error "Expected real number expression here". I guess my first version only worked because the boolean expression I've used happened to start with a numeric value.