### PR TITLE
Add missing include

### DIFF
--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -12,6 +12,7 @@
 
 #include <array>
 #include <map>
+#include <memory>
 #include <set>
 #include <vector>
 #include <unordered_map>


### PR DESCRIPTION
Add a missing include to allow building on Arch Linux.