### PR TITLE
Treat neutral (==ALL_EMPIRES) forces like an empire for visibility

### DIFF
--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -7842,8 +7842,6 @@ namespace {
         bool operator()(const std::shared_ptr<const UniverseObject>& candidate) const {
             if (!candidate)
                 return false;
-            if (m_empire_id == ALL_EMPIRES)
-                return true;
             if (m_vis == Visibility::VIS_NO_VISIBILITY)
                 return true;
 

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -7844,6 +7844,8 @@ namespace {
                 return false;
             if (m_vis == Visibility::VIS_NO_VISIBILITY)
                 return true;
+            if (m_empire_id == ALL_EMPIRES && m_context.combat_bout < 1)
+                return true; // outside of battle neutral forces have full visibility per default
 
             if (m_since_turn == INVALID_GAME_TURN) {
                 // no valid game turn was specified, so use current universe state

--- a/universe/ScriptingContext.h
+++ b/universe/ScriptingContext.h
@@ -313,7 +313,7 @@ struct ScriptingContext {
     const CurrentValueVariant&            current_value = EMPTY_CURRENT_VALUE;
 
     // general gamestate info
-    int                                            combat_bout = 0;
+    int                                            combat_bout = 0; // first round of battle is combat_bout == 1
     int                                            current_turn = CurrentTurn();
     int                                            in_design_id = INVALID_DESIGN_ID;
     int                                            production_block_size = 1;

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -1475,8 +1475,8 @@ Visibility ComplexVariable<Visibility>::Eval(const ScriptingContext& context) co
         int empire_id = ALL_EMPIRES;
         if (m_int_ref1) {
             empire_id = m_int_ref1->Eval(context);
-            if (empire_id == ALL_EMPIRES)
-                return Visibility::VIS_NO_VISIBILITY;
+            if (empire_id == ALL_EMPIRES && context.combat_bout < 1)
+                return Visibility::VIS_FULL_VISIBILITY; // outside of battle neutral forces have full visibility per default
         }
 
         int object_id = INVALID_OBJECT_ID;


### PR DESCRIPTION
Without this fix, stealth does not work against neutral ships (aka monsters):
![2021-11-16 6c3d9f1_combat_report](https://user-images.githubusercontent.com/3252041/142721457-d1d64cea-7e7e-4119-a523-a102639e3a94.png)

With the fix, the hidden ship Guilt gets attacked correctly starting from bout 4

The implementation only changes visibility resolution in battle

Detailed Design:

- the underlying model is: neutral forces per default can see everything
- this gets modified/interpreted differently in many places; usually: local monster detection has to be higher than the object's stealth

Special situations handling of detection:

- initiating combat (ServerApp::GetFleetsVisibleToEmpireAtSystem)
- targeting during combat via FOCS; ship weapons use VisibleToEmpire condition in default/scripting/ship_parts/targeting.macros (this is necessary as the visibility changes while fighting)
- Bombard parts use Stealth high = Source.Detection

Changed in this PR: VisibleToEmpire Condition checks if context.combat_bout > 0 to see if we are in a battle. If not, we return true as before.

No change: Universe::EmpireObjectVisibility does not have a context, so I am unable to decide anything, returns always full visibility.

Changed in this PR: The unused EmpireObjectVisibility complex ValueRef now is consistent with the VisibleToEmpire Condition. I.e. it checks the visibility map if inside combat, else it assumes full vision for unowned objects.
