### PR TITLE
Improve AI invasion handling

### DIFF
--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -260,6 +260,7 @@ class AIFleetMission:
                     debug("EspionageAI predicts we can no longer detect %s, will abort mission" % fleet_order.target)
                     planet_stealthed = True
         if target_is_planet and not planet_stealthed:
+            # TBD use fleet_order.is_valid or add fleet_order.should_abort
             if isinstance(fleet_order, OrderColonize):
                 if planet.initialMeterValue(fo.meterType.population) == 0 and (
                     planet.ownedBy(fo.empireID()) or planet.unowned
@@ -288,8 +289,6 @@ class AIFleetMission:
         # canceling fleet orders
         debug("   %s" % fleet_order)
         debug("Fleet %d had a target planet that is no longer valid for this mission; aborting." % self.fleet.id)
-        self.clear_fleet_orders()
-        self.clear_target()
         FleetUtilsAI.split_fleet(self.fleet.id)
         return True
 
@@ -414,6 +413,7 @@ class AIFleetMission:
             if isinstance(fleet_order, (OrderColonize, OrderOutpost, OrderInvade)) and self._check_abort_mission(
                 fleet_order
             ):
+                self.clear_fleet_orders()
                 self.clear_target()
                 return
         aistate = get_aistate()

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -540,10 +540,10 @@ def evaluate_invasion_planet(planet_id):
     return [planet_score, planned_troops]
 
 
-def secure_system(system_id: SystemId, secure_now: bool):
+def secure_system(system_id: SystemId, secure_now: bool) -> bool:
     """Check whether we have any military fleets in the system.
     If secure_now is True, set one of the fleets to MissionType.SECURE
-    If secure_now is False, return true if there is any fleet that secure it.
+    If secure_now is False, return True if there is any fleet that could secure it.
     """
     universe = fo.getUniverse()
     ai_state = get_aistate()
@@ -561,6 +561,8 @@ def secure_system(system_id: SystemId, secure_now: bool):
         if target_obj is not None and target_obj.id in secure_targets:
             if secure_now and mission.type != MissionType.SECURE:
                 mission.set_target(MissionType.SECURE, mission.target)
+            # TBD whether fleet itself has a sufficient rating against a planet.
+            # E.g. a fleet with Flux Lance cannot keep planetary shields down.
             secured = system_status.get("myFleetRating", 0) > 0
             break
     return secured

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -460,7 +460,7 @@ def _calculate_invasion_priority():
 
 
 def allotted_invasion_targets():
-    return 1 + int(fo.currentTurn() // 25)
+    return min(1 + int(fo.currentTurn() // 50), 3)
 
 
 def _calculate_military_priority():

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -629,15 +629,6 @@ def trooper_move_reqs_met(invasion_target: Target, order: OrderMove, verbose: bo
     if order.target.id not in supplied_systems or fo.getUniverse().jumpDistance(order.fleet.id, invasion_system.id) < 5:
         if invasion_planet.currentMeterValue(fo.meterType.maxShield):
             military_support_fleets = MilitaryAI.get_military_fleets_with_target_system(invasion_system.id)
-            if not military_support_fleets:
-                if verbose:
-                    debug(
-                        "trooper_move_reqs_met() holding Invasion fleet %d before leaving supply "
-                        "because target (%s) has nonzero max shields and there is not yet a military fleet "
-                        "assigned to secure the target system." % (order.fleet.id, invasion_planet)
-                    )
-                return False
-
             # if there is a threat in the enemy system, do give military ships at least 1 turn to clear it
             delay_to_move_troops = 1 if MilitaryAI.get_system_local_threat(order.target.id) else 0
 


### PR DESCRIPTION
This should fix the three points described in #3745. It should conquer more successful and waste less troopers now.
The AI still builds too many troopers (priority calculation sometimes produces strange results) and may ignore good planets (planetary rating also needs work), but these are for another PR.