### PR TITLE
Message data compression

### DIFF
--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -17,6 +17,8 @@
 #include "../util/Version.h"
 #include <boost/algorithm/string/erase.hpp>
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/iostreams/filtering_stream.hpp>
+#include <boost/iostreams/filter/zlib.hpp>
 #include <boost/serialization/deque.hpp>
 #include <boost/serialization/list.hpp>
 #include <boost/serialization/map.hpp>
@@ -183,8 +185,11 @@ Message GameStartMessage(bool single_player_game, int empire_id,
 {
     std::ostringstream os;
     {
+        boost::iostreams::filtering_ostream zos;
+        zos.push(boost::iostreams::zlib_compressor());
+        zos.push(os);
         if (use_binary_serialization) {
-            freeorion_bin_oarchive oa(os);
+            freeorion_bin_oarchive oa(zos);
             oa << BOOST_SERIALIZATION_NVP(single_player_game)
                << BOOST_SERIALIZATION_NVP(empire_id)
                << BOOST_SERIALIZATION_NVP(current_turn);
@@ -200,7 +205,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             galaxy_setup_data.encoding_empire = empire_id;
             oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         } else {
-            freeorion_xml_oarchive oa(os);
+            freeorion_xml_oarchive oa(zos);
             oa << BOOST_SERIALIZATION_NVP(single_player_game)
                << BOOST_SERIALIZATION_NVP(empire_id)
                << BOOST_SERIALIZATION_NVP(current_turn);
@@ -231,8 +236,11 @@ Message GameStartMessage(bool single_player_game, int empire_id,
 {
     std::ostringstream os;
     {
+        boost::iostreams::filtering_ostream zos;
+        zos.push(boost::iostreams::zlib_compressor());
+        zos.push(os);
         if (use_binary_serialization) {
-            freeorion_bin_oarchive oa(os);
+            freeorion_bin_oarchive oa(zos);
             oa << BOOST_SERIALIZATION_NVP(single_player_game)
                << BOOST_SERIALIZATION_NVP(empire_id)
                << BOOST_SERIALIZATION_NVP(current_turn);
@@ -255,7 +263,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             galaxy_setup_data.encoding_empire = empire_id;
             oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         } else {
-            freeorion_xml_oarchive oa(os);
+            freeorion_xml_oarchive oa(zos);
             oa << BOOST_SERIALIZATION_NVP(single_player_game)
                << BOOST_SERIALIZATION_NVP(empire_id)
                << BOOST_SERIALIZATION_NVP(current_turn);
@@ -300,8 +308,11 @@ Message GameStartMessage(bool single_player_game, int empire_id,
 {
     std::ostringstream os;
     {
+        boost::iostreams::filtering_ostream zos;
+        zos.push(boost::iostreams::zlib_compressor());
+        zos.push(os);
         if (use_binary_serialization) {
-            freeorion_bin_oarchive oa(os);
+            freeorion_bin_oarchive oa(zos);
             oa << BOOST_SERIALIZATION_NVP(single_player_game)
                << BOOST_SERIALIZATION_NVP(empire_id)
                << BOOST_SERIALIZATION_NVP(current_turn);
@@ -324,7 +335,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             galaxy_setup_data.encoding_empire = empire_id;
             oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         } else {
-            freeorion_xml_oarchive oa(os);
+            freeorion_xml_oarchive oa(zos);
             oa << BOOST_SERIALIZATION_NVP(single_player_game)
                << BOOST_SERIALIZATION_NVP(empire_id)
                << BOOST_SERIALIZATION_NVP(current_turn);
@@ -853,8 +864,11 @@ void ExtractGameStartMessageData(std::string text, bool& single_player_game, int
             try {
                 // first attempt binary deserialziation
                 std::istringstream is(text);
+                boost::iostreams::filtering_istream zis;
+                zis.push(boost::iostreams::zlib_decompressor());
+                zis.push(is);
 
-                freeorion_bin_iarchive ia(is);
+                freeorion_bin_iarchive ia(zis);
                 ia >> BOOST_SERIALIZATION_NVP(single_player_game)
                    >> BOOST_SERIALIZATION_NVP(empire_id)
                    >> BOOST_SERIALIZATION_NVP(current_turn);
@@ -898,8 +912,11 @@ void ExtractGameStartMessageData(std::string text, bool& single_player_game, int
         if (try_xml) {
             // if binary deserialization failed, try more-portable XML deserialization
             std::istringstream is(text);
+            boost::iostreams::filtering_istream zis;
+            zis.push(boost::iostreams::zlib_decompressor());
+            zis.push(is);
 
-            freeorion_xml_iarchive ia(is);
+            freeorion_xml_iarchive ia(zis);
             ia >> BOOST_SERIALIZATION_NVP(single_player_game)
                >> BOOST_SERIALIZATION_NVP(empire_id)
                >> BOOST_SERIALIZATION_NVP(current_turn);
@@ -945,7 +962,6 @@ void ExtractGameStartMessageData(std::string text, bool& single_player_game, int
     } catch (const std::exception& err) {
         ErrorLogger() << "ExtractGameStartMessageData(...) failed!  Message probably long, so not outputting to log.\n"
                       << "Error: " << err.what();
-        TraceLogger() << "Message: " << text;
         throw err;
     }
 }

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -181,12 +181,12 @@ Message GameStartMessage(bool single_player_game, int empire_id,
                          CombatLogManager& combat_logs, const SupplyManager& supply,
                          const std::map<int, PlayerInfo>& players,
                          GalaxySetupData galaxy_setup_data,
-                         bool use_binary_serialization)
+                         bool use_binary_serialization, int zlib_level)
 {
     std::ostringstream os;
     {
         boost::iostreams::filtering_ostream zos;
-        zos.push(boost::iostreams::zlib_compressor());
+        zos.push(boost::iostreams::zlib_compressor(boost::iostreams::zlib_params{zlib_level}));
         zos.push(os);
         if (use_binary_serialization) {
             freeorion_bin_oarchive oa(zos);
@@ -232,12 +232,12 @@ Message GameStartMessage(bool single_player_game, int empire_id,
                          const std::map<int, PlayerInfo>& players,
                          const OrderSet& orders, const SaveGameUIData* ui_data,
                          GalaxySetupData galaxy_setup_data,
-                         bool use_binary_serialization)
+                         bool use_binary_serialization, int zlib_level)
 {
     std::ostringstream os;
     {
         boost::iostreams::filtering_ostream zos;
-        zos.push(boost::iostreams::zlib_compressor());
+        zos.push(boost::iostreams::zlib_compressor(boost::iostreams::zlib_params{zlib_level}));
         zos.push(os);
         if (use_binary_serialization) {
             freeorion_bin_oarchive oa(zos);
@@ -304,12 +304,12 @@ Message GameStartMessage(bool single_player_game, int empire_id,
                          const std::map<int, PlayerInfo>& players,
                          const OrderSet& orders, const std::string* save_state_string,
                          GalaxySetupData galaxy_setup_data,
-                         bool use_binary_serialization)
+                         bool use_binary_serialization, int zlib_level)
 {
     std::ostringstream os;
     {
         boost::iostreams::filtering_ostream zos;
-        zos.push(boost::iostreams::zlib_compressor());
+        zos.push(boost::iostreams::zlib_compressor(boost::iostreams::zlib_params{zlib_level}));
         zos.push(os);
         if (use_binary_serialization) {
             freeorion_bin_oarchive oa(zos);

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -221,6 +221,9 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             galaxy_setup_data.encoding_empire = empire_id;
             oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         }
+        if (!zos.strict_sync()) {
+            zos.reset();
+        }
     }
     return Message{Message::MessageType::GAME_START, std::move(os).str()};
 }
@@ -293,6 +296,9 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             galaxy_setup_data.encoding_empire = empire_id;
             oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         }
+        if (!zos.strict_sync()) {
+            zos.reset();
+        }
     }
     return Message{Message::MessageType::GAME_START, std::move(os).str()};
 }
@@ -364,6 +370,9 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             }
             galaxy_setup_data.encoding_empire = empire_id;
             oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
+        }
+        if (!zos.strict_sync()) {
+            zos.reset();
         }
     }
     return Message{Message::MessageType::GAME_START, std::move(os).str()};

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -181,43 +181,47 @@ Message GameStartMessage(bool single_player_game, int empire_id,
                          CombatLogManager& combat_logs, const SupplyManager& supply,
                          const std::map<int, PlayerInfo>& players,
                          GalaxySetupData galaxy_setup_data,
-                         bool use_binary_serialization, int zlib_level)
+                         bool use_binary_serialization, bool use_compression)
 {
     std::ostringstream os;
     {
+        boost::iostreams::zlib_params params;
+        params.level = boost::iostreams::zlib::no_compression;
+        if (use_compression)
+            params.level = boost::iostreams::zlib::default_compression;
         boost::iostreams::filtering_ostream zos;
-        zos.push(boost::iostreams::zlib_compressor(boost::iostreams::zlib_params{zlib_level}));
+        zos.push(boost::iostreams::zlib_compressor(params));
         zos.push(os);
         if (use_binary_serialization) {
             freeorion_bin_oarchive oa(zos);
             oa << BOOST_SERIALIZATION_NVP(single_player_game)
-               << BOOST_SERIALIZATION_NVP(empire_id)
-               << BOOST_SERIALIZATION_NVP(current_turn);
+                << BOOST_SERIALIZATION_NVP(empire_id)
+                << BOOST_SERIALIZATION_NVP(current_turn);
             GlobalSerializationEncodingForEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
-               << BOOST_SERIALIZATION_NVP(species);
+                << BOOST_SERIALIZATION_NVP(species);
             SerializeIncompleteLogs(oa, combat_logs, 1);
             oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = false;
             oa << BOOST_SERIALIZATION_NVP(players)
-               << BOOST_SERIALIZATION_NVP(loaded_game_data);
+                << BOOST_SERIALIZATION_NVP(loaded_game_data);
             galaxy_setup_data.encoding_empire = empire_id;
             oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         } else {
             freeorion_xml_oarchive oa(zos);
             oa << BOOST_SERIALIZATION_NVP(single_player_game)
-               << BOOST_SERIALIZATION_NVP(empire_id)
-               << BOOST_SERIALIZATION_NVP(current_turn);
+                << BOOST_SERIALIZATION_NVP(empire_id)
+                << BOOST_SERIALIZATION_NVP(current_turn);
             GlobalSerializationEncodingForEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
-               << BOOST_SERIALIZATION_NVP(species);
+                << BOOST_SERIALIZATION_NVP(species);
             SerializeIncompleteLogs(oa, combat_logs, 1);
             oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = false;
             oa << BOOST_SERIALIZATION_NVP(players)
-               << BOOST_SERIALIZATION_NVP(loaded_game_data);
+                << BOOST_SERIALIZATION_NVP(loaded_game_data);
             galaxy_setup_data.encoding_empire = empire_id;
             oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         }
@@ -235,27 +239,31 @@ Message GameStartMessage(bool single_player_game, int empire_id,
                          const std::map<int, PlayerInfo>& players,
                          const OrderSet& orders, const SaveGameUIData* ui_data,
                          GalaxySetupData galaxy_setup_data,
-                         bool use_binary_serialization, int zlib_level)
+                         bool use_binary_serialization, bool use_compression)
 {
     std::ostringstream os;
     {
+        boost::iostreams::zlib_params params;
+        params.level = boost::iostreams::zlib::no_compression;
+        if (use_compression)
+            params.level = boost::iostreams::zlib::default_compression;
         boost::iostreams::filtering_ostream zos;
-        zos.push(boost::iostreams::zlib_compressor(boost::iostreams::zlib_params{zlib_level}));
+        zos.push(boost::iostreams::zlib_compressor(params));
         zos.push(os);
         if (use_binary_serialization) {
             freeorion_bin_oarchive oa(zos);
             oa << BOOST_SERIALIZATION_NVP(single_player_game)
-               << BOOST_SERIALIZATION_NVP(empire_id)
-               << BOOST_SERIALIZATION_NVP(current_turn);
+            << BOOST_SERIALIZATION_NVP(empire_id)
+            << BOOST_SERIALIZATION_NVP(current_turn);
             GlobalSerializationEncodingForEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
-               << BOOST_SERIALIZATION_NVP(species);
+            << BOOST_SERIALIZATION_NVP(species);
             SerializeIncompleteLogs(oa, combat_logs, 1);
             oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = true;
             oa << BOOST_SERIALIZATION_NVP(players)
-               << BOOST_SERIALIZATION_NVP(loaded_game_data);
+            << BOOST_SERIALIZATION_NVP(loaded_game_data);
             Serialize(oa, orders);
             bool ui_data_available = (ui_data != nullptr);
             oa << BOOST_SERIALIZATION_NVP(ui_data_available);
@@ -268,17 +276,17 @@ Message GameStartMessage(bool single_player_game, int empire_id,
         } else {
             freeorion_xml_oarchive oa(zos);
             oa << BOOST_SERIALIZATION_NVP(single_player_game)
-               << BOOST_SERIALIZATION_NVP(empire_id)
-               << BOOST_SERIALIZATION_NVP(current_turn);
+            << BOOST_SERIALIZATION_NVP(empire_id)
+            << BOOST_SERIALIZATION_NVP(current_turn);
             GlobalSerializationEncodingForEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
-               << BOOST_SERIALIZATION_NVP(species);
+            << BOOST_SERIALIZATION_NVP(species);
             SerializeIncompleteLogs(oa, combat_logs, 1);
             oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = true;
             oa << BOOST_SERIALIZATION_NVP(players)
-               << BOOST_SERIALIZATION_NVP(loaded_game_data);
+            << BOOST_SERIALIZATION_NVP(loaded_game_data);
             Serialize(oa, orders);
             bool ui_data_available = (ui_data != nullptr);
             oa << BOOST_SERIALIZATION_NVP(ui_data_available);
@@ -310,27 +318,31 @@ Message GameStartMessage(bool single_player_game, int empire_id,
                          const std::map<int, PlayerInfo>& players,
                          const OrderSet& orders, const std::string* save_state_string,
                          GalaxySetupData galaxy_setup_data,
-                         bool use_binary_serialization, int zlib_level)
+                         bool use_binary_serialization, bool use_compression)
 {
     std::ostringstream os;
     {
+        boost::iostreams::zlib_params params;
+        params.level = boost::iostreams::zlib::no_compression;
+        if (use_compression)
+            params.level = boost::iostreams::zlib::default_compression;
         boost::iostreams::filtering_ostream zos;
-        zos.push(boost::iostreams::zlib_compressor(boost::iostreams::zlib_params{zlib_level}));
+        zos.push(boost::iostreams::zlib_compressor(params));
         zos.push(os);
         if (use_binary_serialization) {
             freeorion_bin_oarchive oa(zos);
             oa << BOOST_SERIALIZATION_NVP(single_player_game)
-               << BOOST_SERIALIZATION_NVP(empire_id)
-               << BOOST_SERIALIZATION_NVP(current_turn);
+            << BOOST_SERIALIZATION_NVP(empire_id)
+            << BOOST_SERIALIZATION_NVP(current_turn);
             GlobalSerializationEncodingForEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
-               << BOOST_SERIALIZATION_NVP(species);
+            << BOOST_SERIALIZATION_NVP(species);
             SerializeIncompleteLogs(oa, combat_logs, 1);
             oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = true;
             oa << BOOST_SERIALIZATION_NVP(players)
-               << BOOST_SERIALIZATION_NVP(loaded_game_data);
+            << BOOST_SERIALIZATION_NVP(loaded_game_data);
             Serialize(oa, orders);
             bool ui_data_available = false;
             oa << BOOST_SERIALIZATION_NVP(ui_data_available);
@@ -343,17 +355,17 @@ Message GameStartMessage(bool single_player_game, int empire_id,
         } else {
             freeorion_xml_oarchive oa(zos);
             oa << BOOST_SERIALIZATION_NVP(single_player_game)
-               << BOOST_SERIALIZATION_NVP(empire_id)
-               << BOOST_SERIALIZATION_NVP(current_turn);
+            << BOOST_SERIALIZATION_NVP(empire_id)
+            << BOOST_SERIALIZATION_NVP(current_turn);
             GlobalSerializationEncodingForEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
-               << BOOST_SERIALIZATION_NVP(species);
+            << BOOST_SERIALIZATION_NVP(species);
             SerializeIncompleteLogs(oa, combat_logs, 1);
             oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = true;
             oa << BOOST_SERIALIZATION_NVP(players)
-               << BOOST_SERIALIZATION_NVP(loaded_game_data);
+            << BOOST_SERIALIZATION_NVP(loaded_game_data);
             Serialize(oa, orders);
             bool ui_data_available = false;
             oa << BOOST_SERIALIZATION_NVP(ui_data_available);
@@ -462,12 +474,19 @@ Message TurnUpdateMessage(int empire_id, int current_turn,
                           const SpeciesManager& species, CombatLogManager& combat_logs,
                           const SupplyManager& supply,
                           const std::map<int, PlayerInfo>& players,
-                          bool use_binary_serialization)
+                          bool use_binary_serialization, bool use_compression)
 {
     std::ostringstream os;
     {
+        boost::iostreams::zlib_params params;
+        params.level = boost::iostreams::zlib::no_compression;
+        if (use_compression)
+            params.level = boost::iostreams::zlib::default_compression;
+        boost::iostreams::filtering_ostream zos;
+        zos.push(boost::iostreams::zlib_compressor(params));
+        zos.push(os);
         if (use_binary_serialization) {
-            freeorion_bin_oarchive oa(os);
+            freeorion_bin_oarchive oa(zos);
             GlobalSerializationEncodingForEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(current_turn);
             oa << BOOST_SERIALIZATION_NVP(empires);
@@ -477,32 +496,45 @@ Message TurnUpdateMessage(int empire_id, int current_turn,
             Serialize(oa, universe);
             oa << BOOST_SERIALIZATION_NVP(players);
         } else {
-            freeorion_xml_oarchive oa(os);
+            freeorion_xml_oarchive oa(zos);
             GlobalSerializationEncodingForEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(current_turn)
-               << BOOST_SERIALIZATION_NVP(empires)
-               << BOOST_SERIALIZATION_NVP(species);
+            << BOOST_SERIALIZATION_NVP(empires)
+            << BOOST_SERIALIZATION_NVP(species);
             SerializeIncompleteLogs(oa, combat_logs, 1);
             oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             oa << BOOST_SERIALIZATION_NVP(players);
+        }
+        if (!zos.strict_sync()) {
+            zos.reset();
         }
     }
     return Message{Message::MessageType::TURN_UPDATE, std::move(os).str()};
 }
 
 Message TurnPartialUpdateMessage(int empire_id, const Universe& universe,
-                                 bool use_binary_serialization) {
+                                 bool use_binary_serialization, bool use_compression) {
     std::ostringstream os;
     {
+        boost::iostreams::zlib_params params;
+        params.level = boost::iostreams::zlib::no_compression;
+        if (use_compression)
+            params.level = boost::iostreams::zlib::default_compression;
+        boost::iostreams::filtering_ostream zos;
+        zos.push(boost::iostreams::zlib_compressor(params));
+        zos.push(os);
         if (use_binary_serialization) {
-            freeorion_bin_oarchive oa(os);
+            freeorion_bin_oarchive oa(zos);
             GlobalSerializationEncodingForEmpire() = empire_id;
             Serialize(oa, universe);
         } else {
-            freeorion_xml_oarchive oa(os);
+            freeorion_xml_oarchive oa(zos);
             GlobalSerializationEncodingForEmpire() = empire_id;
             Serialize(oa, universe);
+        }
+        if (!zos.strict_sync()) {
+            zos.reset();
         }
     }
     return Message{Message::MessageType::TURN_PARTIAL_UPDATE, std::move(os).str()};
@@ -593,17 +625,27 @@ Message RequestCombatLogsMessage(const std::vector<int>& ids) {
 }
 
 Message DispatchCombatLogsMessage(const std::vector<std::pair<int, const CombatLog>>& logs,
-                                  bool use_binary_serialization)
+                                  bool use_binary_serialization, bool use_compression)
 {
     std::ostringstream os;
     {
         try {
+            boost::iostreams::zlib_params params;
+            params.level = boost::iostreams::zlib::no_compression;
+            if (use_compression)
+                params.level = boost::iostreams::zlib::default_compression;
+            boost::iostreams::filtering_ostream zos;
+            zos.push(boost::iostreams::zlib_compressor(params));
+            zos.push(os);
             if (use_binary_serialization) {
-                freeorion_bin_oarchive oa(os);
+                freeorion_bin_oarchive oa(zos);
                 oa << BOOST_SERIALIZATION_NVP(logs);
             } else {
-                freeorion_xml_oarchive oa(os);
+                freeorion_xml_oarchive oa(zos);
                 oa << BOOST_SERIALIZATION_NVP(logs);
+            }
+            if (!zos.strict_sync()) {
+                zos.reset();
             }
         } catch (const std::exception& e) {
             ErrorLogger() << "Caught exception serializing combat logs: " << e.what();
@@ -650,14 +692,29 @@ Message ServerLobbyUpdateMessage(const MultiplayerLobbyData& lobby_data) {
     return Message{Message::MessageType::LOBBY_UPDATE, std::move(os).str()};
 }
 
-Message ChatHistoryMessage(const std::vector<std::reference_wrapper<const ChatHistoryEntity>>& chat_history) {
+Message ChatHistoryMessage(const std::vector<std::reference_wrapper<const ChatHistoryEntity>>& chat_history,
+                           bool use_compression) {
     std::ostringstream os;
     {
-        freeorion_xml_oarchive oa(os);
-        std::size_t size = chat_history.size();
-        oa << BOOST_SERIALIZATION_NVP(size);
-        for (const auto& elem : chat_history) {
-            oa << boost::serialization::make_nvp(BOOST_PP_STRINGIZE(elem), elem.get());
+        boost::iostreams::zlib_params params;
+        params.level = boost::iostreams::zlib::no_compression;
+        if (use_compression)
+            params.level = boost::iostreams::zlib::default_compression;
+        boost::iostreams::filtering_ostream zos;
+        zos.push(boost::iostreams::zlib_compressor(params));
+        zos.push(os);
+        {
+            // Nested block ensures archive is closed and completes writing before
+            // the filtering_ostream is rendered unusable by reset(). 
+            freeorion_xml_oarchive oa(zos);
+            std::size_t size = chat_history.size();
+            oa << BOOST_SERIALIZATION_NVP(size);
+            for (const auto &elem : chat_history) {
+                oa << boost::serialization::make_nvp(BOOST_PP_STRINGIZE(elem), elem.get());
+            }
+        }
+        if (!zos.strict_sync()) {
+            zos.reset();
         }
     }
     return Message{Message::MessageType::CHAT_HISTORY, std::move(os).str()};
@@ -795,7 +852,10 @@ void ExtractLobbyUpdateMessageData(const Message& msg, MultiplayerLobbyData& lob
 void ExtractChatHistoryMessage(const Message& msg, std::vector<ChatHistoryEntity>& chat_history) {
     try {
         std::istringstream is(msg.Text());
-        freeorion_xml_iarchive ia(is);
+        boost::iostreams::filtering_istream zis;
+        zis.push(boost::iostreams::zlib_decompressor());
+        zis.push(is);
+        freeorion_xml_iarchive ia(zis);
         std::size_t size;
         ia >> BOOST_SERIALIZATION_NVP(size);
         chat_history.clear();
@@ -869,53 +929,49 @@ void ExtractGameStartMessageData(std::string text, bool& single_player_game, int
 {
     try {
         bool try_xml = false;
-        if (strncmp(text.c_str(), "<?xml", 5)) {
-            try {
-                // first attempt binary deserialziation
-                std::istringstream is(text);
-                boost::iostreams::filtering_istream zis;
-                zis.push(boost::iostreams::zlib_decompressor());
-                zis.push(is);
+        try {
+            // first attempt binary deserialziation
+            std::istringstream is(text);
+            boost::iostreams::filtering_istream zis;
+            zis.push(boost::iostreams::zlib_decompressor());
+            zis.push(is);
 
-                freeorion_bin_iarchive ia(zis);
-                ia >> BOOST_SERIALIZATION_NVP(single_player_game)
-                   >> BOOST_SERIALIZATION_NVP(empire_id)
-                   >> BOOST_SERIALIZATION_NVP(current_turn);
-                GlobalSerializationEncodingForEmpire() = empire_id;
+            freeorion_bin_iarchive ia(zis);
+            ia >> BOOST_SERIALIZATION_NVP(single_player_game)
+               >> BOOST_SERIALIZATION_NVP(empire_id)
+               >> BOOST_SERIALIZATION_NVP(current_turn);
+            GlobalSerializationEncodingForEmpire() = empire_id;
 
-                ScopedTimer deserialize_timer;
-                ia >> BOOST_SERIALIZATION_NVP(empires);
-                DebugLogger() << "ExtractGameStartMessage empire deserialization time " << deserialize_timer.DurationString();
+            ScopedTimer deserialize_timer;
+            ia >> BOOST_SERIALIZATION_NVP(empires);
+            DebugLogger() << "ExtractGameStartMessage empire deserialization time " << deserialize_timer.DurationString();
 
-                ia >> BOOST_SERIALIZATION_NVP(species);
-                combat_logs.Clear();    // only needed when loading new game, not when incrementally serializing logs on turn update
-                SerializeIncompleteLogs(ia, combat_logs, 1);
-                ia >> BOOST_SERIALIZATION_NVP(supply);
+            ia >> BOOST_SERIALIZATION_NVP(species);
+            combat_logs.Clear();    // only needed when loading new game, not when incrementally serializing logs on turn update
+            SerializeIncompleteLogs(ia, combat_logs, 1);
+            ia >> BOOST_SERIALIZATION_NVP(supply);
 
-                deserialize_timer.restart();
-                Deserialize(ia, universe);
-                DebugLogger() << "ExtractGameStartMessage universe deserialization time " << deserialize_timer.DurationString();
+            deserialize_timer.restart();
+            Deserialize(ia, universe);
+            DebugLogger() << "ExtractGameStartMessage universe deserialization time " << deserialize_timer.DurationString();
 
 
-                ia >> BOOST_SERIALIZATION_NVP(players)
-                   >> BOOST_SERIALIZATION_NVP(loaded_game_data);
-                if (loaded_game_data) {
-                    Deserialize(ia, orders);
-                    ia >> BOOST_SERIALIZATION_NVP(ui_data_available);
-                    if (ui_data_available)
-                        ia >> BOOST_SERIALIZATION_NVP(ui_data);
-                    ia >> BOOST_SERIALIZATION_NVP(save_state_string_available);
-                    if (save_state_string_available)
-                        ia >> BOOST_SERIALIZATION_NVP(save_state_string);
-                } else {
-                    ui_data_available = false;
-                    save_state_string_available = false;
-                }
-                ia >> BOOST_SERIALIZATION_NVP(galaxy_setup_data);
-            } catch (...) {
-                try_xml = true;
+            ia >> BOOST_SERIALIZATION_NVP(players)
+            >> BOOST_SERIALIZATION_NVP(loaded_game_data);
+            if (loaded_game_data) {
+                Deserialize(ia, orders);
+                ia >> BOOST_SERIALIZATION_NVP(ui_data_available);
+                if (ui_data_available)
+                    ia >> BOOST_SERIALIZATION_NVP(ui_data);
+                ia >> BOOST_SERIALIZATION_NVP(save_state_string_available);
+                if (save_state_string_available)
+                    ia >> BOOST_SERIALIZATION_NVP(save_state_string);
+            } else {
+                ui_data_available = false;
+                save_state_string_available = false;
             }
-        } else {
+            ia >> BOOST_SERIALIZATION_NVP(galaxy_setup_data);
+        } catch (...) {
             try_xml = true;
         }
         if (try_xml) {
@@ -967,7 +1023,6 @@ void ExtractGameStartMessageData(std::string text, bool& single_player_game, int
             ia >> BOOST_SERIALIZATION_NVP(galaxy_setup_data);
             TraceLogger() << "ExtractGameStartMessage galaxy setup data deserialization time " << deserialize_timer.DurationString();
         }
-
     } catch (const std::exception& err) {
         ErrorLogger() << "ExtractGameStartMessageData(...) failed!  Message probably long, so not outputting to log.\n"
                       << "Error: " << err.what();
@@ -1085,29 +1140,33 @@ void ExtractTurnUpdateMessageData(std::string text, int empire_id, int& current_
         ScopedTimer timer("Turn Update Unpacking");
 
         bool try_xml = false;
-        if (std::strncmp(text.c_str(), "<?xml", 5)) {
-            try {
-                // first attempt binary deserialization
-                std::istringstream is(text);
-                freeorion_bin_iarchive ia(is);
-                GlobalSerializationEncodingForEmpire() = empire_id;
-                ia >> BOOST_SERIALIZATION_NVP(current_turn)
-                   >> BOOST_SERIALIZATION_NVP(empires)
-                   >> BOOST_SERIALIZATION_NVP(species);
-                SerializeIncompleteLogs(ia, combat_logs, 1);
-                ia >> BOOST_SERIALIZATION_NVP(supply);
-                Deserialize(ia, universe);
-                ia >> BOOST_SERIALIZATION_NVP(players);
-            } catch (...) {
-                try_xml = true;
-            }
-        } else {
+        try {
+            // first attempt binary deserialization
+            std::istringstream is(text);
+            boost::iostreams::filtering_istream zis;
+            zis.push(boost::iostreams::zlib_decompressor());
+            zis.push(is);
+
+            freeorion_bin_iarchive ia(zis);
+            GlobalSerializationEncodingForEmpire() = empire_id;
+            ia >> BOOST_SERIALIZATION_NVP(current_turn)
+               >> BOOST_SERIALIZATION_NVP(empires)
+               >> BOOST_SERIALIZATION_NVP(species);
+            SerializeIncompleteLogs(ia, combat_logs, 1);
+            ia >> BOOST_SERIALIZATION_NVP(supply);
+            Deserialize(ia, universe);
+            ia >> BOOST_SERIALIZATION_NVP(players);
+        } catch (...) {
             try_xml = true;
         }
         if (try_xml) {
             // try again with more-portable XML deserialization
             std::istringstream is(text);
-            freeorion_xml_iarchive ia(is);
+            boost::iostreams::filtering_istream zis;
+            zis.push(boost::iostreams::zlib_decompressor());
+            zis.push(is);
+
+            freeorion_xml_iarchive ia(zis);
             GlobalSerializationEncodingForEmpire() = empire_id;
             ia >> BOOST_SERIALIZATION_NVP(current_turn)
                >> BOOST_SERIALIZATION_NVP(empires)
@@ -1117,7 +1176,6 @@ void ExtractTurnUpdateMessageData(std::string text, int empire_id, int& current_
             Deserialize(ia, universe);
             ia >> BOOST_SERIALIZATION_NVP(players);
         }
-
     } catch (const std::exception& err) {
         ErrorLogger() << "ExtractTurnUpdateMessageData(...) failed!  Message probably long, so not outputting to log.\n"
                       << "Error: " << err.what();
@@ -1130,27 +1188,30 @@ void ExtractTurnPartialUpdateMessageData(const Message& msg, int empire_id, Univ
         ScopedTimer timer("Mid Turn Update Unpacking");
 
         bool try_xml = false;
-        if (std::strncmp(msg.Data(), "<?xml", 5)) {
-            try {
-                // first attempt binary deserialization
-                std::istringstream is(msg.Text());
-                freeorion_bin_iarchive ia(is);
-                GlobalSerializationEncodingForEmpire() = empire_id;
-                Deserialize(ia, universe);
-            } catch (...) {
-                try_xml = true;
-            }
-        } else {
+        try {
+            // first attempt binary deserialization
+            std::istringstream is(msg.Text());
+            boost::iostreams::filtering_istream zis;
+            zis.push(boost::iostreams::zlib_decompressor());
+            zis.push(is);
+
+            freeorion_bin_iarchive ia(zis);
+            GlobalSerializationEncodingForEmpire() = empire_id;
+            Deserialize(ia, universe);
+        } catch (...) {
             try_xml = true;
         }
         if (try_xml) {
             // try again with more-portable XML deserialization
             std::istringstream is(msg.Text());
-            freeorion_xml_iarchive ia(is);
+            boost::iostreams::filtering_istream zis;
+            zis.push(boost::iostreams::zlib_decompressor());
+            zis.push(is);
+
+            freeorion_xml_iarchive ia(zis);
             GlobalSerializationEncodingForEmpire() = empire_id;
             Deserialize(ia, universe);
         }
-
     } catch (const std::exception& err) {
         ErrorLogger() << "ExtracturnPartialUpdateMessageData(...) failed!  Message probably long, so not outputting to log.\n"
                       << "Error: " << err.what();
@@ -1313,25 +1374,28 @@ FO_COMMON_API void ExtractDispatchCombatLogsMessageData(
 {
     try {
         bool try_xml = false;
-        if (std::strncmp(msg.Data(), "<?xml", 5)) {
-            try {
-                // first attempt binary deserialization
-                std::istringstream is(msg.Text());
-                freeorion_bin_iarchive ia(is);
-                ia >> BOOST_SERIALIZATION_NVP(logs);
-            } catch (...) {
-                try_xml = true;
-            }
-        } else {
+        try {
+            // first attempt binary deserialization
+            std::istringstream is(msg.Text());
+            boost::iostreams::filtering_istream zis;
+            zis.push(boost::iostreams::zlib_decompressor());
+            zis.push(is);
+
+            freeorion_bin_iarchive ia(zis);
+            ia >> BOOST_SERIALIZATION_NVP(logs);
+        } catch (...) {
             try_xml = true;
         }
         if (try_xml) {
             // try again with more-portable XML deserialization
             std::istringstream is(msg.Text());
-            freeorion_xml_iarchive ia(is);
+            boost::iostreams::filtering_istream zis;
+            zis.push(boost::iostreams::zlib_decompressor());
+            zis.push(is);
+
+            freeorion_xml_iarchive ia(zis);
             ia >> BOOST_SERIALIZATION_NVP(logs);
         }
-
     } catch(const std::exception& err) {
         ErrorLogger() << "ExtractDispatchCombatLogMessageData(const Message& msg, std::vector<std::pair<int, const CombatLog&>>& logs) failed!  Message:\n"
                       << msg.Text() << "\n"

--- a/network/Message.h
+++ b/network/Message.h
@@ -207,7 +207,8 @@ FO_COMMON_API Message GameStartMessage(
     const EmpireManager& empires, const Universe& universe,
     const SpeciesManager& species, CombatLogManager& combat_logs,
     const SupplyManager& supply, const std::map<int, PlayerInfo>& players,
-    GalaxySetupData galaxy_setup_data, bool use_binary_serialization);
+    GalaxySetupData galaxy_setup_data, bool use_binary_serialization,
+    int zlib_level);
 
 /** creates a GAME_START message.  Contains the initial game state visible to
   * the player.  Also includes data loaded from a saved game. */
@@ -217,7 +218,8 @@ FO_COMMON_API Message GameStartMessage(
     const SpeciesManager& species, CombatLogManager& combat_logs,
     const SupplyManager& supply, const std::map<int, PlayerInfo>& players,
     const OrderSet& orders, const SaveGameUIData* ui_data,
-    GalaxySetupData galaxy_setup_data, bool use_binary_serialization);
+    GalaxySetupData galaxy_setup_data, bool use_binary_serialization,
+    int zlib_level);
 
 /** creates a GAME_START message.  Contains the initial game state visible to
   * the player.  Also includes state string loaded from a saved game. */
@@ -227,7 +229,8 @@ FO_COMMON_API Message GameStartMessage(
     const SpeciesManager& species, CombatLogManager& combat_logs,
     const SupplyManager& supply, const std::map<int, PlayerInfo>& players,
     const OrderSet& orders, const std::string* save_state_string,
-    GalaxySetupData galaxy_setup_data, bool use_binary_serialization);
+    GalaxySetupData galaxy_setup_data, bool use_binary_serialization,
+    int zlib_level);
 
 /** creates a HOST_SP_GAME acknowledgement message.  The \a player_id is the ID
   * of the receiving player.  This message should only be sent by the server.*/

--- a/network/Message.h
+++ b/network/Message.h
@@ -208,7 +208,7 @@ FO_COMMON_API Message GameStartMessage(
     const SpeciesManager& species, CombatLogManager& combat_logs,
     const SupplyManager& supply, const std::map<int, PlayerInfo>& players,
     GalaxySetupData galaxy_setup_data, bool use_binary_serialization,
-    int zlib_level);
+    bool use_compression);
 
 /** creates a GAME_START message.  Contains the initial game state visible to
   * the player.  Also includes data loaded from a saved game. */
@@ -219,7 +219,7 @@ FO_COMMON_API Message GameStartMessage(
     const SupplyManager& supply, const std::map<int, PlayerInfo>& players,
     const OrderSet& orders, const SaveGameUIData* ui_data,
     GalaxySetupData galaxy_setup_data, bool use_binary_serialization,
-    int zlib_level);
+    bool use_compression);
 
 /** creates a GAME_START message.  Contains the initial game state visible to
   * the player.  Also includes state string loaded from a saved game. */
@@ -230,7 +230,7 @@ FO_COMMON_API Message GameStartMessage(
     const SupplyManager& supply, const std::map<int, PlayerInfo>& players,
     const OrderSet& orders, const std::string* save_state_string,
     GalaxySetupData galaxy_setup_data, bool use_binary_serialization,
-    int zlib_level);
+    bool use_compression);
 
 /** creates a HOST_SP_GAME acknowledgement message.  The \a player_id is the ID
   * of the receiving player.  This message should only be sent by the server.*/
@@ -269,11 +269,13 @@ FO_COMMON_API Message TurnUpdateMessage(int empire_id, int current_turn,
                                         const EmpireManager& empires, const Universe& universe,
                                         const SpeciesManager& species, CombatLogManager& combat_logs,
                                         const SupplyManager& supply,
-                                        const std::map<int, PlayerInfo>& players, bool use_binary_serialization);
+                                        const std::map<int, PlayerInfo>& players, bool use_binary_serialization,
+                                        bool use_compression);
 
 /** create a TURN_PARTIAL_UPDATE message. */
 FO_COMMON_API Message TurnPartialUpdateMessage(int empire_id, const Universe& universe,
-                                               bool use_binary_serialization);
+                                               bool use_binary_serialization,
+                                               bool use_compression);
 
 /** creates a SAVE_GAME_INITIATE request message.  This message should only be sent by
   * the host player.*/
@@ -315,7 +317,7 @@ FO_COMMON_API Message RequestCombatLogsMessage(const std::vector<int>& ids);
 
 /** returns combat logs to the client */
 FO_COMMON_API Message DispatchCombatLogsMessage(const std::vector<std::pair<int, const CombatLog>>& logs,
-                                                bool use_binary_serialization);
+                                                bool use_binary_serialization, bool use_compression);
 
 /** Sends logger configuration details to server or ai process. */
 FO_COMMON_API Message LoggerConfigMessage(int sender, const std::set<std::tuple<std::string, std::string, LogLevel>>& options);
@@ -335,7 +337,8 @@ FO_COMMON_API Message ServerLobbyUpdateMessage(const MultiplayerLobbyData& lobby
 
 /** creates an CHAT_HISTORY message containing latest chat messages.
     This message should only be sent by the server.*/
-FO_COMMON_API Message ChatHistoryMessage(const std::vector<std::reference_wrapper<const ChatHistoryEntity>>& chat_history);
+FO_COMMON_API Message ChatHistoryMessage(const std::vector<std::reference_wrapper<const ChatHistoryEntity>>& chat_history,
+                                         bool use_compression);
 
 /** creates an PLAYER_CHAT message containing a chat string to be broadcast to player \a receiver, or all players if \a
     receiver is Networking::INVALID_PLAYER_ID. Note that the receiver of this message is always the server.*/

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -8,6 +8,7 @@
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/functional/hash.hpp>
+#include <boost/iostreams/filter/zlib.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -920,7 +921,7 @@ void ServerApp::SendNewGameStartMessages() {
                                                         m_universe,              GetSpeciesManager(),
                                                         GetCombatLogManager(),   GetSupplyManager(),
                                                         player_info_map,         m_galaxy_setup_data,
-                                                        use_binary_serialization));
+                                                        use_binary_serialization, boost::iostreams::zlib::default_compression));
     }
 }
 
@@ -1498,7 +1499,8 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
                                                             m_current_turn, m_empires, m_universe,
                                                             GetSpeciesManager(), GetCombatLogManager(),
                                                             GetSupplyManager(), player_info_map, *orders, sss,
-                                                            m_galaxy_setup_data, use_binary_serialization));
+                                                            m_galaxy_setup_data, use_binary_serialization,
+                                                            boost::iostreams::zlib::default_compression));
 
         } else if (client_type == Networking::ClientType::CLIENT_TYPE_HUMAN_PLAYER) {
             player_connection->SendMessage(GameStartMessage(m_single_player_game, empire_id,
@@ -1506,7 +1508,8 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
                                                             GetSpeciesManager(), GetCombatLogManager(),
                                                             GetSupplyManager(), player_info_map, *orders,
                                                             psgd.ui_data.get(), m_galaxy_setup_data,
-                                                            use_binary_serialization));
+                                                            use_binary_serialization,
+                                                            boost::iostreams::zlib::default_compression));
 
         } else if (client_type == Networking::ClientType::CLIENT_TYPE_HUMAN_OBSERVER ||
                    client_type == Networking::ClientType::CLIENT_TYPE_HUMAN_MODERATOR)
@@ -1516,7 +1519,8 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
                                                             m_current_turn, m_empires, m_universe,
                                                             GetSpeciesManager(), GetCombatLogManager(),
                                                             GetSupplyManager(), player_info_map,
-                                                            m_galaxy_setup_data, use_binary_serialization));
+                                                            m_galaxy_setup_data, use_binary_serialization,
+                                                            boost::iostreams::zlib::default_compression));
         } else {
             ErrorLogger() << "ServerApp::CommonGameInit unsupported client type: skipping game start message.";
         }
@@ -1841,7 +1845,8 @@ void ServerApp::AddObserverPlayerIntoGame(const PlayerConnectionPtr& player_conn
                                                         m_current_turn, m_empires, m_universe,
                                                         GetSpeciesManager(), GetCombatLogManager(),
                                                         GetSupplyManager(), player_info_map,
-                                                        m_galaxy_setup_data, use_binary_serialization));
+                                                        m_galaxy_setup_data, use_binary_serialization,
+                                                        boost::iostreams::zlib::default_compression));
     } else {
         ErrorLogger() << "ServerApp::CommonGameInit unsupported client type: skipping game start message.";
     }
@@ -2056,7 +2061,8 @@ int ServerApp::AddPlayerIntoGame(const PlayerConnectionPtr& player_connection, i
         GetSupplyManager(), player_info_map, orders,
         ui_data,
         m_galaxy_setup_data,
-        use_binary_serialization));
+        use_binary_serialization,
+        boost::iostreams::zlib::default_compression));
 
     return empire_id;
 }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -921,7 +921,7 @@ void ServerApp::SendNewGameStartMessages() {
                                                         m_universe,              GetSpeciesManager(),
                                                         GetCombatLogManager(),   GetSupplyManager(),
                                                         player_info_map,         m_galaxy_setup_data,
-                                                        use_binary_serialization, boost::iostreams::zlib::default_compression));
+                                                        use_binary_serialization, !player_connection->IsLocalConnection()));
     }
 }
 
@@ -1068,11 +1068,13 @@ void ServerApp::UpdateCombatLogs(const Message& msg, PlayerConnectionPtr player_
 
     try {
         bool use_binary_serialization = player_connection->IsBinarySerializationUsed();
-        player_connection->SendMessage(DispatchCombatLogsMessage(logs, use_binary_serialization));
+        player_connection->SendMessage(DispatchCombatLogsMessage(logs, use_binary_serialization,
+                                                                 !player_connection->IsLocalConnection()));
     } catch (const std::exception& e) {
         ErrorLogger() << "caught exception sending combat logs message: " << e.what();
         std::vector<std::pair<int, const CombatLog>> empty_logs;
-        player_connection->SendMessage(DispatchCombatLogsMessage(empty_logs, false));
+        player_connection->SendMessage(DispatchCombatLogsMessage(empty_logs, false,
+                                                                 !player_connection->IsLocalConnection()));
     }
 }
 
@@ -1500,7 +1502,7 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
                                                             GetSpeciesManager(), GetCombatLogManager(),
                                                             GetSupplyManager(), player_info_map, *orders, sss,
                                                             m_galaxy_setup_data, use_binary_serialization,
-                                                            boost::iostreams::zlib::default_compression));
+                                                            !player_connection->IsLocalConnection()));
 
         } else if (client_type == Networking::ClientType::CLIENT_TYPE_HUMAN_PLAYER) {
             player_connection->SendMessage(GameStartMessage(m_single_player_game, empire_id,
@@ -1509,7 +1511,7 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
                                                             GetSupplyManager(), player_info_map, *orders,
                                                             psgd.ui_data.get(), m_galaxy_setup_data,
                                                             use_binary_serialization,
-                                                            boost::iostreams::zlib::default_compression));
+                                                            !player_connection->IsLocalConnection()));
 
         } else if (client_type == Networking::ClientType::CLIENT_TYPE_HUMAN_OBSERVER ||
                    client_type == Networking::ClientType::CLIENT_TYPE_HUMAN_MODERATOR)
@@ -1520,7 +1522,7 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
                                                             GetSpeciesManager(), GetCombatLogManager(),
                                                             GetSupplyManager(), player_info_map,
                                                             m_galaxy_setup_data, use_binary_serialization,
-                                                            boost::iostreams::zlib::default_compression));
+                                                            !player_connection->IsLocalConnection()));
         } else {
             ErrorLogger() << "ServerApp::CommonGameInit unsupported client type: skipping game start message.";
         }
@@ -1846,7 +1848,7 @@ void ServerApp::AddObserverPlayerIntoGame(const PlayerConnectionPtr& player_conn
                                                         GetSpeciesManager(), GetCombatLogManager(),
                                                         GetSupplyManager(), player_info_map,
                                                         m_galaxy_setup_data, use_binary_serialization,
-                                                        boost::iostreams::zlib::default_compression));
+                                                        !player_connection->IsLocalConnection()));
     } else {
         ErrorLogger() << "ServerApp::CommonGameInit unsupported client type: skipping game start message.";
     }
@@ -2062,7 +2064,7 @@ int ServerApp::AddPlayerIntoGame(const PlayerConnectionPtr& player_connection, i
         ui_data,
         m_galaxy_setup_data,
         use_binary_serialization,
-        boost::iostreams::zlib::default_compression));
+        !player_connection->IsLocalConnection()));
 
     return empire_id;
 }
@@ -3507,7 +3509,8 @@ void ServerApp::PreCombatProcessTurns() {
         {
             bool use_binary_serialization = player->IsBinarySerializationUsed();
             player->SendMessage(TurnPartialUpdateMessage(PlayerEmpireID(player->PlayerID()),
-                                                         m_universe, use_binary_serialization));
+                                                         m_universe, use_binary_serialization,
+                                                         !player->IsLocalConnection()));
         }
     }
 }
@@ -3832,7 +3835,8 @@ void ServerApp::PostCombatProcessTurns() {
                                                   m_empires,                          m_universe,
                                                   GetSpeciesManager(),                GetCombatLogManager(),
                                                   GetSupplyManager(),                 players,
-                                                  use_binary_serialization));
+                                                  use_binary_serialization,
+                                                  !player->IsLocalConnection()));
         }
     }
     m_turn_expired = false;

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -590,7 +590,7 @@ bool ServerFSM::EstablishPlayer(const PlayerConnectionPtr& player_connection,
             for (const auto& elem : m_server.GetChatHistory())
                 chat_history.push_back(std::cref(elem));
             if (chat_history.size() > 0)
-                player_connection->SendMessage(ChatHistoryMessage(chat_history));
+                player_connection->SendMessage(ChatHistoryMessage(chat_history, !player_connection->IsLocalConnection()));
         }
     }
 
@@ -2686,7 +2686,8 @@ sc::result PlayingGame::react(const ModeratorAct& msg) {
         bool use_binary_serialization = sender->IsBinarySerializationUsed();
         sender->SendMessage(TurnProgressMessage(Message::TurnProgressPhase::DOWNLOADING));
         sender->SendMessage(TurnPartialUpdateMessage(server.PlayerEmpireID(player_id),
-                                                     GetUniverse(), use_binary_serialization));
+                                                     GetUniverse(), use_binary_serialization,
+                                                     !sender->IsLocalConnection()));
     }
 
     delete action;


### PR DESCRIPTION
Stream-based message compression based on #3870, and replacing previous pull request #3854.

Compression is only used for message types that tend to become large; these are all sent by the server. Compression is not used for clients on localhost.