### PR TITLE
Buff population growth to thirdway where it was before

### DIFF
--- a/default/scripting/species/common/population.macros
+++ b/default/scripting/species/common/population.macros
@@ -1,7 +1,7 @@
 
 GROWTH_RATE_FACTOR
 '''
-0.08 *
+0.1 *
 (1 - (Statistic If condition = And [Target EmpireHasAdoptedPolicy name = "PLC_NO_GROWTH"])) *       // no growth with no-growth policy
 (1 + 0.5*(Statistic If condition = And [Target EmpireHasAdoptedPolicy name = "PLC_POPULATION"])) *  // +50% growth with population policy
 (1 + (Statistic If condition = And [Target EmpireHasAdoptedPolicy name = "PLC_AUGMENTATION"]) *     // slower growth with augmentation on low-infrastructure planets


### PR DESCRIPTION
Since the last nerf, normal colony growth is pale in comparison to invading natives.

forum discussion started here https://www.freeorion.org/forum/viewtopic.php?p=108840#p108840
and there is discussion of changing [Population curves](https://www.freeorion.org/forum/viewtopic.php?f=6&t=12222)


Before introducing growth policy in 5c9b5023f00e047f1b33e260677a13f21d4f6c2b,

base growth factor was 0.01
Then it was 0.005, but one could improve it by 50% using the policy
New formula kept that balance for planets of target population 16 (using a base growth factor of 0.08).

with this PR, base growth factor is 0.1; 25% higher (so upping growth a bit)

(Note: with old formula i suggested improving it to 0.008 which would have been ~50% more)