### PR TITLE
Fix policy PROPAGANDA script

### DIFF
--- a/default/scripting/policies/PROPAGANDA.focs.txt
+++ b/default/scripting/policies/PROPAGANDA.focs.txt
@@ -31,7 +31,7 @@ Policy
                 Not EmpireHasAdoptedPolicy empire = LocalCandidate.Owner name = ThisPolicy
                 Number low = 1 condition = And [
                     OwnedBy empire = Source.Owner
-                    VisibleToEmpire empire = Target.Owner
+                    VisibleToEmpire empire = LocalCandidate.Owner
                 ]
             ]
             effects = SetTargetInfluence value = Value + (NamedReal name = "PROPAGANDA_INFLUENCE_ENEMY_FLAT" value = -1.0)


### PR DESCRIPTION
Without this fix, I get the following error in logs:
```
19:42:52.674275 {0x00003a8c} [error] ai : ValueRefs.cpp:98 : FollowReference : top level object (Target) not defined in scripting context.   strings: Owner  source: Royal Turbin γ I target: 0 local c: 0 root c: 0  stacktrace:
 0# boost::stacktrace::basic_stacktrace<std::allocator<boost::stacktrace::frame> >::init at C:\FO\dev\include\boost\stacktrace\stacktrace.hpp:76
 1# `anonymous namespace'::StackTrace at C:\FO\dev\FreeOrion\universe\ValueRefs.cpp:66
 2# `anonymous namespace'::FollowReference at C:\FO\dev\FreeOrion\universe\ValueRefs.cpp:98
 3# ValueRef::Variable<int>::Eval at C:\FO\dev\FreeOrion\universe\ValueRefs.cpp:1040
 4# Condition::VisibleToEmpire::Eval at C:\FO\dev\FreeOrion\universe\Conditions.cpp:7885
 5# Condition::And::Eval at C:\FO\dev\FreeOrion\universe\Conditions.cpp:10377
 6# Condition::Condition::Eval at C:\FO\dev\FreeOrion\universe\Conditions.cpp:312
 7# Condition::Number::Eval at C:\FO\dev\FreeOrion\universe\Conditions.cpp:461
 8# Condition::And::Eval at C:\FO\dev\FreeOrion\universe\Conditions.cpp:10377
 9# Condition::Condition::Eval at C:\FO\dev\FreeOrion\universe\Conditions.cpp:312
10# Condition::Condition::Eval at C:\FO\dev\FreeOrion\universe\Conditions.cpp:334
11# `anonymous namespace'::StoreTargetsAndCausesOfEffectsGroup<boost::container::flat_set<int,std::less<int>,void> const > at C:\FO\dev\FreeOrion\universe\Universe.cpp:1052
12# boost::asio::asio_handler_invoke<``anonymous namespace'::DispatchEffectsGroupScopeEvaluations<std::deque<std::pair<std::vector<std::pair<Effect::SourcedEffectsGroup,Effect::TargetsAndCause>,std::allocator<std::pair<Effect::SourcedEffectsGroup,Effect::TargetsAndCause> > >,std::vector<std::pair<Effect::SourcedEffectsGroup,Effect::TargetsAndCause>,std::allocator<std::pair<Effect::SourcedEffectsGroup,Effect::TargetsAndCause> > > *>,std::allocator<std::pair<std::vector<std::pair<Effect::SourcedEffectsGroup,Effect::TargetsAndCause>,std::allocator<std::pair<Effect::SourcedEffectsGroup,Effect::TargetsAndCause> > >,std::vector<std::pair<Effect::SourcedEffectsGroup,Effect::TargetsAndCause>,std::allocator<std::pair<Effect::SourcedEffectsGroup,Effect::TargetsAndCause> > > *> > >,boost::container::flat_set<int,std::less<int>,void> >'::`43'::<lambda_5> > at C:\FO\dev\include\boost\asio\handler_invoke_hook.hpp:88
13# boost::asio::detail::executor_op<``anonymous namespace'::DispatchEffectsGroupScopeEvaluations<std::deque<std::pair<std::vector<std::pair<Effect::SourcedEffectsGroup,Effect::TargetsAndCause>,std::allocator<std::pair<Effect::SourcedEffectsGroup,Effect::TargetsAndCause> > >,std::vector<std::pair<Effect::SourcedEffectsGroup,Effect::TargetsAndCause>,std::allocator<std::pair<Effect::SourcedEffectsGroup,Effect::TargetsAndCause> > > *>,std::allocator<std::pair<std::vector<std::pair<Effect::SourcedEffectsGroup,Effect::TargetsAndCause>,std::allocator<std::pair<Effect::SourcedEffectsGroup,Effect::TargetsAndCause> > >,std::vector<std::pair<Effect::SourcedEffectsGroup,Effect::TargetsAndCause>,std::allocator<std::pair<Effect::SourcedEffectsGroup,Effect::TargetsAndCause> > > *> > >,boost::container::flat_set<int,std::less<int>,void> >'::`43'::<lambda_5>,std::allocator<void>,boost::asio::detail::scheduler_operation>::do_complete at C:\FO\dev\include\boost\asio\detail\executor_op.hpp:70
14# boost::asio::detail::scheduler::do_run_one at C:\FO\dev\include\boost\asio\detail\impl\scheduler.ipp:481
15# boost::asio::detail::scheduler::run at C:\FO\dev\include\boost\asio\detail\impl\scheduler.ipp:204
16# boost::asio::thread_pool::thread_function::operator() at C:\FO\dev\include\boost\asio\impl\thread_pool.ipp:47
17# boost::asio::detail::win_thread_function at C:\FO\dev\include\boost\asio\detail\impl\win_thread.ipp:128
18# o_iswdigit in ucrtbase
19# BaseThreadInitThunk in KERNEL32
20# RtlGetAppContainerNamedObjectPath in ntdll
21# RtlGetAppContainerNamedObjectPath in ntdll
```

Debugger tells me that EffectsGroup* is from PLC_PROPAGANDA
This seems to fix the error and makes sense to me from a scripting perspective - but not entirely sure if there is another issue?