### PR TITLE
Fix priorities of species scaling effects for PP, RP and IP

### DIFF
--- a/default/scripting/buildings/IMPERIAL_PALACE.focs.txt
+++ b/default/scripting/buildings/IMPERIAL_PALACE.focs.txt
@@ -46,18 +46,14 @@ BuildingType
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS]]
 
-        // flat bonus to influence of capital
+        // sets empire's capital
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
                 Planet
                 OwnedBy empire = Source.ProducedByEmpireID
             ]
-            effects = [
-                SetEmpireCapital
-                SetTargetInfluence value = Value
-                     + (NamedReal name = "BLD_IMPERIAL_PALACE_TARGET_INFLUENCE_FLAT" value = 3) 
-            ]
+            effects = SetEmpireCapital
 
         // one economic policy slot
         EffectsGroup
@@ -112,7 +108,7 @@ BuildingType
             effects = SetTargetHappiness value = Value
                         + (NamedReal name = "BLD_IMPERIAL_PALACE_TARGET_HAPPINESS_FLAT" value = 5) // min(10, max(0, 10 - Target.DistanceToSource/20))
 
-        // flat bonus to defense and troops
+        // flat bonus to defense, troops and influence
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -121,12 +117,14 @@ BuildingType
             ]
             stackinggroup = "PALACE_DEFENSE_STACK"
             accountinglabel = "BLD_IMPERIAL_PALACE"
-            priority = [[TARGET_EARLY_BEFORE_SCALING_PRIORITY]]
+            priority = [[TARGET_AFTER_SCALING_PRIORITY]]
             effects = [
                 SetMaxDefense value = Value + (NamedReal name = "BLD_IMPERIAL_PALACE_MAX_DEFENSE_FLAT"
                                                          value = (5 * [[PLANET_DEFENSE_FACTOR]]))
                 SetMaxTroops value = Value
                     + (NamedReal name = "BLD_IMPERIAL_PALACE_MAX_TROOPS_FLAT" value = 6)
+                SetTargetInfluence value = Value
+                     + (NamedReal name = "BLD_IMPERIAL_PALACE_TARGET_INFLUENCE_FLAT" value = 3) 
             ]
     ]
     icon = "icons/building/palace.png"

--- a/default/scripting/species/common/industry.macros
+++ b/default/scripting/species/common/industry.macros
@@ -41,6 +41,7 @@ VERY_BAD_INDUSTRY
                 Focus type = "FOCUS_INDUSTRY"
             ]
             accountinglabel = "VERY_BAD_INDUSTRY_LABEL"
+            priority = [[TARGET_SCALING_PRIORITY]]
             effects = SetTargetIndustry value = Value
                         * (NamedReal name = "VERY_BAD_INDUSTRY_TARGET_INDUSTRY_SCALING"
                                      value = [[VERY_BAD_MULTIPLIER]])
@@ -59,6 +60,7 @@ BAD_INDUSTRY
                 Focus type = "FOCUS_INDUSTRY"
             ]
             accountinglabel = "BAD_INDUSTRY_LABEL"
+            priority = [[TARGET_SCALING_PRIORITY]]
             effects = SetTargetIndustry value = Value
                         * (NamedReal name = "BAD_INDUSTRY_TARGET_INDUSTRY_SCALING"
                                      value = [[BAD_MULTIPLIER]])
@@ -81,6 +83,7 @@ GOOD_INDUSTRY
                 Focus type = "FOCUS_INDUSTRY"
             ]
             accountinglabel = "GOOD_INDUSTRY_LABEL"
+            priority = [[TARGET_SCALING_PRIORITY]]
             effects = SetTargetIndustry value = Value
                         * (NamedReal name = "GOOD_INDUSTRY_TARGET_INDUSTRY_SCALING"
                                      value = [[GOOD_MULTIPLIER]])
@@ -99,6 +102,7 @@ GREAT_INDUSTRY
                 Focus type = "FOCUS_INDUSTRY"
             ]
             accountinglabel = "GREAT_INDUSTRY_LABEL"
+            priority = [[TARGET_SCALING_PRIORITY]]
             effects = SetTargetIndustry value = Value
                         * (NamedReal name = "GREAT_INDUSTRY_TARGET_INDUSTRY_SCALING"
                                      value = [[GREAT_MULTIPLIER]])
@@ -117,6 +121,7 @@ ULTIMATE_INDUSTRY
                 Focus type = "FOCUS_INDUSTRY"
             ]
             accountinglabel = "ULTIMATE_INDUSTRY_LABEL"
+            priority = [[TARGET_SCALING_PRIORITY]]
             effects = SetTargetIndustry value = Value
                         * (NamedReal name = "ULTIMATE_INDUSTRY_TARGET_INDUSTRY_SCALING"
                                      value = [[ULTIMATE_MULTIPLIER]])

--- a/default/scripting/species/common/research.macros
+++ b/default/scripting/species/common/research.macros
@@ -36,6 +36,7 @@ VERY_BAD_RESEARCH
                 Focus type = "FOCUS_RESEARCH"
             ]
             accountinglabel = "VERY_BAD_RESEARCH_LABEL"
+            priority = [[TARGET_SCALING_PRIORITY]]
             effects = SetTargetResearch value = Value*[[VERY_BAD_MULTIPLIER]]
 '''
 
@@ -50,6 +51,7 @@ BAD_RESEARCH
                 Focus type = "FOCUS_RESEARCH"
             ]
             accountinglabel = "BAD_RESEARCH_LABEL"
+            priority = [[TARGET_SCALING_PRIORITY]]
             effects = SetTargetResearch value = Value*[[BAD_MULTIPLIER]]
 '''
 
@@ -69,6 +71,7 @@ GOOD_RESEARCH
                 Happiness low = 2
             ]
             accountinglabel = "GOOD_RESEARCH_LABEL"
+            priority = [[TARGET_SCALING_PRIORITY]]
             effects = SetTargetResearch value = Value*[[GOOD_MULTIPLIER]]
 '''
 
@@ -84,6 +87,7 @@ GREAT_RESEARCH
                 Happiness low = 0
             ]
             accountinglabel = "GREAT_RESEARCH_LABEL"
+            priority = [[TARGET_SCALING_PRIORITY]]
             effects = SetTargetResearch value = Value*[[GREAT_MULTIPLIER]]
 '''
 
@@ -98,5 +102,6 @@ ULTIMATE_RESEARCH
                 Focus type = "FOCUS_RESEARCH"
             ]
             accountinglabel = "ULTIMATE_RESEARCH_LABEL"
+            priority = [[TARGET_SCALING_PRIORITY]]
             effects = SetTargetResearch value = Value*[[ULTIMATE_MULTIPLIER]]
 '''


### PR DESCRIPTION
The +3 IP from Imperial Palace was default priority (so before TARGET_SCALING_PRIORITY).
The Good/Bad Influence species trait effects have (correctly) set priority as TARGET_SCALING_PRIORITY.
The Good/Bad Industry and Research species trait effects were default priority, which is incorrect since they are scaling effects, not additive effects.

For whatever reason these industry and research scaling effects set as default didn't clash with any other additive effect also set as default (i.e. the scaling effect came after the additive effects, as desired).
However, the IP bonus from imperial palace happening before the species effect makes it weird, as it is affected or not by the species trait depending on the focus.

This PR explicitly sets industry and research species traits as TARGET_SCALING_PRIORITY (playtested for a few turns, everything worked as without this PR) and moves the Imperial Palace flat IP bonus to TARGET_AFTER_SCALING_PRIORITY.

Example numbers for a homeworld with 25 population:

Without this PR:

Influence-focused:
- Influence focus: +5
- Imperial Palace: +3
- Species influence (very bad, bad, avg., good, great, ultimate): -4, -2, 0, +4, +8, +16
Total: +4, +6, +8, +12, +16, +24

Other focus. regardless of species trait:
- Imperial Palace: +3
- Species influence effect does not apply.
Total: +3

With this PR:

Influence-focused:
- Influence focus: +5
- Species influence (very bad, bad, avg., good, great, ultimate): -2.5, -1.25, 0, +2.5, +5, +10
- Imperial Palace: +3
Total: +5.5, +6.75, +8, +10.5, +13, +18

So Imperial Palace bonus is never affected.