### PR TITLE
Move survey_universe to empire module and call it earlier

### DIFF
--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -8,47 +8,18 @@ import AIstate
 import ExplorationAI
 import FleetUtilsAI
 import PlanetUtilsAI
-from AIDependencies import INVALID_ID, OUTPOSTING_TECH, Tags
+from AIDependencies import INVALID_ID, OUTPOSTING_TECH
 from aistate_interface import get_aistate
-from colonization import rate_piloting_tag, special_is_nest
 from colonization.calculate_planet_colonization_rating import (
     calculate_planet_colonization_rating,
-    empire_metabolisms,
 )
-from colonization.calculate_population import active_growth_specials, calc_max_pop
+from colonization.calculate_population import calc_max_pop
 from colonization.colony_score import MINIMUM_COLONY_SCORE
 from colonization.planet_supply import get_planet_supply
-from common.print_utils import Bool, Number, Sequence, Table, Text
-from empire.buildings_locations import set_building_locations
-from empire.colony_builders import (
-    can_build_colony_for_species,
-    get_colony_builders,
-    set_colony_builders,
-)
-from empire.colony_status import (
-    set_colonies_is_under_attack,
-    set_colonies_is_under_treat,
-)
-from empire.growth_specials import set_growth_special
-from empire.pilot_rating import (
-    get_pilot_ratings,
-    set_pilot_rating_for_planet,
-    summarize_pilot_ratings,
-)
-from empire.ship_builders import get_ship_builder_locations, set_ship_builders
-from EnumsAI import (
-    EmpireProductionTypes,
-    FocusType,
-    MissionType,
-    PriorityType,
-    ShipRoleType,
-)
-from freeorion_tools import (
-    get_partial_visibility_turn,
-    get_ship_part,
-    get_species_tag_grade,
-    tech_is_complete,
-)
+from common.print_utils import Number, Sequence, Table, Text
+from empire.colony_builders import can_build_colony_for_species, get_colony_builders
+from EnumsAI import EmpireProductionTypes, MissionType, PriorityType, ShipRoleType
+from freeorion_tools import get_ship_part, tech_is_complete
 from freeorion_tools.caching import cache_by_turn_persistent, cache_for_current_turn
 from freeorion_tools.timers import AITimer
 from target import TargetPlanet
@@ -57,11 +28,7 @@ from turn_state import (
     get_empire_outposts,
     get_empire_planets_by_species,
     get_number_of_colonies,
-    get_owned_planets,
     get_unowned_empty_planets,
-    set_have_asteroids,
-    set_have_gas_giant,
-    set_have_nest,
 )
 from turn_state.design import get_best_ship_info
 
@@ -106,97 +73,6 @@ def galaxy_is_sparse():
 @cache_by_turn_persistent  # helpful to cache history to debug AI supply progress
 def get_supply_tech_range():
     return sum(_range for _tech, _range in AIDependencies.supply_range_techs.items() if tech_is_complete(_tech))
-
-
-def survey_universe():
-    colonization_timer.start("Categorizing Visible Planets")
-    universe = fo.getUniverse()
-    empire_id = fo.empireID()
-    current_turn = fo.currentTurn()
-
-    # set up / reset various variables; the 'if' is purely for code folding convenience
-    if True:
-        AIstate.empireStars.clear()
-        empire_metabolisms.clear()
-        active_growth_specials.clear()
-
-    # var setup done
-    aistate = get_aistate()
-    for sys_id in universe.systemIDs:
-        system = universe.getSystem(sys_id)
-        if not system:
-            continue
-        local_ast = False
-        local_gg = False
-        empire_has_qualifying_planet = False
-        if sys_id in AIstate.colonyTargetedSystemIDs:
-            empire_has_qualifying_planet = True
-        for pid in system.planetIDs:
-            planet = universe.getPlanet(pid)
-            if not planet:
-                continue
-            if pid in aistate.colonisablePlanetIDs:
-                empire_has_qualifying_planet = True
-            if planet.size == fo.planetSize.asteroids:
-                local_ast = True
-            elif planet.size == fo.planetSize.gasGiant:
-                local_gg = True
-            spec_name = planet.speciesName
-            this_spec = fo.getSpecies(spec_name)
-            owner_id = planet.owner
-            planet_population = planet.currentMeterValue(fo.meterType.population)
-            buildings_here = [universe.getBuilding(bldg).buildingTypeName for bldg in planet.buildingIDs]
-            ship_facilities = set(AIDependencies.SHIP_FACILITIES).intersection(buildings_here)
-            weapons_grade = "WEAPONS_0.0"
-            if owner_id == empire_id:
-                if planet_population > 0.0 and this_spec:
-                    empire_has_qualifying_planet = True
-                    for metab in [tag for tag in this_spec.tags if tag in AIDependencies.metabolismBoostMap]:
-                        empire_metabolisms[metab] = empire_metabolisms.get(metab, 0.0) + planet.habitableSize
-                    if this_spec.canProduceShips:
-                        pilot_val = rate_piloting_tag(spec_name)
-                        if spec_name == "SP_ACIREMA":
-                            pilot_val += 1
-                        weapons_grade = "WEAPONS_%.1f" % pilot_val
-                        set_pilot_rating_for_planet(pid, pilot_val)
-                        yard_here = []
-                        if "BLD_SHIPYARD_BASE" in buildings_here:
-                            set_ship_builders(spec_name, pid)
-                            yard_here = [pid]
-                        if this_spec.canColonize and planet.currentMeterValue(fo.meterType.targetPopulation) >= 3:
-                            set_colony_builders(spec_name, yard_here)
-                set_building_locations(weapons_grade, ship_facilities, pid, sys_id)
-
-                for special in planet.specials:
-                    if special_is_nest(special):
-                        set_have_nest()
-                    if special in AIDependencies.metabolismBoosts:
-                        set_growth_special(special, pid)
-                        if planet.focus == FocusType.FOCUS_GROWTH:
-                            active_growth_specials.setdefault(special, []).append(pid)
-            elif owner_id != -1:
-                if get_partial_visibility_turn(pid) >= current_turn - 1:  # only interested in immediately recent data
-                    aistate.misc.setdefault("enemies_sighted", {}).setdefault(current_turn, []).append(pid)
-
-        if empire_has_qualifying_planet:
-            if local_ast:
-                set_have_asteroids()
-            elif local_gg:
-                set_have_gas_giant()
-
-        if sys_id in get_owned_planets():
-            AIstate.empireStars.setdefault(system.starType, []).append(sys_id)
-            sys_status = aistate.systemStatus.setdefault(sys_id, {})
-            if sys_status.get("fleetThreat", 0) > 0:
-                set_colonies_is_under_attack()
-            if sys_status.get("neighborThreat", 0) > 0:
-                set_colonies_is_under_treat()
-
-    _print_empire_species_roster()
-
-    rating_list = sorted(get_pilot_ratings().values(), reverse=True)
-    summarize_pilot_ratings(rating_list)
-    colonization_timer.stop()
 
 
 def get_colony_fleets():
@@ -490,62 +366,6 @@ def send_colony_ships(colony_fleet_ids, evaluated_planets, mission_type):
         already_targeted.append(planet_id)
         ai_target = TargetPlanet(planet_id)
         aistate.get_fleet_mission(fleet_id).set_target(mission_type, ai_target)
-
-
-def _print_empire_species_roster():
-    """Print empire species roster in table format to log."""
-    grade_map = {
-        "ULTIMATE": "+++",
-        "GREAT": "++",
-        "GOOD": "+",
-        "AVERAGE": "o",
-        "BAD": "-",
-        "VERY_BAD": "--",
-        "EXTREMELY_BAD": "---",
-        "NO": "x",
-    }
-
-    grade_tags = [
-        Tags.INDUSTRY,
-        Tags.RESEARCH,
-        Tags.INFLUENCE,
-        Tags.POPULATION,
-        Tags.SUPPLY,
-        Tags.WEAPONS,
-        Tags.ATTACKTROOPS,
-    ]
-
-    grade_tags_names = {
-        Tags.INDUSTRY: "Ind.",
-        Tags.RESEARCH: "Res.",
-        Tags.INFLUENCE: "Infl.",
-        Tags.POPULATION: "Pop.",
-        Tags.SUPPLY: "Supply",
-        Tags.WEAPONS: "Pilot",
-        Tags.ATTACKTROOPS: "Troop",
-    }
-
-    species_table = Table(
-        Text("species"),
-        Sequence("PIDs"),
-        Bool("Colonize"),
-        Text("Shipyards"),
-        *[Text(grade_tags_names[v]) for v in grade_tags],
-        Sequence("Tags"),
-        table_name="Empire species roster Turn %d" % fo.currentTurn(),
-    )
-    for species_name, planet_ids in get_empire_planets_by_species().items():
-        species_tags = fo.getSpecies(species_name).tags
-        number_of_shipyards = len(get_ship_builder_locations(species_name))
-        species_table.add_row(
-            species_name,
-            planet_ids,
-            can_build_colony_for_species(species_name),
-            number_of_shipyards,
-            *[grade_map.get(get_species_tag_grade(species_name, tag).upper(), "o") for tag in grade_tags],
-            [tag for tag in species_tags if not any(s in tag for s in grade_tags) and "PEDIA" not in tag],
-        )
-    species_table.print_table(info)
 
 
 def _print_outpost_candidate_table(candidates, show_detail=False):

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -44,6 +44,7 @@ from character.character_strings_module import (
 )
 from common.handlers import init_handlers
 from common.listeners import listener
+from empire.survey_universe import survey_universe
 from freeorion_tools.timers import AITimer
 
 turn_timer = AITimer("full turn")
@@ -270,6 +271,9 @@ def generateOrders():  # pylint: disable=invalid-name
         info("This empire has been eliminated. Aborting order generation.")
         return
 
+    # results of this function are needed in many places...
+    survey_universe()
+
     generate_order_timer.start("Update states on server")
     # This code block is required for correct AI work.
     info("Meter / Resource Pool updating...")
@@ -343,7 +347,6 @@ def generateOrders():  # pylint: disable=invalid-name
     debug("Calling AI Modules")
     # call AI modules
     action_list = [
-        ColonisationAI.survey_universe,
         ShipDesignAI.Cache.update_for_new_turn,
         PriorityAI.calculate_priorities,
         ExplorationAI.assign_scouts_to_explore_systems,

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -15,9 +15,9 @@ from logging import debug, info, warning
 from operator import itemgetter
 
 import AIDependencies
-import ColonisationAI
 import PlanetUtilsAI
 from aistate_interface import get_aistate
+from colonization.calculate_planet_colonization_rating import empire_metabolisms
 from common.print_utils import Table, Text
 from empire.growth_specials import get_growth_specials
 from EnumsAI import FocusType, PriorityType, get_priority_resource_types
@@ -578,7 +578,7 @@ def set_planet_growth_specials(focus_manager):
             continue
 
         # Find the total population bonus we could get by using growth focus
-        potential_pop_increase = ColonisationAI.empire_metabolisms.get(metabolism, 0)
+        potential_pop_increase = empire_metabolisms.get(metabolism, 0)
         if not potential_pop_increase:
             continue
 

--- a/default/python/AI/empire/buildings_locations.py
+++ b/default/python/AI/empire/buildings_locations.py
@@ -4,15 +4,18 @@ from typing import DefaultDict, Dict, FrozenSet, Set, Union
 import AIDependencies
 from common.fo_typing import BuildingId, PlanetId, SystemId
 from empire.pilot_rating import best_pilot_rating
+from empire.survey_lock import survey_universe_lock
 from freeorion_tools.caching import cache_for_current_turn
 
 
+@survey_universe_lock
 def get_best_pilot_facilities(building: Union[BuildingId, str]) -> FrozenSet[PlanetId]:
     best_pilot_facilities = _get_facilities().get("WEAPONS_%.1f" % best_pilot_rating(), {})
 
     return best_pilot_facilities.get(building, set())
 
 
+@survey_universe_lock
 def get_systems_with_building(bld_name: BuildingId):
     return _get_system_facilities()[bld_name]
 

--- a/default/python/AI/empire/colony_builders.py
+++ b/default/python/AI/empire/colony_builders.py
@@ -2,18 +2,11 @@ from typing import Dict, List, Mapping, Sequence, Union
 
 import AIDependencies
 from common.fo_typing import PlanetId, SpeciesName
-from common.listeners import listener, register_post_handler, register_pre_handler
+from empire.survey_lock import survey_universe_lock
 from freeorion_tools import tech_is_complete
 from freeorion_tools.caching import cache_for_current_turn
-from freeorion_tools.lazy_initializer import InitializerLock
-
-_colony_builder_lock = InitializerLock("colony_builder")
-
-register_pre_handler("generateOrders", _colony_builder_lock.lock)
-register_post_handler("set_colony_builders", lambda *args: _colony_builder_lock.unlock())
 
 
-@listener
 def set_colony_builders(species_name: SpeciesName, yards: Sequence[PlanetId]):
     """
     Add planet where you can build colonies for species.
@@ -25,17 +18,17 @@ def set_colony_builders(species_name: SpeciesName, yards: Sequence[PlanetId]):
     empire_colonizers.setdefault(species_name, []).extend(yards)
 
 
-@_colony_builder_lock
+@survey_universe_lock
 def can_build_colony_for_species(species_name: Union[SpeciesName, str]):
     return species_name in get_colony_builders()
 
 
-@_colony_builder_lock
+@survey_universe_lock
 def get_colony_builder_locations(species_name: SpeciesName) -> List[PlanetId]:
     return get_colony_builders()[species_name]
 
 
-@_colony_builder_lock
+@survey_universe_lock
 def can_build_only_sly_colonies():
     """
     Return true if empire could build only SP_SLY colonies.
@@ -48,7 +41,7 @@ def can_build_only_sly_colonies():
     return list(get_colony_builders()) == ["SP_SLY"]
 
 
-@_colony_builder_lock
+@survey_universe_lock
 def get_colony_builders() -> Mapping[SpeciesName, List[PlanetId]]:
     """
     Return map from the species to list of the planet where you could build a colony ship with it.

--- a/default/python/AI/empire/colony_status.py
+++ b/default/python/AI/empire/colony_status.py
@@ -1,3 +1,4 @@
+from empire.survey_lock import survey_universe_lock
 from freeorion_tools.caching import cache_for_current_turn
 
 
@@ -7,10 +8,12 @@ class _ColonyStatus:
         self.colonies_under_threat = False
 
 
+@survey_universe_lock
 def colonies_is_under_attack() -> bool:
     return bool(_get_colony_status().colonies_under_attack)
 
 
+@survey_universe_lock
 def colonies_is_under_treat() -> bool:
     return bool(_get_colony_status().colonies_under_threat)
 

--- a/default/python/AI/empire/growth_specials.py
+++ b/default/python/AI/empire/growth_specials.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Mapping
 
 from common.fo_typing import PlanetId, SpecialName
+from empire.survey_lock import survey_universe_lock
 from freeorion_tools.caching import cache_for_current_turn
 
 
@@ -8,6 +9,7 @@ def set_growth_special(special: SpecialName, pid: PlanetId):
     _get_growth_specials().setdefault(special, []).append(pid)
 
 
+@survey_universe_lock
 def get_growth_specials() -> Mapping[SpecialName, List[PlanetId]]:
     """
     Return map from the species to list of the planet where you could build a ship with it.

--- a/default/python/AI/empire/pilot_rating.py
+++ b/default/python/AI/empire/pilot_rating.py
@@ -1,6 +1,7 @@
 from typing import Dict, Mapping, Sequence
 
 from common.fo_typing import PlanetId
+from empire.survey_lock import survey_universe_lock, survey_universe_lock2
 from freeorion_tools.caching import cache_for_current_turn
 
 
@@ -14,10 +15,12 @@ def set_pilot_rating_for_planet(pid: PlanetId, pilot_rating: float):
     _get_pilot_ratings()[pid] = pilot_rating
 
 
+@survey_universe_lock
 def get_rating_for_planet(pid: PlanetId) -> float:
     return get_pilot_ratings().get(pid, 0)
 
 
+@survey_universe_lock
 def get_pilot_ratings() -> Mapping[PlanetId, float]:
     return _get_pilot_ratings()
 
@@ -41,10 +44,12 @@ def _get_pilot_summary() -> _Summary:
     return _Summary()
 
 
+@survey_universe_lock2
 def best_pilot_rating() -> float:
     return _get_pilot_summary().best_pilot_rating
 
 
+@survey_universe_lock2
 def medium_pilot_rating() -> float:
     return _get_pilot_summary().medium_pilot_rating
 

--- a/default/python/AI/empire/pilot_rating.py
+++ b/default/python/AI/empire/pilot_rating.py
@@ -1,7 +1,8 @@
+from logging import info
 from typing import Dict, Mapping, Sequence
 
 from common.fo_typing import PlanetId
-from empire.survey_lock import survey_universe_lock, survey_universe_lock2
+from empire.survey_lock import survey_universe_lock
 from freeorion_tools.caching import cache_for_current_turn
 
 
@@ -41,23 +42,26 @@ class _Summary:
 
 @cache_for_current_turn
 def _get_pilot_summary() -> _Summary:
-    return _Summary()
+    summary = _Summary()
+    rating_list = sorted(get_pilot_ratings().values(), reverse=True)
+    _summarize_pilot_ratings(summary, rating_list)
+    return summary
 
 
-@survey_universe_lock2
+@survey_universe_lock
 def best_pilot_rating() -> float:
     return _get_pilot_summary().best_pilot_rating
 
 
-@survey_universe_lock2
+@survey_universe_lock
 def medium_pilot_rating() -> float:
     return _get_pilot_summary().medium_pilot_rating
 
 
-def summarize_pilot_ratings(ratings: Sequence[float]):
+def _summarize_pilot_ratings(summary: _Summary, ratings: Sequence[float]):
     if not ratings:
         return
-    summary = _get_pilot_summary()
+    info("_summarize_pilot_ratings")
     summary.best_pilot_rating = ratings[0]
     if len(ratings) == 1:
         summary.medium_pilot_rating = ratings[0]

--- a/default/python/AI/empire/ship_builders.py
+++ b/default/python/AI/empire/ship_builders.py
@@ -1,13 +1,16 @@
 from typing import Dict, List, Mapping, Set, Union
 
 from common.fo_typing import PlanetId, SpeciesName
+from empire.survey_lock import survey_universe_lock
 from freeorion_tools.caching import cache_for_current_turn
 
 
+@survey_universe_lock
 def can_build_ship_for_species(species_name: Union[SpeciesName, str]):
     return species_name in get_ship_builders()
 
 
+@survey_universe_lock
 def get_ship_builder_locations(species_name: SpeciesName) -> List[PlanetId]:
     return get_ship_builders().get(species_name, [])
 
@@ -23,6 +26,7 @@ def set_ship_builders(species_name: SpeciesName, pid: PlanetId):
     _get_ship_builders().setdefault(species_name, []).append(pid)
 
 
+@survey_universe_lock
 def get_ship_builders() -> Mapping[SpeciesName, List[PlanetId]]:
     """
     Return map from the species to list of the planet where you could build a ship with it.
@@ -43,5 +47,6 @@ def get_shipyards() -> Set[PlanetId]:
     return set()
 
 
+@survey_universe_lock
 def has_shipyard(pid: PlanetId) -> bool:
     return pid in get_shipyards()

--- a/default/python/AI/empire/survey_lock.py
+++ b/default/python/AI/empire/survey_lock.py
@@ -1,0 +1,6 @@
+from freeorion_tools.lazy_initializer import InitializerLock
+
+# put in an extra file only to avoid circular includes
+survey_universe_lock = InitializerLock("survery_universe")
+# some values are used to calculate others, so we need two locks
+survey_universe_lock2 = InitializerLock("survery_universe2")

--- a/default/python/AI/empire/survey_lock.py
+++ b/default/python/AI/empire/survey_lock.py
@@ -2,5 +2,3 @@ from freeorion_tools.lazy_initializer import InitializerLock
 
 # put in an extra file only to avoid circular includes
 survey_universe_lock = InitializerLock("survery_universe")
-# some values are used to calculate others, so we need two locks
-survey_universe_lock2 = InitializerLock("survery_universe2")

--- a/default/python/AI/empire/survey_universe.py
+++ b/default/python/AI/empire/survey_universe.py
@@ -1,0 +1,191 @@
+import freeOrionAIInterface as fo
+from logging import info
+
+import AIDependencies
+import AIstate
+from AIDependencies import Tags
+from aistate_interface import get_aistate
+from colonization import rate_piloting_tag, special_is_nest
+from colonization.calculate_planet_colonization_rating import empire_metabolisms
+from colonization.calculate_population import active_growth_specials
+from common.listeners import register_pre_handler
+from common.print_utils import Bool, Sequence, Table, Text
+from empire.buildings_locations import set_building_locations
+from empire.colony_builders import can_build_colony_for_species, set_colony_builders
+from empire.colony_status import (
+    set_colonies_is_under_attack,
+    set_colonies_is_under_treat,
+)
+from empire.growth_specials import set_growth_special
+from empire.pilot_rating import (
+    get_pilot_ratings,
+    set_pilot_rating_for_planet,
+    summarize_pilot_ratings,
+)
+from empire.ship_builders import get_ship_builder_locations, set_ship_builders
+from empire.survey_lock import survey_universe_lock, survey_universe_lock2
+from EnumsAI import FocusType
+from freeorion_tools import get_partial_visibility_turn, get_species_tag_grade
+from freeorion_tools.timers import AITimer
+from turn_state import (
+    get_empire_planets_by_species,
+    get_owned_planets,
+    set_have_asteroids,
+    set_have_gas_giant,
+    set_have_nest,
+)
+
+register_pre_handler("generateOrders", survey_universe_lock.lock)
+register_pre_handler("generateOrders", survey_universe_lock2.lock)
+
+survey_timer = AITimer("empire.surver_universe()")
+
+
+def survey_universe():
+    survey_timer.start("Categorizing Visible Planets")
+    universe = fo.getUniverse()
+    empire_id = fo.empireID()
+    current_turn = fo.currentTurn()
+
+    # set up / reset various variables; the 'if' is purely for code folding convenience
+    if True:
+        AIstate.empireStars.clear()
+        empire_metabolisms.clear()
+        active_growth_specials.clear()
+
+    # var setup done
+    aistate = get_aistate()
+    for sys_id in universe.systemIDs:
+        system = universe.getSystem(sys_id)
+        if not system:
+            continue
+        local_ast = False
+        local_gg = False
+        empire_has_qualifying_planet = False
+        if sys_id in AIstate.colonyTargetedSystemIDs:
+            empire_has_qualifying_planet = True
+        for pid in system.planetIDs:
+            planet = universe.getPlanet(pid)
+            if not planet:
+                continue
+            if pid in aistate.colonisablePlanetIDs:
+                empire_has_qualifying_planet = True
+            if planet.size == fo.planetSize.asteroids:
+                local_ast = True
+            elif planet.size == fo.planetSize.gasGiant:
+                local_gg = True
+            spec_name = planet.speciesName
+            this_spec = fo.getSpecies(spec_name)
+            owner_id = planet.owner
+            planet_population = planet.currentMeterValue(fo.meterType.population)
+            buildings_here = [universe.getBuilding(bldg).buildingTypeName for bldg in planet.buildingIDs]
+            ship_facilities = set(AIDependencies.SHIP_FACILITIES).intersection(buildings_here)
+            weapons_grade = "WEAPONS_0.0"
+            if owner_id == empire_id:
+                if planet_population > 0.0 and this_spec:
+                    empire_has_qualifying_planet = True
+                    for metab in [tag for tag in this_spec.tags if tag in AIDependencies.metabolismBoostMap]:
+                        empire_metabolisms[metab] = empire_metabolisms.get(metab, 0.0) + planet.habitableSize
+                    if this_spec.canProduceShips:
+                        pilot_val = rate_piloting_tag(spec_name)
+                        if spec_name == "SP_ACIREMA":
+                            pilot_val += 1
+                        weapons_grade = "WEAPONS_%.1f" % pilot_val
+                        set_pilot_rating_for_planet(pid, pilot_val)
+                        yard_here = []
+                        if "BLD_SHIPYARD_BASE" in buildings_here:
+                            set_ship_builders(spec_name, pid)
+                            yard_here = [pid]
+                        if this_spec.canColonize and planet.currentMeterValue(fo.meterType.targetPopulation) >= 3:
+                            set_colony_builders(spec_name, yard_here)
+                set_building_locations(weapons_grade, ship_facilities, pid, sys_id)
+
+                for special in planet.specials:
+                    if special_is_nest(special):
+                        set_have_nest()
+                    if special in AIDependencies.metabolismBoosts:
+                        set_growth_special(special, pid)
+                        if planet.focus == FocusType.FOCUS_GROWTH:
+                            active_growth_specials.setdefault(special, []).append(pid)
+            elif owner_id != -1:
+                if get_partial_visibility_turn(pid) >= current_turn - 1:  # only interested in immediately recent data
+                    aistate.misc.setdefault("enemies_sighted", {}).setdefault(current_turn, []).append(pid)
+
+        if empire_has_qualifying_planet:
+            if local_ast:
+                set_have_asteroids()
+            elif local_gg:
+                set_have_gas_giant()
+
+        if sys_id in get_owned_planets():
+            AIstate.empireStars.setdefault(system.starType, []).append(sys_id)
+            sys_status = aistate.systemStatus.setdefault(sys_id, {})
+            if sys_status.get("fleetThreat", 0) > 0:
+                set_colonies_is_under_attack()
+            if sys_status.get("neighborThreat", 0) > 0:
+                set_colonies_is_under_treat()
+
+    survey_universe_lock.unlock()
+    # main lock must be unlocked before get_pilot_ratings is called
+    rating_list = sorted(get_pilot_ratings().values(), reverse=True)
+    summarize_pilot_ratings(rating_list)
+    survey_universe_lock2.unlock()
+    survey_timer.stop()
+
+    _print_empire_species_roster()
+
+
+def _print_empire_species_roster():
+    """Print empire species roster in table format to log."""
+    grade_map = {
+        "ULTIMATE": "+++",
+        "GREAT": "++",
+        "GOOD": "+",
+        "AVERAGE": "o",
+        "BAD": "-",
+        "VERY_BAD": "--",
+        "EXTREMELY_BAD": "---",
+        "NO": "x",
+    }
+
+    grade_tags = [
+        Tags.INDUSTRY,
+        Tags.RESEARCH,
+        Tags.INFLUENCE,
+        Tags.POPULATION,
+        Tags.SUPPLY,
+        Tags.WEAPONS,
+        Tags.ATTACKTROOPS,
+    ]
+
+    grade_tags_names = {
+        Tags.INDUSTRY: "Ind.",
+        Tags.RESEARCH: "Res.",
+        Tags.INFLUENCE: "Infl.",
+        Tags.POPULATION: "Pop.",
+        Tags.SUPPLY: "Supply",
+        Tags.WEAPONS: "Pilot",
+        Tags.ATTACKTROOPS: "Troop",
+    }
+
+    species_table = Table(
+        Text("species"),
+        Sequence("PIDs"),
+        Bool("Colonize"),
+        Text("Shipyards"),
+        *[Text(grade_tags_names[v]) for v in grade_tags],
+        Sequence("Tags"),
+        table_name="Empire species roster Turn %d" % fo.currentTurn(),
+    )
+    for species_name, planet_ids in get_empire_planets_by_species().items():
+        species_tags = fo.getSpecies(species_name).tags
+        number_of_shipyards = len(get_ship_builder_locations(species_name))
+        species_table.add_row(
+            species_name,
+            planet_ids,
+            can_build_colony_for_species(species_name),
+            number_of_shipyards,
+            *[grade_map.get(get_species_tag_grade(species_name, tag).upper(), "o") for tag in grade_tags],
+            [tag for tag in species_tags if not any(s in tag for s in grade_tags) and "PEDIA" not in tag],
+        )
+    species_table.print_table(info)

--- a/default/python/AI/empire/survey_universe.py
+++ b/default/python/AI/empire/survey_universe.py
@@ -17,13 +17,9 @@ from empire.colony_status import (
     set_colonies_is_under_treat,
 )
 from empire.growth_specials import set_growth_special
-from empire.pilot_rating import (
-    get_pilot_ratings,
-    set_pilot_rating_for_planet,
-    summarize_pilot_ratings,
-)
+from empire.pilot_rating import set_pilot_rating_for_planet
 from empire.ship_builders import get_ship_builder_locations, set_ship_builders
-from empire.survey_lock import survey_universe_lock, survey_universe_lock2
+from empire.survey_lock import survey_universe_lock
 from EnumsAI import FocusType
 from freeorion_tools import get_partial_visibility_turn, get_species_tag_grade
 from freeorion_tools.timers import AITimer
@@ -36,7 +32,6 @@ from turn_state import (
 )
 
 register_pre_handler("generateOrders", survey_universe_lock.lock)
-register_pre_handler("generateOrders", survey_universe_lock2.lock)
 
 survey_timer = AITimer("empire.surver_universe()")
 
@@ -126,12 +121,9 @@ def survey_universe():
                 set_colonies_is_under_treat()
 
     survey_universe_lock.unlock()
-    # main lock must be unlocked before get_pilot_ratings is called
-    rating_list = sorted(get_pilot_ratings().values(), reverse=True)
-    summarize_pilot_ratings(rating_list)
-    survey_universe_lock2.unlock()
     survey_timer.stop()
 
+    # lock must be released before this, since it uses the locked functions
     _print_empire_species_roster()
 
 

--- a/default/python/AI/freeorion_tools/lazy_initializer.py
+++ b/default/python/AI/freeorion_tools/lazy_initializer.py
@@ -1,4 +1,3 @@
-import freeOrionAIInterface as fo
 from functools import wraps
 from typing import Callable
 
@@ -21,7 +20,6 @@ class InitializerLock:
     def __call__(self, function: Callable):
         @wraps(function)
         def wrapper(*args, **kwargs):
-            print("use zzzxxcc3", fo.currentTurn())
             if self.__initialized:
                 return function(*args, **kwargs)
             else:


### PR DESCRIPTION
This should fix #3760 for good.

It also makes sense as a refactoring, since survey_universe mostly sets values in the empire module and was completely independent from the rest of ColonisationAI.

It does also set some value in the colonization module (nice mix of spelling ;-) which should probably be protected by locks as well, but this can be done with a later PR, this one is big enough and is needed as a fix.