### PR TITLE
Improve AI handling of invalid savegame strings

### DIFF
--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -269,59 +269,6 @@ void AIClientApp::HandleMessage(const Message& msg) {
             Orders().ApplyOrders(context);
         } else {
             DebugLogger() << "Message::GAME_START Starting New Game!";
-            // % Distribution of aggression levels
-            // Aggression   :  0   1   2   3   4   5   (0=Beginner, 5=Maniacal)
-            //                __  __  __  __  __  __
-            //Max 0         :100   0   0   0   0   0
-            //Max 1         : 25  75   0   0   0   0
-            //Max 2         :  0  25  75   0   0   0
-            //Max 3         :  0   0  25  75   0   0
-            //Max 4         :  0   0   0  25  75   0
-            //Max 5         :  0   0   0   0  25  75
-
-            // Optional aggression table, possibly for 0.4.4+?
-            // Aggression   :  0   1   2   3   4   5   (0=Beginner, 5=Maniacal)
-            //                __  __  __  __  __  __
-            //Max 0         :100   0   0   0   0   0
-            //Max 1         : 25  75   0   0   0   0
-            //Max 2         :  8  17  75   0   0   0
-            //Max 3         :  0   8  17  75   0   0
-            //Max 4         :  0   0   8  17  75   0
-            //Max 5         :  0   0   0   8  17  75
-
-            const std::string g_seed = GetGalaxySetupData().seed;
-            auto empire = m_empires.GetEmpire(m_empire_id);
-            if (!empire)
-                ErrorLogger() << "HandleMessage GAME_START couldn't get empire with id: " << m_empire_id;
-            const auto& emp_name = empire ? empire->Name() : "";
-            unsigned int my_seed = 0;
-
-            try {
-                // generate consistent my_seed values from galaxy seed & empire name.
-                boost::hash<std::string> string_hash;
-                std::size_t h = string_hash(g_seed);
-                my_seed = 3 * static_cast<unsigned int>(h) * static_cast<unsigned int>(string_hash(emp_name));
-                DebugLogger() << "Message::GAME_START getting " << emp_name << " AI aggression, RNG Seed: " << my_seed;
-            } catch (...) {
-                DebugLogger() << "Message::GAME_START getting " << emp_name << " AI aggression, could not initialise RNG.";
-            }
-
-            int rand_num = 0;
-            int this_aggr = m_max_aggression;
-
-            if (this_aggr > 0  && my_seed > 0) {
-                Seed(my_seed);
-                rand_num = RandInt(0, 99);
-                // if it's in the top 25% then decrease aggression.
-                if (rand_num > 74) this_aggr--;
-                // Leaving the following as commented out code for now. Possibly for 0.4.4+?
-                // in the top 8% ? decrease aggression again, unless it's already as low as it gets.
-                // if (rand_num > 91 && this_aggr > 0) this_aggr--;
-            }
-
-            DebugLogger() << "Message::GAME_START setting AI aggression as " << this_aggr << " (from rnd " << rand_num << "; max aggression " << m_max_aggression << ")";
-
-            m_AI->SetAggression(this_aggr);
             m_AI->StartNewGame();
         }
         m_AI->GenerateOrders();

--- a/client/AI/AIFramework.cpp
+++ b/client/AI/AIFramework.cpp
@@ -180,7 +180,7 @@ void PythonAI::StartNewGame()
     FreeOrionPython::ClearStaticSaveStateString();
     // call Python function that sets up the AI to be able to generate orders for a new game
     py::object startNewGamePythonFunction = m_python_module_ai.attr("startNewGame");
-    startNewGamePythonFunction(m_aggression);
+    startNewGamePythonFunction();
 }
 
 void PythonAI::ResumeLoadedGame(const std::string& save_state_string)
@@ -201,6 +201,3 @@ auto PythonAI::GetSaveStateString() const -> const std::string&
     //DebugLogger() << "PythonAI::GetSaveStateString() returning: " << s_save_state_string;
     return FreeOrionPython::GetStaticSaveStateString();
 }
-
-void PythonAI::SetAggression(int aggr)
-{ m_aggression = aggr; }

--- a/client/AI/AIFramework.h
+++ b/client/AI/AIFramework.h
@@ -98,25 +98,9 @@ public:
      */
     [[nodiscard]] const std::string& GetSaveStateString() const;
 
-    /** @brief Set the aggressiveness of this AI
-     *
-     * The AI should change their behaviour when setting another aggression
-     * level.
-     *
-     * @param aggr The new aggression level.  The value should be one of
-     *      Aggression.
-     */
-    void SetAggression(int aggr);
-
 private:
     // reference to imported Python AI module
     boost::python::object m_python_module_ai;
-
-    /** @brief The current aggressiveness of this AI
-     *
-     * The value should be one of Aggression.
-     */
-    int m_aggression = 0;
 };
 
 

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -156,8 +156,10 @@ def resumeLoadedGame(saved_state_string):  # pylint: disable=invalid-name
 
     if saved_state_string == "NO_STATE_YET" and fo.currentTurn() == 1:
         info("AI given uninitialized state-string to resume from on turn 1.")
-        info("Assuming post-universe-generation autosave before any orders were sent"
-             "and behave as if a new game was started.")
+        info(
+            "Assuming post-universe-generation autosave before any orders were sent "
+            "and behaving as if a new game was started."
+        )
         return startNewGame()
 
     if fo.getEmpire() is None:
@@ -173,8 +175,10 @@ def resumeLoadedGame(saved_state_string):  # pylint: disable=invalid-name
         info("AI assigned to empire previously run by human.")
         chat_human("We have been assigned an empire previously run by a human player. We can manage this.")
     elif saved_state_string == "":
-        error("AI given empty state-string to resume from. "
-              "AI can continue but behaviour may be different from the previous session.")
+        error(
+            "AI given empty state-string to resume from. "
+            "AI can continue but behaviour may be different from the previous session."
+        )
     else:
         try:
             # loading saved state
@@ -182,8 +186,9 @@ def resumeLoadedGame(saved_state_string):  # pylint: disable=invalid-name
         except Exception as e:
             error(
                 "Failed to load the AIstate from the savegame: %s"
-                " AI can continue but behaviour may be different from the previous session.", e,
-                exc_info=True
+                " AI can continue but behaviour may be different from the previous session.",
+                e,
+                exc_info=True,
             )
     if aistate is None:
         info("Creating new ai state due to failed load.")

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -296,3 +296,32 @@ std::string MultiplayerLobbyData::Dump() const {
     return stream.str();
 }
 
+////////////////////////////////////////////////////
+// PlayerSaveGameData
+/////////////////////////////////////////////////////
+PlayerSaveGameData::PlayerSaveGameData(std::string name, int empire_id, 
+                                       std::shared_ptr<OrderSet> orders_,
+                                       std::shared_ptr<SaveGameUIData> ui_data_,
+                                       std::string save_state_string_, 
+                                       Networking::ClientType client_type):
+    PlayerSaveHeaderData{ std::move(name), empire_id, client_type },
+    orders(std::move(orders_)),
+    ui_data(std::move(ui_data_)),
+    save_state_string(std::move(save_state_string_)) 
+{
+    if (client_type != Networking::ClientType::CLIENT_TYPE_AI_PLAYER
+        && save_state_string.empty())
+    {
+        save_state_string = "NOT_SET_BY_CLIENT_TYPE";
+    }
+
+    // The generation of the savegame data may be before any orders have been sent by clients. 
+    // This is expected behaviour and to be handled differently by the AI than a possibly 
+    // default-generated empty save_state_string.
+    if (client_type == Networking::ClientType::CLIENT_TYPE_AI_PLAYER
+        && !orders
+        && save_state_string.empty())
+    {
+        save_state_string = "NO_STATE_YET";
+    }
+}

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -193,12 +193,7 @@ struct FO_COMMON_API PlayerSaveGameData : public PlayerSaveHeaderData {
                        std::shared_ptr<OrderSet> orders_,
                        std::shared_ptr<SaveGameUIData> ui_data_,
                        std::string save_state_string_,
-                       Networking::ClientType client_type) :
-        PlayerSaveHeaderData{std::move(name), empire_id, client_type},
-        orders(std::move(orders_)),
-        ui_data(std::move(ui_data_)),
-        save_state_string(std::move(save_state_string_))
-    {}
+                       Networking::ClientType client_type);
 
     std::shared_ptr<OrderSet>       orders;
     std::shared_ptr<SaveGameUIData> ui_data;


### PR DESCRIPTION
Fix #3800

This PR does 2 things:
1) Add some special values to save_state_string to allow handling special cases.
2) Move AI aggression settings from C++ to python which allows us to address #3800 python-side.