### PR TITLE
adding number of settled worlds to census report

### DIFF
--- a/UI/CensusBrowseWnd.cpp
+++ b/UI/CensusBrowseWnd.cpp
@@ -23,25 +23,25 @@ namespace {
     constexpr GG::Y ICON_BROWSE_ICON_HEIGHT(64);
 
     const GG::X BrowseTextWidth()
-    { return GG::X(FontBasedUpscale(200)); }
+    { return GG::X(FontBasedUpscale(230)); }
 }
 
 class CensusRowPanel : public GG::Control {
 public:
-    CensusRowPanel(GG::X w, GG::Y h, const std::string& name, double census_val, bool show_icon) :
+    CensusRowPanel(GG::X w, GG::Y h, const std::string& name, double census_val, int worlds, bool show_icon) :
         GG::Control(GG::X0, GG::Y0, w, h, GG::NO_WND_FLAGS),
-        m_show_icon(show_icon)
+        m_show_icon(show_icon),
+        m_worlds()
     {
         if (m_show_icon)
             m_icon = GG::Wnd::Create<GG::StaticGraphic>(
                 ClientUI::SpeciesIcon(name), GG::GRAPHIC_FITGRAPHIC);
 
         m_name = GG::Wnd::Create<CUILabel>(UserString(name), GG::FORMAT_RIGHT);
-
-        int num_digits = census_val < 10 ? 1 : 2; // this allows the decimal point to line up when there number above and below 10.
-        num_digits =    census_val < 100 ? num_digits : 3; // this allows the decimal point to line up when there number above and below 100.
-        num_digits =   census_val < 1000 ? num_digits : 4; // this allows the decimal point to line up when there number above and below 1000.
-        m_census_val = GG::Wnd::Create<CUILabel>(DoubleToString(census_val, num_digits, false), GG::FORMAT_RIGHT);
+        std::stringstream ss;
+        ss << std::fixed << std::setprecision(1) << census_val;
+        m_census_val = GG::Wnd::Create<CUILabel>(ss.str(), GG::FORMAT_RIGHT);
+        m_worlds = GG::Wnd::Create<CUILabel>(std::to_string(worlds), GG::FORMAT_RIGHT);
     }
 
     void CompleteConstruction() override {
@@ -54,6 +54,7 @@ public:
 
         AttachChild(m_name);
         AttachChild(m_census_val);
+        AttachChild(m_worlds);
 
         DoLayout();
     }
@@ -83,6 +84,7 @@ private:
     void DoLayout() {
         const GG::X SPECIES_NAME_WIDTH(ClientUI::Pts() * 9);
         const GG::X SPECIES_CENSUS_WIDTH(ClientUI::Pts() * 5);
+        const GG::X SPECIES_WORLDS_WIDTH(ClientUI::Pts() * 3);
 
         GG::X left(GG::X0);
         GG::Y bottom(MeterIconSize().y - GG::Y(EDGE_PAD));
@@ -96,6 +98,9 @@ private:
 
         m_census_val->SizeMove(GG::Pt(left, GG::Y0), GG::Pt(left + SPECIES_CENSUS_WIDTH, bottom));
         left += SPECIES_CENSUS_WIDTH;
+
+        m_worlds->SizeMove(GG::Pt(left, GG::Y0), GG::Pt(left + SPECIES_WORLDS_WIDTH, bottom));
+        left += SPECIES_WORLDS_WIDTH;
 
         InitBuffer();
     }
@@ -115,22 +120,33 @@ private:
     std::shared_ptr<GG::StaticGraphic>  m_icon;
     std::shared_ptr<GG::Label>          m_name;
     std::shared_ptr<GG::Label>          m_census_val;
+    std::shared_ptr<GG::Label>          m_worlds;
     bool                                m_show_icon;
 };
 
-CensusBrowseWnd::CensusBrowseWnd(std::string title_text,
+CensusBrowseWnd::CensusBrowseWnd(std::string                  title_text,
+                                 float                        target_population,
                                  std::map<std::string, float> population_counts,
+                                 std::map<std::string, int>   population_worlds,
                                  std::map<std::string, float> tag_counts,
-                                 std::vector<std::string> census_order) :
+                                 std::map<std::string, int>   tag_worlds,
+                                 std::vector<std::string>     census_order
+                                ):
     GG::BrowseInfoWnd(GG::X0, GG::Y0, BrowseTextWidth(), GG::Y1),
     m_title_text(GG::Wnd::Create<CUILabel>(std::move(title_text), GG::FORMAT_LEFT)),
     m_species_text(GG::Wnd::Create<CUILabel>(UserString("CENSUS_SPECIES_HEADER"), GG::FORMAT_BOTTOM)),
     m_list(GG::Wnd::Create<CUIListBox>()),
     m_tags_text(GG::Wnd::Create<CUILabel>(UserString("CENSUS_TAG_HEADER"), GG::FORMAT_BOTTOM)),
     m_tags_list(GG::Wnd::Create<CUIListBox>()),
+    m_target_population(GG::Wnd::Create<CUILabel>(UserString("CENSUS_TARGET_POPULATION"), GG::FORMAT_BOTTOM)),
+    m_total_population(GG::Wnd::Create<CUILabel>(UserString("CENSUS_TOTAL_POPULATION"), GG::FORMAT_BOTTOM)),
+    m_total_worlds(GG::Wnd::Create<CUILabel>(UserString("CENSUS_TOTAL_WORLDS"), GG::FORMAT_BOTTOM)),
     m_offset(GG::X0, ICON_BROWSE_ICON_HEIGHT/2),
+    m_target_population_value(std::move(target_population)),
     m_population_counts(std::move(population_counts)),
+    m_population_worlds(std::move(population_worlds)),
     m_tag_counts(std::move(tag_counts)),
+    m_tag_worlds(std::move(tag_worlds)),
     m_census_order(std::move(census_order))
 {}
 
@@ -166,12 +182,18 @@ void CensusBrowseWnd::CompleteConstruction() {
         counts_species.emplace(count, name);
     m_population_counts.clear();
 
+    float total_population = 0;
+    int total_worlds = 0;
+
     // add species rows
     for (auto it = counts_species.rbegin(); it != counts_species.rend(); ++it) {
+        total_population += it->first;
+        total_worlds += m_population_worlds[it->second];
         auto row = GG::Wnd::Create<GG::ListBox::Row>(m_list->Width(), ROW_HEIGHT);
         row->SetDragDropDataType("Census Species Row");
         row->push_back(GG::Wnd::Create<CensusRowPanel>(m_list->Width(), ROW_HEIGHT,
-                                                       it->second, it->first, true));
+                                                       it->second, it->first,
+                                                       m_population_worlds[it->second], true));
         m_list->Insert(row);
         row->Resize(GG::Pt(m_list->Width(), ROW_HEIGHT));
         top += ROW_HEIGHT;
@@ -206,7 +228,7 @@ void CensusBrowseWnd::CompleteConstruction() {
         if (it2 != m_tag_counts.end()) {
             auto row = GG::Wnd::Create<GG::ListBox::Row>(m_list->Width(), ROW_HEIGHT);
             row->SetDragDropDataType("Census Characteristics Row");
-            row->push_back(GG::Wnd::Create<CensusRowPanel>(m_tags_list->Width(), ROW_HEIGHT, it2->first, it2->second, false));
+            row->push_back(GG::Wnd::Create<CensusRowPanel>(m_tags_list->Width(), ROW_HEIGHT, it2->first, it2->second, m_tag_worlds[it2->first], false));
             m_tags_list->Insert(row);
             row->Resize(GG::Pt(m_list->Width(), ROW_HEIGHT));
             top2 += ROW_HEIGHT;
@@ -215,6 +237,31 @@ void CensusBrowseWnd::CompleteConstruction() {
     m_tag_counts.clear();
 
     m_tags_list->Resize(GG::Pt(BrowseTextWidth(), top2 -top -ROW_HEIGHT - HALF_HEIGHT + (EDGE_PAD*3)));
+
+    top2 += 0.5 * ROW_HEIGHT;
+
+    m_total_worlds->MoveTo(GG::Pt(GG::X(EDGE_PAD) + m_offset.x, top2 + m_offset.y));
+    m_total_worlds->Resize(GG::Pt(BrowseTextWidth(), ROW_HEIGHT + HALF_HEIGHT));
+    m_total_worlds->SetText(boost::io::str(FlexibleFormat(UserString("CENSUS_TOTAL_WORLDS")) % total_worlds));
+    top2 += ROW_HEIGHT;
+
+    m_total_population->MoveTo(GG::Pt(GG::X(EDGE_PAD) + m_offset.x, top2 + m_offset.y));
+    m_total_population->Resize(GG::Pt(BrowseTextWidth(), ROW_HEIGHT + HALF_HEIGHT));
+    std::stringstream s1;
+    s1 << std::fixed << std::setprecision(1) << total_population;
+    m_total_population->SetText(boost::io::str(FlexibleFormat(UserString("CENSUS_TOTAL_POPULATION")) % s1.str() ));
+    top2 += ROW_HEIGHT;
+
+    m_target_population->MoveTo(GG::Pt(GG::X(EDGE_PAD) + m_offset.x, top2 + m_offset.y));
+    m_target_population->Resize(GG::Pt(BrowseTextWidth(), ROW_HEIGHT + HALF_HEIGHT));
+    std::stringstream s2;
+    s2 << std::fixed << std::setprecision(1) << m_target_population_value;
+    m_target_population->SetText(boost::io::str(FlexibleFormat(UserString("CENSUS_TARGET_POPULATION")) % s2.str() ));
+    top2 += ROW_HEIGHT;
+
+    AttachChild(m_total_worlds);
+    AttachChild(m_total_population);
+    AttachChild(m_target_population);
 
     Resize(GG::Pt(BrowseTextWidth(), top2  + (EDGE_PAD*3)));
 

--- a/UI/CensusBrowseWnd.cpp
+++ b/UI/CensusBrowseWnd.cpp
@@ -30,8 +30,7 @@ class CensusRowPanel : public GG::Control {
 public:
     CensusRowPanel(GG::X w, GG::Y h, const std::string& name, double census_val, int worlds, bool show_icon) :
         GG::Control(GG::X0, GG::Y0, w, h, GG::NO_WND_FLAGS),
-        m_show_icon(show_icon),
-        m_worlds()
+        m_show_icon(show_icon)
     {
         if (m_show_icon)
             m_icon = GG::Wnd::Create<GG::StaticGraphic>(

--- a/UI/CensusBrowseWnd.h
+++ b/UI/CensusBrowseWnd.h
@@ -8,14 +8,13 @@
 /** A popup tooltop for display when mousing over in-game icons.  A title and some detail text.*/
 class CensusBrowseWnd : public GG::BrowseInfoWnd {
 public:
-    CensusBrowseWnd(std::string                  title_text
-                   ,float                        target_population // take as parameter so as not to have to import empire etc.
-                   ,std::map<std::string, float> population_counts
-                   ,std::map<std::string, int>   population_worlds
-                   ,std::map<std::string, float> tag_counts
-                   ,std::map<std::string, int>   tag_worlds
-                   ,std::vector<std::string>     census_order
-                   );
+    CensusBrowseWnd(std::string                  title_text,
+                   float                        target_population, // take as parameter so as not to have to import empire etc.
+                   std::map<std::string, float> population_counts,
+                   std::map<std::string, int>   population_worlds,
+                   std::map<std::string, float> tag_counts,
+                   std::map<std::string, int>   tag_worlds,
+                   std::vector<std::string>     census_order);
     void CompleteConstruction() override;
     bool WndHasBrowseInfo(const Wnd* wnd, std::size_t mode) const override;
 

--- a/UI/CensusBrowseWnd.h
+++ b/UI/CensusBrowseWnd.h
@@ -8,11 +8,14 @@
 /** A popup tooltop for display when mousing over in-game icons.  A title and some detail text.*/
 class CensusBrowseWnd : public GG::BrowseInfoWnd {
 public:
-    CensusBrowseWnd(std::string title_text,
-                    std::map<std::string, float> population_counts,
-                    std::map<std::string, float> tag_counts,
-                    std::vector<std::string> census_order);
-
+    CensusBrowseWnd(std::string                  title_text
+                   ,float                        target_population // take as parameter so as not to have to import empire etc.
+                   ,std::map<std::string, float> population_counts
+                   ,std::map<std::string, int>   population_worlds
+                   ,std::map<std::string, float> tag_counts
+                   ,std::map<std::string, int>   tag_worlds
+                   ,std::vector<std::string>     census_order
+                   );
     void CompleteConstruction() override;
     bool WndHasBrowseInfo(const Wnd* wnd, std::size_t mode) const override;
 
@@ -27,9 +30,15 @@ private:
     std::shared_ptr<GG::ListBox>    m_list;
     std::shared_ptr<GG::Label>      m_tags_text;
     std::shared_ptr<GG::ListBox>    m_tags_list;
+    std::shared_ptr<GG::Label>      m_target_population; // label for target population for next turn
+    std::shared_ptr<GG::Label>      m_total_population;  // label for current population in this turn
+    std::shared_ptr<GG::Label>      m_total_worlds;      // label for number of worlds
     GG::Pt                          m_offset;
+    float                           m_target_population_value;
     std::map<std::string, float>    m_population_counts;
+    std::map<std::string, int>      m_population_worlds; // maps the number of settled worlds per species
     std::map<std::string, float>    m_tag_counts;
+    std::map<std::string, int>      m_tag_worlds;        // maps the number of settled worlds per tag
     std::vector<std::string>        m_census_order;
 
     void InitRowSizes();

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -6939,12 +6939,14 @@ void MapWnd::RefreshIndustryResourceIndicator() {
 }
 
 void MapWnd::RefreshPopulationIndicator() {
-    float target_population = 0.0;
+    float target_population = 0.0f;
     Empire* empire = GetEmpire(GGHumanClientApp::GetApp()->EmpireID());
     if (!empire) {
         m_population->SetValue(0.0);
         return;
-    } else target_population = empire->GetPopulationPool().Population();
+    } else {
+        target_population = empire->GetPopulationPool().Population();
+    }
     m_population->SetValue(target_population);
     m_population->ClearBrowseInfoWnd();
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -6939,17 +6939,20 @@ void MapWnd::RefreshIndustryResourceIndicator() {
 }
 
 void MapWnd::RefreshPopulationIndicator() {
+    float target_population = 0.0;
     Empire* empire = GetEmpire(GGHumanClientApp::GetApp()->EmpireID());
     if (!empire) {
         m_population->SetValue(0.0);
         return;
-    }
-    m_population->SetValue(empire->GetPopulationPool().Population());
+    } else target_population = empire->GetPopulationPool().Population();
+    m_population->SetValue(target_population);
     m_population->ClearBrowseInfoWnd();
 
     const auto& pop_center_ids = empire->GetPopulationPool().PopCenterIDs();
     std::map<std::string, float> population_counts;
+    std::map<std::string, int>   population_worlds;
     std::map<std::string, float> tag_counts;
+    std::map<std::string, int>   tag_worlds;
     const ObjectMap& objects = Objects();
 
     //tally up all species population counts
@@ -6962,16 +6965,22 @@ void MapWnd::RefreshPopulationIndicator() {
             continue;
         float this_pop = pc->GetMeter(MeterType::METER_POPULATION)->Initial();
         population_counts[species_name] += this_pop;
+        population_worlds[species_name] += 1;
         if (const Species* species = GetSpecies(species_name) ) {
-            for (const std::string& tag : species->Tags())
+            for (const std::string& tag : species->Tags()) {
                 tag_counts[tag] += this_pop;
+                tag_worlds[tag] += 1;
+            }
         }
     }
 
     m_population->SetBrowseModeTime(GetOptionsDB().Get<int>("ui.tooltip.delay"));
     m_population->SetBrowseInfoWnd(GG::Wnd::Create<CensusBrowseWnd>(
-        UserString("MAP_POPULATION_DISTRIBUTION"), std::move(population_counts),
-        std::move(tag_counts), GetSpeciesManager().census_order()));
+        UserString("MAP_POPULATION_DISTRIBUTION"),
+        target_population,
+        std::move(population_counts),std::move(population_worlds),
+        std::move(tag_counts), std::move(tag_worlds), GetSpeciesManager().census_order()
+    ));
 }
 
 void MapWnd::UpdateEmpireResourcePools() {

--- a/default/stringtables/de.txt
+++ b/default/stringtables/de.txt
@@ -2103,6 +2103,15 @@ Spezies
 CENSUS_TAG_HEADER
 Merkmale
 
+CENSUS_TARGET_POPULATION
+Ziel-Bevölkerung: %1%
+
+CENSUS_TOTAL_POPULATION
+Gesamtbevölkerung: %1%
+
+CENSUS_TOTAL_WORLDS
+Bevölkerte Welten: %1%
+
 MAP_DETECTION_TITLE
 Imperiumsortung
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3627,6 +3627,15 @@ Species
 CENSUS_TAG_HEADER
 Characteristics
 
+CENSUS_TARGET_POPULATION
+Target population: %1%
+
+CENSUS_TOTAL_POPULATION
+Current population: %1%
+
+CENSUS_TOTAL_WORLDS
+Settled worlds: %1%
+
 MAP_DETECTION_TITLE
 Empire Detection
 


### PR DESCRIPTION
for now without column labels. i'll post maybe another discussion on the forum about how necessary those would be, since i think it should be clear from the early game phase, when you see those numbers rising, what they meen. see screenshots attached.
![1](https://user-images.githubusercontent.com/37298400/148662537-4a5bede7-f44e-40fb-a6ec-0943f6a2585a.png)
![10](https://user-images.githubusercontent.com/37298400/148662538-a9f3587f-aac1-483c-b528-b3c2e7ca9498.png)
seems pretty obvious, like the label below the table says, especially with the one world in the beginning and then there's that ten and one can see quite clearly that the 9 and 1 add up to that … so, yeah. here it is again, pretty much as it was back in https://github.com/freeorion/freeorion/pull/2055