### PR TITLE
Add comment to dump about use of StaticCast and StringCast

### DIFF
--- a/universe/ValueRefs.h
+++ b/universe/ValueRefs.h
@@ -1525,7 +1525,7 @@ std::string StaticCast<FromType, ToType>::Description() const
 
 template <typename FromType, typename ToType>
 std::string StaticCast<FromType, ToType>::Dump(unsigned short ntabs) const
-{ return m_value_ref->Dump(ntabs); }
+{ return "(" + m_value_ref->Dump(ntabs) + ") // StaticCast<" + typeid(FromType).name() + "," + typeid(ToType).name() + ">\n" + DumpIndent(ntabs + 1); }
 
 template <typename FromType, typename ToType>
 void StaticCast<FromType, ToType>::SetTopLevelContent(const std::string& content_name)
@@ -1647,7 +1647,7 @@ std::string StringCast<FromType>::Description() const
 
 template <typename FromType>
 std::string StringCast<FromType>::Dump(unsigned short ntabs) const
-{ return m_value_ref->Dump(ntabs); }
+{ return "(" + m_value_ref->Dump(ntabs) + ") // StringCast<" + typeid(FromType).name() + ">\n" + DumpIndent(ntabs + 1); }
 
 template <typename FromType>
 void StringCast<FromType>::SetTopLevelContent(const std::string& content_name) {


### PR DESCRIPTION
Displays used casts in dump.

Research cost of Singularity of Transcendence from:

```
researchcost = 500 * GalaxySize * (GameRule name = "RULE_SINGULARITY_COST_FACTOR") * [[TECH_COST_MULTIPLIER]]
```

became:

```
researchcost = 500.000000 * /* StaticCast<i,d> */ GalaxySize /* -StaticCast */ * GameRule name = "RULE_SINGULARITY_COST_FACTOR" * GameRule name = "RULE_TECH_COST_FACTOR"
```