### PR TITLE
Change colony influence upkeep to force full influence-focused empire…

### DIFF
--- a/default/scripting/game_rules.focs.py
+++ b/default/scripting/game_rules.focs.py
@@ -316,3 +316,23 @@ GameRule(
     min=1,
     max=10,
 )
+
+GameRule(
+    name="RULE_END_GAME_PROPORTION_INFLUENCE_FOCUSED",
+    description="RULE_END_GAME_PROPORTION_INFLUENCE_FOCUSED_DESC",
+    category="BALANCE",
+    type=float,
+    default=1.0,
+    min=0.1,
+    max=10.0,
+)
+
+GameRule(
+    name="RULE_END_GAME_COLONY_IP_OUTPUT",
+    description="RULE_END_GAME_COLONY_IP_OUTPUT",
+    category="BALANCE",
+    type=float,
+    default=9.0,
+    min=6.0,
+    max=12.0,
+)

--- a/default/scripting/species/common/influence.macros
+++ b/default/scripting/species/common/influence.macros
@@ -1,4 +1,24 @@
 
+// (Owned non-exobot colonies + 0.25*(owned exobots and outposts)) / total planets in galaxy
+PERCENTAGE_OWNED_PLANETS
+'''((Statistic Count condition = And [
+                        Planet
+                        OwnedBy empire = Source.Owner
+                        Species
+                        Not Species name = "SP_EXOBOT"
+                    ]
+                    + ((NamedReal name = "OUTPOST_RELATIVE_ADMIN_COUNT" value = 0.25)
+                    * Statistic Count condition = And [
+                        Planet
+                        OwnedBy empire = Source.Owner
+                        Or [
+                            Not Species
+                            Species name = "SP_EXOBOT"
+                        ]
+                    ]))
+                    / (Statistic Count condition = Planet))'''
+
+
 BASE_INFLUENCE_COSTS
 '''EffectsGroup      // colonies consume influence, proportional to square-root of how many populated planets and non-populated outposts the empire controls
             scope = Source
@@ -11,24 +31,13 @@ BASE_INFLUENCE_COSTS
             accountinglabel = "COLONY_ADMIN_COSTS_LABEL"
             priority = [[TARGET_LAST_BEFORE_OVERRIDE_PRIORITY]]
             effects = SetTargetInfluence value = Value -
-                (NamedReal name = "COLONY_ADMIN_COSTS_PER_PLANET" value = 0.4) * ((
-                    Statistic Count condition = And [
-                        Planet
-                        OwnedBy empire = Source.Owner
-                        Species
-                        Not Species name = "SP_EXOBOT"
-                    ] +
-                    ((NamedReal name = "OUTPOST_RELATIVE_ADMIN_COUNT" value = 0.25) *
-                        (Statistic Count condition = And [
-                            Planet
-                            OwnedBy empire = Source.Owner
-                            Or [
-                                Not Species
-                                Species name = "SP_EXOBOT"
-                            ]
-                        ])
-                    )
-                )^0.5)
+                // Upkeep per colony is
+                //  Desired proportion of infuence-focused colonies when galaxy is fully colonized
+                //  * Average influence output per influence-focused colony at end game
+                //  / logistic function on the percentage of galaxy owned, with steepness 10 and skewness 2/3
+                (NamedReal name = "END_GAME_PROPORTION_INFLUENCE_FOCUSED" value = (GameRule name = "RULE_END_GAME_PROPORTION_INFLUENCE_FOCUSED"))
+                * (NamedReal name = "END_GAME_COLONY_IP_OUTPUT" value = (GameRule name = "RULE_END_GAME_COLONY_IP_OUTPUT"))
+                / (1 + 2.71828182846 ^ (-10*(-2/3 + [[PERCENTAGE_OWNED_PLANETS]])))
 
         EffectsGroup      // species homeworlds consume more influence
             scope = Source

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1385,6 +1385,18 @@ Minimum distance monsters start from Capital
 RULE_MINIMUM_MONSTER_DISTANCE_CAPITAL_DESC
 Minimum distance monsters start from Capital
 
+RULE_END_GAME_PROPORTION_INFLUENCE_FOCUSED
+Influence-focused colonies at end game
+
+RULE_END_GAME_PROPORTION_INFLUENCE_FOCUSED_DESC
+Desired proportion of influence-focused colonies when galaxy is fully colonized.
+
+RULE_END_GAME_COLONY_IP_OUTPUT
+IP output per colony at end game
+
+RULE_END_GAME_COLONY_IP_OUTPUT_DESC
+Expected average IP output per influence-focused colony for fully-developed empires.
+
 RULE_ALLOW_CONCEDE
 Allow Conceding
 


### PR DESCRIPTION
… when certain percent of the galaxy is colonized, parametrizable.

This equation allows to colonize whole galaxies without regardless of the size, without the need to adjust influence upkeep to the galaxy size and without making influence upkeep negligible in small galaxies.

Balance needs playtesting to set the right default values for the new two game rules.

AIs seem to cope well with the change. @Grummel7 @Cjkjvfnby Not sure if the python code is up to standards.


Discussion starting at this comment:
https://www.freeorion.org/forum/viewtopic.php?p=113443#p113443

Edit: new equation, with logistic growth of upkeep per colony. Relevant comment: https://www.freeorion.org/forum/viewtopic.php?p=113527#p113527