### PR TITLE
Let split_ship_from_fleet return INVALID_ID on failure

### DIFF
--- a/client/AI/AIWrapper.cpp
+++ b/client/AI/AIWrapper.cpp
@@ -251,7 +251,7 @@ namespace {
 
         if (!NewFleetOrder::Check(app->EmpireID(), fleet_name, ship_ids,
                                   FleetAggression::FLEET_OBSTRUCTIVE, context))
-        { return 0; } // TODO: why not return INVALID_OBJECT_ID ?
+        { return INVALID_OBJECT_ID; }
 
         auto order = std::make_shared<NewFleetOrder>(app->EmpireID(), fleet_name, ship_ids,
                                                      FleetAggression::FLEET_OBSTRUCTIVE, context);

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -606,7 +606,7 @@ class AIFleetMission:
                                     continue
                                 debug("Splitting from fleet.")
                                 new_fleet_id = FleetUtilsAI.split_ship_from_fleet(fleet_id, ship_id)
-                                if assertion_fails(new_fleet_id not in (None, INVALID_ID)):
+                                if assertion_fails(new_fleet_id != INVALID_ID):
                                     break
                                 new_fleets.append(new_fleet_id)
                                 fleet_remaining_rating = CombatRatingsAI.rating_difference(

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -232,20 +232,24 @@ def split_fleet(fleet_id: int) -> List[int]:
     return new_fleets
 
 
-def split_ship_from_fleet(fleet_id, ship_id):
+def split_ship_from_fleet(fleet_id, ship_id) -> int:
+    """Try to split a ship from the fleet, creating a new fleet.
+
+    :return: ID of the newly created fleet or INVALID_ID if failed
+    """
     universe = fo.getUniverse()
     fleet = universe.getFleet(fleet_id)
     if assertion_fails(fleet is not None):
-        return
+        return INVALID_ID
 
     if assertion_fails(ship_id in fleet.shipIDs):
-        return
+        return INVALID_ID
 
     if assertion_fails(fleet.numShips > 1, "Can't split last ship from fleet"):
-        return
+        return INVALID_ID
 
     new_fleet_id = fo.issueNewFleetOrder("Fleet %4d" % ship_id, ship_id)
-    if new_fleet_id:
+    if new_fleet_id != INVALID_ID:
         aistate = get_aistate()
         new_fleet = universe.getFleet(new_fleet_id)
         if not new_fleet:


### PR DESCRIPTION
Avoids the awkward error checking and prevents potential bugs when using 0 as return code in C++ side...