### PR TITLE
Add doctest runner

### DIFF
--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -46,7 +46,7 @@ jobs:
           --format="::error file=%(path)s,line=%(row)d,col=%(col)d::%(path)s:%(row)d:%(col)d: %(code)s %(text)s"
       - name: Test with pytest
         # Run from root to preserve full path in output
-        run: pytest -v default/python/tests
+        run: pytest -v default/python
       - name: Test st-tool with pytest
         # Run from root to preserve full path in output
         run: pytest -v check --doctest-modules --doctest-continue-on-failure

--- a/default/python/common/print_utils/_table.py
+++ b/default/python/common/print_utils/_table.py
@@ -16,7 +16,7 @@ def print_in_columns(items: Collection[Any], columns=2, printer=print):
     """
     Split flat list to columns and print them.
 
-    >>> print_in_columns(['a', 'b', 'c', 'd', 2])
+    >>> print_in_columns(['a', 'b', 'c', 'd'], 2)
     a   c
     b   d
     """

--- a/default/python/conftest.py
+++ b/default/python/conftest.py
@@ -1,0 +1,38 @@
+import os
+from pathlib import Path
+
+excluded_paths = tuple(
+    os.path.join(*x)
+    for x in (
+        ("python", "AI"),
+        ("python", "universe_generation"),
+        ("python", "turn_events"),
+        ("python", "common", "configure_logging.py"),
+        ("python", "tests", "fixtures"),
+        ("python", "tests", "htmlcov"),
+        ("python", "auth"),
+        ("python", "chat"),
+        (".pyi",),
+        (".txt",),
+        (".pytest_cache",),
+        (".md",),
+        (".coverage",),
+        (".ini",),
+    )
+)
+
+
+def pytest_ignore_collect(path: Path):
+    """
+    Filter out modules that imports C++ bindings.
+
+    With pytest --doctest-modules we try to import every module in the python folder.
+    We create a list of exclusions to manually control files that should not be imported.
+
+    Each exclusion is a suffix of the path. If path is directory all path in it will be e excluded.
+
+    Keep in mind, that we have similar folder in python and tests,
+    for example python/AI and python/tests/AI
+    """
+    if str(path).endswith(excluded_paths):
+        return True

--- a/default/python/conftest.py
+++ b/default/python/conftest.py
@@ -8,6 +8,7 @@ excluded_paths = tuple(
         ("python", "universe_generation"),
         ("python", "turn_events"),
         ("python", "common", "configure_logging.py"),
+        ("python", "common", "charting"),
         ("python", "tests", "fixtures"),
         ("python", "tests", "htmlcov"),
         ("python", "auth"),

--- a/default/python/pytest.ini
+++ b/default/python/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --verbose --showlocals
+addopts = --verbose --showlocals --doctest-continue-on-failure --doctest-modules


### PR DESCRIPTION
Doctest is a quite nice feature to put the test into the documentation. 
https://docs.python.org/3/library/doctest.html

There is a nice part about doctests in that video.  https://www.youtube.com/watch?v=ARKbfWk4Xyw

Since we import runtime libraries, we could not use doctest with that files, since it leads to complicated exclusion rules.   In the next iteration, I'll try to deal with it by mocks. 

