### PR TITLE
Make Trith have average environments (RADIATED_STANDARD)

### DIFF
--- a/default/scripting/species/SP_TRITH.focs.txt
+++ b/default/scripting/species/SP_TRITH.focs.txt
@@ -54,7 +54,7 @@ Species
             effects = UnlockPolicy name = "PLC_RACIAL_PURITY"
     ]
 
-    [[RADIATED_NARROW_EP]]
+    [[RADIATED_STANDARD_EP]]
 
     graphic = "icons/species/trith.png"
 


### PR DESCRIPTION
having some options for adequate environments is a preparation path for terraforming.
before restricting self-sustained to good planets this was basically a no-go, now its possible and a great combination (makes Trith want to do terraforming)

https://freeorion.org/forum/viewtopic.php?p=108839#p108839