### PR TITLE
Add support for Python's asyncio

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1551,6 +1551,9 @@ Drop empire's readiness on joining to the playing game.
 OPTIONS_DB_TAKE_OVER_AI
 Server option to allow human players to take control of AI empires.
 
+OPTIONS_DB_PYTHON_ASYNCIO_INTERVAL
+Interval in seconds to call python asyncio event loop or -1 to disable it. By default asyncio calls disabled.
+
 OPTIONS_DB_UI_MAIN_MENU_X
 Position of the center of the intro screen main menu, as a portion of the application's total width.
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -4,6 +4,7 @@
 #include <set>
 #include <vector>
 #include <boost/circular_buffer.hpp>
+#include <boost/asio/high_resolution_timer.hpp>
 #include "ServerFramework.h"
 #include "ServerNetworking.h"
 #include "../Empire/EmpireManager.h"
@@ -302,8 +303,12 @@ private:
       * an empire is eliminated from the game */
     void    RemoveEmpireTurn(int empire_id);
 
+    /** Called when asyncio timer ends. Executes Python asyncio callbacks if any was generated. */
+    void    AsyncIOTimedoutHandler(const boost::system::error_code& error);
+
     boost::asio::io_context m_io_context;
     boost::asio::signal_set m_signals;
+    boost::asio::high_resolution_timer m_timer;
 
     Universe                m_universe;
     EmpireManager           m_empires;

--- a/server/ServerFramework.h
+++ b/server/ServerFramework.h
@@ -24,6 +24,7 @@ public:
     bool GetPlayerDelegation(const std::string& player_name, std::list<std::string> &result) const; // Wraps call to AuthProvider's method get_player_delegation
     bool LoadChatHistory(boost::circular_buffer<ChatHistoryEntity>& chat_history); // Wraps call to ChatProvider's method load_history
     bool PutChatHistoryEntity(const ChatHistoryEntity& chat_history_entity); // Wraps call to ChatProvider's method put_history_entity
+    bool AsyncIOTick(); // Executes awaiting asyncio callbacks, see https://docs.python.org/3/library/asyncio-eventloop.html#asyncio.loop.run_forever
 
 private:
     // reference to imported Python universe generator module
@@ -37,6 +38,9 @@ private:
 
     // reference to importer Python chat module
     boost::python::object m_python_module_chat;
+
+    // reference to asyncio event loop
+    boost::python::object m_asyncio_event_loop;
 };
 
 // Returns folder containing the Python universe generator scripts

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -71,6 +71,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().Add<int>("network.server.client-message-size.max",               UserStringNop("OPTIONS_DB_CLIENT_MESSAGE_SIZE_MAX"),    0);
         GetOptionsDB().Add<bool>("network.server.drop-empire-ready",                    UserStringNop("OPTIONS_DB_DROP_EMPIRE_READY"),          true);
         GetOptionsDB().Add<bool>("network.server.take-over-ai",                         UserStringNop("OPTIONS_DB_TAKE_OVER_AI"),               false);
+        GetOptionsDB().Add<int>("network.server.python.asyncio-interval",               UserStringNop("OPTIONS_DB_PYTHON_ASYNCIO_INTERVAL"),    -1);
 
         // if config.xml and persistent_config.xml are present, read and set options entries
         GetOptionsDB().SetFromFile(GetConfigPath(), FreeOrionVersionString());


### PR DESCRIPTION
Adds periodical call to asyncio event loop so scheduled callbacks and coroutines could be executed. Disabled by default.