### PR TITLE
Fix minor code smells

### DIFF
--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -11022,6 +11022,8 @@ void And::Eval(const ScriptingContext& parent_context, ObjectSet& matches,
         }
     }
 
+    // TODO: Enable if TraceLogger is needed
+    /*
     auto ObjList = [](const ObjectSet& objs) -> std::string {
         std::string ss;
         ss.reserve(objs.size() * 20); // guesstimate
@@ -11030,7 +11032,6 @@ void And::Eval(const ScriptingContext& parent_context, ObjectSet& matches,
         return ss;
     };
 
-    /*
     TraceLogger(conditions) << [&]() {
         std::stringstream ss;
         ss << "And::Eval searching " << (search_domain == SearchDomain::MATCHES ? "matches" : "non_matches")

--- a/universe/Meter.cpp
+++ b/universe/Meter.cpp
@@ -55,7 +55,6 @@ namespace {
 }
 
 Meter::ToCharsArrayT Meter::ToChars() const {
-    using internal_meter_t = decltype(cur);
     static constexpr auto max_val = std::numeric_limits<int>::max();
     static_assert(max_val < Pow(10LL, 10LL)); // ensure serialized form of int can fit in 11 digits
     static_assert(max_val > Pow(10, 9));

--- a/universe/ObjectMap.cpp
+++ b/universe/ObjectMap.cpp
@@ -136,6 +136,7 @@ namespace {
             // shouldn't be possible to instantiate with this block enabled, but if so,
             // try to generate some useful compiler error messages to indicate what
             // type MappedObjectType is
+            // TODO: Unused alias?
             using GenerateCompileError = typename MappedObjectType::not_a_member_zi23tg;
             return false;
         }

--- a/universe/ObjectMap.cpp
+++ b/universe/ObjectMap.cpp
@@ -136,7 +136,6 @@ namespace {
             // shouldn't be possible to instantiate with this block enabled, but if so,
             // try to generate some useful compiler error messages to indicate what
             // type MappedObjectType is
-            // TODO: Unused alias?
             using GenerateCompileError = typename MappedObjectType::not_a_member_zi23tg;
             return false;
         }

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -677,7 +677,6 @@ void ShipDesign::BuildStatCaches() {
 
     // ensure tags are unique and copy into this->m_tags
     std::sort(tags.begin(), tags.end());
-    auto last = std::unique(tags.begin(), tags.end());
 
     // compile concatenated tags into contiguous storage
     // TODO: transform_reduce when available on all platforms...

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -675,22 +675,20 @@ void ShipDesign::BuildStatCaches() {
         { m_num_part_classes[part_class]++; }
     }
 
-    // ensure tags are unique
+    // collect unique tags
     std::sort(tags.begin(), tags.end());
     auto last = std::unique(tags.begin(), tags.end());
-    tags.erase(last, tags.end());
 
     // compile concatenated tags into contiguous storage
     // TODO: transform_reduce when available on all platforms...
     std::size_t tags_sz = 0;
-    for (const auto& t : tags)
-        tags_sz += t.size();
-    m_tags_concatenated.reserve(tags_sz);
+    std::for_each(tags.begin(), last, [&tags_sz](auto str) { tags_sz += str.size(); });
 
+    m_tags_concatenated.reserve(tags_sz);
     m_tags.clear();
     m_tags.reserve(tags.size());
 
-    std::for_each(tags.begin(), tags.end(), [this](auto& str) {
+    std::for_each(tags.begin(), last, [this](auto str) {
         auto next_start = m_tags_concatenated.size();
         m_tags_concatenated.append(str);
         m_tags.push_back(std::string_view{m_tags_concatenated}.substr(next_start));

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -675,8 +675,10 @@ void ShipDesign::BuildStatCaches() {
         { m_num_part_classes[part_class]++; }
     }
 
-    // ensure tags are unique and copy into this->m_tags
+    // ensure tags are unique
     std::sort(tags.begin(), tags.end());
+    auto last = std::unique(tags.begin(), tags.end());
+    tags.erase(last, tags.end());
 
     // compile concatenated tags into contiguous storage
     // TODO: transform_reduce when available on all platforms...

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -385,29 +385,29 @@ namespace {
         buffer.reserve(buffer_size);
         ar >> make_nvp("meters", buffer);
 
-        size_t count = 0;
+        unsigned int count = 0U;
         const char* const buffer_end = buffer.c_str() + buffer.size();
 
 #if defined(__cpp_lib_to_chars)
         auto result = std::from_chars(buffer.c_str(), buffer_end, count);
-        count = std::min(count, num_meters_possible);
+        count = std::min(count, static_cast<unsigned int>(num_meters_possible));
         if (result.ec != std::errc())
             return;
         auto next{result.ptr};
 #else
         int chars_consumed = 0;
         const char* next = buffer.data();
-        auto matched = sscanf(next, "%lu%n", &count, &chars_consumed);
+        auto matched = sscanf(next, "%u%n", &count, &chars_consumed);
         if (matched < 1)
             return;
 
-        count = std::min(count, num_meters_possible);
+        count = std::min(count, static_cast<unsigned int>(num_meters_possible));
         next += chars_consumed;
 #endif
         while (std::distance(next, buffer_end) > 0 && *next == ' ')
             ++next;
 
-        for (size_t idx = 0; idx < count; ++idx) {
+        for (unsigned int idx = 0; idx < count; ++idx) {
             if (std::distance(next, buffer_end) < 7) // 7 is enough for "POP 0 0" or similar
                 return;
             auto mt = MeterTypeFromTag(std::string_view(next, 3));

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -397,7 +397,7 @@ namespace {
 #else
         int chars_consumed = 0;
         const char* next = buffer.data();
-        auto matched = sscanf(next, "%u%n", &count, &chars_consumed);
+        auto matched = sscanf(next, "%lu%n", &count, &chars_consumed);
         if (matched < 1)
             return;
 


### PR DESCRIPTION
cmake configuration (GCC 9 + Ninja)
```-- Setting build type to 'Release' as none was specified.
-- Build type CMAKE_BUILD_TYPE set to Release
-- CCache version: 3.7.7
-- CCache configured for linux: /usr/bin/ccache
-- The C compiler identification is GNU 9.4.0
-- The CXX compiler identification is GNU 9.4.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Use CCache for Ninja called with: ccache program /usr/bin/ccache 3.7.7
-- Performing Test NOT_GNU_CXX_BUG_94190
-- Performing Test NOT_GNU_CXX_BUG_94190 - Success
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found PythonInterp: /usr/bin/python3 (found suitable version "3.8.10", minimum required is "3.7") 
-- Found PythonLibs: /usr/lib/x86_64-linux-gnu/libpython3.8.so (found suitable version "3.8.10", minimum required is "3.7") 
-- Python library version detected 3.8.10
-- Boost python version 38
-- Boost 1.69.0 found.
-- Found Boost components:
   filesystem;iostreams;locale;log;log_setup;serialization;system;thread
-- Boost  found.
-- Found Boost components:
   python38
-- Found ZLIB: /usr/lib/x86_64-linux-gnu/libz.so (found version "1.2.11") 
-- Found SDL: /usr/lib/x86_64-linux-gnu/libSDL2.so (found version "2.0.10") 
-- Found Freetype: /usr/lib/x86_64-linux-gnu/libfreetype.so (found version "2.10.1") 
-- Found OpenGL: /usr/lib/x86_64-linux-gnu/libOpenGL.so   
-- Found OpenAL: /usr/lib/x86_64-linux-gnu/libopenal.so  
-- Found Ogg: /usr/lib/x86_64-linux-gnu/libogg.so  
-- Found Vorbis: /usr/lib/x86_64-linux-gnu/libvorbis.so   
-- Boost 1.69.0 found.
-- Found Boost components:
   filesystem;regex;system
-- Found GLEW: /usr/include (found version "2.1.0") 
-- Found PNG: /usr/lib/x86_64-linux-gnu/libpng.so (found version "1.6.37") 
-- Found CPPCheck: /usr/bin/cppcheck (found version "1.90") 
-- Found Flake8: /usr/bin/flake8 (found version "3.7.9") 
-- Found Doxygen: /usr/bin/doxygen (found version "1.8.17") found components: doxygen missing components: dot
-- Configuring done
-- Generating done
-- Build files have been written to: /home/amender/projects/freeorion/build
```
Build with GCC 9
```c++
[60/285] cd /home/amender/projects/freeorion/build && /usr/bin/python3 /home/amender/projects/freeorion/cmake/make_versioncpp.py /home/amender/projects/freeorion CMake 38
Build number matches build number in existing Version.cpp, skip regenerating it
Building v0.4.10+ build 2022-08-07.0474342
[98/285] Building CXX object CMakeFiles/freeorioncommon.dir/universe/Conditions.cpp.o
/home/amender/projects/freeorion/universe/Conditions.cpp: In member function ‘virtual void Condition::And::Eval(const ScriptingContext&, Condition::ObjectSet&, Condition::ObjectSet&, Condition::SearchDomain) const’:
/home/amender/projects/freeorion/universe/Conditions.cpp:11025:10: warning: variable ‘ObjList’ set but not used [-Wunused-but-set-variable]
11025 |     auto ObjList = [](const ObjectSet& objs) -> std::string {
      |          ^~~~~~~
[101/285] Building CXX object CMakeFiles/freeorioncommon.dir/universe/Fleet.cpp.o
/home/amender/projects/freeorion/universe/Fleet.cpp:869:32: warning: trigraph ??) ignored, use -trigraphs to enable [-Wtrigraphs]
  869 |                     ss << "  (???) (" << sys_id << ")";
      |                                 
[102/285] Building CXX object CMakeFiles/freeorioncommon.dir/universe/Meter.cpp.o
/home/amender/projects/freeorion/universe/Meter.cpp: In member function ‘Meter::ToCharsArrayT Meter::ToChars() const’:
/home/amender/projects/freeorion/universe/Meter.cpp:58:11: warning: typedef ‘using internal_meter_t = int32_t’ locally defined but not used [-Wunused-local-typedefs]
   58 |     using internal_meter_t = decltype(cur);
      |           ^~~~~~~~~~~~~~~~
[105/285] Building CXX object CMakeFiles/freeorioncommon.dir/universe/ObjectMap.cpp.o
/home/amender/projects/freeorion/universe/ObjectMap.cpp: In function ‘bool {anonymous}::TryInsertIntoMap(ObjectMap::container_type<T>&, PtrType&&)’:
/home/amender/projects/freeorion/universe/ObjectMap.cpp:139:19: warning: typedef ‘using GenerateCompileError = typename MappedObjectType::not_a_member_zi23tg’ locally defined but not used [-Wunused-local-typedefs]
  139 |             using GenerateCompileError = typename MappedObjectType::not_a_member_zi23tg;
      |                   ^~~~~~~~~~~~~~~~~~~~
[112/285] Building CXX object CMakeFiles/freeorioncommon.dir/universe/ShipDesign.cpp.o
/home/amender/projects/freeorion/universe/ShipDesign.cpp: In member function ‘void ShipDesign::BuildStatCaches()’:
/home/amender/projects/freeorion/universe/ShipDesign.cpp:680:10: warning: variable ‘last’ set but not used [-Wunused-but-set-variable]
  680 |     auto last = std::unique(tags.begin(), tags.end());
      |          ^~~~
[150/285] Building CXX object CMakeFiles/freeorioncommon.dir/util/SerializeUniverse.cpp.o
/home/amender/projects/freeorion/util/SerializeUniverse.cpp: In function ‘void {anonymous}::Serialize(Archive&, UniverseObject::MeterMap&, unsigned int) [with Archive = boost::archive::xml_iarchive; UniverseObject::MeterMap = boost::container::flat_map<MeterType, Meter>]’:
/home/amender/projects/freeorion/util/SerializeUniverse.cpp:400:39: warning: format ‘%u’ expects argument of type ‘unsigned int*’, but argument 3 has type ‘size_t*’ {aka ‘long unsigned int*’} [-Wformat=]
  400 |         auto matched = sscanf(next, "%u%n", &count, &chars_consumed);
      |                                      ~^     ~~~~~~
      |                                       |     |
      |                                       |     size_t* {aka long unsigned int*}
      |                                       unsigned int*
      |                                      %lu
[155/285] Building CXX object CMakeFiles/freeoriond.dir/combat/CombatSystem.cpp.o
/home/amender/projects/freeorion/combat/CombatSystem.cpp:1425:10: warning: ‘void {anonymous}::AddAllObjectsSet(const ObjectMap&, Condition::ObjectSet&)’ defined but not used [-Wunused-function]
 1425 |     void AddAllObjectsSet(const ObjectMap& obj_map, Condition::ObjectSet& condition_non_targets) {
      |          ^~~~~~~~~~~~~~~~
[176/285] Building CXX object CMakeFiles/freeorionca.dir/combat/CombatSystem.cpp.o
/home/amender/projects/freeorion/combat/CombatSystem.cpp:1425:10: warning: ‘void {anonymous}::AddAllObjectsSet(const ObjectMap&, Condition::ObjectSet&)’ defined but not used [-Wunused-function]
 1425 |     void AddAllObjectsSet(const ObjectMap& obj_map, Condition::ObjectSet& condition_non_targets) {
      |          ^~~~~~~~~~~~~~~~
[192/285] Building CXX object CMakeFiles/freeorion.dir/combat/CombatSystem.cpp.o
/home/amender/projects/freeorion/combat/CombatSystem.cpp:1425:10: warning: ‘void {anonymous}::AddAllObjectsSet(const ObjectMap&, Condition::ObjectSet&)’ defined but not used [-Wunused-function]
 1425 |     void AddAllObjectsSet(const ObjectMap& obj_map, Condition::ObjectSet& condition_non_targets) {
      |          ^~~~~~~~~~~~~~~~
[210/285] Building CXX object CMakeFiles/freeorion.dir/UI/EncyclopediaDetailPanel.cpp.o
/home/amender/projects/freeorion/UI/EncyclopediaDetailPanel.cpp: In function ‘bool {anonymous}::HasCustomCategory(const std::vector<std::basic_string_view<char> >&, std::string_view)’:
/home/amender/projects/freeorion/UI/EncyclopediaDetailPanel.cpp:90:31: warning: variable ‘len’ set but not used [-Wunused-but-set-variable]
   90 |         static constexpr auto len{TAG_PEDIA_PREFIX.length()};
      |                               ^~~
[285/285] Linking CXX executable freeorion
```

I build FreeOrion for the first time and notice minor 'code smells'. Not all of them can/should be fixed, but I added comments where applicable.