### PR TITLE
Check If Producible Before Enqueuing in AI

### DIFF
--- a/client/AI/AIWrapper.cpp
+++ b/client/AI/AIWrapper.cpp
@@ -358,6 +358,30 @@ namespace {
 
     }
 
+    auto IsProducibleBuilding(const std::string& item_name, int location_id) -> bool
+    {
+        ScriptingContext context;
+        int empire_id = AIClientApp::GetApp()->EmpireID();
+        auto empire = context.GetEmpire(empire_id);
+        if (!empire) {
+            ErrorLogger() << "IsProducibleBuilding : couldn't get empire with id " << empire_id;
+            return false;
+        }
+        return empire->ProducibleItem(BuildType::BT_BUILDING, item_name, location_id, context);
+    }
+
+    auto IsEnqueuableBuilding(const std::string& item_name, int location_id) -> bool
+    {
+        ScriptingContext context;
+        int empire_id = AIClientApp::GetApp()->EmpireID();
+        auto empire = context.GetEmpire(empire_id);
+        if (!empire) {
+            ErrorLogger() << "IsEnqueuableBuilding : couldn't get empire with id " << empire_id;
+            return false;
+        }
+        return empire->EnqueuableItem(BuildType::BT_BUILDING, item_name, location_id, context);
+    }
+
     auto IssueEnqueueBuildingProductionOrder(const std::string& item_name, int location_id) -> int
     {
         ScriptingContext context;
@@ -387,6 +411,31 @@ namespace {
             context);
 
         return 1;
+    }
+
+    auto IsProducibleShip(int design_id, int location_id) -> bool
+    {
+        ScriptingContext context;
+        int empire_id = AIClientApp::GetApp()->EmpireID();
+        auto empire = context.GetEmpire(empire_id);
+        if (!empire) {
+            ErrorLogger() << "IsProducibleShip : couldn't get empire with id " << empire_id;
+            return false;
+        }
+        return empire->ProducibleItem(BuildType::BT_SHIP, design_id, location_id, context);
+    }
+
+    auto IsEnqueuableShip(int design_id, int location_id) -> bool
+    {
+        ScriptingContext context;
+        int empire_id = AIClientApp::GetApp()->EmpireID();
+        auto empire = context.GetEmpire(empire_id);
+        if (!empire) {
+            ErrorLogger() << "IsEnqueuableShip : couldn't get empire with id " << empire_id;
+            return false;
+        }
+        // as of this writing, ships don't have a distinction between producible and enqueuable
+        return empire->ProducibleItem(BuildType::BT_SHIP, design_id, location_id, context);
     }
 
     auto IssueEnqueueShipProductionOrder(int design_id, int location_id) -> int
@@ -707,6 +756,11 @@ namespace FreeOrionPython {
         py::def("updateResourcePools",                  UpdateResourcePools);
         py::def("updateResearchQueue",                  UpdateResearchQueue);
         py::def("updateProductionQueue",                UpdateProductionQueue);
+
+        py::def("isProducibleBuilding",                 IsProducibleBuilding);
+        py::def("isEnqueuableBuilding",                 IsEnqueuableBuilding);
+        py::def("isProducibleShip",                     IsProducibleShip);
+        py::def("isEnqueuableShip",                     IsEnqueuableShip);
 
         py::def("issueFleetMoveOrder",
                 +[](int fleet_id, int destination_id) -> int { return Issue<FleetMoveOrder>(fleet_id, destination_id, false); },

--- a/client/AI/AIWrapper.cpp
+++ b/client/AI/AIWrapper.cpp
@@ -413,18 +413,6 @@ namespace {
         return 1;
     }
 
-    auto IsProducibleShip(int design_id, int location_id) -> bool
-    {
-        ScriptingContext context;
-        int empire_id = AIClientApp::GetApp()->EmpireID();
-        auto empire = context.GetEmpire(empire_id);
-        if (!empire) {
-            ErrorLogger() << "IsProducibleShip : couldn't get empire with id " << empire_id;
-            return false;
-        }
-        return empire->ProducibleItem(BuildType::BT_SHIP, design_id, location_id, context);
-    }
-
     auto IsEnqueuableShip(int design_id, int location_id) -> bool
     {
         ScriptingContext context;
@@ -751,16 +739,39 @@ namespace FreeOrionPython {
                 +[]() -> std::string { return (GetResourceDir() / GetOptionsDB().Get<std::string>("ai-path")).string(); },
                 py::return_value_policy<py::return_by_value>());
 
-        py::def("initMeterEstimatesDiscrepancies",      InitMeterEstimatesAndDiscrepancies);
+        py::def("initMeterEstimatesDiscrepancies",
+                InitMeterEstimatesAndDiscrepancies,
+                "For all objects and max / target meters, determines discrepancies "
+                "between actual meters and what the known universe should produce. "
+                "This is used later when updating meter estimates to incorporate "
+                "those discrepancies.");
         py::def("updateMeterEstimates",                 UpdateMeterEstimates);
         py::def("updateResourcePools",                  UpdateResourcePools);
         py::def("updateResearchQueue",                  UpdateResearchQueue);
         py::def("updateProductionQueue",                UpdateProductionQueue);
 
-        py::def("isProducibleBuilding",                 IsProducibleBuilding);
-        py::def("isEnqueuableBuilding",                 IsEnqueuableBuilding);
-        py::def("isProducibleShip",                     IsProducibleShip);
-        py::def("isEnqueuableShip",                     IsEnqueuableShip);
+        py::def("isProducibleBuilding",
+                IsProducibleBuilding,
+                "Returns true if the specified building type (string) can be produced "
+                "by this client's empire at the specified production location (int). "
+                "Being producible means that if the item is on the production queue, "
+                "it can be allocated production points that are available at its "
+                "location. Being producible does not mean that the building type can "
+                "be added to the queue.");
+        py::def("isEnqueuableBuilding",
+                IsEnqueuableBuilding,
+                "Returns true if the specified building type (string) can be enqueued "
+                "by this client's empire at the specified production location (int). "
+                "Being enqueuable means that the item can be added to the queue, but "
+                "does not mean that the item will be allocated production points once "
+                " it is added");
+        py::def("isEnqueuableShip",
+                IsEnqueuableShip,
+                "Returns true if the specified ship design (int) can be enqueued by "
+                "this client's empire at the specified production location (int). "
+                "Enqueued ships should always also be producible, and thus able to "
+                "be allocated production points once enqueued, if any are available "
+                "at the production location.");
 
         py::def("issueFleetMoveOrder",
                 +[](int fleet_id, int destination_id) -> int { return Issue<FleetMoveOrder>(fleet_id, destination_id, false); },

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -1065,6 +1065,11 @@ def generate_production_orders():
                 ):
                     scanner_locs[planet.systemID] = True
         max_scanner_builds = max(1, int(empire.productionPoints / 30))
+        debug(
+            "Considering building %s, found current and queued systems %s",
+            building_name,
+            PlanetUtilsAI.sys_name_ids(scanner_locs),
+        )
         for sys_id in get_owned_planets().keys():
             if len(queued_locs) >= max_scanner_builds:
                 break
@@ -1081,6 +1086,10 @@ def generate_production_orders():
             for pid in get_owned_planets_in_system(sys_id):
                 planet = universe.getPlanet(pid)
                 if not planet:
+                    continue
+                if not fo.isProducibleBuilding(building_name, pid):
+                    continue
+                if not fo.isEnqueuableBuilding(building_name, pid):
                     continue
                 build_locs.append((planet.currentMeterValue(fo.meterType.maxTroops), pid))
             if not build_locs:
@@ -1134,6 +1143,10 @@ def generate_production_orders():
                     continue
                 if pid in local_drydocks or pid in queued_locs:
                     break
+                if not fo.isProducibleBuilding(building_name, pid):
+                    continue
+                if not fo.isEnqueuableBuilding(building_name, pid):
+                    continue
                 planet = universe.getPlanet(pid)
                 res = fo.issueEnqueueBuildingProductionOrder(building_name, pid)
                 debug("Enqueueing %s at planet %d (%s) , with result %d", building_name, pid, planet.name, res)


### PR DESCRIPTION
Adds functions to the Python API to check of buildings or ships are enqueuable or produbile. Can be used rather than attempting to enqueue them.

Added the checks before attempting to enqueue Scanning Facility and Orbital Drydocks, to reduce error spam in the AI log.