### PR TITLE
SetPlanetType also sets original type during universe creation

### DIFF
--- a/default/scripting/specials/planet/PHILOSOPHER.focs.txt
+++ b/default/scripting/specials/planet/PHILOSOPHER.focs.txt
@@ -30,7 +30,10 @@ Special
             activation = Turn high = 0
             stackinggroup = "GAME_START_MOD_STACK"
             priority = [[BEFORE_ANYTHING_ELSE_PRIORITY]]
-            effects = SetPlanetType type = Radiated
+            effects = [
+                SetPlanetType type = Radiated
+                SetOriginalType type = Radiated
+            ]
 
         EffectsGroup
             scope = And [

--- a/parse/EffectParser2.cpp
+++ b/parse/EffectParser2.cpp
@@ -101,6 +101,12 @@ namespace parse { namespace detail {
                 new_<Effect::SetPlanetType>(deconstruct_movable_(_1, _pass))) ]
             ;
 
+        set_original_type
+            =    tok.SetOriginalType_
+            >    label(tok.type_) > planet_type_rules.expr [ _val = construct_movable_(
+                new_<Effect::SetOriginalType>(deconstruct_movable_(_1, _pass))) ]
+            ;
+
         set_planet_size
             =    tok.SetPlanetSize_
             >    label(tok.planetsize_) > planet_size_rules.expr [
@@ -175,6 +181,7 @@ namespace parse { namespace detail {
             |   set_empire_stockpile
             |   set_empire_capital
             |   set_planet_type
+            |   set_original_type
             |   set_planet_size
             |   set_species
             |   set_species_opinion
@@ -187,6 +194,7 @@ namespace parse { namespace detail {
         set_empire_stockpile.name("SetEmpireStockpile");
         set_empire_capital.name("SetEmpireCapital");
         set_planet_type.name("SetPlanetType");
+        set_original_type.name("SetOriginalType");
         set_planet_size.name("SetPlanetSize");
         set_species.name("SetSpecies");
         set_species_opinion.name("SetSpeciesOpinion");
@@ -200,6 +208,7 @@ namespace parse { namespace detail {
         debug(set_empire_stockpile);
         debug(set_empire_capital);
         debug(set_planet_type);
+        debug(set_original_type);
         debug(set_planet_size);
         debug(set_species);
         debug(set_species_opinion);

--- a/parse/EffectParser2.h
+++ b/parse/EffectParser2.h
@@ -48,6 +48,7 @@ namespace parse::detail {
         set_stockpile_or_vis_rule                   set_empire_stockpile;
         effect_parser_rule                          set_empire_capital;
         effect_parser_rule                          set_planet_type;
+        effect_parser_rule                          set_original_type;
         effect_parser_rule                          set_planet_size;
         effect_parser_rule                          set_species;
         string_string_int_rule                      set_species_opinion;

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -419,6 +419,7 @@
     (SetMaxSupply)                              \
     (SetMaxTroops)                              \
     (SetObstructive)                            \
+    (SetOriginalType)                           \
     (SetOverlayTexture)                         \
     (SetOwner)                                  \
     (SetPassive)                                \

--- a/universe/Effects.h
+++ b/universe/Effects.h
@@ -215,6 +215,25 @@ private:
     std::unique_ptr<ValueRef::ValueRef<PlanetType>> m_type;
 };
 
+/** Sets the original planet type of the target to \a type.  This has no effect on non-Planet targets.
+    This does not change the planet itself, it only affects game effects that compare the current type
+    to the original type. Typically effects that trigger during universe creation will set both
+    current and original type, while later effect will only modify the current type. */
+class FO_COMMON_API SetOriginalType final : public Effect {
+public:
+    explicit SetOriginalType(std::unique_ptr<ValueRef::ValueRef<PlanetType>>&& type);
+
+    void Execute(ScriptingContext& context) const override;
+    [[nodiscard]] std::string Dump(uint8_t ntabs = 0) const override;
+    void SetTopLevelContent(const std::string& content_name) override;
+    [[nodiscard]] unsigned int GetCheckSum() const override;
+
+    [[nodiscard]] std::unique_ptr<Effect> Clone() const override;
+
+private:
+    std::unique_ptr<ValueRef::ValueRef<PlanetType>> m_type;
+};
+
 /** Sets the planet size of the target to \a size.  This has no effect on non-
   * Planet targets.  Note that changing the size of a PlanetType::PT_ASTEROID or PlanetType::PT_GASGIANT
   * planet will also change its type to PlanetType::PT_BARREN.  Similarly, changing size to


### PR DESCRIPTION
I discovered by chance that Honeycomb and Philosopher planets usually start with current type != original type.
This should be the easiest fix.