### PR TITLE
Fix crash in processing turn due failed check for local connection

### DIFF
--- a/server/ServerNetworking.cpp
+++ b/server/ServerNetworking.cpp
@@ -218,11 +218,10 @@ PlayerConnection::~PlayerConnection() {
 bool PlayerConnection::EstablishedPlayer() const noexcept
 { return m_ID != INVALID_PLAYER_ID; }
 
-bool PlayerConnection::IsLocalConnection() const
-{ return (m_socket->remote_endpoint().address().is_loopback()); }
-
-void PlayerConnection::Start()
-{ AsyncReadMessage(); }
+void PlayerConnection::Start() {
+    m_is_local_connection = m_socket->remote_endpoint().address().is_loopback();
+    AsyncReadMessage();
+}
 
 void PlayerConnection::SendMessage(const Message& message) {
     if (!m_valid) {

--- a/server/ServerNetworking.h
+++ b/server/ServerNetworking.h
@@ -229,7 +229,7 @@ public:
 
     /** Checks if client associated with this connection runs on the same
         physical machine as the server */
-    [[nodiscard]] bool IsLocalConnection() const;
+    [[nodiscard]] bool IsLocalConnection() const noexcept { return m_is_local_connection; }
 
     /** Checks if the player is established, has a valid name, id and client type. */
     [[nodiscard]] bool IsEstablished() const;
@@ -319,6 +319,7 @@ private:
     Networking::AuthRoles           m_roles;
     boost::uuids::uuid              m_cookie = boost::uuids::nil_uuid();
     bool                            m_valid = true;
+    bool                            m_is_local_connection = false;
 
     MessageAndConnectionFn          m_nonplayer_message_callback;
     MessageAndConnectionFn          m_player_message_callback;


### PR DESCRIPTION
Fixes #4144 by moving check for local connection earlier and remembering result.