### PR TITLE
Rename fighter tech label to numeric (instead Laser, Plasma,… Fighters)

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -13767,19 +13767,19 @@ Piloting traits do not affect [[FT_HANGAR_1]] fighters.
 At the end of combat, carriers will collect any fighters that have survived. If a carrier is in [[metertype METER_SUPPLY]] immediately after movement is resolved, it will refill hangars to maximum.'''
 
 SHP_FIGHTERS_2
-Laser Fighters
+Fighters and Launch Bays 2
 
 SHP_FIGHTERS_2_DESC
 Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have laser weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 12, [[shippart FT_HANGAR_3]] by 18, and [[shippart FT_HANGAR_4]] by 36. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
 
 SHP_FIGHTERS_3
-Plasma Fighters
+Fighters and Launch Bays 3
 
 SHP_FIGHTERS_3_DESC
 Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have plasma weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 12, [[shippart FT_HANGAR_3]] by 18, and [[shippart FT_HANGAR_4]] by 36. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
 
 SHP_FIGHTERS_4
-Death Ray Fighters
+Fighters and Launch Bays 4
 
 SHP_FIGHTERS_4_DESC
 Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have death ray weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 12, [[shippart FT_HANGAR_3]] by 18, and [[shippart FT_HANGAR_4]] by 36. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.


### PR DESCRIPTION
[forum thread](https://freeorion.org/forum/viewtopic.php?p=112764#p112764)

```
we should rename Laser Fighters etc. tech simply to Fighters 2, as is done for the other parts (Arc Disruptors, Mass Drivers, ...).

So the rule would be: Different parts necessary -> Different tech name, Upgrades for same part -> Same tech name
```
The descriptions still reference laser, plasma, death ray weaponry - that gives some useful indication of power level

Note: the weapon techs should use some valuerefs or similar so changes to damage rules are correctly reflected