### PR TITLE
adding cmake build directory to .gitignore on Windows(VS Code)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -103,6 +103,9 @@ libpython.py
 .vs/
 .vscode/
 
+# CMake
+build/
+
 # linters temp files
 .mypy_cache
 .pytest_cache


### PR DESCRIPTION
On Windows during compile with CMake there is build directory _inside_ source files, which should be on .gitignore file list

[FreeOrion Build howto](https://github.com/freeorion/freeorion/blob/master/BUILD.md)