### PR TITLE
policy combat bonus for other weapons

### DIFF
--- a/default/scripting/policies/CHARGE.focs.txt
+++ b/default/scripting/policies/CHARGE.focs.txt
@@ -7,7 +7,8 @@ Policy
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
 
-        // fast ships do more damage
+        // This is policy which trains your military to efficiently plan and execute charge attacks, i.e.:
+        // fast ships do more damage and fast carriers field fighters more efficiently/closer to the enemy
         EffectsGroup
             scope = And [
                 Ship
@@ -15,12 +16,35 @@ Policy
                 Armed
                 Speed low = NamedReal name = "PLC_CHARGE_MINIMUM_SPEED" value = 100.0
             ]
+            priority = [[TARGET_AFTER_SCALING_PRIORITY]]
             effects = [
+                // fluff-wise: a charge bonus could interact with "range", so e.g. a charging vessel could shoot a bout earlier.
+                // fluff-wise: a charge bonus probably should wear off when already in close combat range
                 SetMaxDamage partname = "SR_WEAPON_1_1" value = Value + (NamedReal name = "PLC_CHARGE_DAMAGE_BOOST" value = 1.0 * [[SHIP_WEAPON_DAMAGE_FACTOR]] )
                 SetMaxDamage partname = "SR_WEAPON_2_1" value = Value + NamedRealLookup name = "PLC_CHARGE_DAMAGE_BOOST"
                 SetMaxDamage partname = "SR_WEAPON_3_1" value = Value + NamedRealLookup name = "PLC_CHARGE_DAMAGE_BOOST"
                 SetMaxDamage partname = "SR_WEAPON_4_1" value = Value + NamedRealLookup name = "PLC_CHARGE_DAMAGE_BOOST"
-                SetMaxShield value = Value - NamedReal name = "PLC_CHARGE_SHIELD_REDUCTION" value = 3.0
+                SetMaxSecondaryStat partname = "SR_ARC_DISRUPTOR" value = (Value + NamedReal name = "PLC_CHARGE_ARC_DISRUPTOR_SHOT_BONUS" value = 1.0)
+                // TODO check monster weapons
+                // fluff-wise: Fighters should not get a charge bonus for fighters from carriers as the carrier speed does not give combat advantage to the fighters.
+                //             XXX but then we also should distinguish between ships which should charge and those which shouldnt for determining the malus
+                //             i.e. in that case, a carrier without other weapons should definitly not charge/have meters lowered
+                // also in order to avoid that we instead increase the launch rate, fluff: more efficient fielding of fighters
+                SetMaxCapacity partname = "FT_BAY_1" value = Value + (NamedInteger name = "PLC_CHARGE_BAY_LAUNCH_BONUS" value = 1)
+                // Point defense and shields are less efficient when charging:
+                SetMaxDamage partname = "SR_WEAPON_0_1" value = Value - (NamedReal name = "PLC_CHARGE_FLAK_SHOT_REDUCTION" value = 1.0)
+                SetMaxShield value = Value - (NamedReal name = "PLC_CHARGE_SHIELD_REDUCTION" value = 3.0 * [[SHIP_SHIELD_FACTOR]] )
+
+//                GenerateSitRepMessage
+//                  message = "Applying CHARGE to %ship% -  %system%"
+//                  label = "Custom_212"
+//                  NoStringtableLookup
+//                  icon = "icons/monsters/kraken-1.png"
+//                  parameters = [
+//                    tag = "ship" data = Target.ID
+//                    tag = "system" data = Target.SystemID
+//                  ]
+//                  empire = Source.Owner
             ]
 
     ]

--- a/default/scripting/policies/CHARGE.focs.txt
+++ b/default/scripting/policies/CHARGE.focs.txt
@@ -34,17 +34,6 @@ Policy
                 // Point defense and shields are less efficient when charging:
                 SetMaxDamage partname = "SR_WEAPON_0_1" value = Value - (NamedReal name = "PLC_CHARGE_FLAK_SHOT_REDUCTION" value = 1.0)
                 SetMaxShield value = Value - (NamedReal name = "PLC_CHARGE_SHIELD_REDUCTION" value = 3.0 * [[SHIP_SHIELD_FACTOR]] )
-
-//                GenerateSitRepMessage
-//                  message = "Applying CHARGE to %ship% -  %system%"
-//                  label = "Custom_212"
-//                  NoStringtableLookup
-//                  icon = "icons/monsters/kraken-1.png"
-//                  parameters = [
-//                    tag = "ship" data = Target.ID
-//                    tag = "system" data = Target.SystemID
-//                  ]
-//                  empire = Source.Owner
             ]
 
     ]

--- a/default/scripting/policies/FLANKING.focs.txt
+++ b/default/scripting/policies/FLANKING.focs.txt
@@ -16,46 +16,6 @@ Policy
         // Multi starlane attack bonus:
         // if, on the previous turn ships were coming in from different starlanes, give them a bonus
         // Note: the system must be set as the final destination
-                EffectsGroup
-            scope = And [
-                Ship
-                OwnedBy empire = Source.Owner
-                Armed
-                   // Stationary ships bonus (prepared defensive flanking)
-                   And [
-                       InSystem
-                       Stationary
-                       ((
-                           Statistic Count condition = And [
-                               Ship
-                               InSystem id = RootCandidate.SystemID
-                               OwnedBy empire = Source.Owner
-                               Armed
-                           ]
-                        ) > (
-                           Statistic Count condition = And [
-                               Ship
-                               InSystem id = RootCandidate.SystemID
-                               OwnedBy affiliation = EnemyOf empire = Source.Owner
-                           ]
-                        )
-                       )
-                   ]
-           ]                   
-           priority = [[TARGET_AFTER_SCALING_PRIORITY]]
-            effects = [
-                GenerateSitRepMessage
-            message = "STATIONARY FLANKING to %ship% -  %system%"
-             label = "Custom_213"
-             NoStringtableLookup
-             icon = "icons/monsters/kraken-1.png"
-             parameters = [
-                 tag = "ship" data = Target.ID
-                 tag = "system" data = Target.SystemID
-             ]
-             empire = Source.Owner
-         ]
-         
         EffectsGroup
             scope = And [
                 Ship
@@ -108,7 +68,7 @@ Policy
                 SetMaxDamage partname = "SR_WEAPON_2_1" value = Value + NamedRealLookup name = "PLC_FLANKING_DAMAGE_BOOST"
                 SetMaxDamage partname = "SR_WEAPON_3_1" value = Value + NamedRealLookup name = "PLC_FLANKING_DAMAGE_BOOST"
                 SetMaxDamage partname = "SR_WEAPON_4_1" value = Value + NamedRealLookup name = "PLC_FLANKING_DAMAGE_BOOST"
-                SetMaxSecondaryStat partname = "SR_ARC_DISRUPTOR" value = Value + NamedReal name = "PLC_CHARGE_ARC_DISRUPTOR_SHOT_BONUS" value = 1.0
+                SetMaxSecondaryStat partname = "SR_ARC_DISRUPTOR" value = Value + NamedReal name = "PLC_FLANKING_ARC_DISRUPTOR_SHOT_BONUS" value = 1.0
                 SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + (NamedReal name = "PLC_FLANKING_FIGHTER_DAMAGE_BOOST" value = 2.0 * [[FIGHTER_DAMAGE_FACTOR]] )
                 SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + NamedRealLookup name = "PLC_FLANKING_FIGHTER_DAMAGE_BOOST"
                 SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value + NamedRealLookup name = "PLC_FLANKING_FIGHTER_DAMAGE_BOOST"
@@ -118,18 +78,6 @@ Policy
                    * (NamedReal name = "PLC_FLANKING_BAY_LAUNCH_BONUS" value = 2.0 ) )
                 // TODO check monster weapons
                 // no bonus to point defense
-                GenerateSitRepMessage
-                  message = "Applying FLANKING to %ship% -  %system%"
-                  label = "Custom_211"
-                  NoStringtableLookup
-                  icon = "icons/monsters/kraken-1.png"
-                  parameters = [
-                    tag = "ship" data = Target.ID
-                    tag = "system" data = Target.SystemID
-                  ]
-                  empire = Source.Owner
-
-
             ]
 
     ]

--- a/default/scripting/policies/FLANKING.focs.txt
+++ b/default/scripting/policies/FLANKING.focs.txt
@@ -16,15 +16,13 @@ Policy
         // Multi starlane attack bonus:
         // if, on the previous turn ships were coming in from different starlanes, give them a bonus
         // Note: the system must be set as the final destination
-        EffectsGroup
+                EffectsGroup
             scope = And [
                 Ship
                 OwnedBy empire = Source.Owner
                 Armed
-                (LocalCandidate.Fleet.ETA = 1)
-                Or [
                    // Stationary ships bonus (prepared defensive flanking)
-                   And [ Planet
+                   And [
                        InSystem
                        Stationary
                        ((
@@ -43,25 +41,95 @@ Policy
                         )
                        )
                    ]
-                   // Multi starlane attack bonus (pincer attack)
-                   (( Statistic CountUnique
-                      value = LocalCandidate.PreviousToFinalDestinationID
-                      condition = And [
-                          Fleet
-                          OwnedBy empire = RootCandidate.Owner
-                          (LocalCandidate.FinalDestinationID = RootCandidate.Fleet.FinalDestinationID)
-                          (LocalCandidate.ETA = 1)
-                          Contains condition = And [ Ship Armed ]
-                      ]
+           ]                   
+           priority = [[TARGET_AFTER_SCALING_PRIORITY]]
+            effects = [
+                GenerateSitRepMessage
+            message = "STATIONARY FLANKING to %ship% -  %system%"
+             label = "Custom_213"
+             NoStringtableLookup
+             icon = "icons/monsters/kraken-1.png"
+             parameters = [
+                 tag = "ship" data = Target.ID
+                 tag = "system" data = Target.SystemID
+             ]
+             empire = Source.Owner
+         ]
+         
+        EffectsGroup
+            scope = And [
+                Ship
+                OwnedBy empire = Source.Owner
+                Armed
+                 Or [
+                   // Stationary ships bonus (prepared defensive flanking)
+                   And [
+                       InSystem
+                       Stationary
+                       ((
+                           Statistic Count condition = And [
+                               Ship
+                               InSystem id = RootCandidate.SystemID
+                               OwnedBy empire = Source.Owner
+                               Armed
+                           ]
+                        ) > (
+                           Statistic Count condition = And [
+                               Ship
+                               InSystem id = RootCandidate.SystemID
+                               OwnedBy affiliation = EnemyOf empire = Source.Owner
+                           ]
+                        )
+                       )
+                   ]
+                   And [
+                       (LocalCandidate.Fleet.ETA = 1)
+
+                       // Multi starlane attack bonus (pincer attack)
+                       (( Statistic CountUnique
+                          value = LocalCandidate.PreviousToFinalDestinationID
+                          condition = And [
+                              Fleet
+                              OwnedBy empire = RootCandidate.Owner
+                              (LocalCandidate.FinalDestinationID = RootCandidate.Fleet.FinalDestinationID)
+                              (LocalCandidate.ETA = 1)
+                              Contains condition = And [ Ship Armed ]
+                          ]
                     ) > 1
                    )
+                   ]
+                   
                 ]
             ]
+            priority = [[TARGET_AFTER_SCALING_PRIORITY]]
             effects = [
+                // Boost damage for ship weapons, strikers, *bombers. Arc disruptor instead increases shots.
                 SetMaxDamage partname = "SR_WEAPON_1_1" value = Value + (NamedReal name = "PLC_FLANKING_DAMAGE_BOOST" value = 1.0 * [[SHIP_WEAPON_DAMAGE_FACTOR]] )
                 SetMaxDamage partname = "SR_WEAPON_2_1" value = Value + NamedRealLookup name = "PLC_FLANKING_DAMAGE_BOOST"
                 SetMaxDamage partname = "SR_WEAPON_3_1" value = Value + NamedRealLookup name = "PLC_FLANKING_DAMAGE_BOOST"
                 SetMaxDamage partname = "SR_WEAPON_4_1" value = Value + NamedRealLookup name = "PLC_FLANKING_DAMAGE_BOOST"
+                SetMaxSecondaryStat partname = "SR_ARC_DISRUPTOR" value = Value + NamedReal name = "PLC_CHARGE_ARC_DISRUPTOR_SHOT_BONUS" value = 1.0
+                SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + (NamedReal name = "PLC_FLANKING_FIGHTER_DAMAGE_BOOST" value = 2.0 * [[FIGHTER_DAMAGE_FACTOR]] )
+                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + NamedRealLookup name = "PLC_FLANKING_FIGHTER_DAMAGE_BOOST"
+                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value + NamedRealLookup name = "PLC_FLANKING_FIGHTER_DAMAGE_BOOST"
+                // Boost interceptor launch rate by 2
+                SetMaxCapacity partname = "FT_BAY_1" value = Value
+                + (  (Statistic If condition = And [ Object id = Target.ID  DesignHasPart low = 1 high = 999 name = "FT_HANGAR_1" ] )
+                   * (NamedReal name = "PLC_FLANKING_BAY_LAUNCH_BONUS" value = 2.0 ) )
+                // TODO check monster weapons
+                // no bonus to point defense
+                GenerateSitRepMessage
+                  message = "Applying FLANKING to %ship% -  %system%"
+                  label = "Custom_211"
+                  NoStringtableLookup
+                  icon = "icons/monsters/kraken-1.png"
+                  parameters = [
+                    tag = "ship" data = Target.ID
+                    tag = "system" data = Target.SystemID
+                  ]
+                  empire = Source.Owner
+
+
             ]
 
     ]

--- a/default/scripting/policies/FLANKING.focs.txt
+++ b/default/scripting/policies/FLANKING.focs.txt
@@ -31,6 +31,7 @@ Policy
                                Ship
                                InSystem id = RootCandidate.SystemID
                                OwnedBy empire = Source.Owner
+                               Stationary
                                Armed
                            ]
                         ) > (

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -12037,7 +12037,14 @@ PLC_FLANKING
 Flanking
 
 PLC_FLANKING_DESC
-In systems where the empire that adopted this policy has more stationary armed ships than there are enemy ships present, that empire's weapons will do [[value PLC_FLANKING_DAMAGE_BOOST]] additional structural damage per shot.
+'''In systems where the empire that adopted this policy has more stationary armed ships than there are enemy ships present, that empire's weapons will do additional structural damage per shot.
+
+Also ships flying a pincer attack do that additional structural damage. A pincer attack happens when ships of the adopting empire are in flight arriving next turn in a system via different starlanes.
+
+• Weapon damage for ship weapons is increased by [[value PLC_FLANKING_DAMAGE_BOOST]] (i.e. for [[shippart SR_WEAPON_1_1]], [[shippart SR_WEAPON_2_1]], [[shippart SR_WEAPON_3_1]], or [[shippart SR_WEAPON_4_1]])
+• Weapon damage for strikers, bombers and heavy bombers is increased by [[value PLC_FLANKING_FIGHTER_DAMAGE_BOOST]] (i.e. for [[shippart FT_HANGAR_1]], [[shippart FT_HANGAR_2]], or [[shippart FT_HANGAR_3]])
+• Number of fighters launched per [[FT_BAY_1]] is increased by [[value PLC_FLANKING_BAY_LAUNCH_BONUS]]
+• Number of shots for [[shippart SR_ARC_DISRUPTOR]] is increased by [[value PLC_FLANKING_ARC_DISRUPTOR_SHOT_BONUS]] '''
 
 PLC_FLANKING_SHORT_DESC
 Boosts Ship Damage

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -12047,7 +12047,10 @@ Charge
 
 PLC_CHARGE_DESC
 '''For armed ships with at least [[value PLC_CHARGE_MINIMUM_SPEED]] [[metertype METER_SPEED]]:
-• Weapon damage is increased by [[value PLC_CHARGE_DAMAGE_BOOST]]
+• Weapon damage for ship weapons is increased by [[value PLC_CHARGE_DAMAGE_BOOST]] (i.e. for [[shippart SR_WEAPON_1_1]], [[shippart SR_WEAPON_2_1]], [[shippart SR_WEAPON_3_1]], or [[shippart SR_WEAPON_4_1]])
+• Number of fighters launched per [[FT_BAY_1]] is increased by [[value PLC_CHARGE_BAY_LAUNCH_BONUS]]
+• Number of shots for [[shippart SR_ARC_DISRUPTOR]] is increased by [[value PLC_CHARGE_ARC_DISRUPTOR_SHOT_BONUS]]
+• Number of shots for [[shippart SR_WEAPON_0_1]] is decreased by [[value PLC_CHARGE_FLAK_SHOT_REDUCTION]]
 • [[metertype METER_MAX_SHIELD]] is reduced by [[value PLC_CHARGE_SHIELD_REDUCTION]] '''
 
 PLC_CHARGE_SHORT_DESC


### PR DESCRIPTION
discussion started in the forums https://freeorion.org/forum/viewtopic.php?p=108138#p108138

Features:
- implementation for #3577 (Give Combat Bonus from Policies also to Fighters and Arc Disruptor lines)
- bugfix for #3578 (PLC_FLANKING stationary bonus is broken)
- also adds pincer attack description for PLC_FLANKING

Changes:
PLC_FLANKING
- Weapon damage for strikers, bombers and heavy bombers is increased by 12 per fighter
- Launch rate for interceptors is increased by 2 per bay
- Weapon shots for arc disruptors is increased by 1 
- Defensive flanking does not expect ETA1 anymore (bugfix)

PLC_CHARGE
- Launch rate for any type of fighter is increased by 1 per bay
- Weapon shots for arc disruptors is increased by 1 
- Weapon shots for flak is decreased by 1 

Following text adapted from the
Feature request
===============

Idea
----
I just recognized the combat policies FLANKING and CHARGE only work for the ship weapons, not fighters nor arc disruptors (also not special monster weapons). Probably that is wrong. The bonus is 1*scaling - for mass drivers this means 1/3rd vs mass drivers one tech.

That would directly translate to 2/3*scaling for arc disruptors, but one could add a shot instead.

For flak one could also think of adding a shot, but it does not fit the theme so I rather wouldn't. Actually CHARGE could/should lower the number of flak shots.

For fighters strikers have a bit higher base damage than mass drivers (4 vs 3), so adding 1x scaling is rather conservative. If taking bombers (6)as a reference point, adding 2x scaling would keep the balance. So I'd suggest adding 2x scaling for all fighter types for PLC_FLANKING. And for CHARGE I suggest increasing launch capacity by 1 per bay instead. This will make CHARGE especially good for heavier designs and FLANKING good for lighter fighters. Combining CHARGE and FLANKING makes a sweet spot for striker fighters (a bay able to launch a complete hangar and also getting the most damage out of FLANKING).
To stress the good-for-lighter-fighters, FLANKING interceptors should get a +2 launch capacity bonus.

For monster weapons dunno. Fluff-wise a small bonus would make sense (trained monsters not following tactics/orders as well as your pilots do). But also no bonus or normal bonus could be argued.

Meta
----
Alternative to giving the bonus to all weapon lines is having specialised policies. Or distinguish a weapon line being more/less dependent on the policies (e.g. like arc disruptors do not depend on pilot skill) but balance that with extra power for those who are not able to get a bonus. 

Also like Oberlus wrote, the policies currently boost the lower tier ship weapons more significantly (which I think is good and interesting).

The three weapon trees are orthogonal. So a typical empire is expected to invest in one of those heavily and investing in multiple lines has slighter return on investment. It makes sense NOT to have specialised policies.

Again for monster weapons dunno.

The CHARGE policy applies a malus - that means a flak-only ship will get a malus but no bonus. But to be efficient on point defense fluff-wise the ship has to charge with the others. For a pure carrier, it might make sense to stay behind, so having no bonus would be more dubious.

Fluffwise it makes not much sense that a faster carrier increases the damage of the fighters, so we increase launch rate instead.

Fluffwise, a charge bonus could interact with "range", so e.g. a charging vessel could shoot a bout earlier (and carriers field interceptors earlier). Seeing this as a nice-to-have, the feature would be too complex (interaction with stealth, fighter launch,..) and also hard to script.

Fluffwise, a charge bonus probably should wear off when already in close combat range. Also not worth it - players would probably surprised that the bonus does not kick in.

It is also not clear yet how the policies interact with damage estimation. Probably the game should show the bonus when it is expected to apply, but distinct such a "temporary effect" from the "base effects". I think thats not possible currently.

@geoffthemedio Also NOTE defensive flanking basically always applies if no enemy is present, so if a larger force arrives, the first turn the defender will get the bonus (which is probably not what we want?).