### PR TITLE
Three minor fixes

### DIFF
--- a/default/scripting/buildings/MILITARY_COMMAND.focs.txt
+++ b/default/scripting/buildings/MILITARY_COMMAND.focs.txt
@@ -43,7 +43,7 @@ BuildingType
             accountinglabel = "BLD_MILITARY_COMMAND"
             priority = [[TARGET_EARLY_BEFORE_SCALING_PRIORITY]]
             effects = [
-                SetMaxDefense value = Value + 5
+                SetMaxDefense value = Value + 5 * [[PLANET_DEFENSE_FACTOR]]
                 SetMaxTroops value = Value + 6
             ]
     ]
@@ -53,3 +53,4 @@ BuildingType
 #include "/scripting/common/priorities.macros"
 #include "/scripting/common/base_prod.macros"
 #include "/scripting/buildings/buildings.macros"
+#include "/scripting/common/misc.macros"

--- a/default/scripting/species/common/research.macros
+++ b/default/scripting/species/common/research.macros
@@ -34,7 +34,6 @@ VERY_BAD_RESEARCH
             activation = And [
                 Planet
                 Focus type = "FOCUS_RESEARCH"
-                Happiness low = 8
             ]
             accountinglabel = "VERY_BAD_RESEARCH_LABEL"
             effects = SetTargetResearch value = Value*[[VERY_BAD_MULTIPLIER]]
@@ -49,7 +48,6 @@ BAD_RESEARCH
             activation = And [
                 Planet
                 Focus type = "FOCUS_RESEARCH"
-                Happiness low = 6
             ]
             accountinglabel = "BAD_RESEARCH_LABEL"
             effects = SetTargetResearch value = Value*[[BAD_MULTIPLIER]]

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -11528,7 +11528,7 @@ PLC_METROPOLES
 Metropoles
 
 PLC_METROPOLES_DESC
-'''Boosts the output of up to [[value METROPOLES_PLANET_LIMIT]] planets. At most 1 / [[value METROPOLES_MIN_PLANETS]] of all populated planets with [[metertype METER_POPULATION]] of at least [[value METROPOLES_MINIMUM_POPULATION]] and [[metertype METER_HAPPINESS]] of at least [[value METROPOLES_MIN_STABILITY]] will be boosted.
+'''Boosts the output of up to [[value METROPOLES_PLANET_LIMIT]] planets, but not more than a fraction of 1 / [[value METROPOLES_MIN_PLANETS]] of all the empire's populated planets. To qualify for being boosted, planets must have [[metertype METER_POPULATION]] of at least [[value METROPOLES_MINIMUM_POPULATION]] and [[metertype METER_HAPPINESS]] of at least [[value METROPOLES_MIN_STABILITY]].
 The highest-populated of the qualified planets will receive, regardless of focus:
 • Increases [[metertype METER_TARGET_RESEARCH]] by [[value METROPOLES_TARGET_RESEARCH_PERPOP]] per population.
 • Increases [[metertype METER_TARGET_INDUSTRY]] by [[value METROPOLES_TARGET_INDUSTRY_PERPOP]] per population.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -11528,7 +11528,7 @@ PLC_METROPOLES
 Metropoles
 
 PLC_METROPOLES_DESC
-'''Boosts the output of up to [[value METROPOLES_PLANET_LIMIT]] planets. At most (1 / [[value METROPOLES_MIN_PLANETS]] or populated planets) with [[metertype METER_POPULATION]] of at least [[value METROPOLES_MINIMUM_POPULATION]] and [[metertype METER_HAPPINESS]] of at least [[value METROPOLES_MIN_STABILITY]] will be boosted.
+'''Boosts the output of up to [[value METROPOLES_PLANET_LIMIT]] planets. At most 1 / [[value METROPOLES_MIN_PLANETS]] of all populated planets with [[metertype METER_POPULATION]] of at least [[value METROPOLES_MINIMUM_POPULATION]] and [[metertype METER_HAPPINESS]] of at least [[value METROPOLES_MIN_STABILITY]] will be boosted.
 The highest-populated of the qualified planets will receive, regardless of focus:
 • Increases [[metertype METER_TARGET_RESEARCH]] by [[value METROPOLES_TARGET_RESEARCH_PERPOP]] per population.
 • Increases [[metertype METER_TARGET_INDUSTRY]] by [[value METROPOLES_TARGET_INDUSTRY_PERPOP]] per population.


### PR DESCRIPTION
First is definitely an oversight.
Not sure about the second, but I cannot see a good reason why e.g. unstable exobots should be better reasearchers. In fact the way it is now, Exobots with stability 7 are better at research than e.g. Replicon with stability 7 since very bad triggers later then bad research.
Last is a grammatical fix of the Metropole description.