### PR TITLE
Python API Tweaks

### DIFF
--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -36,14 +36,13 @@ namespace {
 
     auto obstructedStarlanes(const Empire& empire) -> std::vector<std::pair<int, int>>
     {
-        const std::set<std::pair<int, int>>& laneset = GetSupplyManager().SupplyObstructedStarlaneTraversals(empire.EmpireID());
-        std::vector<std::pair<int, int>> retval;
+        const auto& laneset = GetSupplyManager().SupplyObstructedStarlaneTraversals(empire.EmpireID());
+        static_assert(!std::is_same_v<std::decay_t<decltype(laneset)>, std::vector<std::pair<int, int>>>); // if are the same, don't need to explicitly construct the return value...
         try {
-            for (const std::pair<int, int>& lane : laneset)
-            { retval.push_back(lane); }
+            return {laneset.begin(), laneset.end()};
         } catch (...) {
+            return {};
         }
-        return retval;
     }
 
     auto jumpsToSuppliedSystem(const Empire& empire) -> std::map<int, int>

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -7,6 +7,7 @@
 #include "../universe/UniverseObject.h"
 #include "../universe/UnlockableItem.h"
 #include "../universe/Planet.h"
+#include "../universe/ScriptingContext.h"
 #include "../universe/Tech.h"
 #include "../util/AppInterface.h"
 #include "../util/Logger.h"
@@ -485,7 +486,7 @@ namespace FreeOrionPython {
             .add_property("description",            make_function(&Policy::Description,         py::return_value_policy<py::copy_const_reference>()))
             .add_property("shortDescription",       make_function(&Policy::ShortDescription,    py::return_value_policy<py::copy_const_reference>()))
             .add_property("category",               make_function(&Policy::Category,            py::return_value_policy<py::copy_const_reference>()))
-            .def("adoptionCost",                    &Policy::AdoptionCost)
+            .def("adoptionCost",                    +[](const Policy& p)                       { return p.AdoptionCost(AppEmpireID(), ScriptingContext{}); })
         ;
 
         def("getPolicy",

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -487,6 +487,8 @@ namespace FreeOrionPython {
             .add_property("shortDescription",       make_function(&Policy::ShortDescription,    py::return_value_policy<py::copy_const_reference>()))
             .add_property("category",               make_function(&Policy::Category,            py::return_value_policy<py::copy_const_reference>()))
             .def("adoptionCost",                    +[](const Policy& p)                       { return p.AdoptionCost(AppEmpireID(), ScriptingContext{}); })
+            .def("adoptionCost",                    +[](const Policy& p, const Empire& empire) { return p.AdoptionCost(empire.EmpireID(), ScriptingContext{}); })
+            .def("adoptionCost",                    +[](const Policy& p, int empire_id)        { return p.AdoptionCost(empire_id, ScriptingContext{}); })
         ;
 
         def("getPolicy",

--- a/server/ServerWrapper.cpp
+++ b/server/ServerWrapper.cpp
@@ -1380,8 +1380,8 @@ namespace FreeOrionPython {
         py::def("load_fleet_plan_list",             LoadFleetPlanList);
         py::def("load_monster_fleet_plan_list",     LoadMonsterFleetPlanList);
 
-        py::def("get_name",                         GetName);
-        py::def("set_name",                         SetName);
+        py::def("get_name",                         GetName, "Returns the name (string) of the universe object with the specified object id (int). If there is no such object, returns an empty string and logs an error to the error log.");
+        py::def("set_name",                         SetName, "Sets the name (string) of the universe object with the specified object id (int). If there is no such object, just logs an error to the error log.");
         py::def("get_x",                            GetX);
         py::def("get_y",                            GetY);
         py::def("get_pos",                          GetPos);


### PR DESCRIPTION
Fixes how policy adoption cost is exposed to Python API, which before this requires an impossible-to-provide `ScriptingContext` parameter.

@Cjkjvfnby @Morlic-fo I'm not sure how to regenerate [freeOrionAIInterface.pyi](https://github.com/freeorion/freeorion/blob/master/default/python/AI/freeOrionAIInterface.pyi)