### PR TITLE
Automatically flattens And and Or conditions

### DIFF
--- a/parse/ConditionPythonParser.cpp
+++ b/parse/ConditionPythonParser.cpp
@@ -24,7 +24,7 @@ condition_wrapper operator|(const condition_wrapper& lhs, const condition_wrappe
 }
 
 condition_wrapper operator~(const condition_wrapper& lhs) {
-return condition_wrapper(std::make_shared<Condition::Not>(
+    return condition_wrapper(std::make_shared<Condition::Not>(
         lhs.condition->Clone()
     ));
 }

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -10311,8 +10311,13 @@ And::And(std::unique_ptr<Condition>&& operand1, std::unique_ptr<Condition>&& ope
     Condition()
 {
     // would prefer to initialize the vector m_operands in the initializer list, but this is difficult with non-copyable unique_ptr parameters
-    if (operand1)
-        m_operands.push_back(std::move(operand1));
+    if (operand1) {
+        if (And* operand1_and = dynamic_cast<And*>(operand1.get())) {
+            m_operands = std::move(operand1_and->m_operands);
+        } else {
+            m_operands.push_back(std::move(operand1));
+        }
+    }
     if (operand2)
         m_operands.push_back(std::move(operand2));
     if (operand3)
@@ -10517,8 +10522,13 @@ Or::Or(std::unique_ptr<Condition>&& operand1,
     Condition()
 {
     // would prefer to initialize the vector m_operands in the initializer list, but this is difficult with non-copyable unique_ptr parameters
-    if (operand1)
-        m_operands.push_back(std::move(operand1));
+    if (operand1) {
+        if (Or* operand1_or = dynamic_cast<Or*>(operand1.get())) {
+            m_operands = std::move(operand1_or->m_operands);
+        } else {
+            m_operands.push_back(std::move(operand1));
+        }
+    }
     if (operand2)
         m_operands.push_back(std::move(operand2));
     if (operand3)


### PR DESCRIPTION
Make conditions `And [ A B C ]`, `And [ And [ A B ] C ]`, and pythons `A & B & C` equals.
