### PR TITLE
Give translator a fixed cost

### DIFF
--- a/default/scripting/buildings/TRANSLATOR.focs.txt
+++ b/default/scripting/buildings/TRANSLATOR.focs.txt
@@ -1,10 +1,7 @@
 BuildingType
     name = "BLD_TRANSLATOR"
     description = "BLD_TRANSLATOR_DESC"
-    buildcost = 500 * 2^0.5 * [[BUILDING_COST_MULTIPLIER]] * (1.0 + Statistic CountUnique
-            value = LocalCandidate.Species
-            condition = And [ Planet Species VisibleToEmpire empire = Source.Owner ]
-        )^(-0.5)
+    buildcost = 320
     buildtime = 10
     location = And [
         Planet


### PR DESCRIPTION
Currently translators get cheaper and more powerful, the more species you have, making them a no-brainer for big, diverse empires. As a quick improvement this makes their cost constant 320 (about its current cost it with 4 visible species).

Details see Forum: [Nearly Universal Translator is a spammable building](https://www.freeorion.org/forum/viewtopic.php?p=112776#p112776)