### PR TITLE
[AI] Ensure colony_buildes are initialized before usage

### DIFF
--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -18,11 +18,11 @@ from colonization.calculate_planet_colonization_rating import (
 from colonization.calculate_population import active_growth_specials, calc_max_pop
 from colonization.colony_score import MINIMUM_COLONY_SCORE
 from colonization.planet_supply import get_planet_supply
+from common.listeners import listener
 from common.print_utils import Bool, Number, Sequence, Table, Text
 from empire.buildings_locations import set_building_locations
 from empire.colony_builders import (
     can_build_colony_for_species,
-    colony_builder_lock,
     get_colony_builders,
     set_colony_builders,
 )
@@ -109,6 +109,7 @@ def get_supply_tech_range():
     return sum(_range for _tech, _range in AIDependencies.supply_range_techs.items() if tech_is_complete(_tech))
 
 
+@listener
 def survey_universe():
     colonization_timer.start("Categorizing Visible Planets")
     universe = fo.getUniverse()
@@ -193,7 +194,6 @@ def survey_universe():
             if sys_status.get("neighborThreat", 0) > 0:
                 set_colonies_is_under_treat()
 
-    colony_builder_lock.unlock()
     _print_empire_species_roster()
 
     rating_list = sorted(get_pilot_ratings().values(), reverse=True)

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -22,6 +22,7 @@ from common.print_utils import Bool, Number, Sequence, Table, Text
 from empire.buildings_locations import set_building_locations
 from empire.colony_builders import (
     can_build_colony_for_species,
+    colony_builder_lock,
     get_colony_builders,
     set_colony_builders,
 )
@@ -192,6 +193,7 @@ def survey_universe():
             if sys_status.get("neighborThreat", 0) > 0:
                 set_colonies_is_under_treat()
 
+    colony_builder_lock.unlock()
     _print_empire_species_roster()
 
     rating_list = sorted(get_pilot_ratings().values(), reverse=True)

--- a/default/python/AI/empire/colony_builders.py
+++ b/default/python/AI/empire/colony_builders.py
@@ -2,8 +2,14 @@ from typing import Dict, List, Mapping, Sequence, Union
 
 import AIDependencies
 from common.fo_typing import PlanetId, SpeciesName
+from common.listeners import register_pre_handler
 from freeorion_tools import tech_is_complete
 from freeorion_tools.caching import cache_for_current_turn
+from freeorion_tools.lazy_initializer import InitializerLock
+
+colony_builder_lock = InitializerLock("colony_builder")
+
+register_pre_handler("generateOrders", colony_builder_lock.lock)
 
 
 def set_colony_builders(species_name: SpeciesName, yards: Sequence[PlanetId]):
@@ -17,14 +23,17 @@ def set_colony_builders(species_name: SpeciesName, yards: Sequence[PlanetId]):
     empire_colonizers.setdefault(species_name, []).extend(yards)
 
 
+@colony_builder_lock
 def can_build_colony_for_species(species_name: Union[SpeciesName, str]):
     return species_name in get_colony_builders()
 
 
+@colony_builder_lock
 def get_colony_builder_locations(species_name: SpeciesName) -> List[PlanetId]:
     return get_colony_builders()[species_name]
 
 
+@colony_builder_lock
 def can_build_only_sly_colonies():
     """
     Return true if empire could build only SP_SLY colonies.
@@ -37,6 +46,7 @@ def can_build_only_sly_colonies():
     return list(get_colony_builders()) == ["SP_SLY"]
 
 
+@colony_builder_lock
 def get_colony_builders() -> Mapping[SpeciesName, List[PlanetId]]:
     """
     Return map from the species to list of the planet where you could build a colony ship with it.

--- a/default/python/AI/empire/colony_builders.py
+++ b/default/python/AI/empire/colony_builders.py
@@ -2,14 +2,15 @@ from typing import Dict, List, Mapping, Sequence, Union
 
 import AIDependencies
 from common.fo_typing import PlanetId, SpeciesName
-from common.listeners import register_pre_handler
+from common.listeners import register_post_handler, register_pre_handler
 from freeorion_tools import tech_is_complete
 from freeorion_tools.caching import cache_for_current_turn
 from freeorion_tools.lazy_initializer import InitializerLock
 
-colony_builder_lock = InitializerLock("colony_builder")
+_colony_builder_lock = InitializerLock("colony_builder")
 
-register_pre_handler("generateOrders", colony_builder_lock.lock)
+register_pre_handler("generateOrders", _colony_builder_lock.lock)
+register_post_handler("survey_universe", lambda *args: _colony_builder_lock.unlock())
 
 
 def set_colony_builders(species_name: SpeciesName, yards: Sequence[PlanetId]):
@@ -23,17 +24,17 @@ def set_colony_builders(species_name: SpeciesName, yards: Sequence[PlanetId]):
     empire_colonizers.setdefault(species_name, []).extend(yards)
 
 
-@colony_builder_lock
+@_colony_builder_lock
 def can_build_colony_for_species(species_name: Union[SpeciesName, str]):
     return species_name in get_colony_builders()
 
 
-@colony_builder_lock
+@_colony_builder_lock
 def get_colony_builder_locations(species_name: SpeciesName) -> List[PlanetId]:
     return get_colony_builders()[species_name]
 
 
-@colony_builder_lock
+@_colony_builder_lock
 def can_build_only_sly_colonies():
     """
     Return true if empire could build only SP_SLY colonies.
@@ -46,7 +47,7 @@ def can_build_only_sly_colonies():
     return list(get_colony_builders()) == ["SP_SLY"]
 
 
-@colony_builder_lock
+@_colony_builder_lock
 def get_colony_builders() -> Mapping[SpeciesName, List[PlanetId]]:
     """
     Return map from the species to list of the planet where you could build a colony ship with it.

--- a/default/python/AI/freeorion_tools/lazy_initializer.py
+++ b/default/python/AI/freeorion_tools/lazy_initializer.py
@@ -1,0 +1,32 @@
+import freeOrionAIInterface as fo
+from functools import wraps
+from typing import Callable
+
+
+class InitializerLock:
+    """
+    Class that ensure that it's properly initialized before the first use of data.
+    """
+
+    def __init__(self, name):
+        self.__initialized = False
+        self.__name = name
+
+    def lock(self):
+        self.__initialized = False
+
+    def unlock(self):
+        self.__initialized = True
+
+    def __call__(self, function: Callable):
+        @wraps(function)
+        def wrapper(*args, **kwargs):
+            print("use zzzxxcc3", fo.currentTurn())
+            if self.__initialized:
+                return function(*args, **kwargs)
+            else:
+                raise ValueError(
+                    f"Call of '{function.__name__}' is forbidden before {self.__class__.__name__}('{self.__name}') is initialized"
+                )
+
+        return wrapper

--- a/default/python/tests/AI/test_lazy_initializer.py
+++ b/default/python/tests/AI/test_lazy_initializer.py
@@ -1,0 +1,26 @@
+import pytest
+from freeorion_tools.lazy_initializer import InitializerLock
+
+
+@pytest.fixture
+def lock():
+    lock = InitializerLock("test")
+    return lock
+
+
+def test_function_return_value_when_unlocked(lock):
+    @lock
+    def foo():
+        return 1
+
+    lock.unlock()
+    assert foo() == 1
+
+
+def test_function_call_raise_error_when_locked(lock):
+    @lock
+    def foo():
+        return 1
+
+    with pytest.raises(ValueError, match=r"Call of 'foo' is forbidden before InitializerLock\('test'\) is initialized"):
+        foo()


### PR DESCRIPTION
This PR address the issue that it's hard to track if colony_buildes  is fully initialized before usage.

This code uses [publisher-subscriber](https://en.wikipedia.org/wiki/Publish%E2%80%93subscribe_pattern). We did not use this pattern before for AI. 

Not sure if we should crash or just return the default value and log error.  I am open to suggestions.

@Grummel7, @Morlic-fo, could you take a look?

