### PR TITLE
Make changes in MaxPopulation affect growth without delay

### DIFF
--- a/default/scripting/species/common/population.macros
+++ b/default/scripting/species/common/population.macros
@@ -30,12 +30,12 @@ BASIC_POPULATION
                 // growth is GROWTH_RATE_FACTOR * population * (maximum + 1 - population) / maximum
                 // which gives factor for population 1, best growth around half full and aproaching
                 // factor again when almost full
-                ((Value < Target.TargetPopulation) *
-                    min(Target.TargetPopulation, Value + Value*[[GROWTH_RATE_FACTOR]]*
-                                                               (1 + (1 - Value)/Target.TargetPopulation)))
+                ((Value < Value(Target.TargetPopulation)) *
+                    min(Value(Target.TargetPopulation), Value + Value*[[GROWTH_RATE_FACTOR]]*
+                                                                      (1 + (1 - Value)/Value(Target.TargetPopulation))))
                 // shrink if overpopulated
-              + ((Value >= Target.TargetPopulation) *
-                    max(Target.TargetPopulation, Value - 0.1*(Value - Target.TargetPopulation)))
+              + ((Value >= Value(Target.TargetPopulation)) *
+                    max(Value(Target.TargetPopulation), Value - 0.1*(Value - Value(Target.TargetPopulation))))
 
         // Since all species have the same advanced focus effects and
         // infrastructure, the macros are stashed here, where they don't


### PR DESCRIPTION
I always considered it a minor issue that populations started to grow only in the second turn after a new tech or exported resource increased a planet's MaxPopulation. Now I learned the reason and found it is rather easy to fix.