### PR TITLE
Apply damage scaling  for combat value estimates in ship design pedia entry

### DIFF
--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2810,11 +2810,12 @@ namespace {
             general_type = design.IsMonster() ? UserString("ENC_MONSTER") : UserString("ENC_SHIP_DESIGN");
         }
 
-        float tech_level = boost::algorithm::clamp(context.current_turn / 400.0f, 0.0f, 1.0f);
-        float typical_shot = 3 + 27 * tech_level;
-        float enemy_DR = 20 * tech_level;
-        TraceLogger() << "RefreshDetailPanelShipDesignTag default enemy stats:: tech_level: "
-                      << tech_level << "   DR: " << enemy_DR << "   attack: " << typical_shot;
+        const float tech_level = boost::algorithm::clamp(context.current_turn / 400.0f, 0.0f, 1.0f);
+        const double scaling = GetGameRules().Get<double>("RULE_SHIP_WEAPON_DAMAGE_FACTOR");
+        const float typical_shot = (3 + 27 * tech_level) * scaling;
+        float enemy_DR = 20 * tech_level * scaling;
+        TraceLogger() << "RefreshDetailPanelShipDesignTag default enemy stats:: tech_level: " << tech_level
+                      << "   DR: " << enemy_DR << "   attack: " << typical_shot << "  incl.scaling: " << scaling;
         std::set<float> enemy_shots{typical_shot};
 
 
@@ -2972,10 +2973,11 @@ namespace {
 
         // baseline values, may be overridden
         const float tech_level = boost::algorithm::clamp(context.current_turn / 400.0f, 0.0f, 1.0f);
-        const float typical_shot = 3 + 27 * tech_level;
-        float enemy_DR = 20 * tech_level;
+        const double scaling = GetGameRules().Get<double>("RULE_SHIP_WEAPON_DAMAGE_FACTOR");
+        const float typical_shot = (3 + 27 * tech_level) * scaling;
+        float enemy_DR = 20 * tech_level * scaling;
         DebugLogger() << "default enemy stats:: tech_level: " << tech_level
-                      << "   DR: " << enemy_DR << "   attack: " << typical_shot;
+                      << "   DR: " << enemy_DR << "   attack: " << typical_shot << "  incl.scaling: " << scaling;
         std::set<float> enemy_shots{typical_shot};
 
         std::set<std::string> additional_species; // TODO: from currently selected planet and ship, if any


### PR DESCRIPTION
ship weapon damage scaling was not applied in UI, so the estimates against shields were "slightly" off

before:
![bad_combat_estimate_with_shields](https://user-images.githubusercontent.com/3252041/194722821-9ef9d4fc-ea55-475e-b91b-db9c5e422402.png)

with the PR applied:
![bad_combat_estimate_with_shields_fixed](https://user-images.githubusercontent.com/3252041/194722829-b64261ad-add6-42e8-8489-a020d38ec760.png)
