### PR TITLE
fix set max capacity ship part meter (#3830)

### DIFF
--- a/universe/Effects.cpp
+++ b/universe/Effects.cpp
@@ -651,7 +651,7 @@ void SetMeter::Execute(ScriptingContext& context,
         for (auto& target : targets) {
             if (Meter* meter = target->GetMeter(m_meter))
                 target_new_meter_vals.emplace_back(
-                    NewMeterValue(context, m_meter, m_value, target).first, target->ID(), meter);
+                    NewMeterValue(context, meter, m_value, target).first, target->ID(), meter);
         }
 
         // set new meter values and update accounting

--- a/universe/Effects.cpp
+++ b/universe/Effects.cpp
@@ -887,7 +887,7 @@ void SetShipPartMeter::Execute(ScriptingContext& context, const TargetSet& targe
 
                 if (Meter* meter = ship->GetPartMeter(m_meter, part_name))
                     target_new_meter_vals.emplace_back(
-                        NewMeterValue(std::move(target_context), m_meter, m_value).first,
+                        NewMeterValue(std::move(target_context), meter, m_value).first,
                         target->ID(), meter);
             }
 
@@ -954,7 +954,7 @@ void SetShipPartMeter::Execute(ScriptingContext& context, const TargetSet& targe
             auto ship = static_cast<Ship*>(target.get());
             if (Meter* meter = ship->GetPartMeter(m_meter, part_name))
                 target_new_meter_vals.emplace_back(
-                    NewMeterValue(context, m_meter, m_value, target).first, target->ID(), meter);
+                    NewMeterValue(context, meter, m_value, target).first, target->ID(), meter);
         }
 
         // set new meter values and update accounting


### PR DESCRIPTION
NewMeterValue uses GetMeter to look up meters, but if one wants a ship part meter, one has to use GetPartMeter, so this needs to be passed in currently (two occurences found).

the second commit "fixes" this for a similar occurence for GetMeter (it should work without the fix; one occurence). So not sure.

Fixes #3830