### PR TITLE
Test all checksum and remove some unused tokens

### DIFF
--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -8,8 +8,6 @@
     (abs)                                       \
     (accountinglabel)                           \
     (activation)                                \
-    (AddedBefore)                               \
-    (AddedSince)                                \
     (AddSpecial)                                \
     (AddStarlanes)                              \
     (Adequate)                                  \

--- a/test/system/TestChecksum.cpp
+++ b/test/system/TestChecksum.cpp
@@ -24,16 +24,34 @@ void TestCheckSumFromEnv(const char* env, unsigned int def, unsigned int calcula
 }
 
 /**
- * - Enforces named value reference checksum test if FO_CHECKSUM_NAMED_VALUEREF is set.
+ * - Enforces buildings checksum test if FO_CHECKSUM_BUILDING is set.
+ * - Enforces encyclopedia checksum test if FO_CHECKSUM_ENCYCLOPEDIA is set.
+ * - Enforces fields checksum test if FO_CHECKSUM_FIELD is set.
+ * - Enforces policies checksum test if FO_CHECKSUM_POLICY is set.
+ * - Enforces ship hulls checksum test if FO_CHECKSUM_SHIP_HULL is set.
+ * - Enforces ship parts checksum test if FO_CHECKSUM_SHIP_PART is set.
+ * - Enforces predefined ship designs checksum test if FO_CHECKSUM_SHIP_DESIGN is set.
+ * - Enforces species checksum test if FO_CHECKSUM_SPECIES is set.
+ * - Enforces specials checksum test if FO_CHECKSUM_SPECIALS is set.
  * - Enforces techs checksum test if FO_CHECKSUM_TECH is set.
+ * - Enforces named value reference checksum test if FO_CHECKSUM_NAMED_VALUEREF is set.
  * - Setting each of these environment variables to an integer value will test that value against the corresponding parsed content checksum.
  */
 
 BOOST_AUTO_TEST_CASE(compare_checksum) {
     auto checksums = CheckSumContent();
 
-    TestCheckSumFromEnv("FO_CHECKSUM_NAMED_VALUEREF", 2465801, checksums["NamedValueRefManager"]);
+    TestCheckSumFromEnv("FO_CHECKSUM_BUILDING", 3444689, checksums["BuildingTypeManager"]);
+    TestCheckSumFromEnv("FO_CHECKSUM_ENCYCLOPEDIA", 1078929, checksums["Encyclopedia"]);
+    TestCheckSumFromEnv("FO_CHECKSUM_FIELD", 3780088, checksums["FieldTypeManager"]);
+    TestCheckSumFromEnv("FO_CHECKSUM_POLICY", 1239846, checksums["PolicyManager"]);
+    TestCheckSumFromEnv("FO_CHECKSUM_SHIP_HULL", 9937526, checksums["ShipHullManager"]);
+    TestCheckSumFromEnv("FO_CHECKSUM_SHIP_PART", 9683018, checksums["ShipPartManager"]);
+    TestCheckSumFromEnv("FO_CHECKSUM_SHIP_DESIGN", 872567, checksums["PredefinedShipDesignManager"]);
+    TestCheckSumFromEnv("FO_CHECKSUM_SPECIES", 2811615, checksums["SpeciesManager"]);
+    TestCheckSumFromEnv("FO_CHECKSUM_SPECIALS", 6000305, checksums["SpecialsManager"]);
     TestCheckSumFromEnv("FO_CHECKSUM_TECH", 5355498, checksums["TechManager"]);
+    TestCheckSumFromEnv("FO_CHECKSUM_NAMED_VALUEREF", 2465801, checksums["NamedValueRefManager"]);
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Unused tokens get with bash line:

```bash
grep -Po "^.*\(\K.+(?=\))" parse/Tokens.h | while read TOKEN ; do { grep -Rni --exclude=*.py "${TOKEN}" default/scripting/* 2>&1 1>/dev/null ; USED=$? ; if [ "1" == "${USED}" ] ; then echo $TOKEN ; fi } done
```
