### PR TITLE
Reduce possibly unnessecary warnings if named ValueRef lookup fails

### DIFF
--- a/universe/NamedValueRefManager.cpp
+++ b/universe/NamedValueRefManager.cpp
@@ -94,11 +94,21 @@ template const ValueRef::ValueRef<StarType>* NamedValueRefManager::GetValueRef(s
 const ValueRef::ValueRefBase* NamedValueRefManager::GetValueRefBase(std::string_view name) const {
     if (auto* drefp = GetValueRef<double>(name))
         return drefp;
-    if (auto* irefp = GetValueRef<int>(name))
+    if (auto* irefp = GetValueRef<int>(name)) {
+        DebugLogger() << "NamedValueRefManager::GetValueRefBase found registered (int) valueref for \"" << name << "\" "
+                      << "(After trying (double) registry)";
         return irefp;
+    }
     CheckPendingNamedValueRefs();
     const auto it = m_value_refs.find(name);
-    return it != m_value_refs.end() ? it->second.get() : nullptr;
+    if (it != m_value_refs.end()) {
+        DebugLogger() << "NamedValueRefManager::GetValueRefBase found no registered (generic) valueref for \"" << name << "\" "
+                      << "(After trying (int|double) registries.";
+        return it->second.get();
+    }
+    ErrorLogger() << "NamedValueRefManager::GetValueRefBase found no registered (double|int|generic) valueref for \"" << name << "\". "
+                  << "This should not happen once \"#3225 Refactor initialisation of invariants in value refs to happen after parsing\" is implemented";
+    return nullptr;
 }
 
 NamedValueRefManager& NamedValueRefManager::GetNamedValueRefManager() {

--- a/universe/NamedValueRefManager.h
+++ b/universe/NamedValueRefManager.h
@@ -278,8 +278,8 @@ private:
         if (it != registry.end())
             return it->second.get();
         DebugLogger() << "NamedValueRefManager::GetValueRef found no registered (" << label << ") valueref for \"" << name
-                      << "\". This is either looking in the wrong registry (which can be OK). This should not happen "
-                      << "if looking in the right registry once \"#3225 Refactor initialisation of invariants in value refs to happen after parsing\" is implemented";
+                      << "\". This is may be due to looking in the wrong registry (which can be OK)"
+                      << ".  This should not happen if looking in the right registry.";
         return nullptr;
     }
 

--- a/universe/NamedValueRefManager.h
+++ b/universe/NamedValueRefManager.h
@@ -272,12 +272,14 @@ private:
     V* GetValueRefImpl(const std::map<NamedValueRefManager::key_type, std::unique_ptr<V>, std::less<>>& registry,
                        std::string_view label, std::string_view name) const
     {
-        TraceLogger() << "NamedValueRefManager::GetValueRef look for registered " << label << " valueref for \"" << name << '"';
-        TraceLogger() << "Number of registered " << label << " ValueRefs: " << registry.size();
+        TraceLogger() << "NamedValueRefManager::GetValueRef look for registered (" << label << ") valueref for \"" << name << '"';
+        TraceLogger() << "Number of registered (" << label << ") ValueRefs: " << registry.size();
         const auto it = registry.find(name);
         if (it != registry.end())
             return it->second.get();
-        WarnLogger() << "NamedValueRefManager::GetValueRef found no registered " << label << " valueref for \"" << name << "\". This should not happen once \"#3225 Refactor initialisation of invariants in value refs to happen after parsing\" is implemented";
+        DebugLogger() << "NamedValueRefManager::GetValueRef found no registered (" << label << ") valueref for \"" << name
+                      << "\". This is either looking in the wrong registry (which can be OK). This should not happen "
+                      << "if looking in the right registry once \"#3225 Refactor initialisation of invariants in value refs to happen after parsing\" is implemented";
         return nullptr;
     }
 


### PR DESCRIPTION
Log to debug (instead warn) if named ValueRef lookup fails if it is possible lookup happens in the wrong registry.

That is a standard use case - the pedia does not know or care about the type of named ValueRefs (so it tries all three registries to find a value).

If lookup in all three registries fails, an error is logged (instead of warning).

example output for pedia looking for 
```
12:34:00.354342 {0x00007ff4db407780} [debug] client : NamedValueRefManager.h:280 : NamedValueRefManager::GetValueRef found no registered (double) valueref for "FIRST_COMBAT_ROUND_IN_CLOSE_TARGETING_RANGE". This is either looking in the wrong registry (which can be OK). This should not happen if looking in the right registry once "#3225 Refactor initialisation of invariants in value refs to happen after parsing" is implemented
12:34:00.354393 {0x00007ff4db407780} [debug] client : NamedValueRefManager.cpp:98 : NamedValueRefManager::GetValueRefBase found registered (int) valueref for "FIRST_COMBAT_ROUND_IN_CLOSE_TARGETING_RANGE" (After trying (double) registry)
```