### PR TITLE
Refactor production

### DIFF
--- a/default/python/AI/production/__init__.py
+++ b/default/python/AI/production/__init__.py
@@ -1,0 +1,5 @@
+from production._report import (
+    print_building_list,
+    print_capital_info,
+    print_production_queue,
+)

--- a/default/python/AI/production/_report.py
+++ b/default/python/AI/production/_report.py
@@ -1,0 +1,78 @@
+import freeOrionAIInterface as fo
+from logging import debug, info
+
+from common.print_utils import Sequence, Table, Text
+from EnumsAI import EmpireProductionTypes
+from turn_state import get_all_empire_planets
+
+
+def print_building_list():
+    debug("Buildings present on all owned planets:")
+    universe = fo.getUniverse()
+    for pid in get_all_empire_planets():
+        planet = universe.getPlanet(pid)
+        if planet:
+            debug("%30s: %s" % (planet.name, [universe.getBuilding(bldg).name for bldg in planet.buildingIDs]))
+    debug("")
+
+
+def print_production_queue(after_turn=False):
+    """Print production queue content with relevant info in table format."""
+    universe = fo.getUniverse()
+    s = "after" if after_turn else "before"
+    title = "Production Queue Turn %d %s ProductionAI calls" % (fo.currentTurn(), s)
+    prod_queue_table = Table(
+        Text("Object"),
+        Text("Location"),
+        Text("Quantity"),
+        Text("Progress"),
+        Text("Allocated PP"),
+        Text("Turns left"),
+        table_name=title,
+    )
+    for element in fo.getEmpire().productionQueue:
+        if element.buildType == EmpireProductionTypes.BT_SHIP:
+            item = fo.getShipDesign(element.designID)
+        elif element.buildType == EmpireProductionTypes.BT_BUILDING:
+            item = fo.getBuildingType(element.name)
+        else:
+            continue
+        cost = item.productionCost(fo.empireID(), element.locationID)
+
+        prod_queue_table.add_row(
+            element.name,
+            universe.getPlanet(element.locationID),
+            "%dx %d" % (element.remaining, element.blocksize),
+            "%.1f / %.1f" % (element.progress * cost, cost),
+            "%.1f" % element.allocation,
+            "%d" % element.turnsLeft,
+        )
+    prod_queue_table.print_table(info)
+
+
+def print_capital_info(homeworld):
+    table = Table(
+        Text("Id", description="Building id"),
+        Text("Name"),
+        Text("Type"),
+        Sequence("Tags"),
+        Sequence("Specials"),
+        Text("Owner Id"),
+        table_name="Buildings present at empire Capital in Turn %d" % fo.currentTurn(),
+    )
+
+    universe = fo.getUniverse()
+
+    for building_id in homeworld.buildingIDs:
+        building = universe.getBuilding(building_id)
+
+        table.add_row(
+            building_id,
+            building.name,
+            "_".join(building.buildingTypeName.split("_")[-2:]),
+            sorted(building.tags),
+            sorted(building.specials),
+            building.owner,
+        )
+
+    table.print_table(info)


### PR DESCRIPTION
- Extract code to functions
- Move print related functions to a separate module
- Move variables declarations close to is usages

A bit of background why I am doing it: 
Huge functions make it hard to understand things, because in addition to business logic we need to deal with complexity.  It's a great talk with more deep explanation [The Mental Game of Python - Raymond Hettinger](https://www.youtube.com/watch?v=Uwuv05aZ6ug). Although it has Python in the name, the ideas are language agnostic. I highly recommend it.

I use cognitive complexity (because it's easier to measure) to find the most complex thing to start with.

Result on master:
```shell
% radon cc default/python/AI --total-average -s -a -nF
default/python/AI/ResearchAI.py
    F 701:0 generate_classic_research_orders - F (173)
default/python/AI/MilitaryAI.py
    F 644:0 get_military_fleets - F (72)
default/python/AI/AIstate.py
    M 430:4 AIstate.__update_system_status - F (46)
default/python/AI/AIFleetMission.py
    M 385:4 AIFleetMission.issue_fleet_orders - F (64)
default/python/AI/ResourcesAI.py
    F 665:0 set_planet_industry_and_research_foci - F (43)
default/python/AI/InvasionAI.py
    F 41:0 get_invasion_fleets - F (48)
default/python/AI/ProductionAI.py
    F 79:0 generate_production_orders - F (521)
default/python/AI/colonization/calculate_planet_colonization_rating.py
    F 68:0 _calculate_planet_colonization_rating - F (179)

950 blocks (classes, functions, methods) analyzed.
Average complexity: A (4.674736842105263)
```

After:
```shell
    F 116:0 generate_production_orders - F (508)
```
 

