### PR TITLE
Adapted basic growth formula.

### DIFF
--- a/default/scripting/species/common/population.macros
+++ b/default/scripting/species/common/population.macros
@@ -1,7 +1,7 @@
 
 GROWTH_RATE_FACTOR
 '''
-0.005 *
+0.08 *
 (1 - (Statistic If condition = And [Target EmpireHasAdoptedPolicy name = "PLC_NO_GROWTH"])) *       // no growth with no-growth policy
 (1 + 0.5*(Statistic If condition = And [Target EmpireHasAdoptedPolicy name = "PLC_POPULATION"])) *  // +50% growth with population policy
 (1 + (Statistic If condition = And [Target EmpireHasAdoptedPolicy name = "PLC_AUGMENTATION"]) *     // slower growth with augmentation on low-infrastructure planets
@@ -27,9 +27,13 @@ BASIC_POPULATION
             ]
             priority = [[POPULATION_FIRST_PRIORITY]]
             effects = SetPopulation value =
+                // growth is GROWTH_RATE_FACTOR * population * (maximum + 1 - population) / maximum
+                // which gives factor for population 1, best growth around half full and aproaching
+                // factor again when almost full
                 (Statistic If condition = And [ Target (Value < Target.TargetPopulation)] *
                     min(Target.TargetPopulation, Value + Value*[[GROWTH_RATE_FACTOR]]*
-                                                               (Target.TargetPopulation + 1 - Value)))
+                                                               (1 + (1 - Value)/Target.TargetPopulation)))
+                // shrink if overpopulated
               + (Statistic If condition = And [ Target (Value >= Target.TargetPopulation)] *
                     max(Target.TargetPopulation, Value - 0.1*(Value - Target.TargetPopulation)))
 


### PR DESCRIPTION
The old formula grew quadratic with the planet size,
i.e. big planet became full quite quickly, while small ones
grew extremely slowly.

Also see forum: [Population curves](https://www.freeorion.org/forum/viewtopic.php?p=108864&sid=3d64d8e15f92bad09a6924425847c424#p108864)