### PR TITLE
Add comparison float < ValueRefDouble

### DIFF
--- a/parse/PythonParser.cpp
+++ b/parse/PythonParser.cpp
@@ -123,6 +123,7 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
             .def(py::self_ns::self > py::self_ns::self)
             .def(py::self_ns::self < py::self_ns::self)
             .def(double() < py::self_ns::self)
+            .def(py::self_ns::self < double())
             .def(py::self_ns::pow(py::self_ns::self, double()));
         py::class_<value_ref_wrapper<std::string>>("ValueRefString", py::no_init);
         py::class_<condition_wrapper>("Condition", py::no_init)

--- a/parse/PythonParser.cpp
+++ b/parse/PythonParser.cpp
@@ -122,6 +122,7 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
             .def(py::self_ns::self >= int())
             .def(py::self_ns::self > py::self_ns::self)
             .def(py::self_ns::self < py::self_ns::self)
+            .def(double() < py::self_ns::self)
             .def(py::self_ns::pow(py::self_ns::self, double()));
         py::class_<value_ref_wrapper<std::string>>("ValueRefString", py::no_init);
         py::class_<condition_wrapper>("Condition", py::no_init)

--- a/parse/ValueRefPythonParser.cpp
+++ b/parse/ValueRefPythonParser.cpp
@@ -233,6 +233,14 @@ condition_wrapper operator<(const value_ref_wrapper<double>& lhs, const value_re
     );
 }
 
+condition_wrapper operator<(double lhs, const value_ref_wrapper<double>& rhs) {
+    return condition_wrapper(
+        std::make_shared<Condition::ValueTest>(std::make_unique<ValueRef::Constant<double>>(lhs),
+            Condition::ComparisonType::LESS_THAN,
+            ValueRef::CloneUnique(rhs.value_ref))
+    );
+}
+
 value_ref_wrapper<int> operator*(int lhs, const value_ref_wrapper<int>& rhs) {
     return value_ref_wrapper<int>(
         std::make_shared<ValueRef::Operation<int>>(ValueRef::OpType::TIMES,

--- a/parse/ValueRefPythonParser.cpp
+++ b/parse/ValueRefPythonParser.cpp
@@ -241,6 +241,14 @@ condition_wrapper operator<(double lhs, const value_ref_wrapper<double>& rhs) {
     );
 }
 
+condition_wrapper operator<(const value_ref_wrapper<double>& lhs, double rhs) {
+    return condition_wrapper(
+        std::make_shared<Condition::ValueTest>(ValueRef::CloneUnique(lhs.value_ref),
+            Condition::ComparisonType::LESS_THAN,
+            std::make_unique<ValueRef::Constant<double>>(rhs))
+    );
+}
+
 value_ref_wrapper<int> operator*(int lhs, const value_ref_wrapper<int>& rhs) {
     return value_ref_wrapper<int>(
         std::make_shared<ValueRef::Operation<int>>(ValueRef::OpType::TIMES,

--- a/parse/ValueRefPythonParser.h
+++ b/parse/ValueRefPythonParser.h
@@ -64,6 +64,7 @@ condition_wrapper operator<=(const value_ref_wrapper<double>&, double);
 condition_wrapper operator>(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
 condition_wrapper operator<(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
 condition_wrapper operator<(double, const value_ref_wrapper<double>&);
+condition_wrapper operator<(const value_ref_wrapper<double>&, double);
 
 value_ref_wrapper<int> operator*(int, const value_ref_wrapper<int>&);
 value_ref_wrapper<int> operator-(const value_ref_wrapper<int>&, int);

--- a/parse/ValueRefPythonParser.h
+++ b/parse/ValueRefPythonParser.h
@@ -63,6 +63,7 @@ condition_wrapper operator<=(double, const value_ref_wrapper<double>&);
 condition_wrapper operator<=(const value_ref_wrapper<double>&, double);
 condition_wrapper operator>(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
 condition_wrapper operator<(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
+condition_wrapper operator<(double, const value_ref_wrapper<double>&);
 
 value_ref_wrapper<int> operator*(int, const value_ref_wrapper<int>&);
 value_ref_wrapper<int> operator-(const value_ref_wrapper<int>&, int);


### PR DESCRIPTION
Fixes TypeError: '<' not supported between instances of 'float' and 'ValueRefDouble'