### PR TITLE
Detection Policies balancing for 0.5  (stealth revamp part3) 

### DIFF
--- a/default/scripting/policies/CHECKPOINTS.focs.txt
+++ b/default/scripting/policies/CHECKPOINTS.focs.txt
@@ -17,19 +17,39 @@ Policy
             effects = [
                 SetTargetInfluence value = Value
                    + (NamedReal name = "PLC_CHECKPOINTS_TARGET_INFLUENCE_FLAT" value = -0.5)
-                SetMaxSupply value = Value 
-                   + (NamedReal name = "PLC_CHECKPOINTS_MAX_SUPPLY_FLAT" value = -1)
             ]
 
         EffectsGroup
             scope = And [
-                Capital
-                OwnedBy empire = Source.Owner
+                Ship
+                // own and allied ships should not be affected
+                Not Or [
+                    OwnedBy empire = Source.Owner
+                    OwnedBy affiliation = AllyOf empire = Source.Owner
+                ]
+
+                // check in system and on starlanes if in own supply lines (allied ones dont count)
+                Or [
+                   And [
+                       InSystem
+                       (LocalCandidate.SupplyingEmpire == Source.Owner)
+                   ]
+                   And [
+                       // TODO add .SupplyingEmpire for ships on starlanes
+                       Not InSystem
+                       (2 == Statistic Count condition = And [
+                          System
+                          (LocalCandidate.SupplyingEmpire == Source.Owner)
+                          Or [
+                            (RootCandidate.Fleet.NextSystemID == LocalCandidate.ID)
+                            (RootCandidate.Fleet.PreviousSystemID == LocalCandidate.ID)
+                          ]
+                       ])
+                   ]
+                ]
             ]
-            effects = SetEmpireMeter
-                empire = Source.Owner
-                meter = "METER_DETECTION_STRENGTH"
-                value = Value + min((NamedReal name = "PLC_CHECKPOINTS_DETECTION_STRENGTH_MAX" value = 20.0),
+
+            effects = SetStealth value = Value - min((NamedReal name = "PLC_CHECKPOINTS_MAX_STEALTH_MALUS" value = 20.0),
                                     TurnsSincePolicyAdopted empire = Source.Owner name = ThisPolicy)
     ]
     graphic = "icons/policies/economic_checkpoints.png"

--- a/default/scripting/policies/CONTINUOUS_SCANNING.focs.txt
+++ b/default/scripting/policies/CONTINUOUS_SCANNING.focs.txt
@@ -13,7 +13,7 @@ Policy
                 OwnedBy empire = Source.Owner
             ]
             effects = [
-                SetDetection value = Value + (NamedReal name = "CONTINUOUS_SCANNING_RANGE_BOOST" value = 5.0)
+                SetDetection value = Value + (NamedReal name = "CONTINUOUS_SCANNING_RANGE_BOOST" value = 10.0)
                 SetStealth value = Value - (NamedReal name = "CONTINUOUS_SCANNING_STEALTH_PENALTY" value = 10.0)
             ]
 
@@ -25,7 +25,7 @@ Policy
             effects = SetEmpireMeter
                 empire = Source.Owner
                 meter = "METER_DETECTION_STRENGTH"
-                value = Value + min((NamedReal name = "CONTINUOUS_SCANNING_MAX_DETECTION_BOOST" value = 20.0),
+                value = Value + min((NamedReal name = "CONTINUOUS_SCANNING_MAX_DETECTION_BOOST" value = 10.0),
                                     TurnsSincePolicyAdopted empire = Source.Owner name = ThisPolicy)
     ]
     graphic = "icons/policies/military_continuous_scanning.png"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -12276,7 +12276,9 @@ PLC_CHECKPOINTS
 Border Checkpoints
 
 PLC_CHECKPOINTS_DESC
-'''Increases imperial detection strength by 1 per turn up to [[value PLC_CHECKPOINTS_DETECTION_STRENGTH_MAX]].
+'''Decreases [[metertype METER_STEALTH]] of foreign ships and planets in [[metertype METER_SUPPLY]] by up to [[value PLC_CHECKPOINTS_MAX_STEALTH_MALUS]]. Ships and planets are considered foreign if not owned by or allied to this empire. Unowned planets and monsters are also foreign.
+
+The decrease depends on the time this policy is adapted, decreasing [[metertype METER_STEALTH]] by 1 per turn up to [[value PLC_CHECKPOINTS_MAX_STEALTH_MALUS]].
 
 Reduces imperial [[metertype METER_SUPPLY]] line range ([[value PLC_CHECKPOINTS_MAX_SUPPLY_FLAT]]) and [[metertype METER_INFLUENCE]] generation ([[value PLC_CHECKPOINTS_TARGET_INFLUENCE_FLAT]]).'''
 


### PR DESCRIPTION
 
    PLC_CHECKPOINTS revamp 0.5 poll
    https://freeorion.org/forum/viewtopic.php?f=15&t=12618
    
    Changing PLC_CHECKPOINTS
    https://freeorion.org/forum/viewtopic.php?f=15&t=12593

    * decreases stealth of (neutral|war|peace) ships ( +20 det.str -> -20 in-supply stealth malus)
    * works in systems with own supply (allied supply does not suffice)
    * works in own starlanes (allied supply lanes do not suffice)
    * removed supply malus and detection strength bonus
    
    * still has an influence malus per planet
