### PR TITLE
Make stability penalties for shipyard dislikes work

### DIFF
--- a/default/scripting/buildings/shipyards/ASTEROID.focs.txt
+++ b/default/scripting/buildings/shipyards/ASTEROID.focs.txt
@@ -11,6 +11,8 @@ BuildingType
     ]
     enqueuelocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
     effectsgroups = [
+		[[SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS]]
+    
         EffectsGroup
             scope = Source
             activation = Not Planet type = Asteroids
@@ -20,3 +22,4 @@ BuildingType
 
 #include "/scripting/common/enqueue.macros"
 #include "/scripting/common/base_prod.macros"
+#include "/scripting/buildings/buildings.macros"

--- a/default/scripting/buildings/shipyards/ASTEROID_REF.focs.txt
+++ b/default/scripting/buildings/shipyards/ASTEROID_REF.focs.txt
@@ -12,6 +12,8 @@ BuildingType
     ]
     enqueuelocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
     effectsgroups = [
+		[[SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS]]
+    
         EffectsGroup
             scope = Source
             activation = Not Planet type = Asteroids
@@ -21,3 +23,4 @@ BuildingType
 
 #include "/scripting/common/enqueue.macros"
 #include "/scripting/common/base_prod.macros"
+#include "/scripting/buildings/buildings.macros"

--- a/default/scripting/buildings/shipyards/BASE.focs.txt
+++ b/default/scripting/buildings/shipyards/BASE.focs.txt
@@ -14,14 +14,18 @@ BuildingType
         [[ENQUEUE_BUILD_ONE_PER_PLANET]]
         CanProduceShips
     ]
-    effectsgroups =
+    effectsgroups = [
+		[[SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS]]
+    
         EffectsGroup
             scope = And [ 
                 Object id = Source.PlanetID
                 Planet
             ]
             effects = SetTargetConstruction value = Value - 10
+	]
     icon = "icons/building/shipyard.png"
 
 #include "/scripting/common/enqueue.macros"
 #include "/scripting/common/base_prod.macros"
+#include "/scripting/buildings/buildings.macros"

--- a/default/scripting/buildings/shipyards/CON_ADV_ENGINE.focs.txt
+++ b/default/scripting/buildings/shipyards/CON_ADV_ENGINE.focs.txt
@@ -12,7 +12,11 @@ BuildingType
         OwnedBy empire = Source.Owner
     ]
     enqueuelocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
+	effectsgroups = [
+		[[SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS]]
+	]	
     icon = "icons/building/shipyard-4.png"
 
 #include "/scripting/common/enqueue.macros"
 #include "/scripting/common/base_prod.macros"
+#include "/scripting/buildings/buildings.macros"

--- a/default/scripting/buildings/shipyards/CON_GEOINT.focs.txt
+++ b/default/scripting/buildings/shipyards/CON_GEOINT.focs.txt
@@ -12,7 +12,11 @@ BuildingType
         OwnedBy empire = Source.Owner
     ]
     enqueuelocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
+	effectsgroups = [
+		[[SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS]]
+	]	
     icon = "icons/building/shipyard-3.png"
 
 #include "/scripting/common/enqueue.macros"
 #include "/scripting/common/base_prod.macros"
+#include "/scripting/buildings/buildings.macros"

--- a/default/scripting/buildings/shipyards/CON_NANOROBO.focs.txt
+++ b/default/scripting/buildings/shipyards/CON_NANOROBO.focs.txt
@@ -12,7 +12,11 @@ BuildingType
         OwnedBy empire = Source.Owner
     ]
     enqueuelocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
+	effectsgroups = [
+		[[SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS]]
+	]	
     icon = "icons/building/shipyard-2.png"
 
 #include "/scripting/common/enqueue.macros"
 #include "/scripting/common/base_prod.macros"
+#include "/scripting/buildings/buildings.macros"

--- a/default/scripting/buildings/shipyards/ENERGY_COMP.focs.txt
+++ b/default/scripting/buildings/shipyards/ENERGY_COMP.focs.txt
@@ -25,7 +25,11 @@ BuildingType
         ]
     ]
     enqueuelocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
+	effectsgroups = [
+		[[SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS]]
+	]	
     icon = "icons/building/shipyard-10.png"
 
 #include "/scripting/common/enqueue.macros"
 #include "/scripting/common/base_prod.macros"
+#include "/scripting/buildings/buildings.macros"

--- a/default/scripting/buildings/shipyards/ENERGY_SOLAR.focs.txt
+++ b/default/scripting/buildings/shipyards/ENERGY_SOLAR.focs.txt
@@ -26,7 +26,11 @@ BuildingType
         ]
     ]
     enqueuelocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
+	effectsgroups = [
+		[[SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS]]
+	]	
     icon = "icons/building/shipyard-16.png"
 
 #include "/scripting/common/enqueue.macros"
 #include "/scripting/common/base_prod.macros"
+#include "/scripting/buildings/buildings.macros"

--- a/default/scripting/buildings/shipyards/ORBITAL_DRYDOCK.focs.txt
+++ b/default/scripting/buildings/shipyards/ORBITAL_DRYDOCK.focs.txt
@@ -20,6 +20,8 @@ BuildingType
     ]
     enqueuelocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
     effectsgroups = [
+		[[SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS]]
+		
         // ZERO-POP : With no pop, no repair or sitrep messages
         EffectsGroup
             scope = And [
@@ -234,3 +236,4 @@ PLANET_OWNED_DRYDOCK_HIGHEST_HAPPINESS
 #include "/scripting/common/priorities.macros"
 #include "/scripting/common/base_prod.macros"
 #include "/scripting/common/misc.macros"
+#include "/scripting/buildings/buildings.macros"

--- a/default/scripting/buildings/shipyards/ORGANIC_CEL_GRO.focs.txt
+++ b/default/scripting/buildings/shipyards/ORGANIC_CEL_GRO.focs.txt
@@ -12,7 +12,11 @@ BuildingType
         [[LOCATION_ALLOW_BUILD_IF_PREREQ_ENQUEUED(BLD_SHIPYARD_ORG_ORB_INC)]]
     ]
     enqueuelocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
+	effectsgroups = [
+		[[SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS]]
+	]	
     icon = "icons/building/cellular-growth-chamber.png"
 
 #include "/scripting/common/enqueue.macros"
 #include "/scripting/common/base_prod.macros"
+#include "/scripting/buildings/buildings.macros"

--- a/default/scripting/buildings/shipyards/ORGANIC_ORB_INC.focs.txt
+++ b/default/scripting/buildings/shipyards/ORGANIC_ORB_INC.focs.txt
@@ -11,7 +11,11 @@ BuildingType
         [[LOCATION_ALLOW_ENQUEUE_IF_PREREQ_ENQUEUED(BLD_SHIPYARD_BASE)]]
     ]
     enqueuelocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
+	effectsgroups = [
+		[[SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS]]
+	]	
     icon = "icons/building/orbital-incubator.png"
 
 #include "/scripting/common/enqueue.macros"
 #include "/scripting/common/base_prod.macros"
+#include "/scripting/buildings/buildings.macros"

--- a/default/scripting/buildings/shipyards/ORGANIC_XENO_FAC.focs.txt
+++ b/default/scripting/buildings/shipyards/ORGANIC_XENO_FAC.focs.txt
@@ -12,7 +12,11 @@ BuildingType
         [[LOCATION_ALLOW_BUILD_IF_PREREQ_ENQUEUED(BLD_SHIPYARD_ORG_ORB_INC)]]
     ]
     enqueuelocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
+	effectsgroups = [
+		[[SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS]]
+	]	
     icon = "icons/building/xeno-coordination-facility.png"
 
 #include "/scripting/common/enqueue.macros"
 #include "/scripting/common/base_prod.macros"
+#include "/scripting/buildings/buildings.macros"


### PR DESCRIPTION
Shipyards were missing the lines that creates a stability penalty for species dislikes