### PR TITLE
Add option for Title screen music

### DIFF
--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -499,6 +499,7 @@ namespace {
 
         // sound and music
         db.Add<std::string>("audio.music.path",                         UserStringNop("OPTIONS_DB_BG_MUSIC"),                       (GetRootDataDir() / "default" / "data" / "sound" / "artificial_intelligence_v3.ogg").string());
+        db.Add<std::string>("audio.titlemusic.path",                    UserStringNop("OPTIONS_DB_TITLE_MUSIC"),                    (GetRootDataDir() / "default" / "data" / "sound" / "artificial_intelligence_v3.ogg").string());
         db.Add("audio.music.volume",                                    UserStringNop("OPTIONS_DB_MUSIC_VOLUME"),                   127,                            RangedValidator<int>(1, 255));
         db.Add("audio.effects.volume",                                  UserStringNop("OPTIONS_DB_UI_SOUND_VOLUME"),                255,                            RangedValidator<int>(0, 255));
         db.Add<std::string>("ui.button.rollover.sound.path",            UserStringNop("OPTIONS_DB_UI_SOUND_BUTTON_ROLLOVER"),       (GetRootDataDir() / "default" / "data" / "sound" / "button_rollover.ogg").string());

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -503,6 +503,9 @@ void OptionsWnd::CompleteConstruction() {
     FileOption(current_page, 0, "audio.music.path", UserString("OPTIONS_BACKGROUND_MUSIC"), ClientUI::SoundDir(),
                {UserString("OPTIONS_MUSIC_FILE"), "*" + MUSIC_FILE_SUFFIX},
                ValidMusicFile);
+    FileOption(current_page, 0, "audio.titlemusic.path", UserString("OPTIONS_TITLE_MUSIC"), ClientUI::SoundDir(),
+               {UserString("OPTIONS_TITLE_MUSIC_FILE"), "*" + MUSIC_FILE_SUFFIX},
+               ValidMusicFile);
 
     CreateSectionHeader(current_page, 0, UserString("OPTIONS_SOUNDS"));
     CreateSectionHeader(current_page, 1, UserString("OPTIONS_UI_SOUNDS"));

--- a/UI/Sound.cpp
+++ b/UI/Sound.cpp
@@ -37,6 +37,10 @@ public:
         loops + 1 times otherwise. */
     void PlayMusic(const boost::filesystem::path& path, int loops = 0);
 
+    void PlayBackgroundMusic();
+
+    void PlayTitleMusic();
+
     /** Pauses music play, to be continued from the same position */
     void PauseMusic();
 
@@ -522,6 +526,18 @@ void Sound::Impl::PlayMusic(const boost::filesystem::path& path, int loops) {
     auto openal_error = alGetError();
     if (openal_error != AL_NONE)
         ErrorLogger() << "PlayMusic: OpenAL ERROR: " << alGetString(openal_error);
+}
+
+void Sound::PlayBackgroundMusic() {
+    if ((GetOptionsDB().Get<bool>("audio.music.enabled")))
+        Sound::GetSound().PlayMusic(GetOptionsDB().Get<std::string>("audio.music.path"), -1);
+    return;
+}
+
+void Sound::PlayTitleMusic() {
+    if ((GetOptionsDB().Get<bool>("audio.music.enabled")))
+        Sound::GetSound().PlayMusic(GetOptionsDB().Get<std::string>("audio.titlemusic.path"), -1);
+    return;
 }
 
 void Sound::Impl::PauseMusic() {

--- a/UI/Sound.h
+++ b/UI/Sound.h
@@ -30,6 +30,12 @@ public:
         loops + 1 times otherwise. */
     void PlayMusic(const boost::filesystem::path& path, int loops = 0);
 
+    /** Switch to background music */
+    void PlayBackgroundMusic();
+
+    /** Switch to Title screen music */
+    void PlayTitleMusic();
+
     /** Pauses music play, to be continued from the same position */
     void PauseMusic();
 

--- a/client/human/GGHumanClientApp.cpp
+++ b/client/human/GGHumanClientApp.cpp
@@ -286,9 +286,6 @@ GGHumanClientApp::GGHumanClientApp(int width, int height, bool calculate_fps, st
         if (GetOptionsDB().Get<bool>("audio.effects.enabled") || GetOptionsDB().Get<bool>("audio.music.enabled"))
             Sound::GetSound().Enable();
 
-        if ((GetOptionsDB().Get<bool>("audio.music.enabled")))
-            Sound::GetSound().PlayMusic(GetOptionsDB().Get<std::string>("audio.music.path"), -1);
-
         Sound::GetSound().SetMusicVolume(GetOptionsDB().Get<int>("audio.music.volume"));
         Sound::GetSound().SetUISoundsVolume(GetOptionsDB().Get<int>("audio.effects.volume"));
     } catch (const Sound::InitializationFailureException&) {

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -17,6 +17,7 @@
 #include "../../UI/MultiplayerLobbyWnd.h"
 #include "../../UI/PasswordEnterWnd.h"
 #include "../../UI/MapWnd.h"
+#include "../../UI/Sound.h"
 
 #include <boost/format.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -128,6 +129,7 @@ IntroMenu::IntroMenu(my_context ctx) :
     Base(ctx)
 {
     TraceLogger(FSM) << "(HumanClientFSM) IntroMenu";
+    Sound::GetSound().PlayTitleMusic();
     Client().GetClientUI().ShowIntroScreen();
     GetGameRules().ResetToDefaults();
 }
@@ -138,23 +140,27 @@ IntroMenu::~IntroMenu()
 boost::statechart::result IntroMenu::react(const HostSPGameRequested& a) {
     TraceLogger(FSM) << "(HumanClientFSM) IntroMenu.HostSPGameRequested";
     Client().Remove(Client().GetClientUI().GetIntroScreen());
+    Sound::GetSound().PlayBackgroundMusic();
     return transit<WaitingForSPHostAck>();
 }
 
 boost::statechart::result IntroMenu::react(const HostMPGameRequested& a) {
     TraceLogger(FSM) << "(HumanClientFSM) IntroMenu.HostMPGameRequested";
     Client().Remove(Client().GetClientUI().GetIntroScreen());
+    Sound::GetSound().PlayBackgroundMusic();
     return transit<WaitingForMPHostAck>();
 }
 
 boost::statechart::result IntroMenu::react(const JoinMPGameRequested& a) {
     TraceLogger(FSM) << "(HumanClientFSM) IntroMenu.JoinMPGameRequested";
     Client().Remove(Client().GetClientUI().GetIntroScreen());
+    Sound::GetSound().PlayBackgroundMusic();
     return transit<WaitingForMPJoinAck>();
 }
 
 boost::statechart::result IntroMenu::react(const StartQuittingGame& e) {
     TraceLogger(FSM) << "(HumanClientFSM) Quit or reset to main menu.";
+    Sound::GetSound().PlayTitleMusic();
     post_event(e);
     return transit<QuittingGame>();
 }

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1420,6 +1420,9 @@ Enables music in the game.
 OPTIONS_DB_BG_MUSIC
 Sets the background track to play.
 
+OPTIONS_DB_TITLE_MUSIC
+Sets the track to play on the title screen.
+
 OPTIONS_DB_FULLSCREEN
 Start the game in fullscreen. Clicking Apply may cause this to take effect, or may require a restart.
 
@@ -3119,6 +3122,9 @@ Show Queue Production Location
 
 OPTIONS_MUSIC
 Music
+
+OPTIONS_TITLE_MUSIC
+Title Music
 
 OPTIONS_UI_SOUNDS
 UI sounds


### PR DESCRIPTION
Switches between main background music in gameplay and adds option of different
music for the title screen.

Additional menu entry in settings to select file for title screen music.

NB. No music is included, defaults to using existing music file.

Discussion in Issue #3350 and at https://www.freeorion.org/forum/viewtopic.php?p=105422

Signed-off-by: Rob Gill <rrobgill@protonmail.com>