### PR TITLE
Reduce bonus and malus from influence species trait

### DIFF
--- a/default/scripting/species/common/influence.macros
+++ b/default/scripting/species/common/influence.macros
@@ -153,7 +153,7 @@ VERY_BAD_INFLUENCE
             ]
             accountinglabel = "VERY_BAD_INFLUENCE_LABEL"
             priority = [[TARGET_SCALING_PRIORITY]]
-            effects = SetTargetInfluence value = Value + ([[VERY_BAD_MULTIPLIER]]-1.0)*abs(Value)
+            effects = SetTargetInfluence value = Value + (2.0/3.0-1.0)*abs(Value)
 '''
 
 /*
@@ -184,7 +184,7 @@ BAD_INFLUENCE
             ]
             accountinglabel = "BAD_INFLUENCE_LABEL"
             priority = [[TARGET_SCALING_PRIORITY]]
-            effects = SetTargetInfluence value = Value + ([[BAD_MULTIPLIER]]-1.0)*abs(Value)
+            effects = SetTargetInfluence value = Value + (0.8-1.0)*abs(Value)
 '''
 
 AVERAGE_INFLUENCE
@@ -203,7 +203,7 @@ GOOD_INFLUENCE
             ]
             accountinglabel = "GOOD_INFLUENCE_LABEL"
             priority = [[TARGET_SCALING_PRIORITY]]
-            effects = SetTargetInfluence value = Value + ([[GOOD_MULTIPLIER]]-1.0)*abs(Value)
+            effects = SetTargetInfluence value = Value + (1.25-1.0)*abs(Value)
 '''
 
 GREAT_INFLUENCE
@@ -218,7 +218,7 @@ GREAT_INFLUENCE
             ]
             accountinglabel = "GREAT_INFLUENCE_LABEL"
             priority = [[TARGET_SCALING_PRIORITY]]
-            effects = SetTargetInfluence value = Value + ([[GREAT_MULTIPLIER]]-1.0)*abs(Value)
+            effects = SetTargetInfluence value = Value + (1.5-1.0)*abs(Value)
 '''
 
 ULTIMATE_INFLUENCE
@@ -233,7 +233,7 @@ ULTIMATE_INFLUENCE
             ]
             accountinglabel = "ULTIMATE_INFLUENCE_LABEL"
             priority = [[TARGET_SCALING_PRIORITY]]
-            effects = SetTargetInfluence value = Value + ([[ULTIMATE_MULTIPLIER]]-1.0)*abs(Value)
+            effects = SetTargetInfluence value = Value + (2.0-1.0)*abs(Value)
 '''
 
 #include "/scripting/common/misc.macros"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -16872,22 +16872,22 @@ NO_INFLUENCE_DESC
 −−−	No [[metertype METER_INFLUENCE]]
 
 VERY_BAD_INFLUENCE_DESC
-−−	Very bad [[metertype METER_INFLUENCE]]: 50%
+−−	Very bad [[metertype METER_INFLUENCE]]: 66.7%
 
 BAD_INFLUENCE_DESC
-−	Bad [[metertype METER_INFLUENCE]]: 75%
+−	Bad [[metertype METER_INFLUENCE]]: 80%
 
 AVERAGE_INFLUENCE_DESC
 ⋄	Average [[metertype METER_INFLUENCE]]: 100%
 
 GOOD_INFLUENCE_DESC
-+	Good [[metertype METER_INFLUENCE]]: 150%
++	Good [[metertype METER_INFLUENCE]]: 125%
 
 GREAT_INFLUENCE_DESC
-++	Great [[metertype METER_INFLUENCE]]: 200%
+++	Great [[metertype METER_INFLUENCE]]: 150%
 
 ULTIMATE_INFLUENCE_DESC
-+++	Ultimate [[metertype METER_INFLUENCE]]: 300%
++++	Ultimate [[metertype METER_INFLUENCE]]: 200%
 
 BAD_HAPPINESS_DESC
 −	Bad [[metertype METER_HAPPINESS]]: [[value BAD_HAPPINESS_VAL]]


### PR DESCRIPTION
Same than very bad influence was too bad (compared to very bad industry or research), probably because the species trait affects most bonuses, the other levels of the trait seem a bit too much. This is a small reduction intended to give less importance to what species an empire has early game.

Discussion thread: https://www.freeorion.org/forum/viewtopic.php?p=113382#p113382