### PR TITLE
fix system ship unstealthiness

### DIFF
--- a/default/scripting/techs/spy/PLANET_STEALTH_MOD.focs.txt
+++ b/default/scripting/techs/spy/PLANET_STEALTH_MOD.focs.txt
@@ -20,6 +20,7 @@ Tech
         EffectsGroup
             scope = And [
                 Ship
+                InSystem
                 OwnedBy empire = Source.Owner
             ]
             accountinglabel = "FLEET_UNSTEALTHINESS"

--- a/default/scripting/techs/spy/PLANET_STEALTH_MOD.focs.txt
+++ b/default/scripting/techs/spy/PLANET_STEALTH_MOD.focs.txt
@@ -15,27 +15,7 @@ Tech
             ]
             stackinggroup = "PLANET_STEALTH_MOD_STACK"
             accountinglabel = "BASIC_PLANET_STEALTH"
-            effects = SetStealth value = Value + (NamedReal name = "PLANET_BASIC_STEALTH" value = 5.0)
-        
-        EffectsGroup
-            scope = And [
-                Ship
-                InSystem
-                OwnedBy empire = Source.Owner
-            ]
-            accountinglabel = "FLEET_UNSTEALTHINESS"
-            effects = SetStealth value = Value - (NamedReal name = "FLEET_UNSTEALTH_SHIPS_SCALING" value = 5.0) *
-                floor(
-                    max(
-                        0,
-                        (Statistic Count condition = And [
-                            Ship
-                            InSystem id = Target.SystemID
-                            OwnedBy empire = Source.Owner
-                        ]) - (NamedReal name = "FLEET_UNSTEALTHY_SHIPS_THRESHOLD" value = 10)
-                    ) ^ 0.5
-                )
-                // large fleets only start affecting stealth when there are more than the threshold of ships in a single system
+            effects = SetStealth value = Value + (NamedReal name = "PLANET_BASIC_STEALTH" value = 5.0)        
     ]
     graphic = ""
 

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.txt
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.txt
@@ -42,4 +42,24 @@ Tech
             ]
             accountinglabel = "SPY_DECEPTION_SUBSTELLAR_INTERFERENCE"
             effects = SetStealth value = Value + (NamedReal name = "SPY_DECEPTION_BLACK_INTERFERENCE" value = 10.0)
+
+        EffectsGroup
+            scope = And [
+                Ship
+                InSystem
+                OwnedBy empire = Source.Owner
+            ]
+            accountinglabel = "FLEET_UNSTEALTHINESS"
+            effects = SetStealth value = Value - (NamedReal name = "FLEET_UNSTEALTH_SHIPS_SCALING" value = 5.0) *
+                floor(
+                    max(
+                        0,
+                        (Statistic Count condition = And [
+                            Ship
+                            InSystem id = Target.SystemID
+                            OwnedBy empire = Source.Owner
+                        ]) - (NamedReal name = "FLEET_UNSTEALTHY_SHIPS_THRESHOLD" value = 10)
+                    ) ^ 0.5
+                )
+                // large fleets only start affecting stealth when there are more than the threshold of ships in a single system
     ]

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.txt
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.txt
@@ -13,8 +13,8 @@ Tech
                 OwnedBy empire = Source.Owner
                 Star type = NoStar
             ]
-            accountinglabel = "SPY_DECPTION_EMPTY_SPACE_PENALTY"
-            effects = SetStealth value = Value + (NamedReal name = "SPY_DECPTION_EMPTY_SPACE_PENALTY" value = -10.0)
+            accountinglabel = "SPY_DECEPTION_EMPTY_SPACE_PENALTY"
+            effects = SetStealth value = Value + (NamedReal name = "SPY_DECEPTION_EMPTY_SPACE_PENALTY" value = -10.0)
 
         EffectsGroup
             scope = And [
@@ -22,8 +22,8 @@ Tech
                 OwnedBy empire = Source.Owner
                 Star type = Red
             ]
-            accountinglabel = "SPY_DECPTION_DIM_STAR_PENALTY"
-            effects = SetStealth value = Value + (NamedReal name = "SPY_DECPTION_DIM_STAR_PENALTY" value = -5.0)
+            accountinglabel = "SPY_DECEPTION_DIM_STAR_PENALTY"
+            effects = SetStealth value = Value + (NamedReal name = "SPY_DECEPTION_DIM_STAR_PENALTY" value = -5.0)
 
         EffectsGroup
             scope = And [
@@ -31,8 +31,8 @@ Tech
                 OwnedBy empire = Source.Owner
                 Star type = Neutron
             ]
-            accountinglabel = "SPY_DECPTION_SUBSTELLAR_INTERFERENCE"
-            effects = SetStealth value = Value + (NamedReal name = "SPY_DECPTION_NEUTRON_INTERFERENCE" value = 5.0)
+            accountinglabel = "SPY_DECEPTION_SUBSTELLAR_INTERFERENCE"
+            effects = SetStealth value = Value + (NamedReal name = "SPY_DECEPTION_NEUTRON_INTERFERENCE" value = 5.0)
 
         EffectsGroup
             scope = And [
@@ -40,6 +40,6 @@ Tech
                 OwnedBy empire = Source.Owner
                 Star type = BlackHole
             ]
-            accountinglabel = "SPY_DECPTION_SUBSTELLAR_INTERFERENCE"
-            effects = SetStealth value = Value + (NamedReal name = "SPY_DECPTION_BLACK_INTERFERENCE" value = 10.0)
+            accountinglabel = "SPY_DECEPTION_SUBSTELLAR_INTERFERENCE"
+            effects = SetStealth value = Value + (NamedReal name = "SPY_DECEPTION_BLACK_INTERFERENCE" value = 10.0)
     ]

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -13247,13 +13247,13 @@ Deception
 SPY_ROOT_DECEPTION_DESC
 The art of deception is not natural to every species, but the ability to hide the truth can be most useful.
 
-SPY_DECPTION_EMPTY_SPACE_PENALTY
+SPY_DECEPTION_EMPTY_SPACE_PENALTY
 Conspicuous in Empty Space
 
-SPY_DECPTION_DIM_STAR_PENALTY
+SPY_DECEPTION_DIM_STAR_PENALTY
 Conspicuous Near Dim Star
 
-SPY_DECPTION_SUBSTELLAR_INTERFERENCE
+SPY_DECEPTION_SUBSTELLAR_INTERFERENCE
 High Radiation Background
 
 
@@ -14291,13 +14291,13 @@ SPY_PLANET_STEALTH_MOD_DESC
 
 • Due to [[FLEET_UNSTEALTHINESS]], when there are more than [[value FLEET_UNSTEALTHY_SHIPS_THRESHOLD]] ships of the same empire in a system, their [[metertype METER_STEALTH]] is reduced by [[value FLEET_UNSTEALTH_SHIPS_SCALING]] multiplied by the square root of [[value FLEET_UNSTEALTHY_SHIPS_THRESHOLD]] less than the number of ships that empire has in the system.
 
-• Ships in systems with [[STAR_NONE]] receive a [[value SPY_DECPTION_EMPTY_SPACE_PENALTY]] penalty to [[metertype METER_STEALTH]] due to being [[SPY_DECPTION_EMPTY_SPACE_PENALTY]].
+• Ships in systems with [[STAR_NONE]] receive a [[value SPY_DECEPTION_EMPTY_SPACE_PENALTY]] penalty to [[metertype METER_STEALTH]] due to being [[SPY_DECEPTION_EMPTY_SPACE_PENALTY]].
 
-• Ships in systems with a [[STAR_RED]] star receive a [[value SPY_DECPTION_DIM_STAR_PENALTY]] penalty to [[metertype METER_STEALTH]] due to being [[SPY_DECPTION_DIM_STAR_PENALTY]].
+• Ships in systems with a [[STAR_RED]] star receive a [[value SPY_DECEPTION_DIM_STAR_PENALTY]] penalty to [[metertype METER_STEALTH]] due to being [[SPY_DECEPTION_DIM_STAR_PENALTY]].
 
-• Ships in systems with a [[STAR_NEUTRON]] star receive a [[value SPY_DECPTION_NEUTRON_INTERFERENCE]] bonus to [[metertype METER_STEALTH]] due to [[SPY_DECPTION_SUBSTELLAR_INTERFERENCE]].
+• Ships in systems with a [[STAR_NEUTRON]] star receive a [[value SPY_DECEPTION_NEUTRON_INTERFERENCE]] bonus to [[metertype METER_STEALTH]] due to [[SPY_DECEPTION_SUBSTELLAR_INTERFERENCE]].
 
-• Ships in systems with a [[STAR_BLACK]] star receive a [[value SPY_DECPTION_BLACK_INTERFERENCE]] bonus to [[metertype METER_STEALTH]] due to [[SPY_DECPTION_SUBSTELLAR_INTERFERENCE]].'''
+• Ships in systems with a [[STAR_BLACK]] star receive a [[value SPY_DECEPTION_BLACK_INTERFERENCE]] bonus to [[metertype METER_STEALTH]] due to [[SPY_DECEPTION_SUBSTELLAR_INTERFERENCE]].'''
 
 BASIC_PLANET_STEALTH
 Universal Basic Stealth

--- a/default/stringtables/fr.txt
+++ b/default/stringtables/fr.txt
@@ -13247,13 +13247,13 @@ Tromperie
 SPY_ROOT_DECEPTION_DESC
 L'art de la tromperie n’est pas naturel à toutes les espèces, mais la possibilité de dissimuler la vérité peut s'avérer bien utile.
 
-SPY_DECPTION_EMPTY_SPACE_PENALTY
+SPY_DECEPTION_EMPTY_SPACE_PENALTY
 Visibilité dans l'espace interstellaire
 
-SPY_DECPTION_DIM_STAR_PENALTY
+SPY_DECEPTION_DIM_STAR_PENALTY
 Visibilité à proximité d'une étoile faible
 
-SPY_DECPTION_SUBSTELLAR_INTERFERENCE
+SPY_DECEPTION_SUBSTELLAR_INTERFERENCE
 Milieu à fort rayonnement cosmique
 
 
@@ -14291,13 +14291,13 @@ SPY_PLANET_STEALTH_MOD_DESC
 
 • En raison de la [[FLEET_UNSTEALTHINESS]], lorsque plus de [[value FLEET_UNSTEALTHY_SHIPS_THRESHOLD]] astronefs d'un même empire se trouvent dans un système, leur [[metertype METER_STEALTH]] est réduite de [[value FLEET_UNSTEALTH_SHIPS_SCALING]] multiplié par la racine carrée de [[value FLEET_UNSTEALTHY_SHIPS_THRESHOLD]] moins le nombre d'astronefs appartenant à l'empire dans le système.
 
-• Les astronefs se trouvant dans un système n'abritant [[STAR_NONE]] subissent une pénalité de [[value SPY_DECPTION_EMPTY_SPACE_PENALTY]] en [[metertype METER_STEALTH]] en raison de leur [[SPY_DECPTION_EMPTY_SPACE_PENALTY]].
+• Les astronefs se trouvant dans un système n'abritant [[STAR_NONE]] subissent une pénalité de [[value SPY_DECEPTION_EMPTY_SPACE_PENALTY]] en [[metertype METER_STEALTH]] en raison de leur [[SPY_DECEPTION_EMPTY_SPACE_PENALTY]].
 
-• Les astronefs se trouvant dans un système abritant une Étoile [[STAR_RED]] subissent une pénalité de [[value SPY_DECPTION_DIM_STAR_PENALTY]] en [[metertype METER_STEALTH]] en raison de leur [[SPY_DECPTION_DIM_STAR_PENALTY]].
+• Les astronefs se trouvant dans un système abritant une Étoile [[STAR_RED]] subissent une pénalité de [[value SPY_DECEPTION_DIM_STAR_PENALTY]] en [[metertype METER_STEALTH]] en raison de leur [[SPY_DECEPTION_DIM_STAR_PENALTY]].
 
-• Les astronefs se trouvant dans un système abritant une Étoile [[STAR_NEUTRON]] reçoivent un bonus de [[value SPY_DECPTION_NEUTRON_INTERFERENCE]] en [[metertype METER_STEALTH]] en raison du [[SPY_DECPTION_SUBSTELLAR_INTERFERENCE]].
+• Les astronefs se trouvant dans un système abritant une Étoile [[STAR_NEUTRON]] reçoivent un bonus de [[value SPY_DECEPTION_NEUTRON_INTERFERENCE]] en [[metertype METER_STEALTH]] en raison du [[SPY_DECEPTION_SUBSTELLAR_INTERFERENCE]].
 
-• Les astronefs se trouvant dans un système abritant un [[STAR_BLACK]] reçoivent un bonus de [[value SPY_DECPTION_BLACK_INTERFERENCE]] en [[metertype METER_STEALTH]] en raison du [[SPY_DECPTION_SUBSTELLAR_INTERFERENCE]].'''
+• Les astronefs se trouvant dans un système abritant un [[STAR_BLACK]] reçoivent un bonus de [[value SPY_DECEPTION_BLACK_INTERFERENCE]] en [[metertype METER_STEALTH]] en raison du [[SPY_DECEPTION_SUBSTELLAR_INTERFERENCE]].'''
 
 BASIC_PLANET_STEALTH
 Furtivité Universelle Initiale


### PR DESCRIPTION
lienrag found the fleet unstealthiness to misbehave if in transit. (e.g.  [screenshot in forum](https://freeorion.org/forum/viewtopic.php?p=111772#p111772) )

if a candidate is not in a system (has SystemID -1) it matches nothing. the -1 as target is used to signal "match any system" (i.e. an SystemID but -1). 

not sure if the implementation of InSystem is a bug or if it is correct and simply not helpful/not intuitive. Not Not InSystem id = xxx probably has to be the same as InSystem id = xxx for all xxx .

so for fleet unstealthiness code. the ship the stealth effect applies to is the target. the ships which are counted are the candidates.
according to my code dive the stealth of a ship on a starlane would be decreased depending on the count of all ships which are not on a starlane - which is clearly a bug.

the scope condition needs an InSystem condition (without id).


this PR contains three commits; one fixes a typo; one fixes the unstealthiness ; one moves the effect to a more fitting focs file