### PR TITLE
Avoid repeating playable species

### DIFF
--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -46,10 +46,9 @@ def get_starting_species_pool():
     """
     Empire species pool generator, return random empire species and ensure somewhat even distribution
     """
-    # fill the initial pool with two sets of all playable species
-    # this way we have somewhat, but not absolutely strict even distribution of starting species at least when there
-    # is only a few number of players (some species can occur twice at max while others not at all)
-    pool = fo.get_playable_species() * 2
+    # fill the initial pool with one set of all playable species
+    # species won't repeat unless there are more players than playable species
+    pool = fo.get_playable_species()
 
     # randomize order in initial pool so we don't get the same species all the time
     random.shuffle(pool)


### PR DESCRIPTION
No repeated playable species when #players < #playable_species


It was intended that species could repeat, but I never found any joy from stumbling upon the same species than me in a 4 player's game. There are reports of this in the forum.

https://www.freeorion.org/forum/viewtopic.php?p=106316#p106316
Quoting @Vezzra :
> When I wrote that code years ago, the general consensus was that while the species selection algorithm should take care that a game does not end up with a too monotonous selection of species, it also shouldn't be too restrictive (as in completely prevent having a species more than once if that can be avoided).
>
> Which is why I went with having each species twice in the initial selection pool.
>
> As Oberlus pointed out, that can easily be fixed by removing that `* 2` part (which would be my personal preference too, btw. ;)).

This PR just removes the "* 2" in universe generation, completely disallowing repeated species unless many players.
@geoffthemedio pointed out a game rule or galaxy setup option could be added.
I have no idea how to add a galaxy setup option, and I don't know how to use game rules from python.

I can mark this PR as draft and work on that if someone can point me to examples on how to do it. Otherwise, this is IMO good to merge: until someone else does the game rule part, I guess no one will miss repeated species in the meantime.
