### PR TITLE
Start to return ValueRef::Operation instead of Condition::ValueTest in Python FOCS parser

### DIFF
--- a/parse/PythonParser.cpp
+++ b/parse/PythonParser.cpp
@@ -149,6 +149,7 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
         py::class_<unlockable_item_wrapper>("UnlockableItem", py::no_init);
         py::class_<FocusType>("__FocusType", py::no_init);
         auto py_variable_wrapper = py::class_<variable_wrapper>("__Variable", py::no_init)
+            .def(py::self_ns::self & py::other<value_ref_wrapper<double>>())
             .def(py::self_ns::self & py::other<condition_wrapper>())
             .def(~py::self_ns::self);
 

--- a/parse/SourcePythonParser.cpp
+++ b/parse/SourcePythonParser.cpp
@@ -62,6 +62,60 @@ condition_wrapper operator&(const variable_wrapper& lhs, const condition_wrapper
     ));
 }
 
+condition_wrapper operator&(const variable_wrapper& lhs, const value_ref_wrapper<double>& rhs) {
+    std::unique_ptr<Condition::Condition> variable;
+    switch (lhs.m_reference_type) {
+        case ValueRef::ReferenceType::SOURCE_REFERENCE:
+            variable = std::make_unique<Condition::Source>();
+            break;
+        case ValueRef::ReferenceType::EFFECT_TARGET_REFERENCE:
+            variable = std::make_unique<Condition::Target>();
+            break;
+        case ValueRef::ReferenceType::CONDITION_ROOT_CANDIDATE_REFERENCE:
+            variable = std::make_unique<Condition::RootCandidate>();
+            break;
+        default:
+            throw std::runtime_error(std::string("Not implemented in ") + __func__ + " type " + std::to_string(static_cast<int>(lhs.m_reference_type)) + rhs.value_ref->Dump());
+    }
+
+    std::shared_ptr<ValueRef::Operation<double>> rhs_op = std::dynamic_pointer_cast<ValueRef::Operation<double>>(rhs.value_ref);
+
+    if (rhs_op && rhs_op->LHS() && rhs_op->RHS()) {
+        Condition::ComparisonType cmp_type;
+        switch (rhs_op->GetOpType()) {
+            case ValueRef::OpType::COMPARE_EQUAL:
+                cmp_type = Condition::ComparisonType::EQUAL;
+                break;
+            case ValueRef::OpType::COMPARE_GREATER_THAN:
+                cmp_type = Condition::ComparisonType::GREATER_THAN;
+                break;
+            case ValueRef::OpType::COMPARE_GREATER_THAN_OR_EQUAL:
+                cmp_type = Condition::ComparisonType::GREATER_THAN_OR_EQUAL;
+                break;
+            case ValueRef::OpType::COMPARE_LESS_THAN:
+                cmp_type = Condition::ComparisonType::LESS_THAN;
+                break;
+            case ValueRef::OpType::COMPARE_LESS_THAN_OR_EQUAL:
+                cmp_type = Condition::ComparisonType::LESS_THAN_OR_EQUAL;
+                break;
+            case ValueRef::OpType::COMPARE_NOT_EQUAL:
+                cmp_type = Condition::ComparisonType::NOT_EQUAL;
+                break;
+            default:
+                throw std::runtime_error(std::string("Not implemented in ") + __func__ + " op type " + std::to_string(static_cast<int>(rhs_op->GetOpType())) + rhs.value_ref->Dump());
+        }
+
+        return condition_wrapper(std::make_shared<Condition::And>(
+            std::move(variable),
+            std::make_unique<Condition::ValueTest>(rhs_op->LHS()->Clone(),
+                cmp_type,
+                rhs_op->RHS()->Clone())
+        ));
+    }
+
+    throw std::runtime_error(std::string("Not implemented in ") + __func__ + " type " + std::to_string(static_cast<int>(lhs.m_reference_type)) + rhs.value_ref->Dump());
+}
+
 condition_wrapper operator~(const variable_wrapper& lhs) {
     std::unique_ptr<Condition::Condition> variable;
     switch (lhs.m_reference_type) {

--- a/parse/SourcePythonParser.h
+++ b/parse/SourcePythonParser.h
@@ -26,6 +26,7 @@ struct variable_wrapper {
 };
 
 condition_wrapper operator&(const variable_wrapper&, const condition_wrapper&);
+condition_wrapper operator&(const variable_wrapper&, const value_ref_wrapper<double>&);
 condition_wrapper operator~(const variable_wrapper&);
 
 void RegisterGlobalsSources(boost::python::dict& globals);

--- a/parse/ValueRefPythonParser.cpp
+++ b/parse/ValueRefPythonParser.cpp
@@ -217,10 +217,10 @@ condition_wrapper operator<=(const value_ref_wrapper<double>& lhs, double rhs) {
     );
 }
 
-condition_wrapper operator>(const value_ref_wrapper<double>& lhs, const value_ref_wrapper<double>& rhs) {
-    return condition_wrapper(
-        std::make_shared<Condition::ValueTest>(ValueRef::CloneUnique(lhs.value_ref),
-            Condition::ComparisonType::GREATER_THAN,
+value_ref_wrapper<double> operator>(const value_ref_wrapper<double>& lhs, const value_ref_wrapper<double>& rhs) {
+    return value_ref_wrapper<double>(
+        std::make_shared<ValueRef::Operation<double>>(ValueRef::OpType::COMPARE_GREATER_THAN,
+            ValueRef::CloneUnique(lhs.value_ref),
             ValueRef::CloneUnique(rhs.value_ref))
     );
 }

--- a/parse/ValueRefPythonParser.h
+++ b/parse/ValueRefPythonParser.h
@@ -61,7 +61,7 @@ condition_wrapper operator>=(const value_ref_wrapper<double>&, int);
 condition_wrapper operator<=(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
 condition_wrapper operator<=(double, const value_ref_wrapper<double>&);
 condition_wrapper operator<=(const value_ref_wrapper<double>&, double);
-condition_wrapper operator>(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
+value_ref_wrapper<double> operator>(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
 condition_wrapper operator<(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
 condition_wrapper operator<(double, const value_ref_wrapper<double>&);
 condition_wrapper operator<(const value_ref_wrapper<double>&, double);


### PR DESCRIPTION
As workaround for unknown context when processing comparison https://freeorion.org/forum/viewtopic.php?p=114478#p114478
