### PR TITLE
PLC_LIBERTY kicks in at stability 6 iff target_stability without liberty >= 8

### DIFF
--- a/default/scripting/policies/LIBERTY.focs.txt
+++ b/default/scripting/policies/LIBERTY.focs.txt
@@ -16,13 +16,19 @@ Policy
             Planet
             OwnedBy empire = Source.Owner
             Species
-            Happiness low = (NamedReal name = "PLC_LIBERTY_MIN_STABILITY" value = 8)
+            Happiness low = (NamedReal name = "PLC_LIBERTY_MIN_STABILITY" value = 8.0)
+                          - (NamedReal name = "PLC_LIBERTY_STABILITY_PENALTY_FLAT" value = 2.0)
         ]
+        priority = [[TARGET_AFTER_2ND_SCALING_PRIORITY]]
         effects = [
-            SetTargetResearch value = Value + (NamedReal name = "PLC_LIBERTY_RESEARCH_BONUS_FLAT" value = 2.0)
-            SetTargetHappiness value = Value - (NamedReal name = "PLC_LIBERTY_STABILITY_PENALTY_FLAT" value = 2.0)
+            If condition = (Value(RootCandidate.TargetHappiness) >= (NamedRealLookup name = "PLC_LIBERTY_MIN_STABILITY"))
+            effects = [
+                SetTargetResearch value = Value + (NamedReal name = "PLC_LIBERTY_RESEARCH_BONUS_FLAT" value = 2.0)
+                SetTargetHappiness value = Value - (NamedRealLookup name = "PLC_LIBERTY_STABILITY_PENALTY_FLAT")
+            ]
         ]
     ]
     graphic = "icons/policies/liberty.png"
 
 #include "/scripting/policies/policies.macros"
+#include "/scripting/common/priorities.macros"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -11918,7 +11918,7 @@ Liberty
 
 PLC_LIBERTY_DESC
 '''• Increases the impact of species likes and dislikes on planet stability due to buildings and policies.
-• Increases [[metertype METER_TARGET_RESEARCH]] by [[value PLC_LIBERTY_RESEARCH_BONUS_FLAT]] and decreases [[metertype METER_TARGET_HAPPINESS]] by [[value PLC_LIBERTY_STABILITY_PENALTY_FLAT]] on all planets with a stability of at least [[value PLC_LIBERTY_MIN_STABILITY]].'''
+• Increases [[metertype METER_TARGET_RESEARCH]] by [[value PLC_LIBERTY_RESEARCH_BONUS_FLAT]] and decreases [[metertype METER_TARGET_HAPPINESS]] by [[value PLC_LIBERTY_STABILITY_PENALTY_FLAT]] on all planets which would have a maximum stability of at least [[value PLC_LIBERTY_MIN_STABILITY]] without the Liberty policy.'''
 
 PLC_LIBERTY_SHORT_DESC
 Increases species opinion effects


### PR DESCRIPTION
https://www.freeorion.org/forum/viewtopic.php?f=28&t=11768&p=108838#p108838

Stability 9 may invite to some focus (or other) dancing trying to keep stability at 8 which is NOT ok .
one could make it though something like this (curStability is current stability when the effect gets applied); making getting all the 8+ stability gated bonus harder:

late effect, after second scaling:
* (stability >= 6)&&(targetStability >= 8 ) -> +2 targetResearch, -2 targetStability