### PR TITLE
use INCOMPLETE_DESIGN_ID instead of INVALID for the design view

### DIFF
--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -4839,6 +4839,7 @@ void DesignWnd::MainPanel::RefreshIncompleteDesign() const {
             CurrentTurn(), ClientApp::GetApp()->EmpireID(),
             hull, Parts(), icon, "", name.IsInStringtable(),
             false, std::move(uuid));
+        m_incomplete_design->SetID(INCOMPLETE_DESIGN_ID);
     } catch (const std::invalid_argument& e) {
         ErrorLogger() << "DesignWnd::MainPanel::RefreshIncompleteDesign " << e.what();
     }

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2826,8 +2826,6 @@ namespace {
 
         universe.InsertShipDesignID(new ShipDesign(*incomplete_design), client_empire_id, incomplete_design->ID());
         detailed_description = GetDetailedDescriptionBase(incomplete_design.get());
-        DebugLogger() << "just InsertShipDesignID("  << incomplete_design->ID() << " " << client_empire_id << "  " << TEMPORARY_OBJECT_ID << ")  to a pocket universe";
-        DebugLogger() << "just InsertShipDesignID(..) " << incomplete_design->Name() << "  turns " << turns << "  cost " << cost << "  ";
         float tech_level = boost::algorithm::clamp(context.current_turn / 400.0f, 0.0f, 1.0f);
         float typical_shot = 3 + 27 * tech_level;
         float enemy_DR = 20 * tech_level;
@@ -3962,20 +3960,12 @@ void EncyclopediaDetailPanel::SetDesign(const std::string& design_id) {
 }
 
 void EncyclopediaDetailPanel::SetIncompleteDesign(std::weak_ptr<const ShipDesign> incomplete_design) {
-    auto p = incomplete_design.lock();
-    if (p) {
-        ErrorLogger() << "EncyclopediaDetailPanel::SetIncompleteDesign(..)" << p->Name(false) << "  ID " << p->ID();
-    } else {
-        ErrorLogger() << "EncyclopediaDetailPanel::SetIncompleteDesign(..)";
-    }
     m_incomplete_design = incomplete_design;
 
     if (m_items_it == m_items.end() ||
         m_items_it->first != INCOMPLETE_DESIGN) {
-        ErrorLogger() << "EncyclopediaDetailPanel::SetIncompleteDesign AddItem  INCOMPLETE_DESIGN " << INCOMPLETE_DESIGN ;
         AddItem(INCOMPLETE_DESIGN, EMPTY_STRING);
     } else {
-        ErrorLogger() << "EncyclopediaDetailPanel::SetIncompleteDesign AddItem  Refresh";
         Refresh();
     }
 }

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2824,9 +2824,10 @@ namespace {
         cost_units = UserString("ENC_PP");
 
 
-        universe.InsertShipDesignID(new ShipDesign(*incomplete_design), client_empire_id, TEMPORARY_OBJECT_ID);
+        universe.InsertShipDesignID(new ShipDesign(*incomplete_design), client_empire_id, incomplete_design->ID());
         detailed_description = GetDetailedDescriptionBase(incomplete_design.get());
-
+        DebugLogger() << "just InsertShipDesignID("  << incomplete_design->ID() << " " << client_empire_id << "  " << TEMPORARY_OBJECT_ID << ")  to a pocket universe";
+        DebugLogger() << "just InsertShipDesignID(..) " << incomplete_design->Name() << "  turns " << turns << "  cost " << cost << "  ";
         float tech_level = boost::algorithm::clamp(context.current_turn / 400.0f, 0.0f, 1.0f);
         float typical_shot = 3 + 27 * tech_level;
         float enemy_DR = 20 * tech_level;
@@ -2877,7 +2878,7 @@ namespace {
 
 
         // temporary ship to use for estimating design's meter values
-        auto temp = universe.InsertTemp<Ship>(client_empire_id, INVALID_DESIGN_ID, "",
+        auto temp = universe.InsertTemp<Ship>(client_empire_id, incomplete_design->ID(), "",
                                               universe, species_manager, client_empire_id,
                                               context.current_turn);
 
@@ -3961,12 +3962,20 @@ void EncyclopediaDetailPanel::SetDesign(const std::string& design_id) {
 }
 
 void EncyclopediaDetailPanel::SetIncompleteDesign(std::weak_ptr<const ShipDesign> incomplete_design) {
+    auto p = incomplete_design.lock();
+    if (p) {
+        ErrorLogger() << "EncyclopediaDetailPanel::SetIncompleteDesign(..)" << p->Name(false) << "  ID " << p->ID();
+    } else {
+        ErrorLogger() << "EncyclopediaDetailPanel::SetIncompleteDesign(..)";
+    }
     m_incomplete_design = incomplete_design;
 
     if (m_items_it == m_items.end() ||
         m_items_it->first != INCOMPLETE_DESIGN) {
+        ErrorLogger() << "EncyclopediaDetailPanel::SetIncompleteDesign AddItem  INCOMPLETE_DESIGN " << INCOMPLETE_DESIGN ;
         AddItem(INCOMPLETE_DESIGN, EMPTY_STRING);
     } else {
+        ErrorLogger() << "EncyclopediaDetailPanel::SetIncompleteDesign AddItem  Refresh";
         Refresh();
     }
 }

--- a/combat/CombatDamage.cpp
+++ b/combat/CombatDamage.cpp
@@ -165,8 +165,19 @@ std::vector<float> Combat::WeaponDamageImpl(
         ErrorLogger() << "Combat::WeaponDamageImpl passed null source ship";
         return {};
     } else if (source->DesignID() == INVALID_DESIGN_ID) {
-        ErrorLogger() << "Combat::WeaponDamageImpl passed source ship without a valid design ID: " << source->Dump();
+        if (source->ID() == TEMPORARY_OBJECT_ID) {
+            ErrorLogger() << "Combat::WeaponDamageImpl passed TEMPORARY source ship without a valid design ID: " << source->Dump();
+        } else {
+            ErrorLogger() << "Combat::WeaponDamageImpl passed source ship without a valid design ID: " << source->Dump();
+        }
         return {};
+    }
+    if (source->DesignID() == INCOMPLETE_DESIGN_ID) {
+        ErrorLogger() << "Combat::Weapon ... got INCOMPLETE design id, carry on";
+    }
+
+    if (source->ID() == TEMPORARY_OBJECT_ID) {
+        ErrorLogger() << "Combat::WeaponDamageImpl passed TEMPORARY source ship " << source->Dump();
     }
 
     Universe::EmpireObjectVisibilityMap empire_object_vis{

--- a/combat/CombatDamage.cpp
+++ b/combat/CombatDamage.cpp
@@ -172,13 +172,6 @@ std::vector<float> Combat::WeaponDamageImpl(
         }
         return {};
     }
-    if (source->DesignID() == INCOMPLETE_DESIGN_ID) {
-        ErrorLogger() << "Combat::Weapon ... got INCOMPLETE design id, carry on";
-    }
-
-    if (source->ID() == TEMPORARY_OBJECT_ID) {
-        ErrorLogger() << "Combat::WeaponDamageImpl passed TEMPORARY source ship " << source->Dump();
-    }
 
     Universe::EmpireObjectVisibilityMap empire_object_vis{
         {source->Owner(), {{TEMPORARY_OBJECT_ID, Visibility::VIS_FULL_VISIBILITY}}}};

--- a/universe/ConstantsFwd.h
+++ b/universe/ConstantsFwd.h
@@ -2,6 +2,7 @@
 #define _ConstantsFwd_h_
 
 constexpr int INVALID_DESIGN_ID = -1;
+constexpr int INCOMPLETE_DESIGN_ID = -4;
 constexpr int INVALID_OBJECT_ID = -1; // The ID number assigned to a UniverseObject upon construction; It is assigned an ID later when it is placed in the universe
 constexpr int ALL_EMPIRES = -1;
 

--- a/universe/IDAllocator.cpp
+++ b/universe/IDAllocator.cpp
@@ -29,7 +29,8 @@ IDAllocator::IDAllocator(const int server_id,
     m_exhausted_threshold(std::numeric_limits<int>::max() - 10 * m_stride),
     m_random_generator()
 {
-    TraceLogger(IDallocator) << "IDAllocator() server id = " << server_id << " invalid id = " << invalid_id
+    ErrorLogger(IDallocator) << "IDAllocator() server id = " << server_id << " invalid id = " << invalid_id
+                             << " temp_id = " << m_temp_id
                              << " zero = " << m_zero
                              << " warn threshold =  " << m_warn_threshold << " num clients = " << client_ids.size();
 
@@ -101,8 +102,9 @@ std::pair<bool, bool> IDAllocator::IsIDValidAndUnused(const ID_t checked_id,
         return hard_fail;
     }
 
-    if (checked_id == m_temp_id)
+    if (checked_id == m_temp_id) {
         return complete_success;
+    } else ErrorLogger() << "id = " << checked_id << " != " << m_temp_id;
 
     if (checked_id >= m_exhausted_threshold) {
         ErrorLogger() << " invalid id = " << checked_id << " is greater then the maximum id " << m_exhausted_threshold;

--- a/universe/IDAllocator.cpp
+++ b/universe/IDAllocator.cpp
@@ -29,7 +29,7 @@ IDAllocator::IDAllocator(const int server_id,
     m_exhausted_threshold(std::numeric_limits<int>::max() - 10 * m_stride),
     m_random_generator()
 {
-    ErrorLogger(IDallocator) << "IDAllocator() server id = " << server_id << " invalid id = " << invalid_id
+    TraceLogger(IDallocator) << "IDAllocator() server id = " << server_id << " invalid id = " << invalid_id
                              << " temp_id = " << m_temp_id
                              << " zero = " << m_zero
                              << " warn threshold =  " << m_warn_threshold << " num clients = " << client_ids.size();
@@ -104,7 +104,7 @@ std::pair<bool, bool> IDAllocator::IsIDValidAndUnused(const ID_t checked_id,
 
     if (checked_id == m_temp_id) {
         return complete_success;
-    } else ErrorLogger() << "id = " << checked_id << " != " << m_temp_id;
+    }
 
     if (checked_id >= m_exhausted_threshold) {
         ErrorLogger() << " invalid id = " << checked_id << " is greater then the maximum id " << m_exhausted_threshold;

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -130,7 +130,7 @@ Universe::Universe() :
     m_object_id_allocator(new IDAllocator(ALL_EMPIRES, std::vector<int>(), INVALID_OBJECT_ID,
                                           TEMPORARY_OBJECT_ID, INVALID_OBJECT_ID)),
     m_design_id_allocator(new IDAllocator(ALL_EMPIRES, std::vector<int>(), INVALID_DESIGN_ID,
-                                          TEMPORARY_OBJECT_ID, INVALID_DESIGN_ID))
+                                          INCOMPLETE_DESIGN_ID, INVALID_DESIGN_ID))
 {}
 
 Universe& Universe::operator=(Universe&& other) noexcept {
@@ -224,7 +224,7 @@ void Universe::ResetAllIDAllocation(const std::vector<int>& empire_ids) {
         highest_allocated_design_id = std::max(highest_allocated_design_id, id_and_obj.first);
 
     m_design_id_allocator = std::make_unique<IDAllocator>(ALL_EMPIRES, empire_ids, INVALID_DESIGN_ID,
-                                                          TEMPORARY_OBJECT_ID, highest_allocated_design_id);
+                                                          INCOMPLETE_DESIGN_ID, highest_allocated_design_id);
 
     DebugLogger() << "Reset id allocators with highest object id = " << highest_allocated_id
                   << " and highest design id = " << highest_allocated_design_id;
@@ -502,7 +502,9 @@ bool Universe::InsertShipDesignID(ShipDesign* ship_design, boost::optional<int> 
         return false;
     }
 
-    if (m_ship_designs.count(id)) {
+    if (id == INCOMPLETE_DESIGN_ID) {
+        TraceLogger() << "Update the incomplete Ship design id " << id;
+    } else if (m_ship_designs.count(id)) {
         ErrorLogger() << "Ship design id " << id << " already exists.";
         return false;
     }


### PR DESCRIPTION
this solves #3809 by using ID -4 for the incomplete design from the design view and treating it different from invalid designs

it would be better if someone bisected/did analysis to find out how this got broken in the first place (in order to see if something else broke); and there may be better implementations; but this works