### PR TITLE
Refactor comparison operators in Python FOCS parser

### DIFF
--- a/parse/ConditionPythonParser.cpp
+++ b/parse/ConditionPythonParser.cpp
@@ -61,175 +61,16 @@ condition_wrapper operator&(const condition_wrapper& lhs, const condition_wrappe
 }
 
 condition_wrapper operator&(const condition_wrapper& lhs, const value_ref_wrapper<double>& rhs) {
-    std::shared_ptr<ValueRef::Operation<double>> rhs_op = std::dynamic_pointer_cast<ValueRef::Operation<double>>(rhs.value_ref);
-
-    std::shared_ptr<Condition::ValueTest> rhs_cond;
-    if (rhs_op && rhs_op->LHS() && rhs_op->RHS()) {
-        Condition::ComparisonType cmp_type;
-        switch (rhs_op->GetOpType()) {
-            case ValueRef::OpType::COMPARE_EQUAL:
-                cmp_type = Condition::ComparisonType::EQUAL;
-                break;
-            case ValueRef::OpType::COMPARE_GREATER_THAN:
-                cmp_type = Condition::ComparisonType::GREATER_THAN;
-                break;
-            case ValueRef::OpType::COMPARE_GREATER_THAN_OR_EQUAL:
-                cmp_type = Condition::ComparisonType::GREATER_THAN_OR_EQUAL;
-                break;
-            case ValueRef::OpType::COMPARE_LESS_THAN:
-                cmp_type = Condition::ComparisonType::LESS_THAN;
-                break;
-            case ValueRef::OpType::COMPARE_LESS_THAN_OR_EQUAL:
-                cmp_type = Condition::ComparisonType::LESS_THAN_OR_EQUAL;
-                break;
-            case ValueRef::OpType::COMPARE_NOT_EQUAL:
-                cmp_type = Condition::ComparisonType::NOT_EQUAL;
-                break;
-            default:
-                throw std::runtime_error(std::string("Not implemented in ") + __func__ + " op type " + std::to_string(static_cast<int>(rhs_op->GetOpType())) + rhs.value_ref->Dump());
-        }
-
-        rhs_cond = std::make_shared<Condition::ValueTest>(rhs_op->LHS()->Clone(),
-                cmp_type,
-                rhs_op->RHS()->Clone());
-    } else {
-        throw std::runtime_error(std::string("Not implemented in ") + __func__ + " op " + rhs.value_ref->Dump());
-    }
-
-    std::shared_ptr<Condition::ValueTest> lhs_cond = std::dynamic_pointer_cast<Condition::ValueTest>(lhs.condition);
-
-    if (lhs_cond && rhs_cond) {
-        const auto lhs_vals = lhs_cond->ValuesDouble();
-        const auto rhs_vals = rhs_cond->ValuesDouble();
-
-        if (!lhs_vals[2] && !rhs_vals[2] && lhs_vals[1] && rhs_vals[0] && (*lhs_vals[1] == *rhs_vals[0])) {
-            return condition_wrapper(std::make_shared<Condition::ValueTest>(
-                lhs_vals[0] ? lhs_vals[0]->Clone() : nullptr,
-                lhs_cond->CompareTypes()[0],
-                lhs_vals[1]->Clone(),
-                rhs_cond->CompareTypes()[0],
-                rhs_vals[1] ? rhs_vals[1]->Clone() : nullptr
-            ));
-        }
-
-        const auto lhs_vals_i = lhs_cond->ValuesInt();
-        const auto rhs_vals_i = rhs_cond->ValuesInt();
-
-        if (!lhs_vals_i[2] && !rhs_vals_i[2] && lhs_vals_i[1] && rhs_vals_i[0] && (*lhs_vals_i[1] == *rhs_vals_i[0])) {
-            return condition_wrapper(std::make_shared<Condition::ValueTest>(
-                lhs_vals_i[0] ? lhs_vals_i[0]->Clone() : nullptr,
-                lhs_cond->CompareTypes()[0],
-                lhs_vals_i[1]->Clone(),
-                rhs_cond->CompareTypes()[0],
-                rhs_vals_i[1] ? rhs_vals_i[1]->Clone() : nullptr
-            ));
-        }
-
-        const auto lhs_vals_s = lhs_cond->ValuesString();
-        const auto rhs_vals_s = rhs_cond->ValuesString();
-
-        if (!lhs_vals_s[2] && !rhs_vals_s[2] && lhs_vals_s[1] && rhs_vals_s[0] && (*lhs_vals_s[1] == *rhs_vals_s[0])) {
-            return condition_wrapper(std::make_shared<Condition::ValueTest>(
-                lhs_vals_s[0] ? lhs_vals_s[0]->Clone() : nullptr,
-                lhs_cond->CompareTypes()[0],
-                lhs_vals_s[1]->Clone(),
-                rhs_cond->CompareTypes()[0],
-                rhs_vals_s[1] ? rhs_vals_s[1]->Clone() : nullptr
-            ));
-        }
-    }
-
-    return condition_wrapper(std::make_shared<Condition::And>(
-        lhs.condition->Clone(),
-        rhs_cond->Clone()
-    ));
+    return lhs & rhs.operator condition_wrapper();
 }
 
 condition_wrapper operator&(const condition_wrapper& lhs, const value_ref_wrapper<int>& rhs) {
-    std::shared_ptr<ValueRef::Operation<int>> rhs_op = std::dynamic_pointer_cast<ValueRef::Operation<int>>(rhs.value_ref);
-
-    std::shared_ptr<Condition::ValueTest> rhs_cond;
-    if (rhs_op && rhs_op->LHS() && rhs_op->RHS()) {
-        Condition::ComparisonType cmp_type;
-        switch (rhs_op->GetOpType()) {
-            case ValueRef::OpType::COMPARE_EQUAL:
-                cmp_type = Condition::ComparisonType::EQUAL;
-                break;
-            case ValueRef::OpType::COMPARE_GREATER_THAN:
-                cmp_type = Condition::ComparisonType::GREATER_THAN;
-                break;
-            case ValueRef::OpType::COMPARE_GREATER_THAN_OR_EQUAL:
-                cmp_type = Condition::ComparisonType::GREATER_THAN_OR_EQUAL;
-                break;
-            case ValueRef::OpType::COMPARE_LESS_THAN:
-                cmp_type = Condition::ComparisonType::LESS_THAN;
-                break;
-            case ValueRef::OpType::COMPARE_LESS_THAN_OR_EQUAL:
-                cmp_type = Condition::ComparisonType::LESS_THAN_OR_EQUAL;
-                break;
-            case ValueRef::OpType::COMPARE_NOT_EQUAL:
-                cmp_type = Condition::ComparisonType::NOT_EQUAL;
-                break;
-            default:
-                throw std::runtime_error(std::string("Not implemented in ") + __func__ + " op type " + std::to_string(static_cast<int>(rhs_op->GetOpType())) + rhs.value_ref->Dump());
-        }
-
-        rhs_cond = std::make_shared<Condition::ValueTest>(rhs_op->LHS()->Clone(),
-                cmp_type,
-                rhs_op->RHS()->Clone());
-    } else {
-        throw std::runtime_error(std::string("Not implemented in ") + __func__ + " op " + rhs.value_ref->Dump());
-    }
-
-    std::shared_ptr<Condition::ValueTest> lhs_cond = std::dynamic_pointer_cast<Condition::ValueTest>(lhs.condition);
-
-    if (lhs_cond && rhs_cond) {
-        const auto lhs_vals = lhs_cond->ValuesDouble();
-        const auto rhs_vals = rhs_cond->ValuesDouble();
-
-        if (!lhs_vals[2] && !rhs_vals[2] && lhs_vals[1] && rhs_vals[0] && (*lhs_vals[1] == *rhs_vals[0])) {
-            return condition_wrapper(std::make_shared<Condition::ValueTest>(
-                lhs_vals[0] ? lhs_vals[0]->Clone() : nullptr,
-                lhs_cond->CompareTypes()[0],
-                lhs_vals[1]->Clone(),
-                rhs_cond->CompareTypes()[0],
-                rhs_vals[1] ? rhs_vals[1]->Clone() : nullptr
-            ));
-        }
-
-        const auto lhs_vals_i = lhs_cond->ValuesInt();
-        const auto rhs_vals_i = rhs_cond->ValuesInt();
-
-        if (!lhs_vals_i[2] && !rhs_vals_i[2] && lhs_vals_i[1] && rhs_vals_i[0] && (*lhs_vals_i[1] == *rhs_vals_i[0])) {
-            return condition_wrapper(std::make_shared<Condition::ValueTest>(
-                lhs_vals_i[0] ? lhs_vals_i[0]->Clone() : nullptr,
-                lhs_cond->CompareTypes()[0],
-                lhs_vals_i[1]->Clone(),
-                rhs_cond->CompareTypes()[0],
-                rhs_vals_i[1] ? rhs_vals_i[1]->Clone() : nullptr
-            ));
-        }
-
-        const auto lhs_vals_s = lhs_cond->ValuesString();
-        const auto rhs_vals_s = rhs_cond->ValuesString();
-
-        if (!lhs_vals_s[2] && !rhs_vals_s[2] && lhs_vals_s[1] && rhs_vals_s[0] && (*lhs_vals_s[1] == *rhs_vals_s[0])) {
-            return condition_wrapper(std::make_shared<Condition::ValueTest>(
-                lhs_vals_s[0] ? lhs_vals_s[0]->Clone() : nullptr,
-                lhs_cond->CompareTypes()[0],
-                lhs_vals_s[1]->Clone(),
-                rhs_cond->CompareTypes()[0],
-                rhs_vals_s[1] ? rhs_vals_s[1]->Clone() : nullptr
-            ));
-        }
-    }
-
-    return condition_wrapper(std::make_shared<Condition::And>(
-        lhs.condition->Clone(),
-        rhs_cond->Clone()
-    ));
+    return lhs & rhs.operator condition_wrapper();
 }
 
+condition_wrapper operator&(const value_ref_wrapper<double>& lhs, const value_ref_wrapper<double>& rhs) {
+    return lhs.operator condition_wrapper() & rhs.operator condition_wrapper();
+}
 
 
 condition_wrapper operator|(const condition_wrapper& lhs, const condition_wrapper& rhs) {
@@ -237,6 +78,14 @@ condition_wrapper operator|(const condition_wrapper& lhs, const condition_wrappe
         lhs.condition->Clone(),
         rhs.condition->Clone()
     ));
+}
+
+condition_wrapper operator|(const condition_wrapper& lhs, const value_ref_wrapper<int>& rhs) {
+    return lhs | rhs.operator condition_wrapper();
+}
+
+condition_wrapper operator|(const value_ref_wrapper<int>& lhs, const value_ref_wrapper<int>& rhs) {
+    return lhs.operator condition_wrapper() | rhs.operator condition_wrapper();
 }
 
 condition_wrapper operator~(const condition_wrapper& lhs) {

--- a/parse/ConditionPythonParser.h
+++ b/parse/ConditionPythonParser.h
@@ -22,7 +22,10 @@ struct condition_wrapper {
 condition_wrapper operator&(const condition_wrapper&, const condition_wrapper&);
 condition_wrapper operator&(const condition_wrapper&, const value_ref_wrapper<double>&);
 condition_wrapper operator&(const condition_wrapper&, const value_ref_wrapper<int>&);
+condition_wrapper operator&(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
 condition_wrapper operator|(const condition_wrapper&, const condition_wrapper&);
+condition_wrapper operator|(const value_ref_wrapper<int>&, const value_ref_wrapper<int>&);
+condition_wrapper operator|(const condition_wrapper&, const value_ref_wrapper<int>&);
 condition_wrapper operator~(const condition_wrapper&);
 
 void RegisterGlobalsConditions(boost::python::dict& globals);

--- a/parse/PythonParser.cpp
+++ b/parse/PythonParser.cpp
@@ -96,10 +96,12 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
             .def(py::self_ns::self + int())
             .def(py::self_ns::self < py::self_ns::self)
             .def(py::self_ns::self < int())
+            .def(py::self_ns::self > int())
             .def(py::self_ns::self >= py::self_ns::self)
             .def(py::self_ns::self == py::self_ns::self)
             .def(double() - py::self_ns::self)
-            .def(py::self_ns::self == int());
+            .def(py::self_ns::self == int())
+            .def(py::self_ns::self | py::self_ns::self);
         py::class_<value_ref_wrapper<double>>("ValueRefDouble", py::no_init)
             .def("__call__", &value_ref_wrapper<double>::call)
             .def(int() * py::self_ns::self)
@@ -131,13 +133,15 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
             .def(py::self_ns::self < double())
             .def(py::self_ns::self != int())
             .def(py::self_ns::pow(py::self_ns::self, double()))
-            .def(py::self_ns::pow(double(), py::self_ns::self));
+            .def(py::self_ns::pow(double(), py::self_ns::self))
+            .def(py::self_ns::self & py::self_ns::self);
         py::class_<value_ref_wrapper<std::string>>("ValueRefString", py::no_init);
         py::class_<condition_wrapper>("Condition", py::no_init)
             .def(py::self_ns::self & py::self_ns::self)
             .def(py::self_ns::self & py::other<value_ref_wrapper<double>>())
             .def(py::self_ns::self & py::other<value_ref_wrapper<int>>())
             .def(py::self_ns::self | py::self_ns::self)
+            .def(py::self_ns::self | py::other<value_ref_wrapper<int>>())
             .def(~py::self_ns::self);
         py::class_<effect_wrapper>("Effect", py::no_init);
         py::class_<effect_group_wrapper>("EffectsGroup", py::no_init);
@@ -273,6 +277,7 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
 
         py::implicitly_convertible<variable_wrapper, condition_wrapper>();
         py::implicitly_convertible<value_ref_wrapper<double>, condition_wrapper>();
+        py::implicitly_convertible<value_ref_wrapper<int>, condition_wrapper>();
 
         m_meta_path = py::extract<py::list>(py::import("sys").attr("meta_path"));
         m_meta_path.append(boost::cref(*this));

--- a/parse/ValueRefPythonParser.cpp
+++ b/parse/ValueRefPythonParser.cpp
@@ -210,37 +210,36 @@ value_ref_wrapper<double> operator-(const value_ref_wrapper<double>& lhs, int rh
     );
 }
 
-condition_wrapper operator>=(const value_ref_wrapper<double>& lhs, int rhs) {
-    return condition_wrapper(
-        std::make_shared<Condition::ValueTest>(ValueRef::CloneUnique(lhs.value_ref),
-            Condition::ComparisonType::GREATER_THAN_OR_EQUAL,
+value_ref_wrapper<double> operator>=(const value_ref_wrapper<double>& lhs, int rhs) {
+    return value_ref_wrapper<double>(
+        std::make_shared<ValueRef::Operation<double>>(ValueRef::OpType::COMPARE_GREATER_THAN_OR_EQUAL,
+            ValueRef::CloneUnique(lhs.value_ref),
             std::make_unique<ValueRef::Constant<double>>(rhs)
-        )
-    );
+    ));
 }
 
-condition_wrapper operator<=(const value_ref_wrapper<double>& lhs, const value_ref_wrapper<double>& rhs) {
-    return condition_wrapper(
-        std::make_shared<Condition::ValueTest>(ValueRef::CloneUnique(lhs.value_ref),
-            Condition::ComparisonType::LESS_THAN_OR_EQUAL,
-            ValueRef::CloneUnique(rhs.value_ref))
-    );
+value_ref_wrapper<double> operator<=(const value_ref_wrapper<double>& lhs, const value_ref_wrapper<double>& rhs) {
+    return value_ref_wrapper<double>(
+        std::make_shared<ValueRef::Operation<double>>(ValueRef::OpType::COMPARE_LESS_THAN_OR_EQUAL,
+            ValueRef::CloneUnique(lhs.value_ref),
+            ValueRef::CloneUnique(rhs.value_ref)
+    ));
 }
 
-condition_wrapper operator<=(double lhs, const value_ref_wrapper<double>& rhs) {
-    return condition_wrapper(
-        std::make_shared<Condition::ValueTest>(std::make_unique<ValueRef::Constant<double>>(lhs),
-            Condition::ComparisonType::LESS_THAN_OR_EQUAL,
-            ValueRef::CloneUnique(rhs.value_ref))
-    );
+value_ref_wrapper<double> operator<=(double lhs, const value_ref_wrapper<double>& rhs) {
+    return value_ref_wrapper<double>(
+        std::make_shared<ValueRef::Operation<double>>(ValueRef::OpType::COMPARE_LESS_THAN_OR_EQUAL,
+            std::make_unique<ValueRef::Constant<double>>(lhs),
+            ValueRef::CloneUnique(rhs.value_ref)
+    ));
 }
 
-condition_wrapper operator<=(const value_ref_wrapper<double>& lhs, double rhs) {
-    return condition_wrapper(
-        std::make_shared<Condition::ValueTest>(ValueRef::CloneUnique(lhs.value_ref),
-            Condition::ComparisonType::LESS_THAN_OR_EQUAL,
-            std::make_unique<ValueRef::Constant<double>>(rhs))
-    );
+value_ref_wrapper<double> operator<=(const value_ref_wrapper<double>& lhs, double rhs) {
+    return value_ref_wrapper<double>(
+        std::make_shared<ValueRef::Operation<double>>(ValueRef::OpType::COMPARE_LESS_THAN_OR_EQUAL,
+            ValueRef::CloneUnique(lhs.value_ref),
+            std::make_unique<ValueRef::Constant<double>>(rhs)
+    ));
 }
 
 value_ref_wrapper<double> operator>(const value_ref_wrapper<double>& lhs, const value_ref_wrapper<double>& rhs) {
@@ -267,18 +266,18 @@ value_ref_wrapper<double> operator<(const value_ref_wrapper<double>& lhs, const 
     );
 }
 
-condition_wrapper operator<(double lhs, const value_ref_wrapper<double>& rhs) {
-    return condition_wrapper(
-        std::make_shared<Condition::ValueTest>(std::make_unique<ValueRef::Constant<double>>(lhs),
-            Condition::ComparisonType::LESS_THAN,
+value_ref_wrapper<double> operator<(double lhs, const value_ref_wrapper<double>& rhs) {
+    return value_ref_wrapper<double>(
+        std::make_shared<ValueRef::Operation<double>>(ValueRef::OpType::COMPARE_LESS_THAN,
+            std::make_unique<ValueRef::Constant<double>>(lhs),
             ValueRef::CloneUnique(rhs.value_ref))
     );
 }
 
-condition_wrapper operator<(const value_ref_wrapper<double>& lhs, double rhs) {
-    return condition_wrapper(
-        std::make_shared<Condition::ValueTest>(ValueRef::CloneUnique(lhs.value_ref),
-            Condition::ComparisonType::LESS_THAN,
+value_ref_wrapper<double> operator<(const value_ref_wrapper<double>& lhs, double rhs) {
+    return value_ref_wrapper<double>(
+        std::make_shared<ValueRef::Operation<double>>(ValueRef::OpType::COMPARE_LESS_THAN,
+            ValueRef::CloneUnique(lhs.value_ref),
             std::make_unique<ValueRef::Constant<double>>(rhs))
     );
 }
@@ -336,10 +335,10 @@ value_ref_wrapper<int> operator+(const value_ref_wrapper<int>& lhs, const value_
     );
 }
 
-condition_wrapper operator<(const value_ref_wrapper<int>& lhs, const value_ref_wrapper<int>& rhs) {
-    return condition_wrapper(
-        std::make_shared<Condition::ValueTest>(ValueRef::CloneUnique(lhs.value_ref),
-            Condition::ComparisonType::LESS_THAN,
+value_ref_wrapper<int> operator<(const value_ref_wrapper<int>& lhs, const value_ref_wrapper<int>& rhs) {
+    return value_ref_wrapper<int>(
+        std::make_shared<ValueRef::Operation<int>>(ValueRef::OpType::COMPARE_LESS_THAN,
+            ValueRef::CloneUnique(lhs.value_ref),
             ValueRef::CloneUnique(rhs.value_ref))
     );
 }
@@ -352,26 +351,34 @@ value_ref_wrapper<int> operator<(const value_ref_wrapper<int>& lhs, int rhs) {
     );
 }
 
-condition_wrapper operator>=(const value_ref_wrapper<int>& lhs, const value_ref_wrapper<int>& rhs) {
-    return condition_wrapper(
-        std::make_shared<Condition::ValueTest>(ValueRef::CloneUnique(lhs.value_ref),
-            Condition::ComparisonType::GREATER_THAN_OR_EQUAL,
+value_ref_wrapper<int> operator>(const value_ref_wrapper<int>& lhs, int rhs) {
+    return value_ref_wrapper<int>(
+        std::make_shared<ValueRef::Operation<int>>(ValueRef::OpType::COMPARE_GREATER_THAN,
+            ValueRef::CloneUnique(lhs.value_ref),
+            std::make_unique<ValueRef::Constant<int>>(rhs))
+    );
+}
+
+value_ref_wrapper<int> operator>=(const value_ref_wrapper<int>& lhs, const value_ref_wrapper<int>& rhs) {
+    return value_ref_wrapper<int>(
+        std::make_shared<ValueRef::Operation<int>>(ValueRef::OpType::COMPARE_GREATER_THAN_OR_EQUAL,
+            ValueRef::CloneUnique(lhs.value_ref),
             ValueRef::CloneUnique(rhs.value_ref))
     );
 }
 
-condition_wrapper operator==(const value_ref_wrapper<int>& lhs, const value_ref_wrapper<int>& rhs) {
-    return condition_wrapper(
-        std::make_shared<Condition::ValueTest>(ValueRef::CloneUnique(lhs.value_ref),
-            Condition::ComparisonType::EQUAL,
+value_ref_wrapper<int> operator==(const value_ref_wrapper<int>& lhs, const value_ref_wrapper<int>& rhs) {
+    return value_ref_wrapper<int>(
+        std::make_shared<ValueRef::Operation<int>>(ValueRef::OpType::COMPARE_EQUAL,
+            ValueRef::CloneUnique(lhs.value_ref),
             ValueRef::CloneUnique(rhs.value_ref))
     );
 }
 
-condition_wrapper operator==(const value_ref_wrapper<int>& lhs, int rhs) {
-    return condition_wrapper(
-        std::make_shared<Condition::ValueTest>(ValueRef::CloneUnique(lhs.value_ref),
-            Condition::ComparisonType::EQUAL,
+value_ref_wrapper<int> operator==(const value_ref_wrapper<int>& lhs, int rhs) {
+    return value_ref_wrapper<int>(
+        std::make_shared<ValueRef::Operation<int>>(ValueRef::OpType::COMPARE_EQUAL,
+            ValueRef::CloneUnique(lhs.value_ref),
             std::make_unique<ValueRef::Constant<int>>(rhs))
     );
 }

--- a/parse/ValueRefPythonParser.h
+++ b/parse/ValueRefPythonParser.h
@@ -95,15 +95,15 @@ value_ref_wrapper<double> operator-(const value_ref_wrapper<double>&, const valu
 value_ref_wrapper<double> operator-(int, const value_ref_wrapper<double>&);
 value_ref_wrapper<double> operator-(double, const value_ref_wrapper<int>&);
 value_ref_wrapper<double> operator-(const value_ref_wrapper<double>&, int);
-condition_wrapper operator>=(const value_ref_wrapper<double>&, int);
-condition_wrapper operator<=(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
-condition_wrapper operator<=(double, const value_ref_wrapper<double>&);
-condition_wrapper operator<=(const value_ref_wrapper<double>&, double);
+value_ref_wrapper<double> operator>=(const value_ref_wrapper<double>&, int);
+value_ref_wrapper<double> operator<=(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
+value_ref_wrapper<double> operator<=(double, const value_ref_wrapper<double>&);
+value_ref_wrapper<double> operator<=(const value_ref_wrapper<double>&, double);
 value_ref_wrapper<double> operator>(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
 value_ref_wrapper<double> operator>=(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
 value_ref_wrapper<double> operator<(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
-condition_wrapper operator<(double, const value_ref_wrapper<double>&);
-condition_wrapper operator<(const value_ref_wrapper<double>&, double);
+value_ref_wrapper<double> operator<(double, const value_ref_wrapper<double>&);
+value_ref_wrapper<double> operator<(const value_ref_wrapper<double>&, double);
 value_ref_wrapper<double> operator!=(const value_ref_wrapper<double>&, int);
 
 value_ref_wrapper<int> operator*(int, const value_ref_wrapper<int>&);
@@ -111,11 +111,12 @@ value_ref_wrapper<int> operator-(const value_ref_wrapper<int>&, int);
 value_ref_wrapper<int> operator-(int, const value_ref_wrapper<int>&);
 value_ref_wrapper<int> operator+(const value_ref_wrapper<int>&, int);
 value_ref_wrapper<int> operator+(const value_ref_wrapper<int>&, const value_ref_wrapper<int>&);
-condition_wrapper operator<(const value_ref_wrapper<int>&, const value_ref_wrapper<int>&);
+value_ref_wrapper<int> operator<(const value_ref_wrapper<int>&, const value_ref_wrapper<int>&);
 value_ref_wrapper<int> operator<(const value_ref_wrapper<int>&, int);
-condition_wrapper operator>=(const value_ref_wrapper<int>&, const value_ref_wrapper<int>&);
-condition_wrapper operator==(const value_ref_wrapper<int>&, const value_ref_wrapper<int>&);
-condition_wrapper operator==(const value_ref_wrapper<int>&, int);
+value_ref_wrapper<int> operator>(const value_ref_wrapper<int>&, int);
+value_ref_wrapper<int> operator>=(const value_ref_wrapper<int>&, const value_ref_wrapper<int>&);
+value_ref_wrapper<int> operator==(const value_ref_wrapper<int>&, const value_ref_wrapper<int>&);
+value_ref_wrapper<int> operator==(const value_ref_wrapper<int>&, int);
 
 void RegisterGlobalsValueRefs(boost::python::dict& globals, const PythonParser& parser);
 


### PR DESCRIPTION
Use `ValueRef::Operation` for all comparisons.