### PR TITLE
[AI] Move references to a separate module

### DIFF
--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -40,8 +40,6 @@ from typing import Dict
 # Please refer to the building_supply dictionary below for an example that displays both of these uses.
 
 # <editor-fold desc="Basic Game Rules">
-# TODO look into (enabling) simply retrieving the below values via UserString
-INDUSTRY_PER_POP = 0.2
 RESEARCH_PER_POP = 0.2
 TROOPS_PER_POP = 0.2
 

--- a/default/python/AI/PolicyAI.py
+++ b/default/python/AI/PolicyAI.py
@@ -13,7 +13,7 @@ from EnumsAI import FocusType, PriorityType
 from freeorion_tools import assertion_fails, get_named_real, get_species_influence
 from freeorion_tools.caching import cache_for_current_turn
 from freeorion_tools.statistics import stats
-from references import get_policy_diversity_scaling, get_policy_diversity_threshold
+from references import PLC_DIVERSITY_THRESHOLD, get_policy_diversity_scaling
 from ResearchAI import research_now
 from turn_state import get_empire_planets_by_species
 
@@ -376,7 +376,7 @@ class PolicyManager:
         if diversity not in self._empire.availablePolicies:
             return 0.0
         # diversity affects stability, but also gives a bonus to research-focused planets and a little influence,
-        diversity_value = len(get_empire_planets_by_species()) - get_policy_diversity_threshold()
+        diversity_value = len(get_empire_planets_by_species()) - PLC_DIVERSITY_THRESHOLD
         diversity_scaling = get_policy_diversity_scaling()
         # Research bonus goes to research-focused planets only. With priority there are usually none.
         research_priority = self._aistate.get_priority(PriorityType.RESOURCE_RESEARCH)

--- a/default/python/AI/PolicyAI.py
+++ b/default/python/AI/PolicyAI.py
@@ -10,14 +10,10 @@ from AIDependencies import Tags
 from aistate_interface import get_aistate
 from common.fo_typing import PlanetId, SpeciesName
 from EnumsAI import FocusType, PriorityType
-from freeorion_tools import (
-    assertion_fails,
-    get_named_int,
-    get_named_real,
-    get_species_influence,
-)
+from freeorion_tools import assertion_fails, get_named_real, get_species_influence
 from freeorion_tools.caching import cache_for_current_turn
 from freeorion_tools.statistics import stats
+from references import get_policy_diversity_scaling, get_policy_diversity_threshold
 from ResearchAI import research_now
 from turn_state import get_empire_planets_by_species
 
@@ -380,8 +376,8 @@ class PolicyManager:
         if diversity not in self._empire.availablePolicies:
             return 0.0
         # diversity affects stability, but also gives a bonus to research-focused planets and a little influence,
-        diversity_value = len(get_empire_planets_by_species()) - get_named_int("PLC_DIVERSITY_THRESHOLD")
-        diversity_scaling = get_named_real("PLC_DIVERSITY_SCALING")
+        diversity_value = len(get_empire_planets_by_species()) - get_policy_diversity_threshold()
+        diversity_scaling = get_policy_diversity_scaling()
         # Research bonus goes to research-focused planets only. With priority there are usually none.
         research_priority = self._aistate.get_priority(PriorityType.RESOURCE_RESEARCH)
         research_bonus = max(0, research_priority - 20)

--- a/default/python/AI/colonization/calculate_planet_colonization_rating.py
+++ b/default/python/AI/colonization/calculate_planet_colonization_rating.py
@@ -54,6 +54,7 @@ from freeorion_tools.caching import (
     cache_for_session,
 )
 from PlanetUtilsAI import get_empire_populated_planets, stability_with_focus
+from references import get_industry_per_population
 from turn_state import (
     get_empire_outposts,
     get_empire_planets_by_species,
@@ -329,7 +330,7 @@ def _calculate_planet_colonization_rating(
             elif special == "HONEYCOMB_SPECIAL":
                 honey_val = 0.3 * (
                     AIDependencies.HONEYCOMB_IND_MULTIPLIER
-                    * AIDependencies.INDUSTRY_PER_POP
+                    * get_industry_per_population()
                     * population_with_industry_focus()
                     * discount_multiplier
                 )
@@ -456,7 +457,7 @@ def _calculate_planet_colonization_rating(
         if "HONEYCOMB_SPECIAL" in planet.specials:
             honey_val = (
                 AIDependencies.HONEYCOMB_IND_MULTIPLIER
-                * AIDependencies.INDUSTRY_PER_POP
+                * get_industry_per_population()
                 * population_with_industry_focus()
                 * discount_multiplier
             )
@@ -577,8 +578,8 @@ def _calculate_planet_colonization_rating(
         if FocusType.FOCUS_INDUSTRY in species.foci:
             if "TIDAL_LOCK_SPECIAL" in planet.specials:
                 ind_mult += 1
-            max_ind_factor += AIDependencies.INDUSTRY_PER_POP * mining_bonus
-            max_ind_factor += AIDependencies.INDUSTRY_PER_POP * ind_mult
+            max_ind_factor += get_industry_per_population() * mining_bonus
+            max_ind_factor += get_industry_per_population() * ind_mult
         cur_pop = 1.0  # assume an initial colonization value
         if planet.speciesName != "":
             cur_pop = planet.currentMeterValue(fo.meterType.population)
@@ -595,7 +596,7 @@ def _calculate_planet_colonization_rating(
             # TODO: also consider potential future benefit re currently unpopulated planets
             gbonus = (
                 discount_multiplier
-                * AIDependencies.INDUSTRY_PER_POP
+                * get_industry_per_population()
                 * ind_mult
                 * empire_metabolisms.get(AIDependencies.metabolismBoosts[special], 0)
             )  # due to growth applicability to other planets

--- a/default/python/AI/colonization/calculate_production.py
+++ b/default/python/AI/colonization/calculate_production.py
@@ -7,6 +7,7 @@ from colonization.colony_score import debug_rating
 from freeorion_tools import get_named_real, get_species_industry, tech_soon_available
 from freeorion_tools.bonus_calculation import Bonus
 from freeorion_tools.caching import cache_for_current_turn
+from references import get_industry_per_population
 from turn_state import have_honeycomb
 
 
@@ -26,7 +27,7 @@ def calculate_production(planet: fo.planet, species: fo.species, max_population:
     bonus_unmodified = _get_production_bonus_unmodified(planet, stability)
     bonus_flat = _get_production_flat(planet, stability)
     per_population = (
-        (AIDependencies.INDUSTRY_PER_POP + bonus_modified) * skill_multiplier + bonus_by_policy
+        (get_industry_per_population() + bonus_modified) * skill_multiplier + bonus_by_policy
     ) * policy_multiplier + bonus_unmodified
     result = max_population * per_population + bonus_flat
     debug_rating(
@@ -83,7 +84,7 @@ def _get_production_bonus_modified(planet: fo.planet, stability: float) -> float
     Calculate bonus production per population which would be added before multiplication with the species skill value.
     """
     specials_bonus = sum(
-        AIDependencies.INDUSTRY_PER_POP for s in planet.specials if s in AIDependencies.industry_boost_specials_modified
+        get_industry_per_population() for s in planet.specials if s in AIDependencies.industry_boost_specials_modified
     )
     return specials_bonus + sum(bonus.get_bonus(stability) for bonus in _get_modified_industry_bonuses())
 
@@ -116,7 +117,7 @@ def _get_production_bonus_unmodified(planet: fo.planet, stability: float) -> flo
     """
     specials_bonus = sum(
         # growth.macros: STANDARD_INDUSTRY_BOOST
-        AIDependencies.INDUSTRY_PER_POP
+        get_industry_per_population()
         for s in planet.specials
         if s in AIDependencies.industry_boost_specials_unmodified
     )

--- a/default/python/AI/colonization/calculate_research.py
+++ b/default/python/AI/colonization/calculate_research.py
@@ -11,12 +11,12 @@ from freeorion_tools.bonus_calculation import Bonus
 from freeorion_tools.caching import cache_for_current_turn
 from PlanetUtilsAI import get_empire_populated_planets
 from references import (
+    PLC_DIVERSITY_THRESHOLD,
     get_ancient_ruins_min_stability,
     get_ancient_ruins_target_research_perpop,
     get_industry_per_population,
     get_policy_diversity_min_stability,
     get_policy_diversity_scaling,
-    get_policy_diversity_threshold,
 )
 from turn_state import get_empire_planets_by_species, have_computronium
 
@@ -64,7 +64,7 @@ def _get_modified_research_bonuses(planet: fo.planet) -> List[Bonus]:
         Bonus(
             fo.getEmpire().policyAdopted("PLC_DIVERSITY"),
             get_policy_diversity_min_stability(),
-            (len(get_empire_planets_by_species()) - get_policy_diversity_threshold()) * get_policy_diversity_scaling(),
+            (len(get_empire_planets_by_species()) - PLC_DIVERSITY_THRESHOLD) * get_policy_diversity_scaling(),
         ),
         Bonus(
             tech_soon_available("GRO_ENERGY_META", 3),

--- a/default/python/AI/references/__init__.py
+++ b/default/python/AI/references/__init__.py
@@ -1,0 +1,2 @@
+from references.hardcoded_references import *
+from references.value_references import *

--- a/default/python/AI/references/hardcoded_references.py
+++ b/default/python/AI/references/hardcoded_references.py
@@ -1,0 +1,9 @@
+"""
+This module contains constants that should be done as reference but hardcoded in the AI.
+
+It's recommended to create/use references and move function to corresponding modules.
+"""
+
+
+def get_industry_per_population() -> float:
+    return 0.2

--- a/default/python/AI/references/value_references.py
+++ b/default/python/AI/references/value_references.py
@@ -1,0 +1,21 @@
+from freeorion_tools import get_named_int, get_named_real
+
+
+def get_policy_diversity_threshold() -> int:
+    return get_named_int("PLC_DIVERSITY_THRESHOLD")
+
+
+def get_policy_diversity_scaling() -> float:
+    return get_named_real("PLC_DIVERSITY_SCALING")
+
+
+def get_policy_diversity_min_stability() -> float:
+    return get_named_real("PLC_DIVERSITY_MIN_STABILITY")
+
+
+def get_ancient_ruins_min_stability() -> float:
+    return get_named_real("ANCIENT_RUINS_MIN_STABILITY")
+
+
+def get_ancient_ruins_target_research_perpop() -> float:
+    return get_named_real("ANCIENT_RUINS_TARGET_RESEARCH_PERPOP")

--- a/default/python/AI/references/value_references.py
+++ b/default/python/AI/references/value_references.py
@@ -1,8 +1,32 @@
+import freeOrionAIInterface as fo
+from logging import error
+
 from freeorion_tools import get_named_int, get_named_real
+
+_missed_references = []
+
+
+def _get_named_int(name: str) -> int:
+    """
+    Returns a NamedReal from FOCS.
+    If the value does not exist, reports an error and returns 1.
+    Note that we do not raise and exception so that the AI can continue, as good as it can, with outdated information.
+    This is also why we return 1, returning 0 could cause followup errors if the value is used as divisor.
+    """
+    if fo.namedIntDefined(name):
+        return fo.getNamedInt(name)
+    else:
+        _missed_references.append(name)
+        return 1
 
 
 def get_policy_diversity_threshold() -> int:
     return get_named_int("PLC_DIVERSITY_THRESHOLD")
+
+
+PLC_DIVERSITY_THRESHOLD = _get_named_int("PLC_DIVERSITY_THRESHOLD")
+ZZZZ = _get_named_int("ZZZ")
+BBB = _get_named_int("BBBBBBBB")
 
 
 def get_policy_diversity_scaling() -> float:
@@ -19,3 +43,11 @@ def get_ancient_ruins_min_stability() -> float:
 
 def get_ancient_ruins_target_research_perpop() -> float:
     return get_named_real("ANCIENT_RUINS_TARGET_RESEARCH_PERPOP")
+
+
+if _missed_references:
+    error(
+        "'%s' contains references to the scripting references, that does not exist: %s, please remove them",
+        __name__,
+        sorted(_missed_references),
+    )


### PR DESCRIPTION
This is the proposal. 

I want to isolate working with references in a separate module. 

- This will help to track all constants usage.
- Expose the convenient API for users.
- Collect all missed references in one place, so it will be easy to find what is missed. 

Some boilerplate is required, but I am ok with it since the number of references is not so huge. 

if it's possible to expose the method that gives all references in the game, I could add some validator. 


All are under discussion:  module name, function names schema.