### PR TITLE
remove explicit inheritance from object

### DIFF
--- a/cmake/make_versioncpp.py
+++ b/cmake/make_versioncpp.py
@@ -13,7 +13,7 @@ from subprocess import CalledProcessError, check_output
 INVALID_BUILD_NO = "???"
 
 
-class Generator(object):
+class Generator:
     def __init__(self, infile, outfile):
         self.infile = infile
         self.outfile = outfile

--- a/default/python/tests/AI/character_test/character_test.py
+++ b/default/python/tests/AI/character_test/character_test.py
@@ -42,7 +42,7 @@ rejection_character = Character([left_trait, right_trait])
 permissive_character = Character([left_trait, other_trait])
 
 
-class TestCharacter(object):
+class TestCharacter:
     """Test the Character class which combines traits
     Each combiner test checks that the combiner generates the expected output.
     """

--- a/default/python/tests/AI/save_game_codec/test_savegame_manager.py
+++ b/default/python/tests/AI/save_game_codec/test_savegame_manager.py
@@ -2,7 +2,7 @@ import pytest
 import savegame_codec
 
 
-class DummyTestClass(object):
+class DummyTestClass:
     def __init__(self):
         self.some_int = 812
         self.some_negative_int = -712
@@ -39,12 +39,12 @@ class Success(Exception):
     pass
 
 
-class GetStateTester(object):
+class GetStateTester:
     def __getstate__(self):
         raise Success
 
 
-class SetStateTester(object):
+class SetStateTester:
     def __setstate__(self, state):
         raise Success
 


### PR DESCRIPTION
According to a video I watched, explicitly inheriting from object should be unnecessary after switching to Python3.

Just did a find and replace; didn't test.