### PR TITLE
Stabilitytweaks

### DIFF
--- a/default/scripting/policies/CONFEDERATION.focs.txt
+++ b/default/scripting/policies/CONFEDERATION.focs.txt
@@ -13,17 +13,6 @@ Policy
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
 
-        // compensates for species influence effect that reduces influence when not supply connected to capital
-        EffectsGroup
-            scope = And [
-                Planet
-                OwnedBy empire = Source.Owner
-                Population low = 0.001
-                Not ResourceSupplyConnected empire = LocalCandidate.Owner condition = Source
-            ]
-            effects = SetTargetInfluence value = Value
-                        + (NamedReal name = "PLC_CONFEDERATION_SUPPLY_DISCONNECTED_INFLUENCE_FLAT" value = [[SUPPLY_DISCONNECTED_INFLUENCE_MALUS]])
-
         // makes all planets less stable
         EffectsGroup
             scope = And [
@@ -37,19 +26,6 @@ Policy
                 SetMaxTroops value = Value
                     + (NamedReal name = "PLC_CONFEDERATION_MAX_TROOPS_FLAT" value = 5)
             ]
-
-        // compensates for supply disconnection stability penalty
-        EffectsGroup
-            scope = And [
-                Planet
-                OwnedBy empire = Source.Owner
-                Not ResourceSupplyConnected empire = Source.Owner condition = And [
-                    Or [Capital Building name = "BLD_REGIONAL_ADMIN"]
-                    OwnedBy empire = Source.Owner
-                ]
-                Not Capital
-            ]
-            effects = SetTargetHappiness value = Value + (NamedRealLookup name = "DISCONNECTED_FROM_CAPITAL_AND_REGIONAL_ADMIN_STABILITY_PENALTY")
     ]
     graphic = "icons/policies/social_confederation.png"
 

--- a/default/scripting/species/common/happiness.macros
+++ b/default/scripting/species/common/happiness.macros
@@ -169,6 +169,7 @@ STANDARD_SPECIES_CAPITAL_SUPPLY_CONNECTION_STABILITY
                 Planet
                 Not Unowned
                 Not Capital
+                Not EmpireHasAdoptedPolicy empire = Source.Owner name = "PLC_CONFEDERATION"
                 [[SUPPLY_CONNECTED_TO_CAPITAL_OR_REGAD]]
                 ([[JUMPS_TO_CAPITAL_OR_REGAD]] > 5)
             ]
@@ -181,6 +182,7 @@ STANDARD_SPECIES_CAPITAL_SUPPLY_CONNECTION_STABILITY
                 Planet
                 Not Unowned
                 Not Capital
+                Not EmpireHasAdoptedPolicy empire = Source.Owner name = "PLC_CONFEDERATION"
                 Not [[SUPPLY_CONNECTED_TO_CAPITAL_OR_REGAD]]
             ]
             accountinglabel = "CAPITAL_DISCONNECTION_LABEL"

--- a/default/scripting/species/common/influence.macros
+++ b/default/scripting/species/common/influence.macros
@@ -43,6 +43,7 @@ BASE_INFLUENCE_COSTS
             activation = And [
                 Planet
                 Not Unowned
+                Not EmpireHasAdoptedPolicy empire = Source.Owner name = "PLC_CONFEDERATION"
                 Not ResourceSupplyConnected empire = LocalCandidate.Owner condition = And [
                     Planet
                     OwnedBy empire = Source.Owner

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -11984,8 +11984,8 @@ Confederation
 PLC_CONFEDERATION_DESC
 '''Planets of the empire are organized in a confederacy of independent systems.
 
-• Increases [[metertype METER_TARGET_INFLUENCE]] on colonies disconnected from the capital by [[value PLC_CONFEDERATION_SUPPLY_DISCONNECTED_INFLUENCE_FLAT]]
-• Increases [[metertype METER_TARGET_HAPPINESS]] on colonies disconnected from the capital and regional administrative centres by [[value DISCONNECTED_FROM_CAPITAL_AND_REGIONAL_ADMIN_STABILITY_PENALTY]]
+• Removes [[metertype METER_TARGET_INFLUENCE]] penalty (baseline for most species) on colonies disconnected from the [[buildingtype BLD_IMPERIAL_PALACE]]
+• Removes [[metertype METER_TARGET_HAPPINESS]] penalty (baseline for most species) on colonies disconnected from the [[buildingtype BLD_IMPERIAL_PALACE]] and [[buildingtype BLD_REGIONAL_ADMIN]]
 • Reduces [[metertype METER_TARGET_HAPPINESS]] ([[value PLC_CONFEDERATION_TARGET_HAPPINESS_FLAT]]) on all planets
 • Increases [[metertype METER_MAX_TROOPS]] by [[value PLC_CONFEDERATION_MAX_TROOPS_FLAT]]'''
 


### PR DESCRIPTION
This seems cleaner to me. The old version was giving +10 stability to Sly and Laenfa to compensate for a penalty they did not have. Also you were penalized for a poor supply connection, but not penalized for no supply connection.