### PR TITLE
Split getNamedValue to getNamedReal/Int

### DIFF
--- a/client/AI/AIWrapper.cpp
+++ b/client/AI/AIWrapper.cpp
@@ -394,11 +394,6 @@ namespace {
             return 0;
         }
 
-        if (!empire->ProducibleItem(BuildType::BT_BUILDING, item_name, location_id)) {
-            ErrorLogger() << "IssueEnqueueBuildingProductionOrder : specified item_name and location_id that don't indicate an item that can be built at that location";
-            return 0;
-        }
-
         if (!empire->EnqueuableItem(BuildType::BT_BUILDING, item_name, location_id)) {
             ErrorLogger() << "IssueEnqueueBuildingProductionOrder : specified item_name and location_id that don't indicate an item that can be enqueued at that location";
             return 0;

--- a/default/python/AI/PlanetUtilsAI.py
+++ b/default/python/AI/PlanetUtilsAI.py
@@ -18,7 +18,7 @@ from aistate_interface import get_aistate
 from common.fo_typing import PlanetId, SpeciesName, SystemId
 from empire.colony_builders import get_colony_builders, get_extra_colony_builders
 from empire.ship_builders import get_ship_builders
-from freeorion_tools import ppstring
+from freeorion_tools import get_named_real, ppstring
 from freeorion_tools.caching import cache_for_current_turn
 
 
@@ -285,7 +285,7 @@ def dislike_factor() -> float:
     # See happiness.macros
     has_liberty = fo.getEmpire().policyAdopted("PLC_LIBERTY")
     # conformance not used yet
-    return fo.getNamedValue("PLC_LIBERTY_DISLIKE_FACTOR") if has_liberty else 1.0
+    return get_named_real("PLC_LIBERTY_DISLIKE_FACTOR") if has_liberty else 1.0
 
 
 def focus_stability_effect(species: fo.species, focus: str) -> float:

--- a/default/python/AI/PolicyAI.py
+++ b/default/python/AI/PolicyAI.py
@@ -10,7 +10,12 @@ from AIDependencies import Tags
 from aistate_interface import get_aistate
 from common.fo_typing import PlanetId, SpeciesName
 from EnumsAI import FocusType, PriorityType
-from freeorion_tools import assertion_fails, get_species_tag_value
+from freeorion_tools import (
+    assertion_fails,
+    get_named_int,
+    get_named_real,
+    get_species_tag_value,
+)
 from freeorion_tools.caching import cache_for_current_turn
 from freeorion_tools.statistics import stats
 from ResearchAI import research_now
@@ -375,8 +380,8 @@ class PolicyManager:
         if diversity not in self._empire.availablePolicies:
             return 0.0
         # diversity affects stability, but also gives a bonus to research-focused planets and a little influence,
-        diversity_value = len(get_empire_planets_by_species()) - fo.getNamedValue("PLC_DIVERSITY_THRESHOLD")
-        diversity_scaling = fo.getNamedValue("PLC_DIVERSITY_SCALING")
+        diversity_value = len(get_empire_planets_by_species()) - get_named_int("PLC_DIVERSITY_THRESHOLD")
+        diversity_scaling = get_named_real("PLC_DIVERSITY_SCALING")
         # Research bonus goes to research-focused planets only. With priority there are usually none.
         research_priority = self._aistate.get_priority(PriorityType.RESOURCE_RESEARCH)
         research_bonus = max(0, research_priority - 20)
@@ -411,8 +416,8 @@ class PolicyManager:
         return rating
 
     def _rate_artisan_planet(self, pid: PlanetId, species_name: SpeciesName) -> float:
-        focus_bonus = fo.getNamedValue("ARTISANS_INFLUENCE_FLAT_FOCUS")
-        focus_minimum = fo.getNamedValue("ARTISANS_MIN_STABILITY_FOCUS")
+        focus_bonus = get_named_real("ARTISANS_INFLUENCE_FLAT_FOCUS")
+        focus_minimum = get_named_real("ARTISANS_MIN_STABILITY_FOCUS")
         species_focus_bonus = focus_bonus * get_species_tag_value(species_name, Tags.INFLUENCE)
         planet = self._universe.getPlanet(pid)
         stability = planet.currentMeterValue(fo.meterType.targetHappiness)
@@ -422,8 +427,8 @@ class PolicyManager:
 
         # Planet does not have influence focus...
         # Check for the non-focus bonus. Since we would get this "for free", rate it higher
-        non_focus_bonus = fo.getNamedValue("ARTISANS_INFLUENCE_FLAT_NO_FOCUS")
-        non_focus_minimum = fo.getNamedValue("ARTISANS_MIN_STABILITY_NO_FOCUS")
+        non_focus_bonus = get_named_real("ARTISANS_INFLUENCE_FLAT_NO_FOCUS")
+        non_focus_minimum = get_named_real("ARTISANS_MIN_STABILITY_NO_FOCUS")
         rating = 0.0
         if stability >= non_focus_minimum:
             rating += 4 * non_focus_bonus

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -54,7 +54,7 @@ from EnumsAI import (
     ShipRoleType,
     get_priority_production_types,
 )
-from freeorion_tools import ppstring, tech_is_complete
+from freeorion_tools import get_named_real, ppstring, tech_is_complete
 from production import print_building_list, print_capital_info, print_production_queue
 from turn_state import (
     get_all_empire_planets,
@@ -1540,7 +1540,7 @@ def _build_gas_giant_generator() -> float:
     if not building_type.available():
         return 0.0
 
-    ggg_min_stability = fo.getNamedValue("BLD_GAS_GIANT_GEN_MIN_STABILITY")
+    ggg_min_stability = get_named_real("BLD_GAS_GIANT_GEN_MIN_STABILITY")
     universe = fo.getUniverse()
     colonized_planets = get_colonized_planets()
     opinion = building_type.get_opinions()

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -21,7 +21,12 @@ from colonization.calculate_planet_colonization_rating import empire_metabolisms
 from common.print_utils import Table, Text
 from empire.growth_specials import get_growth_specials
 from EnumsAI import FocusType, PriorityType, get_priority_resource_types
-from freeorion_tools import combine_ratings, policy_is_adopted, tech_is_complete
+from freeorion_tools import (
+    combine_ratings,
+    get_named_real,
+    policy_is_adopted,
+    tech_is_complete,
+)
 from freeorion_tools.statistics import stats
 from freeorion_tools.timers import AITimer
 from PolicyAI import algo_research, bureaucracy
@@ -445,8 +450,8 @@ def assess_protection_focus(pinfo, priority):
     """Return True if planet should use Protection Focus."""
     this_planet = pinfo.planet
     # this is unrelated to military threats
-    stability_bonus = (pinfo.current_focus == PROTECTION) * fo.getNamedValue("PROTECION_FOCUS_STABILITY_BONUS")
-    # industry and research produce nothing below 0
+    stability_bonus = (pinfo.current_focus == PROTECTION) * get_named_real("PROTECION_FOCUS_STABILITY_BONUS")
+    # industry and research produce nothing below
     threshold = -1 * (pinfo.current_focus not in (INDUSTRY, RESEARCH))
     # Negative IP lowers stability. Trying to counter this by setting planets to Protection just makes it worse!
     ip = fo.getEmpire().resourceAvailable(fo.resourceType.influence)

--- a/default/python/AI/colonization/calculate_stability.py
+++ b/default/python/AI/colonization/calculate_stability.py
@@ -5,7 +5,7 @@ import AIDependencies
 import PolicyAI
 from buildings import BuildingType
 from colonization.colony_score import debug_rating
-from freeorion_tools import get_species_tag_value
+from freeorion_tools import get_named_real, get_species_tag_value
 from freeorion_tools.caching import cache_for_current_turn
 from PlanetUtilsAI import dislike_factor
 from turn_state import get_colonized_planets, have_worldtree
@@ -44,7 +44,7 @@ def _evaluate_policies(species: fo.species) -> float:
     result = sum(like_value for p in empire.adoptedPolicies if p in species.likes)
     result -= sum(dislike_value for p in empire.adoptedPolicies if p in species.dislikes)
     if PolicyAI.bureaucracy in empire.adoptedPolicies:
-        result += fo.getNamedValue("PLC_BUREAUCRACY_STABILITY_FLAT")
+        result += get_named_real("PLC_BUREAUCRACY_STABILITY_FLAT")
     # TBD: add conformance, indoctrination, etc. when the AI learns to use them
     return result
 
@@ -119,7 +119,7 @@ def _evaluate_xenophobia(planet, species) -> float:
     relevant_systems = within_n_jumps(planet.systemID, 5) & set(colonies.keys())
     result = 0.0
     universe = fo.getUniverse()
-    value = fo.getNamedValue("XENOPHOBIC_SELF_TARGET_HAPPINESS_COUNT")
+    value = get_named_real("XENOPHOBIC_SELF_TARGET_HAPPINESS_COUNT")
     for sys_id in relevant_systems:
         for pid in colonies[sys_id]:
             planet_species = universe.getPlanet(pid).speciesName

--- a/default/python/AI/freeOrionAIInterface.pyi
+++ b/default/python/AI/freeOrionAIInterface.pyi
@@ -1301,9 +1301,14 @@ def getGameRules() -> GameRules:
     Returns the game rules manager, which can be used to look up the names (string) of rules are defined with what type (boolean / toggle, int, double, string), and what values the rules have in the current game.
     """
 
-def getNamedValue(string: str) -> object:
+def getNamedInt(string: str) -> int:
     """
-    Returns the named value of the scripted constant with name (string). If no such named constant exists, returns none.
+    Returns the named integer value of the scripted constant with name (string). If no such named constant exists, returns 0.
+    """
+
+def getNamedReal(string: str) -> float:
+    """
+    Returns the named real value of the scripted constant with name (string). If no such named constant exists, returns 0.0.
     """
 
 def getOptionsDBOptionBool(string: str) -> object:

--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -371,14 +371,10 @@ def get_named_int(name: str) -> int:
     Note that we do not raise and exception so that the AI can continue, as good as it can, with outdated information.
     This is also why we return 1, returning 0 could cause followup errors if the value is used as divisor.
     """
-    value = fo.getNamedValue(name)
-    if value is None:
-        error(f"Requested NamedInt {name}, which doesn't exist!")
-        value = 1
-    elif not isinstance(value, int):
-        error(f"Requested value {name} of type int got {type(value)}!")
-        value = 1
-    return value
+    if fo.namedIntDefined(name):
+        return fo.getNamedInt(name)
+    error(f"Requested integer {name} does not exist!")
+    return 1
 
 
 def get_named_real(name: str) -> float:
@@ -388,11 +384,7 @@ def get_named_real(name: str) -> float:
     Note that we do not raise and exception so that the AI can continue, as good as it can, with outdated information.
     This is also why we return 1, returning 0 could cause followup errors if the value is used as divisor.
     """
-    value = fo.getNamedValue(name)
-    if value is None:
-        error(f"Requested NamedReal {name}, which doesn't exist!")
-        value = 1.0
-    elif not isinstance(value, float):
-        error(f"Requested value {name} of type float got {type(value)}!")
-        value = 1.0
-    return value
+    if fo.namedRealDefined(name):
+        return fo.getNamedReal(name)
+    error(f"Requested integer {name} does not exist!")
+    return 1.0

--- a/default/python/freeorion.pyi
+++ b/default/python/freeorion.pyi
@@ -1316,9 +1316,14 @@ def getGameRules() -> GameRules:
     Returns the game rules manager, which can be used to look up the names (string) of rules are defined with what type (boolean / toggle, int, double, string), and what values the rules have in the current game.
     """
 
-def getNamedValue(string: str) -> object:
+def getNamedInt(string: str) -> int:
     """
-    Returns the named value of the scripted constant with name (string). If no such named constant exists, returns none.
+    Returns the named integer value of the scripted constant with name (string). If no such named constant exists, returns 0.
+    """
+
+def getNamedReal(string: str) -> float:
+    """
+    Returns the named real value of the scripted constant with name (string). If no such named constant exists, returns 0.0.
     """
 
 def getPolicy(string: str) -> policy:

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -321,24 +321,30 @@ namespace FreeOrionPython {
                 +[](const std::string& name) -> bool { return GetValueRef<int>(name, true); },
                 "Returns true/false (boolean) whether there is a defined int-valued "
                 "scripted constant with name (string).");
-        py::def("getNamedValue",
-                +[](const std::string& name) -> py::object {
-                    auto eval = [](auto&& ref) -> py::object {
+        py::def("getNamedReal",
+                +[](const std::string& name) -> double {
+                    if (const auto ref = GetValueRef<double>(name, true)) {
                         if (ref->ConstantExpr()) 
-                            return py::object(ref->Eval());
+                            return ref->Eval();
                         const ScriptingContext context;
-                        return py::object(ref->Eval(context));
-                    };
-
-                    if (const auto ref = GetValueRef<double>(name, true))
-                        return eval(ref);
-                    else if (const auto ref = GetValueRef<int>(name, true))
-                        return eval(ref);
-                    else
-                        return py::object();
+                        return ref->Eval(context);
+                    }
+                    return 0.0;
                 },
-                "Returns the named value of the scripted constant with name (string). "
-                "If no such named constant exists, returns none.");
+                "Returns the named real value of the scripted constant with name (string). "
+                "If no such named constant exists, returns 0.0.");
+        py::def("getNamedInt",
+                +[](const std::string& name) -> int {
+                    if (const auto ref = GetValueRef<int>(name, true)) {
+                        if (ref->ConstantExpr())
+                            return ref->Eval();
+                        const ScriptingContext context;
+                        return ref->Eval(context);
+                    }
+                    return 0;
+                },
+                "Returns the named integer value of the scripted constant with name (string). "
+                "If no such named constant exists, returns 0.");
 
         ///////////////
         //   Meter   //


### PR DESCRIPTION
Also allow queuing unbuildable buildings and regenerated the python interfaces.

Using functions that return int / float helps with the python code analysis. Also the current function always logs a warning, when accessing a NameInteger.