### PR TITLE
Mostly FreeBSD build fix.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,6 +329,8 @@ set_property(DIRECTORY APPEND
         # fixed this with python bug #10910
         $<$<PLATFORM_ID:Darwin>:BOOST_DATE_TIME_NO_LOCALE>
         $<$<PLATFORM_ID:FreeBSD>:BOOST_DATE_TIME_NO_LOCALE>
+        # Forcing backtrace using api for boost stacktrace due to lacking on ::Unwind side
+        $<$<PLATFORM_ID:FreeBSD>:BOOST_STACKTRACE_USE_LIBC_BACKTRACE_FUNCTION>
 )
 
 
@@ -428,6 +430,9 @@ target_link_libraries(freeorioncommon
         ${CORE_FOUNDATION_LIBRARY}
 )
 
+if(CMAKE_SYSTEM_NAME MATCHES "FreeBSD")
+	target_link_libraries(freeorioncommon PUBLIC execinfo)
+endif()
 if(CMAKE_SYSTEM_NAME MATCHES "Haiku")
 	target_link_libraries(freeorioncommon PUBLIC network)
 endif()

--- a/GG/src/WndEvent.cpp
+++ b/GG/src/WndEvent.cpp
@@ -114,8 +114,8 @@ WndEvent::WndEvent(EventType type, const Pt& pt, const Wnd* const drag_wnd, Flag
 WndEvent::WndEvent(EventType type, Key key, std::uint32_t code_point, Flags<ModKey> mod_keys) :
     m_type(type),
     m_key_code_point(code_point),
-    m_key(key),
-    m_mod_keys(mod_keys)
+    m_mod_keys(mod_keys),
+    m_key(key)
 {}
 
 WndEvent::WndEvent(EventType type, unsigned int ticks, Timer* timer) :

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -846,8 +846,8 @@ private:
 //////////////////////////////////////////////////
 ProductionWnd::ProductionWnd(GG::X w, GG::Y h) :
     GG::Wnd(GG::X0, GG::Y0, w, h, GG::INTERACTIVE | GG::ONTOP),
-    m_order_issuing_enabled(false),
-    m_empire_shown_id(ALL_EMPIRES)
+    m_empire_shown_id(ALL_EMPIRES),
+    m_order_issuing_enabled(false)
 {}
 
 void ProductionWnd::CompleteConstruction() {

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -60,7 +60,6 @@ namespace {
         "monster_freq", "native_freq", "planet_freq", "specials_freq", "starlane_freq", "ai_aggression",
         "number_of_empires", "number_of_humans"
     };
-    constexpr unsigned int VALID_PREVIEW_COLUMN_COUNT = VALID_PREVIEW_COLUMNS.size();
     constexpr int WHEEL_INCREMENT = 80;
 
     std::string operator+(std::string_view lhs, std::string_view rhs) {

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -916,10 +916,10 @@ namespace {
 SidePanel::PlanetPanel::PlanetPanel(GG::X w, int planet_id, StarType star_type) :
     GG::Control(GG::X0, GG::Y0, w, GG::Y1, GG::INTERACTIVE),
     m_planet_id(planet_id),
-    m_selected(false),
-    m_order_issuing_enabled(true),
     m_empire_colour(GG::CLR_ZERO),
-    m_star_type(star_type)
+    m_star_type(star_type),
+    m_selected(false),
+    m_order_issuing_enabled(true)
 {}
 
 void SidePanel::PlanetPanel::CompleteConstruction() {

--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -343,7 +343,7 @@ void InitBinDir(std::string const& argv0)
             bin_dir = p;
         }
     }
-#elif defined(FREEORION_MACOSX) || defined(FREEORION_ADROID)
+#elif defined(FREEORION_MACOSX) || defined(FREEORION_ANDROID)
     // no binary directory setup required.
 #endif
 }


### PR DESCRIPTION
- boost stacktrace using backtrace api instead of unwind due to unsupported field.
- various initialisation constructors reordering warning fixes/unused var.