### PR TITLE
Music separate title and play follow up(with sound launch twice fix)

### DIFF
--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -502,7 +502,8 @@ namespace {
         db.Add("video.fps.unfocused",                      UserStringNop("OPTIONS_DB_MAX_FPS_NO_FOCUS"),               15.0,                           RangedStepValidator<double>(0.125, 0.125, 30.0));
 
         // sound and music
-        db.Add("audio.music.path",                         UserStringNop("OPTIONS_DB_BG_MUSIC"),                       (GetRootDataDir() / "default" / "data" / "sound" / "artificial_intelligence_v3.ogg").string());
+        db.Add("audio.music.title.path",                   UserStringNop("OPTIONS_DB_TITLE_MUSIC"),                    (GetRootDataDir() / "default" / "data" / "sound" / "artificial_intelligence_v3.ogg").string());
+        db.Add("audio.music.ambiance.path",                UserStringNop("OPTIONS_DB_BG_MUSIC"),                       (GetRootDataDir() / "default" / "data" / "sound" / "artificial_intelligence_v3.ogg").string());
         db.Add("audio.music.volume",                       UserStringNop("OPTIONS_DB_MUSIC_VOLUME"),                   127,                            RangedValidator<int>(1, 255));
         db.Add("audio.effects.volume",                     UserStringNop("OPTIONS_DB_UI_SOUND_VOLUME"),                255,                            RangedValidator<int>(0, 255));
         db.Add("ui.button.rollover.sound.path",            UserStringNop("OPTIONS_DB_UI_SOUND_BUTTON_ROLLOVER"),       (GetRootDataDir() / "default" / "data" / "sound" / "button_rollover.ogg").string());

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -1479,35 +1479,31 @@ void OptionsWnd::DoneClicked() {
 }
 
 void OptionsWnd::SoundOptionsFeedback::SoundEffectsEnableClicked(bool checked) {
-    if (checked) {
-        try {
+    try {
+        if (checked) {
             Sound::GetSound().Enable();
             GetOptionsDB().Set("audio.effects.enabled", true);
             Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("ui.button.press.sound.path"), true);
-        } catch (Sound::InitializationFailureException const &e) {
-            SoundInitializationFailure(e);
+        } else {
+            GetOptionsDB().Set("audio.effects.enabled", false);
         }
-    } else {
-        GetOptionsDB().Set("audio.effects.enabled", false);
-        if (!GetOptionsDB().Get<bool>("audio.music.enabled"))
-            Sound::GetSound().Disable();
+    } catch (Sound::InitializationFailureException const &e) {
+        SoundInitializationFailure(e);
     }
 }
 
 void OptionsWnd::SoundOptionsFeedback::MusicClicked(bool checked) {
-    if (checked) {
-        try {
+    try {
+        if (checked) {
             Sound::GetSound().Enable();
             GetOptionsDB().Set("audio.music.enabled", true);
             Sound::GetSound().ResumeMusic();
-        } catch (Sound::InitializationFailureException const &e) {
-            SoundInitializationFailure(e);
+        } else {
+            GetOptionsDB().Set("audio.music.enabled", false);
+            Sound::GetSound().PauseMusic();
         }
-    } else {
-        GetOptionsDB().Set("audio.music.enabled", false);
-        Sound::GetSound().StopMusic();
-        if (!GetOptionsDB().Get<bool>("audio.effects.enabled"))
-            Sound::GetSound().Disable();
+    } catch (Sound::InitializationFailureException const &e) {
+        SoundInitializationFailure(e);
     }
 }
 

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -1497,10 +1497,10 @@ void OptionsWnd::SoundOptionsFeedback::MusicClicked(bool checked) {
         if (checked) {
             Sound::GetSound().Enable();
             GetOptionsDB().Set("audio.music.enabled", true);
-            Sound::GetSound().ResumeMusic();
+            GGHumanClientApp::GetApp()->ResumeMusicTheme();
         } else {
+            GGHumanClientApp::GetApp()->PauseMusicTheme();
             GetOptionsDB().Set("audio.music.enabled", false);
-            Sound::GetSound().PauseMusic();
         }
     } catch (Sound::InitializationFailureException const &e) {
         SoundInitializationFailure(e);
@@ -1531,5 +1531,6 @@ void OptionsWnd::SoundOptionsFeedback::SoundInitializationFailure(Sound::Initial
         m_effects_button->SetCheck(false);
     if (m_music_button)
         m_music_button->SetCheck(false);
+    Sound::GetSound().Disable();
     ClientUI::MessageBox(UserString(e.what()), false);
 }

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -500,7 +500,10 @@ void OptionsWnd::CompleteConstruction() {
     CreateSectionHeader(current_page, 0, UserString("OPTIONS_VOLUME_AND_MUSIC"));
     MusicVolumeOption(current_page, 0, m_sound_feedback);
     VolumeOption(current_page, 0, "audio.effects.enabled", "audio.effects.volume", UserString("OPTIONS_UI_SOUNDS"), UI_sound_enabled, m_sound_feedback);
-    FileOption(current_page, 0, "audio.music.path", UserString("OPTIONS_BACKGROUND_MUSIC"), ClientUI::SoundDir(),
+    FileOption(current_page, 0, "audio.music.title.path", UserString("OPTIONS_TITLE_MUSIC"), ClientUI::SoundDir(),
+               {UserString("OPTIONS_MUSIC_FILE"), "*" + MUSIC_FILE_SUFFIX},
+               ValidMusicFile);
+    FileOption(current_page, 0, "audio.music.ambiance.path", UserString("OPTIONS_BACKGROUND_MUSIC"), ClientUI::SoundDir(),
                {UserString("OPTIONS_MUSIC_FILE"), "*" + MUSIC_FILE_SUFFIX},
                ValidMusicFile);
 
@@ -1496,7 +1499,7 @@ void OptionsWnd::SoundOptionsFeedback::MusicClicked(bool checked) {
         try {
             Sound::GetSound().Enable();
             GetOptionsDB().Set("audio.music.enabled", true);
-            Sound::GetSound().PlayMusic(GetOptionsDB().Get<std::string>("audio.music.path"), -1);
+            Sound::GetSound().ResumeMusic();
         } catch (Sound::InitializationFailureException const &e) {
             SoundInitializationFailure(e);
         }

--- a/client/human/GGHumanClientApp.cpp
+++ b/client/human/GGHumanClientApp.cpp
@@ -213,7 +213,7 @@ std::string GGHumanClientApp::EncodeServerAddressOption(const std::string& serve
 }
 
 GGHumanClientApp::GGHumanClientApp(int width, int height, bool calculate_fps, std::string name,
-                                   int x, int y, bool fullscreen, bool fake_mode_change) :
+                                       int x, int y, bool fullscreen, bool fake_mode_change) :
     ClientApp(),
     SDLGUI(width, height, calculate_fps, std::move(name), x, y, fullscreen, fake_mode_change),
     m_fsm(*this)

--- a/client/human/GGHumanClientApp.cpp
+++ b/client/human/GGHumanClientApp.cpp
@@ -289,10 +289,6 @@ GGHumanClientApp::GGHumanClientApp(int width, int height, bool calculate_fps, st
     try {
         if (GetOptionsDB().Get<bool>("audio.effects.enabled") || GetOptionsDB().Get<bool>("audio.music.enabled"))
             Sound::GetSound().Enable();
-
-        if ((GetOptionsDB().Get<bool>("audio.music.enabled")))
-            Sound::GetSound().PlayMusic(GetOptionsDB().Get<std::string>("audio.music.path"), -1);
-
         Sound::GetSound().SetMusicVolume(GetOptionsDB().Get<int>("audio.music.volume"));
         Sound::GetSound().SetUISoundsVolume(GetOptionsDB().Get<int>("audio.effects.volume"));
     } catch (const Sound::InitializationFailureException&) {

--- a/client/human/GGHumanClientApp.h
+++ b/client/human/GGHumanClientApp.h
@@ -130,6 +130,10 @@ public:
     [[nodiscard]] boost::intrusive_ptr<const boost::statechart::event_base> GetDeferredPostedEvent();
     void PostDeferredEvent(boost::intrusive_ptr<const boost::statechart::event_base> event);
 
+    void ChangeMusicTheme(const std::string& music_theme);
+    void PauseMusicTheme();
+    void ResumeMusicTheme();
+
 protected:
     void Initialize() noexcept override {};
 
@@ -191,6 +195,9 @@ private:
     bool m_connected = false;           ///< true if we are in a state in which we are supposed to be connected to the server
     bool m_have_window_focus = true;
     int  m_auto_turns = 0;              ///< auto turn counter
+
+    std::string                         m_music_theme;
+    bool                                m_music_theme_is_changed = false;
 
     /** Filenames of all in progress saves.  There maybe multiple saves in
         progress if a player and an autosave are initiated at the same time. */

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -129,6 +129,7 @@ IntroMenu::IntroMenu(my_context ctx) :
     Base(ctx)
 {
     TraceLogger(FSM) << "(HumanClientFSM) IntroMenu";
+    
     Client().GetClientUI().ShowIntroScreen();
     GetGameRules().ResetToDefaults();
 

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -17,6 +17,7 @@
 #include "../../UI/MultiplayerLobbyWnd.h"
 #include "../../UI/PasswordEnterWnd.h"
 #include "../../UI/MapWnd.h"
+#include "../../UI/Sound.h"
 
 #include <boost/format.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -130,6 +131,9 @@ IntroMenu::IntroMenu(my_context ctx) :
     TraceLogger(FSM) << "(HumanClientFSM) IntroMenu";
     Client().GetClientUI().ShowIntroScreen();
     GetGameRules().ResetToDefaults();
+
+    if ((GetOptionsDB().Get<bool>("audio.music.enabled")))
+        Sound::GetSound().PlayMusic(GetOptionsDB().Get<std::string>("audio.music.title.path"), -1);
 }
 
 IntroMenu::~IntroMenu()
@@ -657,6 +661,9 @@ PlayingGame::PlayingGame(my_context ctx) :
 
     Client().Register(Client().GetClientUI().GetMapWnd());
     Client().GetClientUI().GetMapWnd()->Show();
+
+    if ((GetOptionsDB().Get<bool>("audio.music.enabled")))
+        Sound::GetSound().PlayMusic(GetOptionsDB().Get<std::string>("audio.music.ambiance.path"), -1);
 }
 
 PlayingGame::~PlayingGame()

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -132,9 +132,8 @@ IntroMenu::IntroMenu(my_context ctx) :
     
     Client().GetClientUI().ShowIntroScreen();
     GetGameRules().ResetToDefaults();
-
-    if ((GetOptionsDB().Get<bool>("audio.music.enabled")))
-        Sound::GetSound().PlayMusic(GetOptionsDB().Get<std::string>("audio.music.title.path"), -1);
+    
+    Client().ChangeMusicTheme(std::string("audio.music.title.path"));
 }
 
 IntroMenu::~IntroMenu()
@@ -663,8 +662,7 @@ PlayingGame::PlayingGame(my_context ctx) :
     Client().Register(Client().GetClientUI().GetMapWnd());
     Client().GetClientUI().GetMapWnd()->Show();
 
-    if ((GetOptionsDB().Get<bool>("audio.music.enabled")))
-        Sound::GetSound().PlayMusic(GetOptionsDB().Get<std::string>("audio.music.ambiance.path"), -1);
+    Client().ChangeMusicTheme(std::string("audio.music.ambiance.path"));
 }
 
 PlayingGame::~PlayingGame()

--- a/default/credits.xml
+++ b/default/credits.xml
@@ -73,6 +73,7 @@
       <PERSON name="Justin Wood"              nick="swaqvalley"       task="Programming"/>
       <PERSON name="Rob Gill"                 nick="rrobgill"         task="Programming"/>
       <PERSON name="Frank Muzzulini"          nick="Grummel7"         task="Programming"/>
+      <PERSON name=""                         nick="hifron"           task="Programming"/>
     </GROUP>
     <GROUP name="GAMEDESIGN and CONTENT">
       <PERSON name="Krum Stanoev"             nick=""                 task="Game Design"/>

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1515,8 +1515,11 @@ Enables sound in the game.
 OPTIONS_DB_MUSIC_ON
 Enables music in the game.
 
+OPTIONS_DB_TITLE_MUSIC
+Sets the title screen music track to play.
+
 OPTIONS_DB_BG_MUSIC
-Sets the background track to play.
+Sets the background music track to play.
 
 OPTIONS_DB_FULLSCREEN
 Start the game in fullscreen. Clicking Apply may cause this to take effect, or may require a restart.
@@ -2369,7 +2372,7 @@ OPTIONS_DB_SECTION_AUDIO
 Audio
 
 OPTIONS_DB_SECTION_AUDIO_MUSIC
-Background music
+Music
 
 OPTIONS_DB_SECTION_AUDIO_EFFECTS
 Sound effects
@@ -3246,8 +3249,11 @@ Music
 OPTIONS_UI_SOUNDS
 UI sounds
 
+OPTIONS_TITLE_MUSIC
+Title Screen Music
+
 OPTIONS_BACKGROUND_MUSIC
-Music
+Background Music
 
 OPTIONS_SOUNDS
 Sounds


### PR DESCRIPTION
Fixes https://github.com/freeorion/freeorion/issues/3350 and superseeds https://github.com/freeorion/freeorion/pull/3358 by Geoff . This PR is also with fix of music starting twice on FreeOrion program start due OpenAL sound problems errors in current FO sound implementation.

In next PRs I want to enable to have theme dirs and then also species/empires music, but not in this PR.

Some unrelated problem with Python background parsing causing some unresponding window in some Linuxes, but this problem is not caused by this PR and may be solved by increasing timeout for a few seconds(see article on Medium)...
[Medium article about recent changes in Ubuntu/Fedora about waiting for response](https://medium.com/@mathnodes/remove-the-annoying-force-quit-wait-dialog-in-fedora-ubuntu-ca97157ccd08)