### PR TITLE
missing #include

### DIFF
--- a/default/scripting/ship_parts/General/SP_SOLAR_CONCENTRATOR.focs.txt
+++ b/default/scripting/ship_parts/General/SP_SOLAR_CONCENTRATOR.focs.txt
@@ -94,3 +94,4 @@ SOLAR_CONCENTRATOR_EFFECT
 '''
 
 #include "/scripting/common/upkeep.macros"
+#include "/scripting/common/misc.macros"


### PR DESCRIPTION
fixes parse error probably introduced in 2f594f9d41
````
SP_SOLAR_CONCENTRATOR.focs.txt:73:9: Parse error.  Expected ] here:
                DesignHasPart low = 1 high = 999 name = "SP_SOLAR_CONCENTRATOR"
                WithinStarlaneJumps jumps = 0 condition = Source
            ]
) ^ 0.5 ) + 4 ),
        15)
    ,3)) * [[SHIP_WEAPON_DAMAGE_FACTOR]]
         ^
 * 0.5
                SetCapacity partname = "SR_WEAPON_2_1" value = Value +
(max(
    min(
        min(
````