### PR TITLE
Balance policy Metropoles

### DIFF
--- a/default/scripting/policies/METROPOLES.focs.txt
+++ b/default/scripting/policies/METROPOLES.focs.txt
@@ -3,28 +3,36 @@ Policy
     description = "PLC_METROPOLES_DESC"
     short_description = "PLC_METROPOLES_SHORT_DESC"
     category = "ECONOMIC_CATEGORY"
-    adoptioncost = 1.0 * floor(5 + 0.25 * Statistic Sum value = LocalCandidate.Population
-                                          condition = And [ Planet OwnedBy empire = Source.Owner ])
+    adoptioncost = 1.0 * floor(15 + 0.25 * Statistic Sum value = LocalCandidate.Population
+                                           condition = And [ Planet OwnedBy empire = Source.Owner ])
     exclusions = [ "PLC_CONFEDERATION" "PLC_COLONIZATION" ]
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
 
-        // TODO: limit of planets based on number of regional admins?
-
-        // boosts to largest-population planets...
+        // Boost largest-population planets, provided they have enough population and stability.
+        // Metropoles need some "umland", so no more than 1 in 4 can become a metropole.
+        // Note that to raise a planet to a metropole, you have to reach the minimum stability
+        // while suffering from the non-metropole penalty below.
         EffectsGroup
-            scope = MaximumNumberOf number = (NamedInteger name = "METROPOLES_PLANET_LIMIT" value = 6) sortkey = LocalCandidate.Population condition = And [
+            scope = MaximumNumberOf number = min((NamedInteger name = "METROPOLES_PLANET_LIMIT" value = 6),
+                                                 floor(Statistic Count condition = And [
+                                                           Planet
+                                                           OwnedBy empire = Source.Owner
+                                                           Species
+                                                       ] / (NamedInteger name = "METROPOLES_MIN_PLANETS" value = 4)))
+                                    sortkey = LocalCandidate.Population condition = And [
                 Planet
                 OwnedBy empire = Source.Owner
                 Population low = (NamedReal name = "METROPOLES_MINIMUM_POPULATION" value = 20.0)
+                Happiness low = (NamedReal name = "METROPOLES_MIN_STABILITY" value = 12)
             ]
             effects = [
                 SetTargetIndustry value = Value + Target.Population
                     * (NamedReal name = "METROPOLES_TARGET_INDUSTRY_PERPOP"
-                                 value = 2.0 * [[INDUSTRY_PER_POP]])
+                                 value = [[INDUSTRY_PER_POP]])
                 SetTargetResearch value = Value + Target.Population
                     * (NamedReal name = "METROPOLES_TARGET_RESEARCH_PERPOP"
-                                 value = 2.0 * [[RESEARCH_PER_POP]])
+                                 value = [[RESEARCH_PER_POP]])
                 SetTargetConstruction value = Value
                     + (NamedReal name = "METROPOLES_TARGET_CONSTRUCTION_FLAT" value = 10)
                 SetMaxSupply value = Value
@@ -33,16 +41,23 @@ Policy
                     + (NamedReal name = "METROPOLES_MAX_STOCKPILE_FLAT" value = -2)
             ]
 
-        // reduced stability outside of largest-population planets
+        // reduce stability on all other planets
         EffectsGroup
             scope = And [
                 Planet
                 OwnedBy empire = Source.Owner
                 Species // excludes non-populated planets
-                Not MaximumNumberOf number = (NamedIntegerLookup name = "METROPOLES_PLANET_LIMIT") sortkey = LocalCandidate.Population condition = And [
+                Not MaximumNumberOf number = min((NamedIntegerLookup name = "METROPOLES_PLANET_LIMIT"),
+                                                 floor(Statistic Count condition = And [
+                                                           Planet
+                                                           OwnedBy empire = Source.Owner
+                                                           Species
+                                                       ] / (NamedIntegerLookup name = "METROPOLES_MIN_PLANETS")))
+                                    sortkey = LocalCandidate.Population condition = And [
                     Planet
                     OwnedBy empire = Source.Owner
                     Population low = (NamedRealLookup name = "METROPOLES_MINIMUM_POPULATION")
+                    Happiness low = (NamedRealLookup name = "METROPOLES_MIN_STABILITY")
                 ]
             ]
             effects =

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -11519,15 +11519,16 @@ PLC_METROPOLES
 Metropoles
 
 PLC_METROPOLES_DESC
-'''Boosts the output of up to [[value METROPOLES_PLANET_LIMIT]] planets with population of at least [[value METROPOLES_MINIMUM_POPULATION]]. The highest-[[metertype METER_POPULATION]] of the qualified planets will receive, regardless of focus:
-• Increases [[metertype METER_TARGET_RESEARCH]] by [[value METROPOLES_TARGET_RESEARCH_PERPOP]] per [[metertype METER_POPULATION]].
+'''Boosts the output of up to [[value METROPOLES_PLANET_LIMIT]] planets (but no more than 1 / [[value METROPOLES_MIN_PLANETS]] or your populated planets) with [[metertype METER_POPULATION]] of at least [[value METROPOLES_MINIMUM_POPULATION]] and [[metertype METER_HAPPINESS]] of at least [[value METROPOLES_MIN_STABILITY]].
+The highest-populated of the qualified planets will receive, regardless of focus:
+• Increases [[metertype METER_TARGET_RESEARCH]] by [[value METROPOLES_TARGET_RESEARCH_PERPOP]] per population.
 • Increases [[metertype METER_TARGET_INDUSTRY]] by [[value METROPOLES_TARGET_INDUSTRY_PERPOP]] per population.
 • Increases [[metertype METER_TARGET_CONSTRUCTION]] by [[value METROPOLES_TARGET_CONSTRUCTION_FLAT]].
 • Increases [[metertype METER_MAX_SUPPLY]] by [[value METROPOLES_MAX_SUPPLY_FLAT]].
 but also has a penalty:
 • Decreases [[metertype METER_MAX_STOCKPILE]] by [[value METROPOLES_MAX_STOCKPILE_FLAT]].
 
-Additionally, other populated planets (with lower than the highest population planets, including all with less than [[value METROPOLES_MINIMUM_POPULATION]] [[metertype METER_POPULATION]]) have a penalty applied:
+Additionally, other planets (with lower than the highest population planets, including all with less than [[value METROPOLES_MINIMUM_POPULATION]] population or less than [[value METROPOLES_MIN_STABILITY]] stability) have a penalty applied:
 • Decreases [[metertype METER_TARGET_HAPPINESS]] by [[value METROPOLES_STABILITY_PENALTY]].'''
 
 PLC_METROPOLES_SHORT_DESC


### PR DESCRIPTION
Halved production and research bonus.
Require stability of 12.
No more than 1 in 4 of an empires populated planets can become a metropole.
Increased adaption cost.