### PR TITLE
Removed unused AVERAGE_OFFENSE_TROOPS macro

### DIFF
--- a/default/scripting/species/SP_FULVER.focs.txt
+++ b/default/scripting/species/SP_FULVER.focs.txt
@@ -65,7 +65,6 @@ Species
         [[BAD_HAPPINESS]]
         [[AVERAGE_SUPPLY]]
         [[BAD_DEFENSE_TROOPS]]
-        [[AVERAGE_OFFENSE_TROOPS]]
         [[GOOD_WEAPONS]]
         [[GREAT_FUEL]]
 

--- a/default/scripting/species/common/troops.macros
+++ b/default/scripting/species/common/troops.macros
@@ -279,13 +279,7 @@ BAD_OFFENSE_TROOPS
             ]
 '''
 
-AVERAGE_OFFENSE_TROOPS
-'''       EffectsGroup
-            description = "AVERAGE_OFFENSE_TROOPS_DESC"
-            scope = Source
-            activation = None
-            effects = SetTargetResearch value = Value
-'''
+//AVERAGE_OFFENSE_TROOPS has no effects
 
 GOOD_OFFENSE_TROOPS
 '''EffectsGroup


### PR DESCRIPTION
This macro is not used anywhere, except in Fulver species where it does nothing.
And it is annoying that it matches searches for SetTargetResearch (used in the useless macro to not have an empty effect, ugly hack).
If average offense troops does ever need an actual effect, it can be created then.

Edit: made the effect NoOp, removed it from Fulver (unneded).