### PR TITLE
Influence upkeep with elliptic curve, parametrizable

### DIFF
--- a/default/python/tests/AI/test_calculate_planet_colonization_rating.py
+++ b/default/python/tests/AI/test_calculate_planet_colonization_rating.py
@@ -1,0 +1,38 @@
+import pytest
+from colonization.calculate_planet_colonization_rating import _colony_upkeep
+
+
+@pytest.mark.parametrize(
+    (
+        "num_exobots",
+        "num_normal",
+        "num_outpost",
+        "max_colony_upkeep",
+        "owned_colonies_at_max_upkeep",
+        "outpost_factor",
+        "expected",
+    ),
+    (
+        (0, 1, 0, 9.0, 1000, 0.25, 0.0),  # Game start: one capital and nothing else, no upkeep
+        (0, 2, 0, 9.0, 1000, 0.25, 0.568925303),  # First colony (non-exobot)
+        (0, 1, 5, 9.0, 1000, 0.25, 0.0),  # Capital and many outposts.
+        (0, 2, 1, 9.0, 1000, 0.25, 0.603398656),  # One colony and one outpost.
+        (0, 11, 2, 9.0, 1000, 0.25, 13.609877847),  # Ten colonies, two outposts.
+        (10, 1, 0, 9.0, 1000, 0.25, 7.523348656),  # Capital and 10 exobots.
+        (0, 999, 0, 9.0, 1000, 0.25, 8981.9955),  # One less than max colonies
+        (0, 1000, 0, 9.0, 1000, 0.25, 8991.0),  # Max colonies
+        (0, 1001, 0, 9.0, 1000, 0.25, 9000.0),  # One more than max colonies
+    ),
+)
+def test_colony_upkeep(
+    num_exobots: int,
+    num_normal: int,
+    num_outpost: int,
+    max_colony_upkeep: float,
+    owned_colonies_at_max_upkeep: int,
+    outpost_factor: float,
+    expected: float,
+):
+    assert pytest.approx(expected) == _colony_upkeep(
+        num_exobots, num_normal, num_outpost, max_colony_upkeep, owned_colonies_at_max_upkeep, outpost_factor
+    )

--- a/default/scripting/game_rules.focs.py
+++ b/default/scripting/game_rules.focs.py
@@ -316,3 +316,23 @@ GameRule(
     min=1,
     max=10,
 )
+
+GameRule(
+    name="RULE_OWNED_COLONIES_AT_MAXIMUM_UPKEEP",
+    description="RULE_OWNED_COLONIES_AT_MAXIMUM_UPKEEP_DESC",
+    category="BALANCE",
+    type=int,
+    default=1000,
+    min=10,
+    max=60000,
+)
+
+GameRule(
+    name="RULE_MAXIMUM_COLONY_UPKEEP",
+    description="RULE_MAXIMUM_COLONY_UPKEEP_DESC",
+    category="BALANCE",
+    type=float,
+    default=9.0,
+    min=1.0,
+    max=30.0,
+)

--- a/default/scripting/species/common/influence.macros
+++ b/default/scripting/species/common/influence.macros
@@ -1,6 +1,24 @@
 
+// Owned non-exobot colonies + 0.25*(owned exobots and outposts)
+OWNED_PLANETS
+'''((Statistic Count condition = And [
+                            Planet
+                            OwnedBy empire = Source.Owner
+                            Species
+                            Not Species name = "SP_EXOBOT"
+                        ])
+                        + ((NamedReal name = "OUTPOST_RELATIVE_ADMIN_COUNT" value = 0.25)
+                        * Statistic Count condition = And [
+                            Planet
+                            OwnedBy empire = Source.Owner
+                            Or [
+                                Not Species
+                                Species name = "SP_EXOBOT"
+                            ]
+                        ]))'''
+
 BASE_INFLUENCE_COSTS
-'''EffectsGroup      // colonies consume influence, proportional to square-root of how many populated planets and non-populated outposts the empire controls
+'''EffectsGroup  // Influence upkeep per colony
             scope = Source
             activation = And [
                 Planet
@@ -11,24 +29,16 @@ BASE_INFLUENCE_COSTS
             accountinglabel = "COLONY_ADMIN_COSTS_LABEL"
             priority = [[TARGET_LAST_BEFORE_OVERRIDE_PRIORITY]]
             effects = SetTargetInfluence value = Value -
-                (NamedReal name = "COLONY_ADMIN_COSTS_PER_PLANET" value = 0.4) * ((
-                    Statistic Count condition = And [
-                        Planet
-                        OwnedBy empire = Source.Owner
-                        Species
-                        Not Species name = "SP_EXOBOT"
-                    ] +
-                    ((NamedReal name = "OUTPOST_RELATIVE_ADMIN_COUNT" value = 0.25) *
-                        (Statistic Count condition = And [
-                            Planet
-                            OwnedBy empire = Source.Owner
-                            Or [
-                                Not Species
-                                Species name = "SP_EXOBOT"
-                            ]
-                        ])
-                    )
-                )^0.5)
+                (NamedReal name = "MAXIMUM_COLONY_UPKEEP" value = (GameRule name = "RULE_MAXIMUM_COLONY_UPKEEP"))
+                * ( 1.0
+                    - (min(
+                        [[OWNED_PLANETS]],
+                        (NamedInteger
+                            name = "OWNED_COLONIES_AT_MAXIMUM_UPKEEP"
+                            value = (GameRule name = "RULE_OWNED_COLONIES_AT_MAXIMUM_UPKEEP")
+                        )
+                    ) / (NamedIntegerLookup name = "OWNED_COLONIES_AT_MAXIMUM_UPKEEP") - 1.0)^2.0
+                )^0.5
 
         EffectsGroup      // species homeworlds consume more influence
             scope = Source

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1385,6 +1385,18 @@ Minimum distance monsters start from Capital
 RULE_MINIMUM_MONSTER_DISTANCE_CAPITAL_DESC
 Minimum distance monsters start from Capital
 
+RULE_OWNED_COLONIES_AT_MAXIMUM_UPKEEP
+Owned colonies at maximum upkeep
+
+RULE_OWNED_COLONIES_AT_MAXIMUM_UPKEEP_DESC
+Number of owned colonies at which upkeep per colony reaches its maximum.
+
+RULE_MAXIMUM_COLONY_UPKEEP
+Maximum upkeep per colony
+
+RULE_MAXIMUM_COLONY_UPKEEP_DESC
+Maximum influence upkeep per colony.
+
 RULE_ALLOW_CONCEDE
 Allow Conceding
 


### PR DESCRIPTION
Influence upkeep per colony based on a elliptic curve that reaches maximum at a given parameter then stops at a given number of owned colonies (parameter, a game rule, default 1000), at which point upkeep per colony is a given maximum (parameter, a game rule, default 9).

With default values, the upkeep per colony for the first dozens of planets is practically equal to the current equation, 0.4*owned_planets^0.5.

Discussion: https://www.freeorion.org/forum/viewtopic.php?p=113607#p113607

Edit: Explanatory post in the forum:
https://www.freeorion.org/forum/viewtopic.php?f=2&t=12548&p=113678#p113678

Supersedes #4082