### PR TITLE
Limit stacktrace logging rate when evaluating named ValueRefs

### DIFF
--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -105,6 +105,7 @@ namespace {
             static auto previous_mins = std::chrono::duration_cast<std::chrono::minutes>(clock_now.time_since_epoch()).count();
             if (now_mins > previous_mins) {
                 trace_count = 0;
+                previous_mins = now_mins;
             }
             if (trace_count < 11) {
                 trace_count++;

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -98,7 +98,23 @@ namespace {
                           << " target: " << (context.effect_target ? context.effect_target->Name() : "0")
                           << " local c: " << (context.condition_local_candidate ? context.condition_local_candidate->Name() : "0")
                           << " root c: " << (context.condition_root_candidate ? context.condition_root_candidate->Name() : "0")
-                          << "  " << StackTrace();
+                          << " stacktrace: see trace logging";
+            static std::atomic<uint32_t> trace_count = 0;
+            const auto clock_now = std::chrono::system_clock::now();
+            const auto now_mins = std::chrono::duration_cast<std::chrono::minutes>(clock_now.time_since_epoch()).count();
+            static auto previous_mins = std::chrono::duration_cast<std::chrono::minutes>(clock_now.time_since_epoch()).count();
+            if (now_mins > previous_mins) {
+                trace_count = 0;
+            }
+            if (trace_count < 11) {
+                trace_count++;
+                ErrorLogger() << " FollowReference stacktrace : top level object (" << type_string << ") not defined in scripting context.\n"
+                          << StackTrace(); // only output stack trace some times per minute, as this was very slow on windows
+            } else {
+                ErrorLogger() << " FollowReference stacktrace : top level object (" << type_string << ") not defined in scripting context. Skip on error logger level. Already printed enough stacktraces. This can be very slow on windows.\n";
+                TraceLogger() << " FollowReference stacktrace : top level object (" << type_string << ") not defined in scripting context.\n"
+                              << StackTrace(); // only output stack trace some times per minute, as this was very slow on windows
+            }
             return nullptr;
         }
 

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -110,7 +110,7 @@ namespace {
             if (trace_count < 11) {
                 trace_count++;
                 ErrorLogger() << " FollowReference stacktrace : top level object (" << type_string << ") not defined in scripting context.\n"
-                          << StackTrace(); // only output stack trace some times per minute, as this was very slow on windows
+                              << StackTrace(); // only output stack trace some times per minute, as this was very slow on windows
             } else {
                 ErrorLogger() << " FollowReference stacktrace : top level object (" << type_string << ") not defined in scripting context. Skip on error logger level. Already printed enough stacktraces. This can be very slow on windows.\n";
                 TraceLogger() << " FollowReference stacktrace : top level object (" << type_string << ") not defined in scripting context.\n"


### PR DESCRIPTION
using named value ref without necessary context object was very slow in windows, so we calculate the stack trace only if we actually enable trace logging

the case will always happen when printing the list of all named values in the game, whenever a named value ref references e.g. Source, Target...

this is a workaround for the lag in https://github.com/freeorion/freeorion/issues/3392