### PR TITLE
[AI] Remove duplicated dependency and improvments

### DIFF
--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -845,25 +845,6 @@ building_supply = {
 }
 # </editor-fold>
 
-# <editor-fold desc="Shipyards">
-SHIP_FACILITIES = {
-    "BLD_SHIPYARD_BASE",
-    "BLD_SHIPYARD_ORBITAL_DRYDOCK",
-    "BLD_SHIPYARD_CON_NANOROBO",
-    "BLD_SHIPYARD_CON_GEOINT",
-    "BLD_SHIPYARD_CON_ADV_ENGINE",
-    "BLD_SHIPYARD_AST",
-    "BLD_SHIPYARD_AST_REF",
-    "BLD_SHIPYARD_ORG_ORB_INC",
-    "BLD_SHIPYARD_ORG_CELL_GRO_CHAMB",
-    "BLD_SHIPYARD_ORG_XENO_FAC",
-    "BLD_SHIPYARD_ENRG_COMP",
-    "BLD_SHIPYARD_ENRG_SOLAR",
-    "BLD_NEUTRONIUM_FORGE",
-}
-
-# </editor-fold>
-
 # </editor-fold>
 
 

--- a/default/python/AI/buildings.py
+++ b/default/python/AI/buildings.py
@@ -51,14 +51,6 @@ class _BuildingOperations:
     This class contains operations that applicable for all building enums.
     """
 
-    @classmethod
-    def get(cls, name: BuildingName):
-        """Get BuildType for a given BuildingName."""
-        for bt in BuildingType:
-            if bt.value == name:
-                return bt
-        raise ValueError(f"{cls.__name__}.get(): got unknown name {name}")
-
     def is_this_type(self, building_id: BuildingId):
         """Return whether the building with the given identifier is of this type."""
         return fo.getUniverse().getBuilding(building_id) == self.value

--- a/default/python/AI/colonization/rate_pilots.py
+++ b/default/python/AI/colonization/rate_pilots.py
@@ -1,8 +1,8 @@
 import freeOrionAIInterface as fo
 from logging import debug
 
-import AIDependencies
 from AIDependencies import Tags
+from buildings import Shipyard
 from colonization.claimed_stars import has_claimed_star
 from colonization.colony_score import MINIMUM_COLONY_SCORE, debug_rating, use_new_rating
 from common.fo_typing import SpeciesName
@@ -98,7 +98,7 @@ def rate_piloting(species_name: SpeciesName) -> float:
     detection_val = detection_value(species_name) * DETECTION_SCALING
     # TODO add something for Sly and Laenfa ability to regenerate fuel quickly in certain systems?
     fuel_val = get_species_fuel(species_name) * FUEL_SCALING
-    dislikes = sum(1 for bld in AIDependencies.SHIP_FACILITIES if bld in species.dislikes)
+    dislikes = sum(1 for bld in Shipyard if bld.value in species.dislikes)
     # basic shipyard is specifically important, cannot build any ships without it
     discount = 0.93 if "BLD_SHIPYARD_BASE" in species.dislikes else 0.96
     result = (weapon_val + shield_value + detection_val + fuel_val) * discount**dislikes

--- a/default/python/AI/empire/buildings_locations.py
+++ b/default/python/AI/empire/buildings_locations.py
@@ -1,6 +1,6 @@
 from typing import Dict, FrozenSet, Set
 
-import AIDependencies
+from buildings import Shipyard
 from common.fo_typing import BuildingName, PlanetId
 from empire.pilot_rating import best_pilot_rating
 from empire.survey_lock import survey_universe_lock
@@ -29,5 +29,8 @@ def set_building_locations(
 ):
     this_grade_facilities = _get_facilities().setdefault(weapons_grade, {})
     for building in buildings_here:
-        if building in AIDependencies.SHIP_FACILITIES:
-            this_grade_facilities.setdefault(building, set()).add(pid)
+        try:
+            Shipyard(building)
+        except ValueError:
+            continue
+        this_grade_facilities.setdefault(building, set()).add(pid)

--- a/default/python/tests/AI/test_buildings.py
+++ b/default/python/tests/AI/test_buildings.py
@@ -1,0 +1,11 @@
+import pytest
+from buildings import Shipyard
+
+
+def test_get_shipyard_by_calling_constructor():
+    assert Shipyard.GEO == Shipyard("BLD_SHIPYARD_CON_GEOINT")
+
+
+def test_invalid_shipyard_raises_value_error_if_passed_via_constructor():
+    with pytest.raises(ValueError, match="'XXX' is not a valid Shipyard"):
+        Shipyard("XXX")


### PR DESCRIPTION
- Remove SHIP_FACILITIES, since they duplicate Shipyards
- Remove the get method from enums, since they have their own way for it, see tests
- Add tests for enums,  they are quite useless as a test but shows the way how enums could be used


Using Shipyard instead if the string breaks every time when we met pure fo code. 