### PR TITLE
Detection Tweaks

### DIFF
--- a/default/scripting/buildings/SCANNING_FACILITY.focs.txt
+++ b/default/scripting/buildings/SCANNING_FACILITY.focs.txt
@@ -17,7 +17,7 @@ BuildingType
                 Object id = Source.PlanetID
                 Planet
             ]
-            effects = SetDetection value = Value + 75
+            effects = SetDetection value = Value + 50
     ]
     icon = "icons/building/scanning-facility.png"
 

--- a/default/scripting/ship_hulls/monster/SH_PSIONIC_SNOWFLAKE_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_PSIONIC_SNOWFLAKE_BODY.focs.txt
@@ -23,7 +23,7 @@ Hull
         [[INFINITE_FUEL]]
         [[ADD_HULL_FUEL_TO_MAX_FUEL_METER]]
         [[MONSTER_SHIELD_REGENERATION]]
-        [[EXCELLENT_VISION]]
+        [[GOOD_VISION]]
 
         EffectsGroup
             scope = NumberOf number = 4 condition = And [

--- a/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_1_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_1_BODY.focs.txt
@@ -74,7 +74,7 @@ Hull
                     ]
                     empire = Source.Owner
             ]
-        [[EXCELLENT_VISION]]
+        [[GOOD_VISION]]
     ]
     icon = ""
     graphic = "icons/monsters/snowflake-1.png"

--- a/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_2_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_2_BODY.focs.txt
@@ -56,7 +56,7 @@ Hull
                 SetCapacity partname = "SR_ICE_BEAM" value = Value + min(Source.Age*0.15, 4)
             ]
         
-        [[EXCELLENT_VISION]]
+        [[GOOD_VISION]]
     ]
     icon = ""
     graphic = "icons/monsters/snowflake-2.png"

--- a/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_3_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_3_BODY.focs.txt
@@ -28,7 +28,7 @@ Hull
                 SetMaxCapacity partname = "SR_ICE_BEAM" value = Value + min(Source.Age*0.3, 18)
                 SetCapacity partname = "SR_ICE_BEAM" value = Value + min(Source.Age*0.3, 18)
             ]
-        [[EXCELLENT_VISION]]
+        [[GOOD_VISION]]
     ]
     icon = ""
     graphic = "icons/monsters/snowflake-3.png"

--- a/default/scripting/ship_hulls/organic/organic.macros
+++ b/default/scripting/ship_hulls/organic/organic.macros
@@ -4,7 +4,7 @@ LIVING_HULL_EFFECTS_GROUPS
     scope = Source
     effects = [
         SetStructure value = Value + (2 * [[SHIP_STRUCTURE_FACTOR]])
-        SetDetection value = Value + 50
+        SetDetection value = Value + 40
     ]
 
     [[LIVING_HULL_BASE_FUEL_REGEN]]

--- a/default/scripting/techs/spy/DETECT_1.focs.txt
+++ b/default/scripting/techs/spy/DETECT_1.focs.txt
@@ -19,7 +19,7 @@ Tech
                 Not OwnerHasTech name = "SPY_DETECT_4"
                 Not OwnerHasTech name = "SPY_DETECT_5"
             ]
-            effects = SetDetection value = Value + 50
+            effects = SetDetection value = Value + (NamedReal name = "SPY_DETECT_1_RANGE" value = 50.0)
 
         EffectsGroup
             scope = Source

--- a/default/scripting/techs/spy/DETECT_2.focs.txt
+++ b/default/scripting/techs/spy/DETECT_2.focs.txt
@@ -22,7 +22,7 @@ Tech
                 Not OwnerHasTech name = "SPY_DETECT_4"
                 Not OwnerHasTech name = "SPY_DETECT_5"
             ]
-            effects = SetDetection value = Value + 75
+            effects = SetDetection value = Value + (NamedReal name = "SPY_DETECT_2_RANGE" value = 75.0)
 
         EffectsGroup
             scope = Source

--- a/default/scripting/techs/spy/DETECT_3.focs.txt
+++ b/default/scripting/techs/spy/DETECT_3.focs.txt
@@ -18,7 +18,7 @@ Tech
                 Not OwnerHasTech name = "SPY_DETECT_4"
                 Not OwnerHasTech name = "SPY_DETECT_5"
             ]
-            effects = SetDetection value = Value + 150
+            effects = SetDetection value = Value + (NamedReal name = "SPY_DETECT_3_RANGE" value = 100.0)
 
         EffectsGroup
             scope = Source

--- a/default/scripting/techs/spy/DETECT_4.focs.txt
+++ b/default/scripting/techs/spy/DETECT_4.focs.txt
@@ -15,7 +15,7 @@ Tech
                 OwnedBy empire = Source.Owner
             ]
             activation = Not OwnerHasTech name = "SPY_DETECT_5"
-            effects = SetDetection value = Value + 200
+            effects = SetDetection value = Value + (NamedReal name = "SPY_DETECT_4_RANGE" value = 125.0)
 
         EffectsGroup
             scope = Source

--- a/default/scripting/techs/spy/DETECT_5.focs.txt
+++ b/default/scripting/techs/spy/DETECT_5.focs.txt
@@ -13,7 +13,7 @@ Tech
                 Planet
                 OwnedBy empire = Source.Owner
             ]
-            effects = SetDetection value = Value + 300
+            effects = SetDetection value = Value + (NamedReal name = "SPY_DETECT_5_RANGE" value = 150.0)
 
         EffectsGroup
             scope = Source

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -13669,7 +13669,7 @@ SPY_DETECT_1
 Optical Scanner
 
 SPY_DETECT_1_DESC
-All colonies start the game with a [[metertype METER_DETECTION]] of 50, and the imperial [[encyclopedia DETECTION_TITLE]] to 10, and the ship part [[shippart DT_DETECTOR_1]] permits ships to reach the same level of detection.
+All colonies start the game with a [[metertype METER_DETECTION]] of [[value SPY_DETECT_1_RANGE]], and the imperial [[encyclopedia DETECTION_TITLE]] to 10, and the ship part [[shippart DT_DETECTOR_1]] permits ships to reach the same level of detection.
 
 SPY_DETECT_STELLAR_INTERFERENCE
 Stellar Interference
@@ -13684,7 +13684,7 @@ SPY_DETECT_2
 Active Radar
 
 SPY_DETECT_2_DESC
-'''Unlocks the [[shippart DT_DETECTOR_2]] ship part and the [[buildingtype BLD_SCANNING_FACILITY]] building, increases the [[metertype METER_DETECTION]] of all planets to 75, and increases the imperial [[encyclopedia DETECTION_TITLE]] to 30.
+'''Unlocks the [[shippart DT_DETECTOR_2]] ship part and the [[buildingtype BLD_SCANNING_FACILITY]] building, increases the [[metertype METER_DETECTION]] of all planets to [[value SPY_DETECT_2_RANGE]], and increases the imperial [[encyclopedia DETECTION_TITLE]] to 30.
 
 Passively relying on incoming electromagnetic radiation for information about objects in the vicinity is crude and impractical, as this radiation can be masked or dampened. By emitting electromagnetic radiation and detecting returning radiation, it is possible to determine the location and velocity of many objects.'''
 
@@ -13692,7 +13692,7 @@ SPY_DETECT_3
 Neutron Scanner
 
 SPY_DETECT_3_DESC
-'''Unlocks the [[shippart DT_DETECTOR_3]] ship part, increases the [[metertype METER_DETECTION]] of all planets to 150, and increases the imperial [[encyclopedia DETECTION_TITLE]] to 50.
+'''Unlocks the [[shippart DT_DETECTOR_3]] ship part, increases the [[metertype METER_DETECTION]] of all planets to [[value SPY_DETECT_3_RANGE]], and increases the imperial [[encyclopedia DETECTION_TITLE]] to 50.
 
 Electromagnetic radiation has no rest mass and is easily manipulable. Simply by bending waves of light around an object, it is possible to render radar devices virtually useless. By firing waves of neutrons instead of electromagnetic radiation, more effective active scanning can be utilized.'''
 
@@ -13700,13 +13700,13 @@ SPY_DETECT_4
 Sensors
 
 SPY_DETECT_4_DESC
-Unlocks the [[shippart DT_DETECTOR_4]] ship part, increases the [[metertype METER_DETECTION]] of all planets to 200, and increases the imperial [[encyclopedia DETECTION_TITLE]] to 70.
+Unlocks the [[shippart DT_DETECTOR_4]] ship part, increases the [[metertype METER_DETECTION]] of all planets to [[value SPY_DETECT_4_RANGE]], and increases the imperial [[encyclopedia DETECTION_TITLE]] to 70.
 
 SPY_DETECT_5
 Omni-scanner
 
 SPY_DETECT_5_DESC
-The ultimate in detection. Increases the [[metertype METER_DETECTION]] of all planets to 300, and increases the imperial [[encyclopedia DETECTION_TITLE]] to 200.
+The ultimate in detection. Increases the [[metertype METER_DETECTION]] of all planets to [[value SPY_DETECT_5_RANGE]], and increases the imperial [[encyclopedia DETECTION_TITLE]] to 200.
 
 SPY_STEALTH_1
 Planetary Cloud Cover


### PR DESCRIPTION
Based on https://freeorion.org/forum/viewtopic.php?p=109150#p109150
-make snowflake bodies have good instead of excellent vision
-make detection techs increment range in steps of 25 instead of 25 or 50
-use value reference for tech detection ranges in pedia
-reduce living hull detection boost from 50 to 40
-reduce scanning facility range boost from 75 to 50