### PR TITLE
Add dependencies data to HOST_* messages

### DIFF
--- a/client/godot/GodotClientApp.cpp
+++ b/client/godot/GodotClientApp.cpp
@@ -255,7 +255,7 @@ void GodotClientApp::NewSinglePlayerGame() {
 
 
     DebugLogger() << "Sending host SP setup message";
-    m_networking->SendMessage(HostSPGameMessage(setup_data));
+    m_networking->SendMessage(HostSPGameMessage(setup_data, DependencyVersions()));
     DebugLogger() << "GodotClientApp::NewSinglePlayerGame done";
 }
 #endif

--- a/client/human/GGHumanClientApp.cpp
+++ b/client/human/GGHumanClientApp.cpp
@@ -619,7 +619,7 @@ void GGHumanClientApp::NewSinglePlayerGame(bool quickstart) {
 
 
     TraceLogger() << "Sending host SP setup message";
-    m_networking->SendMessage(HostSPGameMessage(setup_data));
+    m_networking->SendMessage(HostSPGameMessage(setup_data, DependencyVersions()));
     m_fsm->process_event(HostSPGameRequested());
     TraceLogger() << "GGHumanClientApp::NewSinglePlayerGame done";
 }
@@ -668,7 +668,7 @@ void GGHumanClientApp::MultiPlayerGame() {
     }
 
     if (server_connect_wnd->GetResult().server_dest == "HOST GAME SELECTED") {
-        m_networking->SendMessage(HostMPGameMessage(server_connect_wnd->GetResult().player_name));
+        m_networking->SendMessage(HostMPGameMessage(server_connect_wnd->GetResult().player_name, DependencyVersions()));
         m_fsm->process_event(HostMPGameRequested());
     } else {
         boost::uuids::uuid cookie = boost::uuids::nil_uuid();
@@ -804,7 +804,7 @@ void GGHumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
     // leving setup_data.m_players empty : not specified when loading a game, as server will generate from save file
 
 
-    m_networking->SendMessage(HostSPGameMessage(setup_data));
+    m_networking->SendMessage(HostSPGameMessage(setup_data, DependencyVersions()));
     m_fsm->process_event(HostSPGameRequested());
 }
 

--- a/msvc2019/Test/Test.vcxproj
+++ b/msvc2019/Test/Test.vcxproj
@@ -118,7 +118,7 @@
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;FREEORION_BUILD_HUMAN;FREEORION_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;FREEORION_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../;../../GG/;../../../include/;../include/;../../../include/python3.7/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
@@ -147,7 +147,7 @@
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;FREEORION_BUILD_HUMAN;FREEORION_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;FREEORION_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../../include/;../../GG/;../../;../../../include/python3.7/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
@@ -188,6 +188,7 @@
     <ClCompile Include="..\..\test\system\ClientAppFixture.cpp" />
     <ClCompile Include="..\..\test\system\SmokeTestGame.cpp" />
     <ClCompile Include="..\..\test\system\SmokeTestHostless.cpp" />
+    <ClCompile Include="..\..\util\DependencyVersions.cpp" />
     <ClCompile Include="..\..\util\Process.cpp" />
     <ClCompile Include="StdAfx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>

--- a/msvc2019/Test/Test.vcxproj.filters
+++ b/msvc2019/Test/Test.vcxproj.filters
@@ -43,6 +43,9 @@
     <ClCompile Include="..\..\client\ClientNetworking.cpp">
       <Filter>Test\client</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\util\DependencyVersions.cpp">
+      <Filter>Test\util</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\util\Process.cpp">
       <Filter>Test\util</Filter>
     </ClCompile>

--- a/msvc2022/Test/Test.vcxproj
+++ b/msvc2022/Test/Test.vcxproj
@@ -118,7 +118,7 @@
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;FREEORION_BUILD_HUMAN;FREEORION_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;FREEORION_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../;../../GG/;../../../include/;../include/;../../../include/python3.7/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
@@ -147,7 +147,7 @@
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;FREEORION_BUILD_HUMAN;FREEORION_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;FREEORION_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../../include/;../../GG/;../../;../../../include/python3.7/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
@@ -188,6 +188,7 @@
     <ClCompile Include="..\..\test\system\ClientAppFixture.cpp" />
     <ClCompile Include="..\..\test\system\SmokeTestGame.cpp" />
     <ClCompile Include="..\..\test\system\SmokeTestHostless.cpp" />
+    <ClCompile Include="..\..\util\DependencyVersions.cpp" />
     <ClCompile Include="..\..\util\Process.cpp" />
     <ClCompile Include="StdAfx.cpp">
       <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>

--- a/msvc2022/Test/Test.vcxproj.filters
+++ b/msvc2022/Test/Test.vcxproj.filters
@@ -43,6 +43,9 @@
     <ClCompile Include="..\..\client\ClientNetworking.cpp">
       <Filter>Test\client</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\util\DependencyVersions.cpp">
+      <Filter>Test\util</Filter>
+    </ClCompile>
     <ClCompile Include="..\..\util\Process.cpp">
       <Filter>Test\util</Filter>
     </ClCompile>

--- a/network/Message.h
+++ b/network/Message.h
@@ -186,10 +186,10 @@ FO_COMMON_API Message ErrorMessage(const std::string& problem, bool fatal = true
                                    int player_id = Networking::INVALID_PLAYER_ID);
 
 /** creates a HOST_SP_GAME message*/
-FO_COMMON_API Message HostSPGameMessage(const SinglePlayerSetupData& setup_data);
+FO_COMMON_API Message HostSPGameMessage(const SinglePlayerSetupData& setup_data, const std::map<std::string, std::string>& dependencies);
 
 /** creates a minimal HOST_MP_GAME message used to initiate multiplayer "lobby" setup*/
-FO_COMMON_API Message HostMPGameMessage(const std::string& host_player_name);
+FO_COMMON_API Message HostMPGameMessage(const std::string& host_player_name, const std::map<std::string, std::string>& dependencies);
 
 /** creates a JOIN_GAME message.  The sender's player name, client type, and
   * cookie are sent in the message.*/
@@ -378,7 +378,7 @@ FO_COMMON_API Message AutoTurnMessage(int turns_count);
 FO_COMMON_API void ExtractErrorMessageData(const Message& msg, int& player_id, std::string& problem, bool& fatal);
 
 FO_COMMON_API void ExtractHostMPGameMessageData(const Message& msg, std::string& host_player_name,
-                                                std::string& client_version_string);
+                                                std::string& client_version_string, std::map<std::string, std::string>& dependencies);
 
 FO_COMMON_API void ExtractLobbyUpdateMessageData(const Message& msg, MultiplayerLobbyData& lobby_data);
 
@@ -439,7 +439,7 @@ FO_COMMON_API void ExtractPlayerStatusMessageData(const Message& msg,
                                                   Message::PlayerStatus& status,
                                                   int& about_empire_id);
 
-FO_COMMON_API void ExtractHostSPGameMessageData(const Message& msg, SinglePlayerSetupData& setup_data, std::string& client_version_string);
+FO_COMMON_API void ExtractHostSPGameMessageData(const Message& msg, SinglePlayerSetupData& setup_data, std::string& client_version_string, std::map<std::string, std::string>& dependencies);
 
 FO_COMMON_API void ExtractEndGameMessageData(const Message& msg, Message::EndGameReason& reason, std::string& reason_player_name);
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -631,7 +631,8 @@ sc::result Idle::react(const HostMPGame& msg) {
 
     std::string host_player_name;
     std::string client_version_string;
-    ExtractHostMPGameMessageData(message, host_player_name, client_version_string);
+    std::map<std::string, std::string> dependencies;
+    ExtractHostMPGameMessageData(message, host_player_name, client_version_string, dependencies);
 
     // validate host name (was found and wasn't empty)
     if (host_player_name.empty()) {
@@ -673,7 +674,8 @@ sc::result Idle::react(const HostSPGame& msg) {
 
     auto single_player_setup_data = std::make_shared<SinglePlayerSetupData>();
     std::string client_version_string;
-    ExtractHostSPGameMessageData(message, *single_player_setup_data, client_version_string);
+    std::map<std::string, std::string> dependencies;
+    ExtractHostSPGameMessageData(message, *single_player_setup_data, client_version_string, dependencies);
 
 
     // get host player's name from setup data or saved file

--- a/test/system/CMakeLists.txt
+++ b/test/system/CMakeLists.txt
@@ -10,7 +10,6 @@ add_executable(fo_systemtest_game
 
 target_compile_definitions(fo_systemtest_game
     PRIVATE
-        -DFREEORION_BUILD_HUMAN
         -DBOOST_TEST_IGNORE_SIGCHLD
 )
 
@@ -45,6 +44,7 @@ target_sources(fo_systemtest_game
         ${PROJECT_SOURCE_DIR}/client/ClientApp.cpp
         ${PROJECT_SOURCE_DIR}/client/ClientFSMEvents.cpp
         ${PROJECT_SOURCE_DIR}/client/ClientNetworking.cpp
+        ${PROJECT_SOURCE_DIR}/util/DependencyVersions.cpp
 )
 
 set(FO_TEST_GAME

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -119,7 +119,7 @@ void ClientAppFixture::HostSPGame(unsigned int num_AIs) {
         setup_data.players.push_back(ai_setup_data);
     }
 
-    m_networking->SendMessage(HostSPGameMessage(setup_data));
+    m_networking->SendMessage(HostSPGameMessage(setup_data, DependencyVersions()));
 }
 
 void ClientAppFixture::JoinGame() {


### PR DESCRIPTION
Make it same as JOIN_GAME message. Will allow to use those data when establish player connection.