### PR TITLE
Improve AI systems_connected performance

### DIFF
--- a/default/python/AI/universe/system_network.py
+++ b/default/python/AI/universe/system_network.py
@@ -1,7 +1,8 @@
 import freeOrionAIInterface as fo
-from typing import Sequence
+from typing import Sequence, Set
 
 from AIDependencies import INVALID_ID
+from PlanetUtilsAI import get_capital_sys_id
 from common.fo_typing import SystemId
 from freeorion_tools.caching import cache_for_current_turn
 
@@ -35,6 +36,23 @@ def _systems_connected(system1: SystemId, system2: SystemId) -> bool:
     if system1 == INVALID_ID:
         return False
 
+    # optimization: We cache a set of systems connected to the capital
+    # system in a single DFS and check if the systems are both in that set.
+    # This allows us to avoid a BFS for each pair of systems.
+    # Only in case neither of the system connects to the capital, we need to
+    # run the BFS.
+    connected_system_set = systems_connected_to_system(get_capital_sys_id())
+    sys1_connected_to_capital = system1 in connected_system_set
+    sys2_connected_to_capital = system2 in connected_system_set
+    if sys1_connected_to_capital and sys2_connected_to_capital:
+        # both connected to the capital - so must be connected to each other
+        return True
+
+    if sys1_connected_to_capital != sys2_connected_to_capital:
+        # Only one connected to the capital - can't be connected to each other
+        return False
+
+    # both are not connected to the home system - they may or may not be connected to each other
     return fo.getUniverse().systemsConnected(system1, system2, fo.empireID())
 
 
@@ -53,3 +71,24 @@ def _get_shortest_distance(system_1: SystemId, system_2: SystemId) -> float:
 @cache_for_current_turn
 def get_neighbors(sid: SystemId):
     return set(fo.getUniverse().getImmediateNeighbors(sid, fo.empireID()))
+
+
+@cache_for_current_turn
+def systems_connected_to_system(system_id: SystemId) -> Set[SystemId]:
+    """
+    Use depth-first-search to find connected systems to system_id
+    """
+    connected_systems = set()
+    if system_id == INVALID_ID:
+        return connected_systems
+
+    to_visit = [system_id]
+    while to_visit:
+        current_system = to_visit.pop()
+        if current_system in connected_systems:
+            continue
+
+        connected_systems.add(current_system)
+        to_visit.extend(get_neighbors(current_system))
+
+    return connected_systems

--- a/default/python/AI/universe/system_network.py
+++ b/default/python/AI/universe/system_network.py
@@ -2,9 +2,9 @@ import freeOrionAIInterface as fo
 from typing import Sequence, Set
 
 from AIDependencies import INVALID_ID
-from PlanetUtilsAI import get_capital_sys_id
 from common.fo_typing import SystemId
 from freeorion_tools.caching import cache_for_current_turn
+from PlanetUtilsAI import get_capital_sys_id
 
 
 def _min_max(a, b) -> Sequence:


### PR DESCRIPTION
### Context: 
There have recently been PRs to improve AI pathfinding performance by caching results (in particular, https://github.com/freeorion/freeorion/pull/3548)

However, caching the results will only help so much - the number of distinct queries is still large.
With N visible systems, the AI may ask connectivity between O(N) start and O(N) target systems. So it will run (and cache the results of) O(N^2)  queries. Each query seems to involve a full breadth-first-search (BFS) which again has complexity O(N). Overall complexity is O(N^3).
In my test game with 400 visible systems, this results in ~4-5% of AI processing time.
![image](https://user-images.githubusercontent.com/11706951/132962960-fa6ac218-672f-4057-b257-e8688bd10f2c.png)

### Proposed solution:
Instead of running a BFS each time, we can calculate and cache the disjoint sets of mutually connected systems and check if the queried systems are in the same set. Each disjoint set can be found in a single BFS/DFS with complexity O(N). The lookup itself is O(1). Thus, complexity of typical AI usage of systems_connected is reduced from O(N^3) to O(N).

The present implementation will only calculate and check connectivity with the capital and default to BFS if both systems are both not connected to it. This is based on the following reasoning
1) Most visible systems will be connected to the capital since this is the route along which exploration happens
2) If disconnected system sets are small, BFS covers a sufficiently small search space to be efficient
3) The AI will most often request connectivity with a starting system that is connected to the capital since that is where its fleets and shipyards are expected to be

Note that if all visible systems are connected to the capital, the single python DFS will handle everything and ```Pathfinder::PathfinderImpl::SystemsConnected``` will not be called, so python profiling must be used.
Before: ![image](https://user-images.githubusercontent.com/11706951/132963347-7b5740bc-7688-44a1-8feb-497a17564e57.png)
After: ![image](https://user-images.githubusercontent.com/11706951/132963357-54d6e24a-5967-4f57-a4fd-1dda4335ae4f.png)
--> execution time of 217 ms reduced to 15 ms

@Cjkjvfnby: I understand you may prefer to inject the (result of) get_capital_sys_id here - feel free to make a suggestion