### PR TITLE
Add CI test for Fedora Rawhide with recent 3.11 python

### DIFF
--- a/.github/fedora-rawhide/Dockerfile
+++ b/.github/fedora-rawhide/Dockerfile
@@ -1,0 +1,18 @@
+FROM docker.io/fedora:rawhide
+
+RUN dnf update -y
+RUN dnf install -y cmake \
+	ccache \
+	python3-devel \
+	gcc-c++ \
+	git \
+	boost-devel \
+	boost-python3-devel \
+	zlib-devel \
+	SDL2-devel \
+	freetype-devel \
+	openal-devel \
+	libogg-devel \
+	libvorbis-devel \
+	glew-devel
+

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        image: [ubuntu-22.10, fedora-32, manjaro]
+        image: [ubuntu-22.10, fedora-32, fedora-rawhide, manjaro]
     env:
       CACHE_NAME: linux
     steps:

--- a/parse/PythonParser.cpp
+++ b/parse/PythonParser.cpp
@@ -48,6 +48,7 @@ struct module_spec {
     {}
 
     py::list path;
+    py::list uninitialized_submodules;
     std::string fullname;
     std::string parent;
     const PythonParser& parser;
@@ -77,6 +78,7 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
 
         py::class_<module_spec>("PythonParserSpec", py::no_init)
             .def_readonly("name", &module_spec::fullname)
+            .def_readonly("_uninitialized_submodules", &module_spec::uninitialized_submodules)
             .add_static_property("loader", py::make_getter(*this, py::return_value_policy<py::reference_existing_object>()))
             .def_readonly("submodule_search_locations", &module_spec::path)
             .def_readonly("has_location", false)


### PR DESCRIPTION
Fixes error in pyhton 3.11:

```
Error: 4.694917 {0x00007f342676d6c0} [error] test : PythonCommon.cpp:101 : Traceback (most recent call last):
Error: 4.708787 {0x00007f342676d6c0} [error] test : PythonCommon.cpp:101 :   File "<string>", line 1, in <module>
Error: 4.709408 {0x00007f342676d6c0} [error] test : PythonCommon.cpp:101 :   File "<frozen importlib._bootstrap>", line 1178, in _find_and_load
Error: 4.710118 {0x00007f342676d6c0} [error] test : PythonCommon.cpp:101 :   File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
Error: 4.710747 {0x00007f342676d6c0} [error] test : PythonCommon.cpp:101 : AttributeError: 'PythonParserSpec' object has no attribute '_uninitialized_submodules'
```