### PR TITLE
Rework Liberty and Conformance

### DIFF
--- a/default/scripting/buildings/buildings.macros
+++ b/default/scripting/buildings/buildings.macros
@@ -1,14 +1,21 @@
-// sets stability (happiness) on planets in empire that has adopted the policy this macro effect is added to, if those planets' species like or dislike the policy
+// sets stability (happiness) on planets in empire that have the building this macro effect is added to, if those planets' species like or dislike the building
 
-POLICY_LIKE_DISLIKE_SCALING
-'''(1.0 + (Statistic If condition = And [Source EmpireHasAdoptedPolicy empire = Target.Owner name = "PLC_LIBERTY"])
-    - 0.5*(Statistic If condition = And [Source EmpireHasAdoptedPolicy empire = Target.Owner name = "PLC_CONFORMANCE"]))'''
+// Policy Liberty doubles de effect, policy Conformance halves it, values are declared in common/named_values.focs.txt
+POLICY_DISLIKE_SCALING
+'''(1.0 * (NamedRealLookup name = "PLC_LIBERTY_DISLIKE_FACTOR")^(Statistic If condition = And [Source EmpireHasAdoptedPolicy empire = Target.Owner name = "PLC_LIBERTY"])
+        * (NamedRealLookup name = "PLC_CONFORMANCE_DISLIKE_FACTOR")^(Statistic If condition = And [Source EmpireHasAdoptedPolicy empire = Target.Owner name = "PLC_CONFORMANCE"]))'''
 
-STABILITY_PER_LIKED_OR_DISLIKED_BUILDING_ON_PLANET
-'''4.0 * [[POLICY_LIKE_DISLIKE_SCALING]]'''
+STABILITY_PER_LIKED_BUILDING_ON_PLANET
+'''4.0'''
 
-STABILITY_PER_LIKED_OR_DISLIKED_BUILDING_IN_SYSTEM
-'''1.0 * [[POLICY_LIKE_DISLIKE_SCALING]]'''
+STABILITY_PER_DISLIKED_BUILDING_ON_PLANET
+'''4.0 * [[POLICY_DISLIKE_SCALING]]'''
+
+STABILITY_PER_LIKED_BUILDING_IN_SYSTEM
+'''1.0'''
+
+STABILITY_PER_DISLIKED_BUILDING_IN_SYSTEM
+'''1.0 * [[POLICY_DISLIKE_SCALING]]'''
 
 SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS
 '''
@@ -20,8 +27,7 @@ SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS
                 (SpeciesContentOpinion species = LocalCandidate.Species name = ThisBuilding > 0)
             ]
             accountinglabel = "LIKES_BUILDING_LABEL"
-            effects =
-                SetTargetHappiness value = Value + [[STABILITY_PER_LIKED_OR_DISLIKED_BUILDING_ON_PLANET]] * SpeciesContentOpinion species = Target.Species name = ThisBuilding
+            effects = SetTargetHappiness value = Value + [[STABILITY_PER_LIKED_BUILDING_ON_PLANET]]
 
         // species dislike building on the same planet
         EffectsGroup
@@ -31,8 +37,7 @@ SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS
                 (SpeciesContentOpinion species = LocalCandidate.Species name = ThisBuilding < 0)
             ]
             accountinglabel = "DISLIKES_BUILDING_LABEL"
-            effects =
-                SetTargetHappiness value = Value + [[STABILITY_PER_LIKED_OR_DISLIKED_BUILDING_ON_PLANET]] * SpeciesContentOpinion species = Target.Species name = ThisBuilding
+            effects = SetTargetHappiness value = Value - [[STABILITY_PER_DISLIKED_BUILDING_ON_PLANET]]
                 
         // species like building in the same system
         EffectsGroup
@@ -44,8 +49,7 @@ SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS
                 (SpeciesContentOpinion species = LocalCandidate.Species name = ThisBuilding < 0)
             ]
             accountinglabel = "DISLIKES_BUILDING_LABEL"
-            effects =
-                SetTargetHappiness value = Value + [[STABILITY_PER_LIKED_OR_DISLIKED_BUILDING_IN_SYSTEM]] * SpeciesContentOpinion species = Target.Species name = ThisBuilding
+            effects = SetTargetHappiness value = Value + [[STABILITY_PER_LIKED_BUILDING_IN_SYSTEM]]
 
         // species dislike building in the same system
         EffectsGroup
@@ -57,8 +61,7 @@ SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS
                 (SpeciesContentOpinion species = LocalCandidate.Species name = ThisBuilding > 0)
             ]
             accountinglabel = "LIKES_BUILDING_LABEL"
-            effects =
-                SetTargetHappiness value = Value + [[STABILITY_PER_LIKED_OR_DISLIKED_BUILDING_IN_SYSTEM]] * SpeciesContentOpinion species = Target.Species name = ThisBuilding
+            effects = SetTargetHappiness value = Value - [[STABILITY_PER_DISLIKED_BUILDING_IN_SYSTEM]]
 
         // species like building in empire
         EffectsGroup
@@ -71,7 +74,7 @@ SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS
             ]
             accountinglabel = "LIKES_BUILDING_LABEL"
             effects =
-                SetTargetHappiness value = Value + ((NamedReal name = "BUILDING_LIKE_EMPIRE_SQRT_SCALING" value = 1.0) * 
+                SetTargetHappiness value = Value + ((NamedReal name = "BUILDING_LIKE_EMPIRE_SQRT_SCALING" value = 0.5) * 
                     max(1.0,
                         Statistic Count condition = And [
                             Building
@@ -80,7 +83,7 @@ SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS
                             Not InSystem id = Target.SystemID
                         ]
                     )^(-0.5)
-                ) * [[POLICY_LIKE_DISLIKE_SCALING]] * SpeciesContentOpinion species = Target.Species name = ThisBuilding
+                )
  
         // species dislike building in empire
         EffectsGroup
@@ -93,7 +96,7 @@ SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS
             ]
             accountinglabel = "DISLIKES_BUILDING_LABEL"
             effects =
-                SetTargetHappiness value = Value + ((NamedRealLookup name = "BUILDING_LIKE_EMPIRE_SQRT_SCALING") * 
+                SetTargetHappiness value = Value - ((NamedRealLookup name = "BUILDING_LIKE_EMPIRE_SQRT_SCALING") * 
                     max(1.0,
                         Statistic Count condition = And [
                             Building
@@ -102,7 +105,7 @@ SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS
                             Not InSystem id = Target.SystemID
                         ]
                     )^(-0.5)
-                ) * [[POLICY_LIKE_DISLIKE_SCALING]] * SpeciesContentOpinion species = Target.Species name = ThisBuilding
+                ) * [[POLICY_DISLIKE_SCALING]]
 '''
 
 DO_STARLANE_BORE

--- a/default/scripting/common/named_values.focs.txt
+++ b/default/scripting/common/named_values.focs.txt
@@ -40,6 +40,9 @@ SPATIAL_FLUX_STEALTH_HULL_BASE
 SPATIAL_FLUX_STEALTH_NON_AGGRESSIVE_BONUS
 '''10'''
 
+NamedReal name = "PLC_LIBERTY_DISLIKE_FACTOR" value = 2.0
+
+NamedReal name = "PLC_CONFORMANCE_DISLIKE_FACTOR" value = 0.5
 
 #include "/scripting/common/misc.macros"
 #include "/scripting/common/base_prod.macros"

--- a/default/scripting/policies/CONFORMANCE.focs.txt
+++ b/default/scripting/policies/CONFORMANCE.focs.txt
@@ -8,31 +8,17 @@ Policy
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
 
-        // used in setting stability adjustments for species likes / dislikes
+        // EmpireHasAdoptedPolicy PLC_CONFORMANCE is used in setting stability adjustments for species dislikes in
+        // species/common/happiness.macros (foci), buildings/buildings.macros and policies/policies.macros (policies)
 
-        // reduces research but boosts infrastructure and stockpiling and stability
-        EffectsGroup
-        scope = And [
-            Planet
-            OwnedBy empire = Source.Owner
-            Species
-            Happiness low = (NamedReal name = "PLC_CONFORMANCE_MIN_STABILITY" value = 4)
-        ]
-        effects = [
-            SetTargetConstruction value = Value + (NamedReal name = "PLC_CONFORMANCE_INFRASTRUCTURE_BONUS_FLAT" value = 5.0)
-            SetMaxStockpile value = Value + (NamedReal name = "PLC_CONFORMANCE_STOCKPILING_BONUS_FLAT" value = 1.0)
-        ]
-
+        // Small unconditional boost to stability
         EffectsGroup
         scope = And [
             Planet
             OwnedBy empire = Source.Owner
             Species
         ]
-        effects = [
-            SetTargetHappiness value = Value + (NamedReal name = "PLC_CONFORMANCE_STABILITY_BONUS_FLAT" value = 2.0)
-            SetTargetResearch value = Value - (NamedReal name = "PLC_CONFORMANCE_RESEARCH_PENALTY_FLAT" value = 2.0)
-        ]
+        effects = SetTargetHappiness value = Value + (NamedReal name = "PLC_CONFORMANCE_STABILITY_BONUS_FLAT" value = 2.0)
     ]
     graphic = "icons/policies/social_conformance.png"
 

--- a/default/scripting/policies/LIBERTY.focs.txt
+++ b/default/scripting/policies/LIBERTY.focs.txt
@@ -8,29 +8,22 @@ Policy
     effectsgroups = [
         [[SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS]]
 
-        // EmpireHasAdoptedPolicy PLC_LIBERTY used in setting stability adjustments for species likes / dislikes
+        // EmpireHasAdoptedPolicy PLC_LIBERTY is used in setting stability adjustments for species dislikes in
+        // species/common/happiness.macros (foci), buildings/buildings.macros and policies/policies.macros (policies)
 
-        // effects: penalizes stability, conditionally increases research
+        // increases research by +(stability-5)/5 RP for planets with stability>5
         EffectsGroup
         scope = And [
             Planet
             OwnedBy empire = Source.Owner
             Species
+            Happiness low = (NamedReal name = "PLC_LIBERTY_MIN_STABILITY" value = 5)
         ]
-        effects = [
-            SetTargetHappiness value = Value - (NamedReal name = "PLC_LIBERTY_STABILITY_PENALTY_FLAT" value = 2.0)
-        ]
-        EffectsGroup
-        scope = And [
-            Planet
-            OwnedBy empire = Source.Owner
-            Species
-            Happiness low = (NamedReal name = "PLC_LIBERTY_MIN_STABILITY" value = 6)
-        ]
-        effects = [
-            SetTargetResearch value = Value + (NamedReal name = "PLC_LIBERTY_RESEARCH_BONUS_FLAT" value = 2.0)
-        ]
+        priority = [[TARGET_AFTER_SCALING_PRIORITY]]
+        effects = SetTargetResearch value = Value + (Target.Happiness - NamedRealLookup name = "PLC_LIBERTY_MIN_STABILITY")*
+                                                    (NamedReal name = "PLC_LIBERTY_RESEARCH_BONUS_PER_STABILITY" value = 0.2)
     ]
     graphic = "icons/policies/social_liberty.png"
 
 #include "/scripting/policies/policies.macros"
+#include "/scripting/common/priorities.macros"

--- a/default/scripting/policies/policies.macros
+++ b/default/scripting/policies/policies.macros
@@ -1,11 +1,15 @@
 // sets stability (happiness) on planets in empire that has adopted the policy this macro effect is added to, if those planets' species like or dislike the policy
 
-POLICY_LIKE_DISLIKE_SCALING
-'''(1.0 + (Statistic If condition = And [Source EmpireHasAdoptedPolicy empire = Target.Owner name = "PLC_LIBERTY"])
-    - 0.5*(Statistic If condition = And [Source EmpireHasAdoptedPolicy empire = Target.Owner name = "PLC_CONFORMANCE"]))'''
+// Policy Liberty doubles de effect, policy Conformance halves it, values are declared in common/named_values.focs.txt
+POLICY_DISLIKE_SCALING
+'''(1.0 * (NamedRealLookup name = "PLC_LIBERTY_DISLIKE_FACTOR")^(Statistic If condition = And [Source EmpireHasAdoptedPolicy empire = Target.Owner name = "PLC_LIBERTY"])
+        * (NamedRealLookup name = "PLC_CONFORMANCE_DISLIKE_FACTOR")^(Statistic If condition = And [Source EmpireHasAdoptedPolicy empire = Target.Owner name = "PLC_CONFORMANCE"]))'''
 
-STABILITY_PER_LIKED_OR_DISLIKED_POLICY
-'''2.0 * [[POLICY_LIKE_DISLIKE_SCALING]]'''
+STABILITY_PER_LIKED_POLICY
+'''2.0'''
+
+STABILITY_PER_DISLIKED_POLICY
+'''2.0 * [[POLICY_DISLIKE_SCALING]]'''
 
 SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS
 '''
@@ -18,7 +22,7 @@ SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS
             ]
             accountinglabel = "LIKES_POLICY_LABEL"
             effects =
-                SetTargetHappiness value = Value + [[STABILITY_PER_LIKED_OR_DISLIKED_POLICY]] * SpeciesContentOpinion species = Target.Species name = ThisPolicy
+                SetTargetHappiness value = Value + [[STABILITY_PER_LIKED_POLICY]]
 
         EffectsGroup
             scope = And [
@@ -29,7 +33,7 @@ SPECIES_LIKES_OR_DISLIKES_POLICY_STABILITY_EFFECTS
             ]
             accountinglabel = "DISLIKES_POLICY_LABEL"
             effects =
-                SetTargetHappiness value = Value + [[STABILITY_PER_LIKED_OR_DISLIKED_POLICY]] * SpeciesContentOpinion species = Target.Species name = ThisPolicy
+                SetTargetHappiness value = Value - [[STABILITY_PER_DISLIKED_POLICY]]
 '''
 
 POPULATION_OWNED_BY_EMPIRE

--- a/default/scripting/species/common/happiness.macros
+++ b/default/scripting/species/common/happiness.macros
@@ -1,6 +1,13 @@
-STABILITY_PER_LIKED_OR_DISLIKED_FOCUS
-'''2.0 * (1.0 + (Statistic If condition = And [Source EmpireHasAdoptedPolicy empire = Target.Owner name = "PLC_LIBERTY"])
-          - 0.5*(Statistic If condition = And [Source EmpireHasAdoptedPolicy empire = Target.Owner name = "PLC_CONFORMANCE"]))'''
+// For focus like/dislike, Policy Liberty doubles de effect, policy Conformance halves it, values are declared in common/named_values.focs.txt
+POLICY_DISLIKE_SCALING
+'''(1.0 * (NamedRealLookup name = "PLC_LIBERTY_DISLIKE_FACTOR")^(Statistic If condition = And [Source EmpireHasAdoptedPolicy empire = Target.Owner name = "PLC_LIBERTY"])
+        * (NamedRealLookup name = "PLC_CONFORMANCE_DISLIKE_FACTOR")^(Statistic If condition = And [Source EmpireHasAdoptedPolicy empire = Target.Owner name = "PLC_CONFORMANCE"]))'''
+
+STABILITY_PER_LIKED_FOCUS
+'''2.0'''
+
+STABILITY_PER_DISLIKED_FOCUS
+'''2.0 * [[POLICY_DISLIKE_SCALING]]'''
 
 BAD_HAPPINESS
 '''
@@ -91,7 +98,7 @@ COMMON_HAPPINESS_EFFECTS
                 (SpeciesContentOpinion species = LocalCandidate.Species name = LocalCandidate.Focus > 0)
             ]
             accountinglabel = "LIKES_FOCUS_LABEL"
-            effects = SetTargetHappiness value = Value + [[STABILITY_PER_LIKED_OR_DISLIKED_FOCUS]] * SpeciesContentOpinion species = Target.Species name = Target.Focus
+            effects = SetTargetHappiness value = Value + [[STABILITY_PER_LIKED_FOCUS]]
 
         EffectsGroup    // less stable when disliked focuses are adopted
             scope = Source
@@ -101,7 +108,7 @@ COMMON_HAPPINESS_EFFECTS
                 (SpeciesContentOpinion species = LocalCandidate.Species name = LocalCandidate.Focus < 0)
             ]
             accountinglabel = "DISLIKES_FOCUS_LABEL"
-            effects = SetTargetHappiness value = Value + [[STABILITY_PER_LIKED_OR_DISLIKED_FOCUS]] * SpeciesContentOpinion species = Target.Species name = Target.Focus
+            effects = SetTargetHappiness value = Value - [[STABILITY_PER_DISLIKED_FOCUS]]
 
         EffectsGroup    // species on their own homeworld are more stable
             scope = Source

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -12198,26 +12198,21 @@ PLC_CONFORMANCE
 Conformance
 
 PLC_CONFORMANCE_DESC
-'''• Reduces the impact of species likes and dislikes on planet stability due to buildings and policies.
-• Descreases [[metertype METER_TARGET_RESEARCH]] by [[value PLC_CONFORMANCE_RESEARCH_PENALTY_FLAT]] on all planets 
-• Increases [[metertype METER_TARGET_HAPPINESS]] by [[value PLC_CONFORMANCE_STABILITY_BONUS_FLAT]]
-
-On planets with a stability of at least [[value PLC_CONFORMANCE_MIN_STABILITY]]:
-• Increases [[metertype METER_TARGET_CONSTRUCTION]] by [[value PLC_CONFORMANCE_INFRASTRUCTURE_BONUS_FLAT]]
-• Increases [[metertype METER_STOCKPILE]] by [[value PLC_CONFORMANCE_STOCKPILING_BONUS_FLAT]]'''
+'''• Reduces the impact of species dislikes on planet stability due to buildings, policies or focus (x[[value PLC_CONFORMANCE_DISLIKE_FACTOR]]).
+• Increases [[metertype METER_TARGET_HAPPINESS]] by [[value PLC_CONFORMANCE_STABILITY_BONUS_FLAT]]'''
 
 PLC_CONFORMANCE_SHORT_DESC
-Reduces species opinion effects
+Reduces species dislikes effects and increases stability
 
 PLC_LIBERTY
 Liberty
 
 PLC_LIBERTY_DESC
-'''• Increases the impact of species likes and dislikes on planet stability due to buildings and policies.
-• Increases [[metertype METER_TARGET_RESEARCH]] by [[value PLC_LIBERTY_RESEARCH_BONUS_FLAT]] and decreases [[metertype METER_TARGET_HAPPINESS]] by [[value PLC_LIBERTY_STABILITY_PENALTY_FLAT]] on all planets with a stability of at least [[value PLC_LIBERTY_MIN_STABILITY]].'''
+'''• Increases the impact of species dislikes on planet stability due to buildings, policies or planetary focus (x[[value PLC_LIBERTY_DISLIKE_FACTOR]]).
+• Increases [[metertype METER_TARGET_RESEARCH]] by [[value PLC_LIBERTY_RESEARCH_BONUS_PER_STABILITY]] RP per each point of [[metertype METER_HAPPINESS]] above [[value PLC_LIBERTY_MIN_STABILITY]], on all planets regardless of focus.'''
 
 PLC_LIBERTY_SHORT_DESC
-Increases species opinion effects
+Increases species dislikes effects and research
 
 PLC_TRAFFIC_CONTROL
 Traffic Control


### PR DESCRIPTION
- Liberty doubles dislike effects and increases RP based on stability: +(stability-5)/5
- Conformance halves dislike effects and increases stability (+2)
- Removed RP malus and infrastructure&stockpiling bonus from Conformance, and stability malus from Liberty
- Grooming: effectsgroups for content like/dislike only need to query SpeciesContentOpinion in scope, not in effects

Discussion: https://www.freeorion.org/forum/viewtopic.php?f=15&t=12335
