### PR TITLE
Add unique name for binary artefact

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -87,7 +87,7 @@ jobs:
         if: true # only for weekly-test-build push
         uses: actions/upload-artifact@v2
         with:
-          name: freeorion-binaries-win32-build
+          name: freeorion-binaries-win32-build-$GITHUB_RUN_NUMBER
           path: build/FreeOrion-*.zip
           if-no-files-found: error
           retention-days: 14


### PR DESCRIPTION
https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables

> GITHUB_RUN_NUMBER | A unique  number for each run of a particular workflow in a repository. This  number begins at 1 for the workflow's first run, and increments with  each new run. This number does not change if you re-run the workflow  run. For example, 3.

I choose this variable because it's short, unique, and ordered.   We could implement this with date, branch name and short SHA, but this wont be short and will be much more complicated.