### PR TITLE
Fix population reducing effect of planetary drive

### DIFF
--- a/default/scripting/specials/planet/STARLANE_DRIVE_ACTIVATED.focs.txt
+++ b/default/scripting/specials/planet/STARLANE_DRIVE_ACTIVATED.focs.txt
@@ -5,31 +5,11 @@ Special
     effectsgroups = [
         EffectsGroup
             scope = Source
-            activation = Not And [
-                Planet
-                Focus type = "FOCUS_PLANET_DRIVE"
-                // FOCUS_PLANET_DRIVE halfs the population, but it only works if the
-                // condition is still met after the move. So this effect corrects it,
-                // if and only if the same condition is not met after the move.
-                WithinStarlaneJumps jumps = 1 condition = And [
-                    System
-                    Contains And [
-                        Or [
-                            Building name = "BLD_PLANET_BEACON"
-                            And [
-                                Ship
-                                DesignHasPart low = 1 high = 999 name = "SP_PLANET_BEACON"
-                                Turn low = LocalCandidate.ArrivedOnTurn + 1
-                            ]
-                        ]
-                        OwnedBy empire = Source.Owner
-                    ]
-                    Not Contains Source
-                ]
-            ]
-            // this special is added with POPULATION_DEFAULT_PRIORITY,
-            // activate it in the next level
-            priority = [[POPULATION_OVERRIDE_PRIORITY]]
+            // FOCUS_PLANET_DRIVE halfs the population, but it only works if the
+            // condition is still met after the move. So this effect corrects it,
+            // if and only if the same condition is not met after the move.
+            activation = Not [[PLANETARY_DRIVE_ACTIVATION]]
+            priority = [[POPULATION_DEFAULT_PRIORITY]]
             effects = SetPopulation value = Value / 2
         EffectsGroup
             scope = Source
@@ -40,3 +20,4 @@ Special
     graphic = "icons/building/planetary_stardrive.png"
 
 #include "/scripting/common/priorities.macros"
+#include "/scripting/species/common/advanced_focus.macros"

--- a/default/scripting/specials/planet/STARLANE_DRIVE_ACTIVATED.focs.txt
+++ b/default/scripting/specials/planet/STARLANE_DRIVE_ACTIVATED.focs.txt
@@ -1,0 +1,17 @@
+Special
+    name = "STARLANE_DRIVE_ACTIVATED_SPECIAL"
+    description = "STARLANE_DRIVE_ACTIVATED_SPECIAL_DESC"
+    stealth = 9999
+    effectsgroups = [
+        EffectsGroup
+            scope = Source
+            priority = [[POPULATION_OVERRIDE_PRIORITY]]
+            effects = SetPopulation value = Value / 2
+        EffectsGroup
+            scope = Source
+            priority = [[BEFORE_ANYTHING_ELSE_PRIORITY]]
+            effects = RemoveSpecial name = "STARLANE_DRIVE_ACTIVATED_SPECIAL"
+    ]
+    graphic = "icons/building/planetary_stardrive.png"
+
+#include "/scripting/common/priorities.macros"

--- a/default/scripting/specials/planet/STARLANE_DRIVE_ACTIVATED.focs.txt
+++ b/default/scripting/specials/planet/STARLANE_DRIVE_ACTIVATED.focs.txt
@@ -5,10 +5,35 @@ Special
     effectsgroups = [
         EffectsGroup
             scope = Source
+            activation = Not And [
+                Planet
+                Focus type = "FOCUS_PLANET_DRIVE"
+                // FOCUS_PLANET_DRIVE halfs the population, but it only works if the
+                // condition is still met after the move. So this effect corrects it,
+                // if and only if the same condition is not met after the move.
+                WithinStarlaneJumps jumps = 1 condition = And [
+                    System
+                    Contains And [
+                        Or [
+                            Building name = "BLD_PLANET_BEACON"
+                            And [
+                                Ship
+                                DesignHasPart low = 1 high = 999 name = "SP_PLANET_BEACON"
+                                Turn low = LocalCandidate.ArrivedOnTurn + 1
+                            ]
+                        ]
+                        OwnedBy empire = Source.Owner
+                    ]
+                    Not Contains Source
+                ]
+            ]
+            // this special is added with POPULATION_DEFAULT_PRIORITY,
+            // activate it in the next level
             priority = [[POPULATION_OVERRIDE_PRIORITY]]
             effects = SetPopulation value = Value / 2
         EffectsGroup
             scope = Source
+            // remove it early, FOCUS_PLANET_DRIVE may have to add it again
             priority = [[BEFORE_ANYTHING_ELSE_PRIORITY]]
             effects = RemoveSpecial name = "STARLANE_DRIVE_ACTIVATED_SPECIAL"
     ]

--- a/default/scripting/species/common/advanced_focus.macros
+++ b/default/scripting/species/common/advanced_focus.macros
@@ -104,6 +104,7 @@ ADVANCED_FOCUS_EFFECTS
                                 tag = "system" data = Source.SystemID
                         ]
                         empire = Source.Owner
+                SetPopulation value = Value / 2
                 AddSpecial name = "STARLANE_DRIVE_ACTIVATED_SPECIAL"
             ]
 

--- a/default/scripting/species/common/advanced_focus.macros
+++ b/default/scripting/species/common/advanced_focus.macros
@@ -1,3 +1,25 @@
+PLANETARY_DRIVE_ACTIVATION
+'''
+    And [
+        Planet
+        Focus type = "FOCUS_PLANET_DRIVE"
+        WithinStarlaneJumps jumps = 1 condition = And [
+            System
+            Contains And [
+                Or [
+                    Building name = "BLD_PLANET_BEACON"
+                    And [
+                        Ship
+                        DesignHasPart low = 1 high = 999 name = "SP_PLANET_BEACON"
+                        Turn low = LocalCandidate.ArrivedOnTurn + 1
+                    ]
+                ]
+                OwnedBy empire = Source.Owner
+            ]
+            Not Contains Source
+        ]
+    ]
+'''
 
 ADVANCED_FOCUS_EFFECTS
 '''     EffectsGroup
@@ -58,25 +80,15 @@ ADVANCED_FOCUS_EFFECTS
 
         EffectsGroup
             scope = Source
-            activation = And [
-                Planet
-                Focus type = "FOCUS_PLANET_DRIVE"
-                WithinStarlaneJumps jumps = 1 condition = And [
-                    System
-                    Contains And [
-                        Or [
-                            Building name = "BLD_PLANET_BEACON"
-                            And [
-                                Ship
-                                DesignHasPart low = 1 high = 999 name = "SP_PLANET_BEACON"
-                                Turn low = LocalCandidate.ArrivedOnTurn + 1
-                            ]
-                        ]
-                        OwnedBy empire = Source.Owner
-                    ]
-                    Not Contains Source
-                ]
-            ]
+            activation = [[PLANETARY_DRIVE_ACTIVATION]]
+            // add the special with higher priority, so it can trigger with the same
+            // priotity as the effect below
+            priority = [[POPULATION_FIRST_PRIORITY]]
+            effects = AddSpecial name = "STARLANE_DRIVE_ACTIVATED_SPECIAL"
+
+        EffectsGroup
+            scope = Source
+            activation = [[PLANETARY_DRIVE_ACTIVATION]]
             priority = [[POPULATION_DEFAULT_PRIORITY]]
             effects = [
                 MoveTo destination = And [
@@ -105,7 +117,6 @@ ADVANCED_FOCUS_EFFECTS
                         ]
                         empire = Source.Owner
                 SetPopulation value = Value / 2
-                AddSpecial name = "STARLANE_DRIVE_ACTIVATED_SPECIAL"
             ]
 
         EffectsGroup

--- a/default/scripting/species/common/advanced_focus.macros
+++ b/default/scripting/species/common/advanced_focus.macros
@@ -104,7 +104,7 @@ ADVANCED_FOCUS_EFFECTS
                                 tag = "system" data = Source.SystemID
                         ]
                         empire = Source.Owner
-                SetPopulation value = Value / 2
+                AddSpecial name = "STARLANE_DRIVE_ACTIVATED_SPECIAL"
             ]
 
         EffectsGroup

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -9741,6 +9741,12 @@ This planet has pools of mimetic alloy on its surface, which morphs to resemble 
 MIMETIC_ALLOY_SPECIAL_IMPORTS
 Imported [[MIMETIC_ALLOY_SPECIAL]]
 
+STARLANE_DRIVE_ACTIVATED_SPECIAL
+Scripting auxiliary
+
+STARLANE_DRIVE_ACTIVATED_SPECIAL_DESC
+A special you will never see, it is used internally by the content scripting.
+
 
 ##
 ## Enumeration values


### PR DESCRIPTION
Another attempt to fix #3715, this time using an invisible special. With the second commit, now even the forecast is correct.

The special should possibly get a different picture (single black pixel?).