### PR TITLE
Remove Narrow tolerance description from Trith

### DIFF
--- a/default/scripting/species/SP_TRITH.focs.txt
+++ b/default/scripting/species/SP_TRITH.focs.txt
@@ -57,7 +57,6 @@ Species
         // not for description
         [[AVERAGE_PLANETARY_SHIELDS]]
         [[AVERAGE_PLANETARY_DEFENSE]]
-        [[NARROW_EP]]
         [[GOOD_SHIP_SHIELDS]]
 
         EffectsGroup


### PR DESCRIPTION
Trith got narrow tolerance removed some time ago, this removes the lingering narrow env. description macro.