### PR TITLE
Abandoned first try on: Fix population reducing effect of planetary drive

### DIFF
--- a/default/scripting/buildings/PLANET_DRIVE_EFFECT.focs.txt
+++ b/default/scripting/buildings/PLANET_DRIVE_EFFECT.focs.txt
@@ -1,0 +1,19 @@
+BuildingType
+    name = "BLD_PLANET_DRIVE_EFFECT"
+    description = "BLD_PLANET_DRIVE_EFFECT_DESC"
+    buildcost = 9999
+    buildtime = 9999
+    effectsgroups = [
+        EffectsGroup
+            scope = And [
+                Object id = Source.PlanetID
+                Planet
+            ]
+            effects = [
+                SetPopulation value = Value / 2
+            ]
+        EffectsGroup
+            scope = Source
+            effects = Destroy
+    ]
+    icon = "icons/building/planetary_stardrive.png"

--- a/default/scripting/species/common/advanced_focus.macros
+++ b/default/scripting/species/common/advanced_focus.macros
@@ -104,7 +104,7 @@ ADVANCED_FOCUS_EFFECTS
                                 tag = "system" data = Source.SystemID
                         ]
                         empire = Source.Owner
-                SetPopulation value = Value / 2
+                CreateBuilding type = "BLD_PLANET_DRIVE_EFFECT"
             ]
 
         EffectsGroup

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -14801,6 +14801,12 @@ Planetary Beacon
 BLD_PLANET_BEACON_DESC
 Designates the target for the [[buildingtype BLD_PLANET_DRIVE]]. This building can only be constructed in systems with fewer than 7 planets (including Gas Giants and Asteroids). [[BUILDING_AVAILABLE_ON_OUTPOSTS]].
 
+BLD_PLANET_DRIVE_EFFECT
+Pseudo building
+
+BLD_PLANET_DRIVE_EFFECT_DESC
+This pseudo building shows that a [[buildingtype BLD_PLANET_DRIVE]] has just been activated an killed have the planet's population.
+
 BLD_ART_PLANET
 Artificial Planet
 


### PR DESCRIPTION
This should fix #3715.

Sadly the population forecast is now all wrong. The client shows no reduction before the jump, but indicates one afterwards.

I tried keeping the original effect for the forecast, but when doing consecutive jumps, the original effect actually worked and so you'd get the population quartered.

Perhaps we could explain the error in the buildings description...