### PR TITLE
Add option to use pre-opened file descriptor to accept connections

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1577,6 +1577,9 @@ Server option to allow human players to take control of AI empires.
 OPTIONS_DB_ALLOW_OBSERVERS
 Server option to allow any players connect to the games as Observer.
 
+OPTIONS_DB_LISTEN_FD
+Server option to choose pre-opened file descriptor to accept connections. Works on Linux with xinetd or systemd socket activation. By default disabled.
+
 OPTIONS_DB_PYTHON_ASYNCIO_INTERVAL
 Interval in seconds to call python asyncio event loop or -1 to disable it. By default asyncio calls disabled.
 

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -72,6 +72,9 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().Add<bool>("network.server.drop-empire-ready",                    UserStringNop("OPTIONS_DB_DROP_EMPIRE_READY"),          true);
         GetOptionsDB().Add<bool>("network.server.take-over-ai",                         UserStringNop("OPTIONS_DB_TAKE_OVER_AI"),               false);
         GetOptionsDB().Add<bool>("network.server.allow-observers",                      UserStringNop("OPTIONS_DB_ALLOW_OBSERVERS"),            false);
+#if defined(FREEORION_LINUX)
+        GetOptionsDB().Add<int>("network.server.listen.fd",                             UserStringNop("OPTIONS_DB_LISTEN_FD"),                  -1);
+#endif
         GetOptionsDB().Add<int>("network.server.python.asyncio-interval",               UserStringNop("OPTIONS_DB_PYTHON_ASYNCIO_INTERVAL"),    -1);
 
         // if config.xml and persistent_config.xml are present, read and set options entries


### PR DESCRIPTION
Xinetd or systemd socket activation allows to start application only when someone connected to its port but the application itself should be able to get accepting socket from provided file descriptor.