### PR TITLE
Apply defensive flanking bonus only if there are at least two defenders

### DIFF
--- a/default/scripting/policies/FLANKING.focs.txt
+++ b/default/scripting/policies/FLANKING.focs.txt
@@ -34,7 +34,7 @@ Policy
                                Stationary
                                Armed
                            ]
-                        ) > (
+                        ) > max( 1, // no bonus if there is only a single defender
                            Statistic Count condition = And [
                                Ship
                                InSystem id = RootCandidate.SystemID


### PR DESCRIPTION
defensive flanking bonus should not be applied when there is a single defending ship.

this matters mostly because of 1-turn delay and also of stealthed enemies. 

With the current system we cant exempt stealthed attackers from the defensive flanking as it would give away the position. At least for the single defender we can correct this.