### PR TITLE
Apply SPATIAL_FLUX_STEALTH_TECH_BONUS boost for all stealth tech upgrades

### DIFF
--- a/default/scripting/ship_hulls/spatial_flux/spatial_flux.macros
+++ b/default/scripting/ship_hulls/spatial_flux/spatial_flux.macros
@@ -9,9 +9,12 @@ EffectsGroup
     scope = Source
     activation = Not Aggressive
     accountinglabel = "SPATIAL_FLUX_BONUS"
-    effects = SetStealth value = Value + NamedRealLookup name = "SPATIAL_FLUX_STEALTH_NON_AGGRESSIVE_BONUS" + ( NamedRealLookup name = "SPATIAL_FLUX_STEALTH_TECH_BONUS" *
-        (Statistic If condition = And [ Source OwnerHasTech name = "SPY_STEALTH_PART_1" ]) +
-        (Statistic If condition = And [ Source OwnerHasTech name = "SPY_STEALTH_PART_2" ]) +
-        (Statistic If condition = And [ Source OwnerHasTech name = "SPY_STEALTH_PART_3" ]) +
-        (Statistic If condition = And [ Source OwnerHasTech name = "SPY_STEALTH_4" ]) )
+    effects = SetStealth value = Value
+      + NamedRealLookup name = "SPATIAL_FLUX_STEALTH_NON_AGGRESSIVE_BONUS"
+      + ( NamedRealLookup name = "SPATIAL_FLUX_STEALTH_TECH_BONUS" * (
+          (Statistic If condition = And [ Source OwnerHasTech name = "SPY_STEALTH_PART_1" ]) +
+          (Statistic If condition = And [ Source OwnerHasTech name = "SPY_STEALTH_PART_2" ]) +
+          (Statistic If condition = And [ Source OwnerHasTech name = "SPY_STEALTH_PART_3" ]) +
+          (Statistic If condition = And [ Source OwnerHasTech name = "SPY_STEALTH_4" ])
+      ) )
 '''


### PR DESCRIPTION
* fixes bug found by Oberlus
  https://freeorion.org/forum/viewtopic.php?p=112255&sid=6279f996d237f31db727cac11366812b#p112255
  Only SPY_STEALTH_PART_1 was multiplied by SPATIAL_FLUX_STEALTH_TECH_BONUS.
  Now also the bonus for other stealth techs are multiplied