### PR TITLE
Use default WindowsTargetPlatformVersion

### DIFF
--- a/msvc2022/Common/Common.vcxproj
+++ b/msvc2022/Common/Common.vcxproj
@@ -22,7 +22,6 @@
     <ProjectGuid>{BEDF460A-EAE9-4E20-AFB2-2C8434051150}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Common</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/msvc2022/FreeOrion/FreeOrion.vcxproj
+++ b/msvc2022/FreeOrion/FreeOrion.vcxproj
@@ -22,7 +22,6 @@
     <ProjectGuid>{311D02C0-427D-4A03-AAEB-B819A9ACF5AB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>FreeOrion</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/msvc2022/FreeOrionCA/FreeOrionCA.vcxproj
+++ b/msvc2022/FreeOrionCA/FreeOrionCA.vcxproj
@@ -22,7 +22,6 @@
     <ProjectGuid>{77E8E74E-F581-4850-A4C6-A088564DF9A7}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>FreeOrionCA</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/msvc2022/FreeOrionD/FreeOrionD.vcxproj
+++ b/msvc2022/FreeOrionD/FreeOrionD.vcxproj
@@ -22,7 +22,6 @@
     <ProjectGuid>{B9808A04-CE5E-4660-99CB-B8C8C4E64402}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>FreeOrionD</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/msvc2022/GiGi/GiGi.vcxproj
+++ b/msvc2022/GiGi/GiGi.vcxproj
@@ -139,7 +139,6 @@
     <ProjectGuid>{2CEC3AB3-36A0-4037-AEC2-DA0435A4DADB}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>GiGi</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/msvc2022/Parsers/Parsers.vcxproj
+++ b/msvc2022/Parsers/Parsers.vcxproj
@@ -22,7 +22,6 @@
     <ProjectGuid>{9925F25C-A72E-42AE-B2E3-6657255BF293}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>Parsers</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">

--- a/msvc2022/Test/Test.vcxproj
+++ b/msvc2022/Test/Test.vcxproj
@@ -22,7 +22,6 @@
     <ProjectGuid>{650719CA-7F2F-4C39-84F4-3F4684788117}</ProjectGuid>
     <Keyword>Win32Proj</Keyword>
     <RootNamespace>FreeOrion</RootNamespace>
-    <WindowsTargetPlatformVersion>8.1</WindowsTargetPlatformVersion>
     <ProjectName>UnitTests</ProjectName>
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />


### PR DESCRIPTION
Considering that mainstream windows 8.1 support ended over 4 years ago, I propose to update the target platform version.
If a fixed version is preferred rather than using default value, I propose we should at least target 10.0 (i.e. latest version of windows 10 SDK) rather than 8.1...