### PR TITLE
Add NamedString and NamedStringLookup for FOCS

### DIFF
--- a/parse/NamedValueRefParser.cpp
+++ b/parse/NamedValueRefParser.cpp
@@ -83,6 +83,11 @@ namespace parse {
                    > label(tok.value_) > qi::as<parse::detail::MovableEnvelope<ValueRef::ValueRef<double>>>()[double_rules.expr]
                     ) [ insert_named_ref_(_r1, _2, _3, _pass) ]
                     |
+                    ((omit_[tok.Named_] >> tok.String_)
+                   > label(tok.name_) > tok.string
+                   > label(tok.value_) > qi::as<parse::detail::MovableEnvelope<ValueRef::ValueRef<std::string>>>()[string_grammar.expr]
+                    ) [ insert_named_ref_(_r1, _2, _3, _pass) ]
+                    |
                     ((omit_[tok.Named_] >> tok.PlanetType_) > label(tok.name_) > tok.string > label(tok.value_) > planet_type_rules.expr
                     ) [ insert_named_ref_(_r1, _2, _3, _pass) ]
                     |

--- a/parse/ValueRefParser.h
+++ b/parse/ValueRefParser.h
@@ -225,6 +225,8 @@ namespace parse {
         detail::variable_rule<std::string>      value_wrapped_bound_variable;
         detail::value_ref_rule<std::string>     statistic_sub_value_ref;
         detail::statistic_rule<std::string>     statistic;
+        detail::value_ref_rule<std::string>     named_string_valueref;
+        detail::value_ref_rule<std::string>     named_lookup_expr;
         detail::expression_rule<std::string>    function_expr;
         detail::expression_rule<std::string>    operated_expr;
         detail::value_ref_rule<std::string>     expr;

--- a/universe/NamedValueRefManager.cpp
+++ b/universe/NamedValueRefManager.cpp
@@ -178,6 +178,11 @@ void NamedValueRefManager::RegisterValueRef(std::string&& valueref_name,
 
 template <>
 void NamedValueRefManager::RegisterValueRef(std::string&& valueref_name,
+                                            std::unique_ptr<ValueRef::ValueRef<std::string>>&& vref)
+{ RegisterValueRefImpl(m_value_refs, m_value_refs_mutex, "string", std::move(valueref_name), std::move(vref)); }
+
+template <>
+void NamedValueRefManager::RegisterValueRef(std::string&& valueref_name,
                                             std::unique_ptr<ValueRef::ValueRef<int>>&& vref)
 { RegisterValueRefImpl(m_value_refs_int, m_value_refs_int_mutex, "int", std::move(valueref_name), std::move(vref)); }
 
@@ -220,6 +225,7 @@ namespace ValueRef {
     // trigger instantiations
     template struct NamedRef<double>;
     template struct NamedRef<int>;
+    template struct NamedRef<std::string>;
     template struct NamedRef<PlanetEnvironment>;
     template struct NamedRef<PlanetSize>;
     template struct NamedRef<PlanetType>;


### PR DESCRIPTION
* NamedString declaration can be used in named_values.focs.txt
* NamedString can be used in any FOCS file (named in the middle)
* NamedStringLookup can be used in any FOCS file

as requested in [Preventing boxed in starts](https://freeorion.org/forum/viewtopic.php?p=112715#p112715)