### PR TITLE
Add README to st-tool

### DIFF
--- a/check/README.md
+++ b/check/README.md
@@ -5,7 +5,7 @@
 - `string table` a file with translation
 - `reference table` en.txt string table.
   English is the development language, so any changes related to text should be in that file.
-  Also, this table us used as fallback for other translations, if a needed key is missing.
+  Also, this table is used as a fallback for other translations, if a key is missing.
   This file is mostly maintained by people who change game code,
   so the list of entries in this file should be the most up-to-date.
 - `entry` one piece of translation, it consists of
@@ -100,7 +100,7 @@ Supported types
 [[buildingtype BLD_SHIPYARD_ORBITAL_DRYDOCK]]
 ```
 
-- `value` inserts value from the script to the text,
+- `value` inserts value from content scripts into the text,
   eg. `[[value FLD_NANITE_SWARM_STRUCTURE_FLAT]]` will look up the value from
   the named valueref scripted as
   `NamedReal name = "FLD_NANITE_SWARM_STRUCTURE_FLAT" value = 5 * [[SHIP_STRUCTURE_FACTOR]])`

--- a/check/README.md
+++ b/check/README.md
@@ -7,20 +7,20 @@
   English is the development language, so any changes related to text should be in that file.
   Also, this table us used as fallback for other translations, if a needed key is missing.
   This file is mostly maintained by people who change game code,
-  so the list of entries in this file should be the most actual.
+  so the list of entries in this file should be the most up-to-date.
 - `entry` one piece of translation, it consists of
   - `key` a sting that represents entry in the codebase (C++, Python).
     This string must be unique.
   - `value` actual translation that will be shown to the user.
 
 ### Key
-Only English chars in uppercase and dash are allowed.
+Only uppercase Latin alphabet (A-Z) and underscore (_) are allowed.
 Renaming a key should be done with caution.
 Many of the keys in the stringtable are used in the game source code explicitly,
 or in content scripts.
 Some keys are also generated programatically, such as by adding a prefix to other text.
-In C++ `UserString` and `UserStringNop` are used to get keys values,
-In Python `fo.userString` and `fo.userStringList` are used.
+C++ uses UserString(...) or UserStringNop(...) to look up strings or to mark stringtable keys that are used in code.
+Python uses `fo.userString` and `fo.userStringList` for look up.
 
 ### Value syntax
 #### Simple (single line)
@@ -80,7 +80,7 @@ Hello world
 
 This feature should be used to keep the translation in a consistent state.
 You define term once and use it everywhere.
-For most common used things like tech, building, etc. we have more advanced type of reference: link
+For various kinds of game content, like techs, buildings, or species, etc., there are links
 
 - `link` inserts a link to a wiki page about some scripted content or a ship design in the game universe.
 Supported types
@@ -111,4 +111,4 @@ Supported types
 ## Maintain string tables
 Formatting and basic checks are maintained by tool: `st-tool.py`.
 See `.check/st-tool.py format --help` and `.check/st-tool.py check --help`
-This two commands are part of GitHub automatic checks.
+These two commands are part of GitHub automatic checks.

--- a/check/README.md
+++ b/check/README.md
@@ -19,8 +19,8 @@ Renaming a key should be done with caution.
 Many of the keys in the stringtable are used in the game source code explicitly,
 or in content scripts.
 Some keys are also generated programatically, such as by adding a prefix to other text.
-C++ use `UserString` and `UserStringNop` to retrieve keys,
-Python `fo.userString`, and `fo.userStringList`.
+In C++ `UserString` and `UserStringNop` are used to get keys values,
+In Python `fo.userString` and `fo.userStringList` are used.
 
 ### Value syntax
 #### Simple (single line)

--- a/check/README.md
+++ b/check/README.md
@@ -60,10 +60,9 @@ world
 ```
 
 #### Tags
-You can customize text with special markup tags. Not full list of tags:
+You can customize text with special markup tags. Not a full list of tags:
 
-- `[[]]` inserts text from another entry.
-  You add a key in double square braces and user will see the value of that key.
+- `[[KEY]]` will be replaced with the text in the entry with key `KEY`.
   Substitution is recursive, if text has another substitution it will be resolved too.
   If key was not found in this table, it will be looked in the reference table. 
 
@@ -108,6 +107,35 @@ Supported types
   which might be just a constant in some cases,
   but in this case will depend on the value of a game rule.
 
+### Comments
+
+Comments can be added to stringtables by starting a line with `#`.
+Comment lines are ignored when processing the stringtable. 
+Comments are often written immediatley before a key line, 
+and may contain information about parameters that will be substituted by 
+the game engine into that string at runtime.
+
+```text
+# %1% amount of research points required to research the technology.
+# %2% number of turns required to research the technology.
+TECH_TOTAL_COST_ALT_STR
+%1% RP / %2% Turns
+```
+
+Groups of related stringtable entries are often preceeded 
+by a section marker comment, which is formatted with two initial blank lines,
+and then three lines starting with `##`, with the middle ## line having a section title, eg.
+
+```text
+
+
+##
+## TechTreeWnd
+##
+
+TECH_DISPLAY
+Display
+```
 
 ## Maintain string tables
 Formatting and basic checks are maintained by tool: `st-tool.py`.

--- a/check/README.md
+++ b/check/README.md
@@ -37,7 +37,7 @@ value
 
 #### Full (single or multiline)
 Start and end with triple single quotes.
-You can put anything except triple singe quotes inside.
+You can put anything except triple single quotes inside.
 
 ```
 KEY_WITH_LEADING_SPACE
@@ -61,8 +61,11 @@ world
 
 #### Tags
 You can customize text with special markup tags. Not full list of tags:
-- `reference` special syntax that allows to put value from another entry.
+
+- `[[]]` inserts text from another entry.
   You add a key in double square braces and user will see the value of that key.
+  Substitution is recursive, if text has another substitution it will be resolved too.
+
 ```
 KEY_WORLD
 world
@@ -77,10 +80,9 @@ Hello world
 
 This feature should be used to keep the translation in a consistent state.
 You define term once and use it everywhere.
-For most common used things like tech, building, etc we have more advanced type of reference: link
+For most common used things like tech, building, etc. we have more advanced type of reference: link
 
-
-- `link` special syntax that will be rendered as a link to a wiki page about some scripted content or a ship design in the game universe.
+- `link` inserts a link to a wiki page about some scripted content or a ship design in the game universe.
 Supported types
   - encyclopedia
   - buildingtype
@@ -93,7 +95,17 @@ Supported types
   - species
   - tech
   - policy
-  - value
+```
+[[buildingtype BLD_SHIPYARD_ORBITAL_DRYDOCK]]
+```
+
+- `value` inserts value from the script to the text,
+  eg. `[[value FLD_NANITE_SWARM_STRUCTURE_FLAT]]` will look up the value from
+  the named valueref scripted as
+  `NamedReal name = "FLD_NANITE_SWARM_STRUCTURE_FLAT" value = 5 * [[SHIP_STRUCTURE_FACTOR]])`
+  and be replaced by whatever `5 * [[SHIP_STRUCTURE_FACTOR]]` equals,
+  which might be just a constant in some cases,
+  but in this case will depend on the value of a game rule.
 
 
 ## Maintain string tables

--- a/check/README.md
+++ b/check/README.md
@@ -9,7 +9,8 @@
   This file is mostly maintained by people who change game code,
   so the list of entries in this file should be the most up-to-date.
 - `entry` one piece of translation, it consists of
-  - `key` a sting that represents entry in the codebase (C++, Python).
+  - `key` a sting that represents entry. It could be referenced from code: C++, Python, FOCS.
+     Also, new key could be added just for substitution purposes to the string table.
     This string must be unique.
   - `value` actual translation that will be shown to the user.
 
@@ -58,13 +59,13 @@ world
 
 ```
 
-
 #### Tags
 You can customize text with special markup tags. Not full list of tags:
 
 - `[[]]` inserts text from another entry.
   You add a key in double square braces and user will see the value of that key.
   Substitution is recursive, if text has another substitution it will be resolved too.
+  If key was not found in this table, it will be looked in the reference table. 
 
 ```
 KEY_WORLD

--- a/check/README.md
+++ b/check/README.md
@@ -1,0 +1,99 @@
+# Tool for work with string tables
+
+## Glossary
+
+- `string table` a file with translation
+- `reference table` en.txt string table.
+  English is the main game language, so any changes related to text should be in that file.
+  Also this table us used as fallback for other translation.
+  This file is mostly maintained by people who change game code,
+  so the list of entries in this file should be the most actual.
+- `entry` one piece of translation, it consists of
+  - `key` a sting that represents entry in the codebase (C++, Python).
+    This string must be unique.
+  - `value` actual translation that will be shown to the user.
+
+
+### Key
+Only English chars in uppercase and dash are allowed.
+Rename of a key should be done with caution. Usually key used as is in code,
+but sometimes it could be used as prefix and code logic based on name could be present.
+
+### Value syntax
+#### Simple (single line)
+A single line of text, should not be started and ended by any whitespace character.
+
+```
+KEY
+value
+
+>>>
+value
+<<<
+```
+
+#### Full (single or multiline)
+Start and end with triple single quotes.
+You can put anything except triple singe quotes inside.
+
+```
+KEY_WITH_LEADING_SPACE
+''' value'''
+
+>>>
+ value
+<<<
+
+KEY_WITH_MULTILINE
+'''Hello
+world'''
+
+>>>
+Hello
+world
+<<<
+
+```
+
+
+#### Tags
+You can customize text with special markup tags. Not full list of tags:
+- `reference` special syntax that allows to put value from another entry.
+  You add a key in double square braces and user will see the value of that key.
+```
+KEY_WORLD
+world
+
+KEY_HELLO
+Hello [[KEY_WORLD]]!
+
+>>>
+Hello world
+<<<
+```
+
+This feature should be used to keep the translation in a consistent state.
+You define term once and use it everywhere.
+For most common used things like tech, building, etc we have more advanced type of reference: link
+
+
+- `link` special syntax that will be rendered as a link to an object wiki page.
+Supported types
+  - encyclopedia
+  - buildingtype
+  - fieldtype
+  - metertype
+  - predefinedshipdesign
+  - shiphull
+  - shippart
+  - special
+  - species
+  - tech
+  - policy
+  - value
+
+
+## Maintain string tables
+Formatting and basic checks are maintained by tool: `st-tool.py`.
+See `.check/st-tool.py format --help` and `.check/st-tool.py check --help`
+This too commands are mandatory and part of our GitHub automatic checks.

--- a/check/README.md
+++ b/check/README.md
@@ -4,8 +4,8 @@
 
 - `string table` a file with translation
 - `reference table` en.txt string table.
-  English is the main game language, so any changes related to text should be in that file.
-  Also this table us used as fallback for other translation.
+  English is the development language, so any changes related to text should be in that file.
+  Also, this table us used as fallback for other translations, if a needed key is missing.
   This file is mostly maintained by people who change game code,
   so the list of entries in this file should be the most actual.
 - `entry` one piece of translation, it consists of
@@ -13,11 +13,14 @@
     This string must be unique.
   - `value` actual translation that will be shown to the user.
 
-
 ### Key
 Only English chars in uppercase and dash are allowed.
-Rename of a key should be done with caution. Usually key used as is in code,
-but sometimes it could be used as prefix and code logic based on name could be present.
+Renaming a key should be done with caution.
+Many of the keys in the stringtable are used in the game source code explicitly,
+or in content scripts.
+Some keys are also generated programatically, such as by adding a prefix to other text.
+C++ use `UserString` and `UserStringNop` to retrieve keys,
+Python `fo.userString`, and `fo.userStringList`.
 
 ### Value syntax
 #### Simple (single line)
@@ -77,7 +80,7 @@ You define term once and use it everywhere.
 For most common used things like tech, building, etc we have more advanced type of reference: link
 
 
-- `link` special syntax that will be rendered as a link to an object wiki page.
+- `link` special syntax that will be rendered as a link to a wiki page about some scripted content or a ship design in the game universe.
 Supported types
   - encyclopedia
   - buildingtype
@@ -96,4 +99,4 @@ Supported types
 ## Maintain string tables
 Formatting and basic checks are maintained by tool: `st-tool.py`.
 See `.check/st-tool.py format --help` and `.check/st-tool.py check --help`
-This too commands are mandatory and part of our GitHub automatic checks.
+This two commands are part of GitHub automatic checks.


### PR DESCRIPTION
I'd like to collect all info about string tables in the repository.  

This is the first step. 

The following steps are (as separate PRs):
- Move content of the https://www.freeorion.org/forum/viewtopic.php?f=27&t=9275
- Add some description about the translation processes.  
- Put references to this file from other places (forum, other readmes, etc).

For the review I expect: logic check, I might misunderstand/forget something, spelling check, and formatting check.  For formatting, I'd recommend opening the file in a separate tab when it is rendered by GitHub https://github.com/Cjkjvfnby/freeorion/tree/sa/refactor-st-tool/check.

@geoffthemedio , could you add https://github.com/st-pa-fo as a collaborator to the repo, so I could use mention?