### PR TITLE
Mark as single window application in .desktop file

### DIFF
--- a/packaging/org.freeorion.FreeOrion.desktop
+++ b/packaging/org.freeorion.FreeOrion.desktop
@@ -11,3 +11,4 @@ Terminal=false
 Type=Application
 Categories=Game;StrategyGame;
 Keywords=space;strategy;empire;galaxy;turn-based;aliens;species;planets;fleet;research;resources;
+SingleMainWindow=true


### PR DESCRIPTION
SingleMainWindow is a standard .desktop entry key signaling that an app only supports having a single one of its main window open. 
( https://specifications.freedesktop.org/desktop-entry-spec/latest/ar01s06.html )

Signed-off-by: Rob Gill <rrobgill@protonmail.com>