### PR TITLE
Make it possible to hide the kraken nests from turn 1 und 2

### DIFF
--- a/default/scripting/specials/planet/monster_guard.macros
+++ b/default/scripting/specials/planet/monster_guard.macros
@@ -114,7 +114,12 @@ CHANCE_OF_HIDE_1
 '''        EffectsGroup
             scope = Source
             activation = And [
-                Turn high = 0
+                // Note: Kraken nests are created in the initial turn and also turns 1 and 2
+                // only check in the first turns of the game. 
+                Turn high = 5
+                Not HasSpecial name = "CLOUD_COVER_MASTER_SPECIAL"
+                // every nest has only one chance to get clouds, no matter which turn it was created:
+                (CurrentTurn <= max(1, 1 + SpecialAddedOnTurn name = ThisSpecial object = Source.ID))
                 Random probability = 0.15
                 (GalaxyMaxAIAggression >= 1)
                 Not ContainedBy Contains Or [


### PR DESCRIPTION
monster nests are supposed to have a chance to go hidden under cloud spawns

this does not work correctly for krakens (because those nests can also be created in turns 1 and 2)

discussion https://www.freeorion.org/forum/viewtopic.php?p=114618#p114618

this fixes this extending the possible turns and at the same time restricting to the turn after the nest was added