### PR TITLE
Remove flatten_list from Python FOCS parser

### DIFF
--- a/default/scripting/custom_sitreps.py
+++ b/default/scripting/custom_sitreps.py
@@ -67,7 +67,7 @@ effectsgroups = [
         scope=Planet()
         & Planet(type=[GasGiantType])
         & OwnedBy(empire=Source.Owner)
-        & ~Contains(Building(name="BLD_GAS_GIANT_GEN"))
+        & ~Contains(Building(name=["BLD_GAS_GIANT_GEN"]))
         & ContainedBy(
             Contains(
                 Planet()
@@ -78,7 +78,7 @@ effectsgroups = [
                 Planet()
                 & OwnedBy(empire=Source.Owner)
                 & (
-                    Contains(Building(name="BLD_GAS_GIANT_GEN"))
+                    Contains(Building(name=["BLD_GAS_GIANT_GEN"]))
                     | Enqueued(type=BuildBuilding, name="BLD_GAS_GIANT_GEN")
                 )
             )

--- a/default/scripting/custom_sitreps.py
+++ b/default/scripting/custom_sitreps.py
@@ -65,7 +65,7 @@ effectsgroups = [
     # but haven't yet built or enqueued a GG Generator in that system yet
     EffectsGroup(
         scope=Planet()
-        & Planet(type=GasGiantType)
+        & Planet(type=[GasGiantType])
         & OwnedBy(empire=Source.Owner)
         & ~Contains(Building(name="BLD_GAS_GIANT_GEN"))
         & ContainedBy(

--- a/default/scripting/custom_sitreps.py
+++ b/default/scripting/custom_sitreps.py
@@ -131,13 +131,15 @@ effectsgroups = [
                 & Turn(low=ETA_NEXT_TURN, high=ETA_NEXT_TURN)
                 & (RootCandidate.ID == LocalCandidate.NextSystemID),
             ),
-            effects=GenerateSitRepMessage(
-                message="SITREP_SYSTEM_GOT_INCOMING_WARNING",
-                label="SITREP_SYSTEM_GOT_INCOMING_WARNING_LABEL",
-                icon="icons/meter/ammo.png",
-                parameters={"system": Target.ID},
-                empire=Source.Owner,
-            ),
+            effects=[
+                GenerateSitRepMessage(
+                    message="SITREP_SYSTEM_GOT_INCOMING_WARNING",
+                    label="SITREP_SYSTEM_GOT_INCOMING_WARNING_LABEL",
+                    icon="icons/meter/ammo.png",
+                    parameters={"system": Target.ID},
+                    empire=Source.Owner,
+                )
+            ],
         ),
     ),
     # *********************************************************************************************************************************************************

--- a/default/scripting/techs/construction/ARCH_MONOFIL.focs.py
+++ b/default/scripting/techs/construction/ARCH_MONOFIL.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=125 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_CONSTRUCTION_CATEGORY"],
-    prerequisites="CON_ASYMP_MATS",
+    prerequisites=["CON_ASYMP_MATS"],
     unlock=Item(type=UnlockBuilding, name="BLD_SPACE_ELEVATOR"),
     graphic="icons/tech/architectural_monofilaments.png",
 )

--- a/default/scripting/techs/construction/ARCH_PSYCH.focs.py
+++ b/default/scripting/techs/construction/ARCH_PSYCH.focs.py
@@ -10,9 +10,11 @@ Tech(
     tags=["PEDIA_CONSTRUCTION_CATEGORY", "THEORY"],
     prerequisites=["CON_ASYMP_MATS"],
     unlock=[Item(type=UnlockPolicy, name="PLC_MODERATION"), Item(type=UnlockPolicy, name="PLC_RACIAL_PURITY")],
-    effectsgroups=EffectsGroup(
-        scope=Source,
-        effects=SetEmpireMeter(empire=Source.Owner, meter="SOCIAL_CATEGORY_NUM_POLICY_SLOTS", value=Value + 1),
-    ),
+    effectsgroups=[
+        EffectsGroup(
+            scope=Source,
+            effects=SetEmpireMeter(empire=Source.Owner, meter="SOCIAL_CATEGORY_NUM_POLICY_SLOTS", value=Value + 1),
+        )
+    ],
     graphic="icons/tech/architecture_psychology.png",
 )

--- a/default/scripting/techs/construction/ARCH_PSYCH.focs.py
+++ b/default/scripting/techs/construction/ARCH_PSYCH.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=84 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_CONSTRUCTION_CATEGORY", "THEORY"],
-    prerequisites="CON_ASYMP_MATS",
+    prerequisites=["CON_ASYMP_MATS"],
     unlock=[Item(type=UnlockPolicy, name="PLC_MODERATION"), Item(type=UnlockPolicy, name="PLC_RACIAL_PURITY")],
     effectsgroups=EffectsGroup(
         scope=Source,

--- a/default/scripting/techs/construction/CONC_CAMP.focs.py
+++ b/default/scripting/techs/construction/CONC_CAMP.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=80 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_CONSTRUCTION_CATEGORY"],
-    prerequisites="CON_ARCH_PSYCH",
+    prerequisites=["CON_ARCH_PSYCH"],
     unlock=Item(type=UnlockBuilding, name="BLD_CONC_CAMP"),
     graphic="icons/building/concentration-camp.png",
 )

--- a/default/scripting/techs/construction/CONTROL_GRAV_ARCH.focs.py
+++ b/default/scripting/techs/construction/CONTROL_GRAV_ARCH.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=160 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_CONSTRUCTION_CATEGORY"],
-    prerequisites="CON_ARCH_MONOFILS",
+    prerequisites=["CON_ARCH_MONOFILS"],
     effectsgroups=EffectsGroup(
         scope=Planet() & OwnedBy(empire=Source.Owner) & Focus(type="FOCUS_LOGISTICS"),
         effects=SetMaxSupply(value=Value + 1),

--- a/default/scripting/techs/construction/CONTROL_GRAV_ARCH.focs.py
+++ b/default/scripting/techs/construction/CONTROL_GRAV_ARCH.focs.py
@@ -11,7 +11,7 @@ Tech(
     prerequisites=["CON_ARCH_MONOFILS"],
     effectsgroups=[
         EffectsGroup(
-            scope=Planet() & OwnedBy(empire=Source.Owner) & Focus(type="FOCUS_LOGISTICS"),
+            scope=Planet() & OwnedBy(empire=Source.Owner) & Focus(type=["FOCUS_LOGISTICS"]),
             effects=SetMaxSupply(value=Value + 1),
         )
     ],

--- a/default/scripting/techs/construction/CONTROL_GRAV_ARCH.focs.py
+++ b/default/scripting/techs/construction/CONTROL_GRAV_ARCH.focs.py
@@ -9,9 +9,11 @@ Tech(
     researchturns=4,
     tags=["PEDIA_CONSTRUCTION_CATEGORY"],
     prerequisites=["CON_ARCH_MONOFILS"],
-    effectsgroups=EffectsGroup(
-        scope=Planet() & OwnedBy(empire=Source.Owner) & Focus(type="FOCUS_LOGISTICS"),
-        effects=SetMaxSupply(value=Value + 1),
-    ),
+    effectsgroups=[
+        EffectsGroup(
+            scope=Planet() & OwnedBy(empire=Source.Owner) & Focus(type="FOCUS_LOGISTICS"),
+            effects=SetMaxSupply(value=Value + 1),
+        )
+    ],
     graphic="icons/tech/controlled_gravity_architecture.png",
 )

--- a/default/scripting/techs/construction/FORCE_ENERGY_STRC.focs.py
+++ b/default/scripting/techs/construction/FORCE_ENERGY_STRC.focs.py
@@ -18,71 +18,87 @@ Tech(
             effects=[
                 Conditional(
                     condition=(Value(LocalCandidate.Industry) <= Value(LocalCandidate.TargetIndustry)),
-                    effects=SetIndustry(
-                        value=MinOf(
-                            float,
-                            Value + NamedReal(name="FORCE_ENERGY_RATE_INCREASE", value=3.0),
-                            Value(Target.TargetIndustry),
+                    effects=[
+                        SetIndustry(
+                            value=MinOf(
+                                float,
+                                Value + NamedReal(name="FORCE_ENERGY_RATE_INCREASE", value=3.0),
+                                Value(Target.TargetIndustry),
+                            )
                         )
-                    ),
-                    else_=SetIndustry(
-                        value=MaxOf(
-                            float,
-                            Value - NamedRealLookup(name="FORCE_ENERGY_RATE_INCREASE"),
-                            Value(Target.TargetIndustry),
+                    ],
+                    else_=[
+                        SetIndustry(
+                            value=MaxOf(
+                                float,
+                                Value - NamedRealLookup(name="FORCE_ENERGY_RATE_INCREASE"),
+                                Value(Target.TargetIndustry),
+                            )
                         )
-                    ),
+                    ],
                 ),
                 Conditional(
                     condition=(Value(LocalCandidate.Research) <= Value(LocalCandidate.TargetResearch)),
-                    effects=SetResearch(
-                        value=MinOf(
-                            float,
-                            Value + NamedRealLookup(name="FORCE_ENERGY_RATE_INCREASE"),
-                            Value(Target.TargetResearch),
+                    effects=[
+                        SetResearch(
+                            value=MinOf(
+                                float,
+                                Value + NamedRealLookup(name="FORCE_ENERGY_RATE_INCREASE"),
+                                Value(Target.TargetResearch),
+                            )
                         )
-                    ),
-                    else_=SetResearch(
-                        value=MaxOf(
-                            float,
-                            Value - NamedRealLookup(name="FORCE_ENERGY_RATE_INCREASE"),
-                            Value(Target.TargetResearch),
+                    ],
+                    else_=[
+                        SetResearch(
+                            value=MaxOf(
+                                float,
+                                Value - NamedRealLookup(name="FORCE_ENERGY_RATE_INCREASE"),
+                                Value(Target.TargetResearch),
+                            )
                         )
-                    ),
+                    ],
                 ),
                 Conditional(
                     condition=(Value(LocalCandidate.Construction) <= Value(LocalCandidate.TargetConstruction)),
-                    effects=SetConstruction(
-                        value=MinOf(
-                            float,
-                            Value + NamedRealLookup(name="FORCE_ENERGY_RATE_INCREASE"),
-                            Value(Target.TargetConstruction),
+                    effects=[
+                        SetConstruction(
+                            value=MinOf(
+                                float,
+                                Value + NamedRealLookup(name="FORCE_ENERGY_RATE_INCREASE"),
+                                Value(Target.TargetConstruction),
+                            )
                         )
-                    ),
-                    else_=SetConstruction(
-                        value=MaxOf(
-                            float,
-                            Value - NamedRealLookup(name="FORCE_ENERGY_RATE_INCREASE"),
-                            Value(Target.TargetConstruction),
+                    ],
+                    else_=[
+                        SetConstruction(
+                            value=MaxOf(
+                                float,
+                                Value - NamedRealLookup(name="FORCE_ENERGY_RATE_INCREASE"),
+                                Value(Target.TargetConstruction),
+                            )
                         )
-                    ),
+                    ],
                 ),
                 Conditional(
                     condition=(Value(LocalCandidate.Stockpile) <= Value(LocalCandidate.MaxStockpile)),
-                    effects=SetStockpile(
-                        value=MinOf(
-                            float,
-                            Value + NamedRealLookup(name="FORCE_ENERGY_RATE_INCREASE"),
-                            Value(Target.MaxStockpile),
+                    effects=[
+                        SetStockpile(
+                            value=MinOf(
+                                float,
+                                Value + NamedRealLookup(name="FORCE_ENERGY_RATE_INCREASE"),
+                                Value(Target.MaxStockpile),
+                            )
                         )
-                    ),
-                    else_=SetStockpile(
-                        value=MaxOf(
-                            float,
-                            Value - NamedRealLookup(name="FORCE_ENERGY_RATE_INCREASE"),
-                            Value(Target.MaxStockpile),
+                    ],
+                    else_=[
+                        SetStockpile(
+                            value=MaxOf(
+                                float,
+                                Value - NamedRealLookup(name="FORCE_ENERGY_RATE_INCREASE"),
+                                Value(Target.MaxStockpile),
+                            )
                         )
-                    ),
+                    ],
                 ),
             ],
         )

--- a/default/scripting/techs/construction/INTERSTELLAR_LOG.focs.py
+++ b/default/scripting/techs/construction/INTERSTELLAR_LOG.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=120 * TECH_COST_MULTIPLIER,
     researchturns=3,
     tags=["PEDIA_CONSTRUCTION_CATEGORY"],
-    prerequisites="CON_ORBITAL_CON",
+    prerequisites=["CON_ORBITAL_CON"],
     unlock=[
         Item(type=UnlockPolicy, name="PLC_NO_SUPPLY"),
         Item(type=UnlockPolicy, name="PLC_CONFEDERATION"),

--- a/default/scripting/techs/construction/ORBITAL_CON.focs.py
+++ b/default/scripting/techs/construction/ORBITAL_CON.focs.py
@@ -8,10 +8,12 @@ Tech(
     researchcost=72 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_CONSTRUCTION_CATEGORY"],
-    effectsgroups=EffectsGroup(
-        scope=Planet() & OwnedBy(empire=Source.Owner),
-        accountinglabel="CON_TECH_ACCOUNTING_LABEL",
-        effects=SetMaxSupply(value=Value + 1),
-    ),
+    effectsgroups=[
+        EffectsGroup(
+            scope=Planet() & OwnedBy(empire=Source.Owner),
+            accountinglabel="CON_TECH_ACCOUNTING_LABEL",
+            effects=SetMaxSupply(value=Value + 1),
+        )
+    ],
     graphic="icons/tech/orbital_construction.png",
 )

--- a/default/scripting/techs/construction/PLANET_DRIVE.focs.py
+++ b/default/scripting/techs/construction/PLANET_DRIVE.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=360 * TECH_COST_MULTIPLIER,
     researchturns=6,
     tags=["PEDIA_CONSTRUCTION_CATEGORY"],
-    prerequisites="LRN_SPATIAL_DISTORT_GEN",
+    prerequisites=["LRN_SPATIAL_DISTORT_GEN"],
     unlock=[
         Item(type=UnlockBuilding, name="BLD_PLANET_DRIVE"),
         Item(type=UnlockBuilding, name="BLD_PLANET_BEACON"),

--- a/default/scripting/techs/construction/TRANSCEND_ARCH.focs.py
+++ b/default/scripting/techs/construction/TRANSCEND_ARCH.focs.py
@@ -16,9 +16,11 @@ Tech(
         Item(type=UnlockBuilding, name="BLD_MEGALITH"),
         Item(type=UnlockPolicy, name="PLC_DIVINE_AUTHORITY"),
     ],
-    effectsgroups=EffectsGroup(
-        scope=Source,
-        effects=SetEmpireMeter(empire=Source.Owner, meter="SOCIAL_CATEGORY_NUM_POLICY_SLOTS", value=Value + 1),
-    ),
+    effectsgroups=[
+        EffectsGroup(
+            scope=Source,
+            effects=SetEmpireMeter(empire=Source.Owner, meter="SOCIAL_CATEGORY_NUM_POLICY_SLOTS", value=Value + 1),
+        )
+    ],
     graphic="icons/tech/transcendent_architecture.png",
 )

--- a/default/scripting/techs/defense/BarrierShield.focs.py
+++ b/default/scripting/techs/defense/BarrierShield.focs.py
@@ -10,7 +10,7 @@ Tech(
     researchcost=125 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="LRN_FORCE_FIELD",
+    prerequisites=["LRN_FORCE_FIELD"],
     effectsgroups=[
         EffectsGroup(
             scope=Planet() & OwnedBy(empire=Source.Owner),
@@ -41,7 +41,7 @@ Tech(
     researchcost=192 * TECH_COST_MULTIPLIER,
     researchturns=6,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="DEF_PLAN_BARRIER_SHLD_1",
+    prerequisites=["DEF_PLAN_BARRIER_SHLD_1"],
     effectsgroups=[
         EffectsGroup(
             scope=Planet() & OwnedBy(empire=Source.Owner),
@@ -74,7 +74,7 @@ Tech(
     researchcost=360 * TECH_COST_MULTIPLIER,
     researchturns=8,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="DEF_PLAN_BARRIER_SHLD_2",
+    prerequisites=["DEF_PLAN_BARRIER_SHLD_2"],
     effectsgroups=[
         EffectsGroup(
             scope=Planet() & OwnedBy(empire=Source.Owner),
@@ -107,7 +107,7 @@ Tech(
     researchcost=600 * TECH_COST_MULTIPLIER,
     researchturns=10,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="DEF_PLAN_BARRIER_SHLD_3",
+    prerequisites=["DEF_PLAN_BARRIER_SHLD_3"],
     effectsgroups=[
         EffectsGroup(
             scope=Planet() & OwnedBy(empire=Source.Owner),
@@ -140,7 +140,7 @@ Tech(
     researchcost=1200 * TECH_COST_MULTIPLIER,
     researchturns=12,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="DEF_PLAN_BARRIER_SHLD_4",
+    prerequisites=["DEF_PLAN_BARRIER_SHLD_4"],
     effectsgroups=[
         EffectsGroup(
             scope=Planet() & OwnedBy(empire=Source.Owner),

--- a/default/scripting/techs/defense/Defense.focs.py
+++ b/default/scripting/techs/defense/Defense.focs.py
@@ -53,7 +53,7 @@ Tech(
     researchturns=9999,
     researchable=False,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="SPY_STEALTH_3",
+    prerequisites=["SPY_STEALTH_3"],
     unlock=Item(type=UnlockBuilding, name="BLD_PLANET_CLOAK"),
 )
 
@@ -65,7 +65,7 @@ Tech(
     researchcost=192 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="DEF_DEFENSE_NET_1",
+    prerequisites=["DEF_DEFENSE_NET_1"],
     effectsgroups=[
         EG_SYSTEM_MINES(2 * SYSTEM_MINES_DAMAGE_FACTOR, 75, "EMPIRE")
     ],  # Priority deliberately not a macro and before all priority macros
@@ -80,7 +80,7 @@ Tech(
     researchcost=360 * TECH_COST_MULTIPLIER,
     researchturns=6,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="DEF_SYST_DEF_MINE_1",
+    prerequisites=["DEF_SYST_DEF_MINE_1"],
     effectsgroups=[EG_SYSTEM_MINES(6 * SYSTEM_MINES_DAMAGE_FACTOR, 65, "EMPIRE")],
     graphic="icons/tech/system_defense_mines.png",
 )
@@ -93,7 +93,7 @@ Tech(
     researchcost=600 * TECH_COST_MULTIPLIER,
     researchturns=8,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="DEF_SYST_DEF_MINE_2",
+    prerequisites=["DEF_SYST_DEF_MINE_2"],
     effectsgroups=[EG_SYSTEM_MINES(14 * SYSTEM_MINES_DAMAGE_FACTOR, 60, "EMPIRE")],
     graphic="icons/tech/system_defense_mines.png",
 )

--- a/default/scripting/techs/defense/Defense.focs.py
+++ b/default/scripting/techs/defense/Defense.focs.py
@@ -66,9 +66,9 @@ Tech(
     researchturns=4,
     tags=["PEDIA_DEFENSE_CATEGORY"],
     prerequisites=["DEF_DEFENSE_NET_1"],
-    effectsgroups=[
-        EG_SYSTEM_MINES(2 * SYSTEM_MINES_DAMAGE_FACTOR, 75, "EMPIRE")
-    ],  # Priority deliberately not a macro and before all priority macros
+    effectsgroups=EG_SYSTEM_MINES(
+        2 * SYSTEM_MINES_DAMAGE_FACTOR, 75, "EMPIRE"
+    ),  # Priority deliberately not a macro and before all priority macros
     graphic="icons/tech/system_defense_mines.png",
 )
 
@@ -81,7 +81,7 @@ Tech(
     researchturns=6,
     tags=["PEDIA_DEFENSE_CATEGORY"],
     prerequisites=["DEF_SYST_DEF_MINE_1"],
-    effectsgroups=[EG_SYSTEM_MINES(6 * SYSTEM_MINES_DAMAGE_FACTOR, 65, "EMPIRE")],
+    effectsgroups=EG_SYSTEM_MINES(6 * SYSTEM_MINES_DAMAGE_FACTOR, 65, "EMPIRE"),
     graphic="icons/tech/system_defense_mines.png",
 )
 
@@ -94,6 +94,6 @@ Tech(
     researchturns=8,
     tags=["PEDIA_DEFENSE_CATEGORY"],
     prerequisites=["DEF_SYST_DEF_MINE_2"],
-    effectsgroups=[EG_SYSTEM_MINES(14 * SYSTEM_MINES_DAMAGE_FACTOR, 60, "EMPIRE")],
+    effectsgroups=EG_SYSTEM_MINES(14 * SYSTEM_MINES_DAMAGE_FACTOR, 60, "EMPIRE"),
     graphic="icons/tech/system_defense_mines.png",
 )

--- a/default/scripting/techs/defense/Garrison.focs.py
+++ b/default/scripting/techs/defense/Garrison.focs.py
@@ -12,7 +12,7 @@ Tech(
     researchcost=9 * TECH_COST_MULTIPLIER,
     researchturns=3,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="DEF_ROOT_DEFENSE",
+    prerequisites=["DEF_ROOT_DEFENSE"],
     effectsgroups=[
         EffectsGroup(
             scope=Planet() & OwnedBy(empire=Source.Owner),
@@ -33,7 +33,7 @@ Tech(
     researchcost=25 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="DEF_GARRISON_1",
+    prerequisites=["DEF_GARRISON_1"],
     unlock=Item(type=UnlockPolicy, name="PLC_CHECKPOINTS"),
     effectsgroups=[
         EffectsGroup(
@@ -70,7 +70,7 @@ Tech(
     researchcost=84 * TECH_COST_MULTIPLIER,
     researchturns=7,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="DEF_GARRISON_2",
+    prerequisites=["DEF_GARRISON_2"],
     effectsgroups=[
         EffectsGroup(
             scope=Planet()
@@ -104,7 +104,7 @@ Tech(
     researchcost=216 * TECH_COST_MULTIPLIER,
     researchturns=9,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="DEF_GARRISON_3",
+    prerequisites=["DEF_GARRISON_3"],
     unlock=Item(type=UnlockPolicy, name="PLC_MARTIAL_LAW"),
     effectsgroups=[
         EffectsGroup(

--- a/default/scripting/techs/defense/Network.focs.py
+++ b/default/scripting/techs/defense/Network.focs.py
@@ -21,7 +21,7 @@ Tech(
     researchcost=30 * TECH_COST_MULTIPLIER,
     researchturns=3,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="DEF_ROOT_DEFENSE",
+    prerequisites=["DEF_ROOT_DEFENSE"],
     effectsgroups=[EG_DEFENSE_NET(5, "1")],
     graphic="icons/tech/defense.png",
 )
@@ -34,7 +34,7 @@ Tech(
     researchcost=96 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="DEF_DEFENSE_NET_1",
+    prerequisites=["DEF_DEFENSE_NET_1"],
     effectsgroups=[EG_DEFENSE_NET(15, "2")],
     graphic="icons/tech/defense.png",
 )
@@ -47,7 +47,7 @@ Tech(
     researchcost=240 * TECH_COST_MULTIPLIER,
     researchturns=6,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="DEF_DEFENSE_NET_2",
+    prerequisites=["DEF_DEFENSE_NET_2"],
     effectsgroups=[EG_DEFENSE_NET(25, "3")],
     graphic="icons/tech/defense.png",
 )
@@ -60,7 +60,7 @@ Tech(
     researchcost=120 * TECH_COST_MULTIPLIER,
     researchturns=6,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="DEF_DEFENSE_NET_2",
+    prerequisites=["DEF_DEFENSE_NET_2"],
     effectsgroups=[
         EffectsGroup(
             scope=Planet() & OwnedBy(empire=Source.Owner),
@@ -79,7 +79,7 @@ Tech(
     researchcost=240 * TECH_COST_MULTIPLIER,
     researchturns=8,
     tags=["PEDIA_DEFENSE_CATEGORY"],
-    prerequisites="DEF_DEFENSE_NET_REGEN_1",
+    prerequisites=["DEF_DEFENSE_NET_REGEN_1"],
     effectsgroups=[
         EffectsGroup(
             scope=Planet() & OwnedBy(empire=Source.Owner),

--- a/default/scripting/techs/growth/ADV_ECOMAN.focs.py
+++ b/default/scripting/techs/growth/ADV_ECOMAN.focs.py
@@ -8,6 +8,6 @@ Tech(
     researchcost=78 * TECH_COST_MULTIPLIER,
     researchturns=3,
     tags=["PEDIA_GROWTH_CATEGORY", "THEORY"],
-    prerequisites="GRO_SUBTER_HAB",
+    prerequisites=["GRO_SUBTER_HAB"],
     graphic="icons/tech/advanced_eco_man.png",
 )

--- a/default/scripting/techs/growth/BIOTERROR.focs.py
+++ b/default/scripting/techs/growth/BIOTERROR.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=80 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_GROWTH_CATEGORY"],
-    prerequisites="GRO_NANOTECH_MED",
+    prerequisites=["GRO_NANOTECH_MED"],
     unlock=Item(type=UnlockBuilding, name="BLD_BIOTERROR_PROJECTOR"),
     graphic="icons/tech/bioterror_facilities.png",
 )

--- a/default/scripting/techs/growth/ENERGY_META.focs.py
+++ b/default/scripting/techs/growth/ENERGY_META.focs.py
@@ -44,7 +44,7 @@ Tech(
         EffectsGroup(
             scope=ProductionCenter
             & OwnedBy(empire=Source.Owner)
-            & Focus(type="FOCUS_INDUSTRY")
+            & Focus(type=["FOCUS_INDUSTRY"])
             & Happiness(low=NamedReal(name="GRO_ENERGY_META_MIN_STABILITY", value=20)),
             priority=TARGET_EARLY_BEFORE_SCALING_PRIORITY,
             effects=SetTargetIndustry(
@@ -56,7 +56,7 @@ Tech(
         EffectsGroup(
             scope=ProductionCenter
             & OwnedBy(empire=Source.Owner)
-            & Focus(type="FOCUS_RESEARCH")
+            & Focus(type=["FOCUS_RESEARCH"])
             & Happiness(low=NamedRealLookup(name="GRO_ENERGY_META_MIN_STABILITY")),
             priority=TARGET_EARLY_BEFORE_SCALING_PRIORITY,
             effects=SetTargetResearch(

--- a/default/scripting/techs/growth/GAIA_TRANS.focs.py
+++ b/default/scripting/techs/growth/GAIA_TRANS.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=420 * TECH_COST_MULTIPLIER,
     researchturns=7,
     tags=["PEDIA_GROWTH_CATEGORY"],
-    prerequisites="GRO_TRANSORG_SENT",
+    prerequisites=["GRO_TRANSORG_SENT"],
     unlock=Item(type=UnlockBuilding, name="BLD_GAIA_TRANS"),
     graphic="icons/tech/the_living_planet.png",
 )

--- a/default/scripting/techs/growth/GENETIC_MED.focs.py
+++ b/default/scripting/techs/growth/GENETIC_MED.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=24 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_GROWTH_CATEGORY"],
-    prerequisites="GRO_GENETIC_ENG",
+    prerequisites=["GRO_GENETIC_ENG"],
     unlock=Item(type=UnlockBuilding, name="BLD_GENOME_BANK"),
     graphic="icons/tech/genetic_medicine.png",
 )

--- a/default/scripting/techs/growth/LIFECYCLE_MAN.focs.py
+++ b/default/scripting/techs/growth/LIFECYCLE_MAN.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=240 * TECH_COST_MULTIPLIER,
     researchturns=6,
     tags=["PEDIA_GROWTH_CATEGORY"],
-    prerequisites="GRO_GENETIC_ENG",
+    prerequisites=["GRO_GENETIC_ENG"],
     unlock=[
         Item(type=UnlockShipPart, name="CO_SUSPEND_ANIM_POD"),
         Item(type=UnlockPolicy, name="PLC_NO_GROWTH"),

--- a/default/scripting/techs/growth/NANO_CYBERNET.focs.py
+++ b/default/scripting/techs/growth/NANO_CYBERNET.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=120 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_GROWTH_CATEGORY"],
-    prerequisites="GRO_NANOTECH_MED",
+    prerequisites=["GRO_NANOTECH_MED"],
     unlock=[Item(type=UnlockShipPart, name="GT_TROOP_POD_2"), Item(type=UnlockPolicy, name="PLC_AUGMENTATION")],
     graphic="icons/tech/nanotech_cybernetics.png",
 )

--- a/default/scripting/techs/growth/ORBITAL_HAB.focs.py
+++ b/default/scripting/techs/growth/ORBITAL_HAB.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=350 * TECH_COST_MULTIPLIER,
     researchturns=7,
     tags=["PEDIA_GROWTH_CATEGORY"],
-    prerequisites="PRO_MICROGRAV_MAN",
+    prerequisites=["PRO_MICROGRAV_MAN"],
     effectsgroups=[
         EffectsGroup(
             scope=HasSpecies() & OwnedBy(empire=Source.Owner),

--- a/default/scripting/techs/growth/SUBTER_HAB.focs.py
+++ b/default/scripting/techs/growth/SUBTER_HAB.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=24 * TECH_COST_MULTIPLIER,
     researchturns=2,
     tags=["PEDIA_GROWTH_CATEGORY"],
-    prerequisites="GRO_PLANET_ECOL",
+    prerequisites=["GRO_PLANET_ECOL"],
     effectsgroups=[
         EffectsGroup(
             scope=HasSpecies() & OwnedBy(empire=Source.Owner),

--- a/default/scripting/techs/growth/SYMBIOTIC_BIO.focs.py
+++ b/default/scripting/techs/growth/SYMBIOTIC_BIO.focs.py
@@ -13,7 +13,7 @@ Tech(
     ),
     researchturns=6,
     tags=["PEDIA_GROWTH_CATEGORY"],
-    prerequisites="GRO_PLANET_ECOL",
+    prerequisites=["GRO_PLANET_ECOL"],
     unlock=[
         Item(type=UnlockPolicy, name="PLC_DIVERSITY"),
         Item(type=UnlockPolicy, name="PLC_BLACK_MARKET"),

--- a/default/scripting/techs/growth/TERRAFORM.focs.py
+++ b/default/scripting/techs/growth/TERRAFORM.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=160 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_GROWTH_CATEGORY"],
-    prerequisites="GRO_ADV_ECOMAN",
+    prerequisites=["GRO_ADV_ECOMAN"],
     unlock=[
         Item(type=UnlockBuilding, name="BLD_TERRAFORM_BEST"),
         Item(type=UnlockBuilding, name="BLD_TERRAFORM_TERRAN"),

--- a/default/scripting/techs/growth/TRANSORG_SENT.focs.py
+++ b/default/scripting/techs/growth/TRANSORG_SENT.focs.py
@@ -17,20 +17,24 @@ Tech(
             priority=AFTER_ALL_TARGET_MAX_METERS_PRIORITY,
             effects=Conditional(
                 condition=(Value(LocalCandidate.Influence) <= Value(LocalCandidate.TargetInfluence)),
-                effects=SetInfluence(
-                    value=MinOf(
-                        float,
-                        Value + NamedReal(name="GRO_TRANSORG_INFLUENCE_RATE", value=1.0),
-                        Value(Target.TargetInfluence),
+                effects=[
+                    SetInfluence(
+                        value=MinOf(
+                            float,
+                            Value + NamedReal(name="GRO_TRANSORG_INFLUENCE_RATE", value=1.0),
+                            Value(Target.TargetInfluence),
+                        )
                     )
-                ),
-                else_=SetInfluence(
-                    value=MaxOf(
-                        float,
-                        Value - NamedRealLookup(name="GRO_TRANSORG_INFLUENCE_RATE"),
-                        Value(Target.TargetInfluence),
+                ],
+                else_=[
+                    SetInfluence(
+                        value=MaxOf(
+                            float,
+                            Value - NamedRealLookup(name="GRO_TRANSORG_INFLUENCE_RATE"),
+                            Value(Target.TargetInfluence),
+                        )
                     )
-                ),
+                ],
             ),
         )
     ],

--- a/default/scripting/techs/growth/XENO_HYBRIDS.focs.py
+++ b/default/scripting/techs/growth/XENO_HYBRIDS.focs.py
@@ -13,7 +13,7 @@ Tech(
     ),
     researchturns=10,
     tags=["PEDIA_GROWTH_CATEGORY"],
-    prerequisites="GRO_XENO_GENETICS",
+    prerequisites=["GRO_XENO_GENETICS"],
     effectsgroups=[
         EffectsGroup(
             scope=Planet() & OwnedBy(empire=Source.Owner) & Planet(environment=[Poor]),

--- a/default/scripting/techs/learning/ART_BLACK_HOLE.focs.py
+++ b/default/scripting/techs/learning/ART_BLACK_HOLE.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=480 * TECH_COST_MULTIPLIER,
     researchturns=8,
     tags=["PEDIA_LEARNING_CATEGORY"],
-    prerequisites="LRN_TIME_MECH",
+    prerequisites=["LRN_TIME_MECH"],
     unlock=Item(type=UnlockBuilding, name="BLD_ART_BLACK_HOLE"),
     graphic="icons/tech/artificial_black_hole.png",
 )

--- a/default/scripting/techs/learning/DISTRIB_THOUGHT.focs.py
+++ b/default/scripting/techs/learning/DISTRIB_THOUGHT.focs.py
@@ -14,7 +14,7 @@ Tech(
         EffectsGroup(
             scope=ProductionCenter
             & OwnedBy(empire=Source.Owner)
-            & Focus(type="FOCUS_RESEARCH")
+            & Focus(type=["FOCUS_RESEARCH"])
             & Happiness(low=NamedReal(name="LRN_DISTRIB_THOUGHT_MIN_STABILITY", value=10)),
             priority=TARGET_AFTER_2ND_SCALING_PRIORITY,
             effects=SetTargetResearch(
@@ -31,7 +31,7 @@ Tech(
                             Max,
                             value=DirectDistanceBetween(Target.ID, LocalCandidate.ID),
                             condition=System
-                            & Contains(Planet() & OwnedBy(empire=Source.Owner) & Focus(type="FOCUS_RESEARCH")),
+                            & Contains(Planet() & OwnedBy(empire=Source.Owner) & Focus(type=["FOCUS_RESEARCH"])),
                         )
                         ** 0.5,
                     ),

--- a/default/scripting/techs/learning/DISTRIB_THOUGHT.focs.py
+++ b/default/scripting/techs/learning/DISTRIB_THOUGHT.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=120 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_LEARNING_CATEGORY"],
-    prerequisites="LRN_PSIONICS",
+    prerequisites=["LRN_PSIONICS"],
     effectsgroups=[
         EffectsGroup(
             scope=ProductionCenter

--- a/default/scripting/techs/learning/EVERYTHING.focs.py
+++ b/default/scripting/techs/learning/EVERYTHING.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=600 * TECH_COST_MULTIPLIER,
     researchturns=6,
     tags=["PEDIA_LEARNING_CATEGORY", "THEORY"],
-    prerequisites="LRN_GRAVITONICS",
+    prerequisites=["LRN_GRAVITONICS"],
     unlock=Item(type=UnlockBuilding, name="BLD_FIELD_REPELLOR"),
     graphic="icons/tech/the_theory_of_everything.png",
 )

--- a/default/scripting/techs/learning/FORCE_FIELD.focs.py
+++ b/default/scripting/techs/learning/FORCE_FIELD.focs.py
@@ -10,7 +10,7 @@ Tech(
     researchcost=80 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_LEARNING_CATEGORY"],
-    prerequisites="LRN_NASCENT_AI",
+    prerequisites=["LRN_NASCENT_AI"],
     unlock=Item(type=UnlockShipPart, name="SH_DEFENSE_GRID"),
     effectsgroups=[
         EffectsGroup(

--- a/default/scripting/techs/learning/GRAVITONICS.focs.py
+++ b/default/scripting/techs/learning/GRAVITONICS.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=128 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_LEARNING_CATEGORY"],
-    prerequisites="LRN_FORCE_FIELD",
+    prerequisites=["LRN_FORCE_FIELD"],
     unlock=[
         Item(type=UnlockBuilding, name="BLD_STARLANE_BORE"),
         Item(type=UnlockBuilding, name="BLD_SCRYING_SPHERE"),

--- a/default/scripting/techs/learning/MIND_VOID.focs.py
+++ b/default/scripting/techs/learning/MIND_VOID.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=120 * TECH_COST_MULTIPLIER,
     researchturns=10,
     tags=["PEDIA_LEARNING_CATEGORY", "THEORY"],
-    prerequisites="LRN_XENOARCH",
+    prerequisites=["LRN_XENOARCH"],
     unlock=Item(type=UnlockPolicy, name="PLC_DESIGN_SIMPLICITY"),
     effectsgroups=EffectsGroup(
         scope=Source,

--- a/default/scripting/techs/learning/MIND_VOID.focs.py
+++ b/default/scripting/techs/learning/MIND_VOID.focs.py
@@ -10,9 +10,11 @@ Tech(
     tags=["PEDIA_LEARNING_CATEGORY", "THEORY"],
     prerequisites=["LRN_XENOARCH"],
     unlock=Item(type=UnlockPolicy, name="PLC_DESIGN_SIMPLICITY"),
-    effectsgroups=EffectsGroup(
-        scope=Source,
-        effects=SetEmpireMeter(empire=Source.Owner, meter="SOCIAL_CATEGORY_NUM_POLICY_SLOTS", value=Value + 1),
-    ),
+    effectsgroups=[
+        EffectsGroup(
+            scope=Source,
+            effects=SetEmpireMeter(empire=Source.Owner, meter="SOCIAL_CATEGORY_NUM_POLICY_SLOTS", value=Value + 1),
+        )
+    ],
     graphic="icons/tech/mind_of_the_void.png",
 )

--- a/default/scripting/techs/learning/NASCENT_AI.focs.py
+++ b/default/scripting/techs/learning/NASCENT_AI.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=48 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_LEARNING_CATEGORY"],
-    prerequisites="LRN_ALGO_ELEGANCE",
+    prerequisites=["LRN_ALGO_ELEGANCE"],
     effectsgroups=[
         EffectsGroup(
             scope=ProductionCenter

--- a/default/scripting/techs/learning/N_DIM_SUBSPACE.focs.py
+++ b/default/scripting/techs/learning/N_DIM_SUBSPACE.focs.py
@@ -8,6 +8,6 @@ Tech(
     researchcost=128 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_LEARNING_CATEGORY", "THEORY"],
-    prerequisites="LRN_FORCE_FIELD",
+    prerequisites=["LRN_FORCE_FIELD"],
     graphic="icons/tech/n-dimensional_subspace.png",
 )

--- a/default/scripting/techs/learning/PSIONICS.focs.py
+++ b/default/scripting/techs/learning/PSIONICS.focs.py
@@ -19,7 +19,7 @@ Tech(
     ),
     researchturns=4,
     tags=["PEDIA_LEARNING_CATEGORY", "THEORY"],
-    prerequisites="LRN_TRANSLING_THT",
+    prerequisites=["LRN_TRANSLING_THT"],
     unlock=[
         Item(type=UnlockPolicy, name="PLC_INDOCTRINATION"),
         Item(type=UnlockPolicy, name="PLC_CONFORMANCE"),

--- a/default/scripting/techs/learning/PSY_DOM.focs.py
+++ b/default/scripting/techs/learning/PSY_DOM.focs.py
@@ -9,44 +9,46 @@ Tech(
     researchturns=7,
     tags=["PEDIA_LEARNING_CATEGORY"],
     prerequisites=["LRN_UNIF_CONC", "LRN_TIME_MECH"],
-    effectsgroups=EffectsGroup(
-        scope=Ship
-        & ~OwnedBy(empire=Source.Owner)
-        & VisibleToEmpire(empire=Source.Owner)
-        & Random(probability=0.1)
-        & ~Monster
-        &
-        # @content_tag{TELEPATHIC} For ships with this tag, prevents chance of ownership loss to suitable planet
-        ~HasTag(name="TELEPATHIC")
-        & ~OwnerHasTech(name="LRN_PSY_DOM")
-        & ContainedBy(
-            System
-            & Contains(
-                Planet()
-                & OwnedBy(empire=Source.Owner)
-                &
-                # @content_tag{TELEPATHIC} On owned planet with focus FOCUS_DOMINATION and this tag, chance of taking ownership of suitable ships
-                HasTag(name="TELEPATHIC")
-                & Focus(type="FOCUS_DOMINATION")
-            )
-        ),
-        effects=[
-            GenerateSitRepMessage(
-                message="EFFECT_PSY_DOM",
-                label="EFFECT_PSY_DOM_LABEL",
-                icon="icons/sitrep/ship_produced.png",
-                parameters={"empire": Target.Owner, "ship": Target.ID},
-                empire=Target.Owner,
+    effectsgroups=[
+        EffectsGroup(
+            scope=Ship
+            & ~OwnedBy(empire=Source.Owner)
+            & VisibleToEmpire(empire=Source.Owner)
+            & Random(probability=0.1)
+            & ~Monster
+            &
+            # @content_tag{TELEPATHIC} For ships with this tag, prevents chance of ownership loss to suitable planet
+            ~HasTag(name="TELEPATHIC")
+            & ~OwnerHasTech(name="LRN_PSY_DOM")
+            & ContainedBy(
+                System
+                & Contains(
+                    Planet()
+                    & OwnedBy(empire=Source.Owner)
+                    &
+                    # @content_tag{TELEPATHIC} On owned planet with focus FOCUS_DOMINATION and this tag, chance of taking ownership of suitable ships
+                    HasTag(name="TELEPATHIC")
+                    & Focus(type="FOCUS_DOMINATION")
+                )
             ),
-            GenerateSitRepMessage(
-                message="EFFECT_PSY_DOM",
-                label="EFFECT_PSY_DOM_LABEL",
-                icon="icons/sitrep/ship_produced.png",
-                parameters={"empire": Target.Owner, "ship": Target.ID},
-                empire=Source.Owner,
-            ),
-            SetOwner(empire=Source.Owner),
-        ],
-    ),
+            effects=[
+                GenerateSitRepMessage(
+                    message="EFFECT_PSY_DOM",
+                    label="EFFECT_PSY_DOM_LABEL",
+                    icon="icons/sitrep/ship_produced.png",
+                    parameters={"empire": Target.Owner, "ship": Target.ID},
+                    empire=Target.Owner,
+                ),
+                GenerateSitRepMessage(
+                    message="EFFECT_PSY_DOM",
+                    label="EFFECT_PSY_DOM_LABEL",
+                    icon="icons/sitrep/ship_produced.png",
+                    parameters={"empire": Target.Owner, "ship": Target.ID},
+                    empire=Source.Owner,
+                ),
+                SetOwner(empire=Source.Owner),
+            ],
+        )
+    ],
     graphic="icons/tech/psychogenic_domination.png",
 )

--- a/default/scripting/techs/learning/PSY_DOM.focs.py
+++ b/default/scripting/techs/learning/PSY_DOM.focs.py
@@ -28,7 +28,7 @@ Tech(
                     &
                     # @content_tag{TELEPATHIC} On owned planet with focus FOCUS_DOMINATION and this tag, chance of taking ownership of suitable ships
                     HasTag(name="TELEPATHIC")
-                    & Focus(type="FOCUS_DOMINATION")
+                    & Focus(type=["FOCUS_DOMINATION"])
                 )
             ),
             effects=[

--- a/default/scripting/techs/learning/QUANT_NET.focs.py
+++ b/default/scripting/techs/learning/QUANT_NET.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=300 * TECH_COST_MULTIPLIER,
     researchturns=6,
     tags=["PEDIA_LEARNING_CATEGORY"],
-    prerequisites="LRN_NDIM_SUBSPACE",
+    prerequisites=["LRN_NDIM_SUBSPACE"],
     effectsgroups=[
         EffectsGroup(
             scope=ProductionCenter

--- a/default/scripting/techs/learning/QUANT_NET.focs.py
+++ b/default/scripting/techs/learning/QUANT_NET.focs.py
@@ -14,7 +14,7 @@ Tech(
         EffectsGroup(
             scope=ProductionCenter
             & OwnedBy(empire=Source.Owner)
-            & Focus(type="FOCUS_RESEARCH")
+            & Focus(type=["FOCUS_RESEARCH"])
             & Happiness(low=NamedReal(name="LRN_QUANT_NET_MIN_STABILITY", value=10)),
             priority=TARGET_AFTER_SCALING_PRIORITY,
             effects=SetTargetResearch(

--- a/default/scripting/techs/learning/SPATIAL_DISTORT_GEN.focs.py
+++ b/default/scripting/techs/learning/SPATIAL_DISTORT_GEN.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=200 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_LEARNING_CATEGORY"],
-    prerequisites="LRN_NDIM_SUBSPACE",
+    prerequisites=["LRN_NDIM_SUBSPACE"],
     unlock=Item(type=UnlockBuilding, name="BLD_SPATIAL_DISTORT_GEN"),
     graphic="icons/tech/controlled_gravity_wells.png",
 )

--- a/default/scripting/techs/learning/STELLAR_TOMOGRAPHY.focs.py
+++ b/default/scripting/techs/learning/STELLAR_TOMOGRAPHY.focs.py
@@ -15,7 +15,7 @@ Tech(
             scope=Planet()
             & OwnedBy(empire=Source.Owner)
             & Star(type=BlackHole)
-            & Focus(type="FOCUS_RESEARCH")
+            & Focus(type=["FOCUS_RESEARCH"])
             & Happiness(low=0),
             priority=TARGET_AFTER_SCALING_PRIORITY,
             effects=SetTargetResearch(
@@ -25,7 +25,7 @@ Tech(
                     condition=Planet()
                     & OwnedBy(empire=Source.Owner)
                     & InSystem(id=Target.SystemID)
-                    & Focus(type="FOCUS_RESEARCH"),
+                    & Focus(type=["FOCUS_RESEARCH"]),
                 )
                 * NamedReal(name="LRN_STELLAR_TOMO_BLACK_TARGET_RESEARCH_PERPLANET", value=3.0)
             ),
@@ -34,7 +34,7 @@ Tech(
             scope=Planet()
             & OwnedBy(empire=Source.Owner)
             & Star(type=Neutron)
-            & Focus(type="FOCUS_RESEARCH")
+            & Focus(type=["FOCUS_RESEARCH"])
             & Happiness(low=0),
             priority=TARGET_AFTER_SCALING_PRIORITY,
             effects=SetTargetResearch(
@@ -44,7 +44,7 @@ Tech(
                     condition=Planet()
                     & OwnedBy(empire=Source.Owner)
                     & InSystem(id=Target.SystemID)
-                    & Focus(type="FOCUS_RESEARCH"),
+                    & Focus(type=["FOCUS_RESEARCH"]),
                 )
                 * NamedReal(name="LRN_STELLAR_TOMO_NEUTRON_TARGET_RESEARCH_PERPLANET", value=1.0)
             ),
@@ -53,7 +53,7 @@ Tech(
             scope=Planet()
             & OwnedBy(empire=Source.Owner)
             & Star(type=[Blue, White, Red, Orange, Yellow])
-            & Focus(type="FOCUS_RESEARCH")
+            & Focus(type=["FOCUS_RESEARCH"])
             & Happiness(low=0),
             priority=TARGET_AFTER_SCALING_PRIORITY,
             effects=SetTargetResearch(
@@ -63,7 +63,7 @@ Tech(
                     condition=Planet()
                     & OwnedBy(empire=Source.Owner)
                     & InSystem(id=Target.SystemID)
-                    & Focus(type="FOCUS_RESEARCH"),
+                    & Focus(type=["FOCUS_RESEARCH"]),
                 )
                 * NamedReal(name="LRN_STELLAR_TOMO_NORMAL_STAR_TARGET_RESEARCH_PERPLANET", value=0.2)
             ),

--- a/default/scripting/techs/learning/STELLAR_TOMOGRAPHY.focs.py
+++ b/default/scripting/techs/learning/STELLAR_TOMOGRAPHY.focs.py
@@ -14,7 +14,7 @@ Tech(
         EffectsGroup(
             scope=Planet()
             & OwnedBy(empire=Source.Owner)
-            & Star(type=BlackHole)
+            & Star(type=[BlackHole])
             & Focus(type=["FOCUS_RESEARCH"])
             & Happiness(low=0),
             priority=TARGET_AFTER_SCALING_PRIORITY,
@@ -33,7 +33,7 @@ Tech(
         EffectsGroup(
             scope=Planet()
             & OwnedBy(empire=Source.Owner)
-            & Star(type=Neutron)
+            & Star(type=[Neutron])
             & Focus(type=["FOCUS_RESEARCH"])
             & Happiness(low=0),
             priority=TARGET_AFTER_SCALING_PRIORITY,

--- a/default/scripting/techs/learning/STELLAR_TOMOGRAPHY.focs.py
+++ b/default/scripting/techs/learning/STELLAR_TOMOGRAPHY.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=180 * TECH_COST_MULTIPLIER,
     researchturns=6,
     tags=["PEDIA_LEARNING_CATEGORY"],
-    prerequisites="LRN_EVERYTHING",
+    prerequisites=["LRN_EVERYTHING"],
     effectsgroups=[
         EffectsGroup(
             scope=Planet()

--- a/default/scripting/techs/learning/TEMPORAL_MECH.focs.py
+++ b/default/scripting/techs/learning/TEMPORAL_MECH.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=120 * TECH_COST_MULTIPLIER,
     researchturns=10,
     tags=["PEDIA_LEARNING_CATEGORY"],
-    prerequisites="LRN_EVERYTHING",
+    prerequisites=["LRN_EVERYTHING"],
     unlock=Item(type=UnlockBuilding, name="BLD_STARLANE_NEXUS"),
     effectsgroups=EffectsGroup(
         scope=Source,

--- a/default/scripting/techs/learning/TEMPORAL_MECH.focs.py
+++ b/default/scripting/techs/learning/TEMPORAL_MECH.focs.py
@@ -10,9 +10,11 @@ Tech(
     tags=["PEDIA_LEARNING_CATEGORY"],
     prerequisites=["LRN_EVERYTHING"],
     unlock=Item(type=UnlockBuilding, name="BLD_STARLANE_NEXUS"),
-    effectsgroups=EffectsGroup(
-        scope=Source,
-        effects=SetEmpireMeter(empire=Source.Owner, meter="MILITARY_CATEGORY_NUM_POLICY_SLOTS", value=Value + 1),
-    ),
+    effectsgroups=[
+        EffectsGroup(
+            scope=Source,
+            effects=SetEmpireMeter(empire=Source.Owner, meter="MILITARY_CATEGORY_NUM_POLICY_SLOTS", value=Value + 1),
+        )
+    ],
     graphic="icons/tech/temporal_mechanics.png",
 )

--- a/default/scripting/techs/learning/TRANSCEND.focs.py
+++ b/default/scripting/techs/learning/TRANSCEND.focs.py
@@ -14,6 +14,6 @@ Tech(
         "PRO_ZERO_GEN",
         "GRO_ENERGY_META",
     ],
-    effectsgroups=EffectsGroup(scope=Source, effects=[Victory(reason="VICTORY_TECH")]),
+    effectsgroups=[EffectsGroup(scope=Source, effects=[Victory(reason="VICTORY_TECH")])],
     graphic="icons/tech/singularity_of_transcendence.png",
 )

--- a/default/scripting/techs/learning/XENO_ARCH.focs.py
+++ b/default/scripting/techs/learning/XENO_ARCH.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=70 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_LEARNING_CATEGORY"],
-    prerequisites="LRN_TRANSLING_THT",
+    prerequisites=["LRN_TRANSLING_THT"],
     unlock=[
         Item(type=UnlockBuilding, name="BLD_XENORESURRECTION_LAB"),
         Item(type=UnlockPolicy, name="PLC_DIVINE_AUTHORITY"),

--- a/default/scripting/techs/production/FUSION_GEN.focs.py
+++ b/default/scripting/techs/production/FUSION_GEN.focs.py
@@ -15,7 +15,7 @@ Tech(
         EffectsGroup(
             scope=ProductionCenter
             & OwnedBy(empire=Source.Owner)
-            & Focus(type="FOCUS_INDUSTRY")
+            & Focus(type=["FOCUS_INDUSTRY"])
             & Happiness(low=NamedReal(name="PRO_FUSION_GEN_MIN_STABILITY", value=18)),
             effects=SetTargetIndustry(
                 value=Value

--- a/default/scripting/techs/production/FUSION_GEN.focs.py
+++ b/default/scripting/techs/production/FUSION_GEN.focs.py
@@ -10,7 +10,7 @@ Tech(
     * (1 - 0.25 * StatisticIf(float, condition=EmpireHasAdoptedPolicy(empire=Source.Owner, name="PLC_INDUSTRIALISM"))),
     researchturns=3,
     tags=["PEDIA_PRODUCTION_CATEGORY"],
-    prerequisites="PRO_ROBOTIC_PROD",
+    prerequisites=["PRO_ROBOTIC_PROD"],
     effectsgroups=[
         EffectsGroup(
             scope=ProductionCenter

--- a/default/scripting/techs/production/GENERIC_SUPPLIES.focs.py
+++ b/default/scripting/techs/production/GENERIC_SUPPLIES.focs.py
@@ -26,7 +26,7 @@ Tech(
             ),
         ),
         EffectsGroup(
-            scope=ProductionCenter & OwnedBy(empire=Source.Owner) & Focus(type="FOCUS_STOCKPILE"),
+            scope=ProductionCenter & OwnedBy(empire=Source.Owner) & Focus(type=["FOCUS_STOCKPILE"]),
             effects=SetMaxStockpile(value=Value + 3, accountinglabel="GENERIC_SUPPLIES_FOCUS_BONUS_LABEL"),
         ),
     ],

--- a/default/scripting/techs/production/INDUSTRY_CENTER_I.focs.py
+++ b/default/scripting/techs/production/INDUSTRY_CENTER_I.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=60 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_PRODUCTION_CATEGORY"],
-    prerequisites="PRO_ROBOTIC_PROD",
+    prerequisites=["PRO_ROBOTIC_PROD"],
     unlock=[
         Item(type=UnlockBuilding, name="BLD_INDUSTRY_CENTER"),
         Item(type=UnlockPolicy, name="PLC_INDUSTRIALISM"),

--- a/default/scripting/techs/production/INDUSTRY_CENTER_II.focs.py
+++ b/default/scripting/techs/production/INDUSTRY_CENTER_II.focs.py
@@ -8,6 +8,6 @@ Tech(
     researchcost=240 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_PRODUCTION_CATEGORY"],
-    prerequisites="PRO_INDUSTRY_CENTER_I",
+    prerequisites=["PRO_INDUSTRY_CENTER_I"],
     graphic="icons/tech/industrial_centre_ii.png",
 )

--- a/default/scripting/techs/production/INDUSTRY_CENTER_III.focs.py
+++ b/default/scripting/techs/production/INDUSTRY_CENTER_III.focs.py
@@ -8,6 +8,6 @@ Tech(
     researchcost=700 * TECH_COST_MULTIPLIER,
     researchturns=7,
     tags=["PEDIA_PRODUCTION_CATEGORY"],
-    prerequisites="PRO_INDUSTRY_CENTER_II",
+    prerequisites=["PRO_INDUSTRY_CENTER_II"],
     graphic="icons/tech/industrial_centre_iii.png",
 )

--- a/default/scripting/techs/production/INTERSTELLAR_ENTANGLEMENT_FACTORY.focs.py
+++ b/default/scripting/techs/production/INTERSTELLAR_ENTANGLEMENT_FACTORY.focs.py
@@ -17,7 +17,7 @@ Tech(
             effects=SetMaxStockpile(value=Value + 1.0 * Target.Population * STOCKPILE_PER_POP),
         ),
         EffectsGroup(
-            scope=ProductionCenter & OwnedBy(empire=Source.Owner) & Focus(type="FOCUS_STOCKPILE"),
+            scope=ProductionCenter & OwnedBy(empire=Source.Owner) & Focus(type=["FOCUS_STOCKPILE"]),
             accountinglabel="INTERSTELLAR_ENTANGLEMENT_FACTORY_FIXED_BONUS_LABEL",
             effects=SetMaxStockpile(value=Value + 6),
         ),

--- a/default/scripting/techs/production/MICRO_MANUF.focs.py
+++ b/default/scripting/techs/production/MICRO_MANUF.focs.py
@@ -15,7 +15,7 @@ Tech(
             scope=ProductionCenter
             & OwnedBy(empire=Source.Owner)
             & ~Population(high=0)
-            & Focus(type="FOCUS_INDUSTRY")
+            & Focus(type=["FOCUS_INDUSTRY"])
             & Happiness(low=NamedReal(name="PRO_MICROGRAV_MAN_MIN_STABILITY", value=10))
             & InSystem()
             & ContainedBy(Contains(Planet() & Planet(type=[AsteroidsType]) & OwnedBy(empire=Source.Owner))),

--- a/default/scripting/techs/production/MICRO_MANUF.focs.py
+++ b/default/scripting/techs/production/MICRO_MANUF.focs.py
@@ -18,7 +18,7 @@ Tech(
             & Focus(type="FOCUS_INDUSTRY")
             & Happiness(low=NamedReal(name="PRO_MICROGRAV_MAN_MIN_STABILITY", value=10))
             & InSystem()
-            & ContainedBy(Contains(Planet() & Planet(type=AsteroidsType) & OwnedBy(empire=Source.Owner))),
+            & ContainedBy(Contains(Planet() & Planet(type=[AsteroidsType]) & OwnedBy(empire=Source.Owner))),
             priority=TARGET_AFTER_2ND_SCALING_PRIORITY,
             effects=SetTargetIndustry(value=Value + NamedReal(name="PRO_MICROGRAV_MAN_TARGET_INDUSTRY_FLAT", value=2)),
         )

--- a/default/scripting/techs/production/MICRO_MANUF.focs.py
+++ b/default/scripting/techs/production/MICRO_MANUF.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=80 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_PRODUCTION_CATEGORY"],
-    prerequisites="CON_ORBITAL_CON",
+    prerequisites=["CON_ORBITAL_CON"],
     effectsgroups=[
         EffectsGroup(
             scope=ProductionCenter

--- a/default/scripting/techs/production/NANOTECH_PROD.focs.py
+++ b/default/scripting/techs/production/NANOTECH_PROD.focs.py
@@ -8,6 +8,6 @@ Tech(
     researchcost=80 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_PRODUCTION_CATEGORY", "THEORY"],
-    prerequisites="PRO_ROBOTIC_PROD",
+    prerequisites=["PRO_ROBOTIC_PROD"],
     graphic="icons/tech/nanotech_production.png",
 )

--- a/default/scripting/techs/production/N_DIM_ASSEM.focs.py
+++ b/default/scripting/techs/production/N_DIM_ASSEM.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=320 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_PRODUCTION_CATEGORY"],
-    prerequisites="LRN_NDIM_SUBSPACE",
+    prerequisites=["LRN_NDIM_SUBSPACE"],
     unlock=Item(type=UnlockBuilding, name="BLD_HYPER_DAM"),
     graphic="icons/tech/n-dimensional_assembly.png",
 )

--- a/default/scripting/techs/production/PREDICTIVE_STOCKPILING.focs.py
+++ b/default/scripting/techs/production/PREDICTIVE_STOCKPILING.focs.py
@@ -9,7 +9,7 @@ Tech(
     effectsgroups=[
         # Set initial meters
         EffectsGroup(
-            scope=ProductionCenter & OwnedBy(empire=Source.Owner) & Focus(type="FOCUS_STOCKPILE"),
+            scope=ProductionCenter & OwnedBy(empire=Source.Owner) & Focus(type=["FOCUS_STOCKPILE"]),
             effects=SetMaxStockpile(value=Value + 1),
         )
     ],

--- a/default/scripting/techs/production/ROBOTIC_PROD.focs.py
+++ b/default/scripting/techs/production/ROBOTIC_PROD.focs.py
@@ -13,7 +13,7 @@ Tech(
         EffectsGroup(
             scope=ProductionCenter
             & OwnedBy(empire=Source.Owner)
-            & Focus(type="FOCUS_INDUSTRY")
+            & Focus(type=["FOCUS_INDUSTRY"])
             & Happiness(low=NamedReal(name="PRO_ROBOTIC_PROD_MIN_STABILITY", value=5)),
             priority=TARGET_AFTER_SCALING_PRIORITY,
             effects=SetTargetIndustry(

--- a/default/scripting/techs/production/SENTIENT_AUTOMATION.focs.py
+++ b/default/scripting/techs/production/SENTIENT_AUTOMATION.focs.py
@@ -15,7 +15,7 @@ Tech(
             scope=ProductionCenter
             & OwnedBy(empire=Source.Owner)
             & TargetPopulation(low=0.0001)
-            & Focus(type="FOCUS_INDUSTRY")
+            & Focus(type=["FOCUS_INDUSTRY"])
             & Happiness(low=0),
             priority=TARGET_AFTER_2ND_SCALING_PRIORITY,
             effects=SetTargetIndustry(value=Value + NamedReal(name="PRO_SENTIENT_AUTO_TARGET_INDUSTRY_FLAT", value=3)),

--- a/default/scripting/techs/production/SOLAR_ORB_GEN.focs.py
+++ b/default/scripting/techs/production/SOLAR_ORB_GEN.focs.py
@@ -14,7 +14,7 @@ Tech(
     ),
     researchturns=8,
     tags=["PEDIA_PRODUCTION_CATEGORY"],
-    prerequisites="PRO_ORBITAL_GEN",
+    prerequisites=["PRO_ORBITAL_GEN"],
     unlock=Item(type=UnlockBuilding, name="BLD_SOL_ORB_GEN"),
     graphic="icons/building/miniature_sun.png",
 )

--- a/default/scripting/techs/production/VOID_PREDICTION.focs.py
+++ b/default/scripting/techs/production/VOID_PREDICTION.focs.py
@@ -10,8 +10,10 @@ Tech(
     tags=["PEDIA_PRODUCTION_CATEGORY"],
     prerequisites=["LRN_MIND_VOID", "PRO_GENERIC_SUPPLIES"],
     unlock=Item(type=UnlockPolicy, name="PLC_STOCKPILE_LIQUIDATION"),
-    effectsgroups=EffectsGroup(
-        scope=ProductionCenter & OwnedBy(empire=Source.Owner) & ~Population(high=0) & Focus(type="FOCUS_STOCKPILE"),
-        effects=SetMaxStockpile(value=Value + 10 * Target.Population * STOCKPILE_PER_POP),
-    ),
+    effectsgroups=[
+        EffectsGroup(
+            scope=ProductionCenter & OwnedBy(empire=Source.Owner) & ~Population(high=0) & Focus(type="FOCUS_STOCKPILE"),
+            effects=SetMaxStockpile(value=Value + 10 * Target.Population * STOCKPILE_PER_POP),
+        )
+    ],
 )

--- a/default/scripting/techs/production/VOID_PREDICTION.focs.py
+++ b/default/scripting/techs/production/VOID_PREDICTION.focs.py
@@ -12,7 +12,10 @@ Tech(
     unlock=Item(type=UnlockPolicy, name="PLC_STOCKPILE_LIQUIDATION"),
     effectsgroups=[
         EffectsGroup(
-            scope=ProductionCenter & OwnedBy(empire=Source.Owner) & ~Population(high=0) & Focus(type="FOCUS_STOCKPILE"),
+            scope=ProductionCenter
+            & OwnedBy(empire=Source.Owner)
+            & ~Population(high=0)
+            & Focus(type=["FOCUS_STOCKPILE"]),
             effects=SetMaxStockpile(value=Value + 10 * Target.Population * STOCKPILE_PER_POP),
         )
     ],

--- a/default/scripting/techs/ship_hulls/SHP_DOMESTIC_MONSTER.focs.py
+++ b/default/scripting/techs/ship_hulls/SHP_DOMESTIC_MONSTER.focs.py
@@ -8,6 +8,6 @@ Tech(
     researchcost=18 * TECH_COST_MULTIPLIER,
     researchturns=3,
     tags=["PEDIA_SHIP_HULLS_CATEGORY"],
-    prerequisites="GRO_PLANET_ECOL",
+    prerequisites=["GRO_PLANET_ECOL"],
     graphic="icons/monsters/kraken-5.png",
 )

--- a/default/scripting/techs/ship_hulls/SHP_GAL_EXPLO.focs.py
+++ b/default/scripting/techs/ship_hulls/SHP_GAL_EXPLO.focs.py
@@ -14,22 +14,22 @@ Tech(
     unlock=Item(type=UnlockPolicy, name="PLC_EXPLORATION"),
     effectsgroups=[
         EffectsGroup(
-            scope=Planet(size=Tiny) & OwnedBy(empire=Source.Owner),
+            scope=Planet(size=[Tiny]) & OwnedBy(empire=Source.Owner),
             accountinglabel="TINY_PLANET_LABEL",
             effects=SetMaxSupply(value=Value + 2),
         ),
         EffectsGroup(
-            scope=Planet(size=Small) & OwnedBy(empire=Source.Owner),
+            scope=Planet(size=[Small]) & OwnedBy(empire=Source.Owner),
             accountinglabel="SMALL_PLANET_LABEL",
             effects=SetMaxSupply(value=Value + 1),
         ),
         EffectsGroup(
-            scope=Planet(size=Large) & OwnedBy(empire=Source.Owner),
+            scope=Planet(size=[Large]) & OwnedBy(empire=Source.Owner),
             accountinglabel="LARGE_PLANET_LABEL",
             effects=SetMaxSupply(value=Value - 1),
         ),
         EffectsGroup(
-            scope=Planet(size=Huge) & OwnedBy(empire=Source.Owner),
+            scope=Planet(size=[Huge]) & OwnedBy(empire=Source.Owner),
             accountinglabel="HUGE_PLANET_LABEL",
             effects=SetMaxSupply(value=Value - 2),
         ),

--- a/default/scripting/techs/ship_hulls/SHP_GAL_EXPLO.focs.py
+++ b/default/scripting/techs/ship_hulls/SHP_GAL_EXPLO.focs.py
@@ -34,7 +34,7 @@ Tech(
             effects=SetMaxSupply(value=Value - 2),
         ),
         EffectsGroup(
-            scope=Planet(type=GasGiantType) & OwnedBy(empire=Source.Owner),
+            scope=Planet(type=[GasGiantType]) & OwnedBy(empire=Source.Owner),
             accountinglabel="GAS_GIANT_LABEL",
             effects=SetMaxSupply(value=Value - 1),
         ),

--- a/default/scripting/techs/ship_hulls/SHP_XENTRONIUM_HULL.focs.py
+++ b/default/scripting/techs/ship_hulls/SHP_XENTRONIUM_HULL.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=600 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_SHIP_HULLS_CATEGORY"],
-    prerequisites="SHP_XENTRONIUM_PLATE",
+    prerequisites=["SHP_XENTRONIUM_PLATE"],
     unlock=[Item(type=UnlockShipHull, name="SH_XENTRONIUM")],
     graphic="icons/ship_hulls/xentronium_hull_small.png",
 )

--- a/default/scripting/techs/ship_hulls/asteroid/SHP_ASTEROID_HULLS.focs.py
+++ b/default/scripting/techs/ship_hulls/asteroid/SHP_ASTEROID_HULLS.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=45 * TECH_COST_MULTIPLIER,
     researchturns=3,
     tags=["PEDIA_ASTEROID_HULL_TECHS"],
-    prerequisites="PRO_MICROGRAV_MAN",
+    prerequisites=["PRO_MICROGRAV_MAN"],
     unlock=[
         Item(type=UnlockShipHull, name="SH_SMALL_ASTEROID"),
         Item(type=UnlockShipHull, name="SH_ASTEROID"),

--- a/default/scripting/techs/ship_hulls/asteroid/SHP_ASTEROID_REFORM.focs.py
+++ b/default/scripting/techs/ship_hulls/asteroid/SHP_ASTEROID_REFORM.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=180 * TECH_COST_MULTIPLIER,
     researchturns=3,
     tags=["PEDIA_ASTEROID_HULL_TECHS"],
-    prerequisites="SHP_ASTEROID_HULLS",
+    prerequisites=["SHP_ASTEROID_HULLS"],
     unlock=[
         # Item type = ShipHull name = "SH_AGREGATE_ASTEROID"
         Item(type=UnlockBuilding, name="BLD_SHIPYARD_AST_REF"),

--- a/default/scripting/techs/ship_hulls/asteroid/SHP_CAMO_AST_HULL.focs.py
+++ b/default/scripting/techs/ship_hulls/asteroid/SHP_CAMO_AST_HULL.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=52 * TECH_COST_MULTIPLIER,
     researchturns=2,
     tags=["PEDIA_ASTEROID_HULL_TECHS"],
-    prerequisites="SHP_ASTEROID_HULLS",
+    prerequisites=["SHP_ASTEROID_HULLS"],
     unlock=[
         Item(type=UnlockShipHull, name="SH_SMALL_CAMOUFLAGE_ASTEROID"),
         Item(type=UnlockShipHull, name="SH_CAMOUFLAGE_ASTEROID"),

--- a/default/scripting/techs/ship_hulls/asteroid/SHP_HEAVY_AST_HULL.focs.py
+++ b/default/scripting/techs/ship_hulls/asteroid/SHP_HEAVY_AST_HULL.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=128 * TECH_COST_MULTIPLIER,
     researchturns=8,
     tags=["PEDIA_ASTEROID_HULL_TECHS"],
-    prerequisites="SHP_ASTEROID_REFORM",
+    prerequisites=["SHP_ASTEROID_REFORM"],
     unlock=[Item(type=UnlockShipHull, name="SH_HEAVY_ASTEROID")],
     graphic="icons/ship_hulls/heavy_asteroid_hull_small.png",
 )

--- a/default/scripting/techs/ship_hulls/asteroid/SHP_MINIAST_SWARM.focs.py
+++ b/default/scripting/techs/ship_hulls/asteroid/SHP_MINIAST_SWARM.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=128 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_ASTEROID_HULL_TECHS"],
-    prerequisites="SHP_ASTEROID_REFORM",
+    prerequisites=["SHP_ASTEROID_REFORM"],
     unlock=[
         Item(type=UnlockShipHull, name="SH_MINIASTEROID_SWARM"),
     ],

--- a/default/scripting/techs/ship_hulls/asteroid/SHP_MONOMOLEC_LATTIC.focs.py
+++ b/default/scripting/techs/ship_hulls/asteroid/SHP_MONOMOLEC_LATTIC.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=1000 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_ASTEROID_HULL_TECHS"],
-    prerequisites="SHP_ASTEROID_REFORM",
+    prerequisites=["SHP_ASTEROID_REFORM"],
     unlock=[
         Item(type=UnlockShipHull, name="SH_CRYSTALLIZED_ASTEROID"),
         Item(type=UnlockShipPart, name="AR_CRYSTAL_PLATE"),

--- a/default/scripting/techs/ship_hulls/organic/SHP_ORG_HULL.focs.py
+++ b/default/scripting/techs/ship_hulls/organic/SHP_ORG_HULL.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=16 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_ORGANIC_HULL_TECHS"],
-    prerequisites="SHP_DOMESTIC_MONSTER",
+    prerequisites=["SHP_DOMESTIC_MONSTER"],
     unlock=[Item(type=UnlockShipHull, name="SH_ORGANIC"), Item(type=UnlockBuilding, name="BLD_SHIPYARD_ORG_ORB_INC")],
     graphic="hulls_design/organic_hull.png",
 )

--- a/default/scripting/techs/ship_hulls/robotic/SHP_MASSPROP_SPEC.focs.py
+++ b/default/scripting/techs/ship_hulls/robotic/SHP_MASSPROP_SPEC.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=1000 * TECH_COST_MULTIPLIER,
     researchturns=10,
     tags=["PEDIA_ROBOTIC_HULL_TECHS"],
-    prerequisites="SHP_CONTGRAV_MAINT",
+    prerequisites=["SHP_CONTGRAV_MAINT"],
     unlock=[Item(type=UnlockShipHull, name="SH_TITANIC")],
     graphic="icons/ship_hulls/titanic_hull_small.png",
 )

--- a/default/scripting/techs/ship_hulls/robotic/SHP_MIL_ROBO_CONT.focs.py
+++ b/default/scripting/techs/ship_hulls/robotic/SHP_MIL_ROBO_CONT.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=24 * TECH_COST_MULTIPLIER,
     researchturns=3,
     tags=["PEDIA_ROBOTIC_HULL_TECHS"],
-    prerequisites="PRO_ROBOTIC_PROD",
+    prerequisites=["PRO_ROBOTIC_PROD"],
     unlock=[
         Item(type=UnlockShipHull, name="SH_ROBOTIC"),
         Item(type=UnlockShipPart, name="SH_ROBOTIC_INTERFACE_SHIELDS"),

--- a/default/scripting/techs/ship_hulls/robotic/SHP_TRANSSPACE_DRIVE.focs.py
+++ b/default/scripting/techs/ship_hulls/robotic/SHP_TRANSSPACE_DRIVE.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=480 * TECH_COST_MULTIPLIER,
     researchturns=8,
     tags=["PEDIA_ROBOTIC_HULL_TECHS"],
-    prerequisites="SHP_NANOROBO_MAINT",
+    prerequisites=["SHP_NANOROBO_MAINT"],
     unlock=[
         Item(type=UnlockShipHull, name="SH_TRANSSPATIAL"),
         Item(type=UnlockShipPart, name="FU_TRANSPATIAL_DRIVE"),

--- a/default/scripting/techs/ship_parts/armor/SHP_DIAMOND_PLATE.focs.py
+++ b/default/scripting/techs/ship_parts/armor/SHP_DIAMOND_PLATE.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=280 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_ARMOR_PART_TECHS"],
-    prerequisites="SHP_ZORTRIUM_PLATE",
+    prerequisites=["SHP_ZORTRIUM_PLATE"],
     unlock=Item(type=UnlockShipPart, name="AR_DIAMOND_PLATE"),
     graphic="icons/tech/armor_plating.png",
 )

--- a/default/scripting/techs/ship_parts/armor/SHP_XENTRONIUM_PLATE.focs.py
+++ b/default/scripting/techs/ship_parts/armor/SHP_XENTRONIUM_PLATE.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=1200 * TECH_COST_MULTIPLIER,
     researchturns=6,
     tags=["PEDIA_ARMOR_PART_TECHS"],
-    prerequisites="SHP_DIAMOND_PLATE",
+    prerequisites=["SHP_DIAMOND_PLATE"],
     unlock=Item(type=UnlockShipPart, name="AR_XENTRONIUM_PLATE"),
     graphic="icons/tech/armor_plating.png",
 )

--- a/default/scripting/techs/ship_parts/armor/SHP_ZORTRIUM_PLATE.focs.py
+++ b/default/scripting/techs/ship_parts/armor/SHP_ZORTRIUM_PLATE.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=60 * TECH_COST_MULTIPLIER,
     researchturns=2,
     tags=["PEDIA_ARMOR_PART_TECHS"],
-    prerequisites="SHP_ROOT_ARMOR",
+    prerequisites=["SHP_ROOT_ARMOR"],
     unlock=Item(type=UnlockShipPart, name="AR_ZORTRIUM_PLATE"),
     graphic="icons/tech/armor_plating.png",
 )

--- a/default/scripting/techs/ship_parts/damage_control/SHP_ADV_DAM_CONT.focs.py
+++ b/default/scripting/techs/ship_parts/damage_control/SHP_ADV_DAM_CONT.focs.py
@@ -9,12 +9,14 @@ Tech(
     researchturns=5,
     tags=["PEDIA_DAMAGE_CONTROL_PART_TECHS"],
     prerequisites=["SHP_FLEET_REPAIR"],
-    effectsgroups=EffectsGroup(
-        scope=Ship
-        & OwnedBy(empire=Source.Owner)
-        & InSystem()
-        & Stationary
-        & Turn(low=LocalCandidate.System.LastTurnBattleHere + 1),
-        effects=SetStructure(value=Value + (Target.MaxStructure / 10)),
-    ),
+    effectsgroups=[
+        EffectsGroup(
+            scope=Ship
+            & OwnedBy(empire=Source.Owner)
+            & InSystem()
+            & Stationary
+            & Turn(low=LocalCandidate.System.LastTurnBattleHere + 1),
+            effects=SetStructure(value=Value + (Target.MaxStructure / 10)),
+        )
+    ],
 )

--- a/default/scripting/techs/ship_parts/damage_control/SHP_BASIC_DAM_CONT.focs.py
+++ b/default/scripting/techs/ship_parts/damage_control/SHP_BASIC_DAM_CONT.focs.py
@@ -11,11 +11,13 @@ Tech(
     tags=["PEDIA_DAMAGE_CONTROL_PART_TECHS"],
     prerequisites=["SHP_MIL_ROBO_CONT"],
     unlock=Item(type=UnlockPolicy, name="PLC_ENGINEERING"),
-    effectsgroups=EffectsGroup(
-        scope=Ship
-        & OwnedBy(empire=Source.Owner)
-        & (~InSystem() | InSystem() & Turn(low=LocalCandidate.System.LastTurnBattleHere + 1))
-        & Structure(high=LocalCandidate.MaxStructure - 0.001),
-        effects=SetStructure(value=Value + SHIP_STRUCTURE_FACTOR),
-    ),
+    effectsgroups=[
+        EffectsGroup(
+            scope=Ship
+            & OwnedBy(empire=Source.Owner)
+            & (~InSystem() | InSystem() & Turn(low=LocalCandidate.System.LastTurnBattleHere + 1))
+            & Structure(high=LocalCandidate.MaxStructure - 0.001),
+            effects=SetStructure(value=Value + SHIP_STRUCTURE_FACTOR),
+        )
+    ],
 )

--- a/default/scripting/techs/ship_parts/damage_control/SHP_BASIC_DAM_CONT.focs.py
+++ b/default/scripting/techs/ship_parts/damage_control/SHP_BASIC_DAM_CONT.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=80 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_DAMAGE_CONTROL_PART_TECHS"],
-    prerequisites="SHP_MIL_ROBO_CONT",
+    prerequisites=["SHP_MIL_ROBO_CONT"],
     unlock=Item(type=UnlockPolicy, name="PLC_ENGINEERING"),
     effectsgroups=EffectsGroup(
         scope=Ship

--- a/default/scripting/techs/ship_parts/damage_control/SHP_FLEET_REPAIR.focs.py
+++ b/default/scripting/techs/ship_parts/damage_control/SHP_FLEET_REPAIR.focs.py
@@ -9,25 +9,27 @@ Tech(
     researchturns=10,
     tags=["PEDIA_DAMAGE_CONTROL_PART_TECHS"],
     prerequisites=["SHP_INTSTEL_LOG", "SHP_BASIC_DAM_CONT"],
-    effectsgroups=EffectsGroup(
-        scope=Ship
-        & InSystem()
-        & Stationary
-        & (
-            OwnedBy(empire=Source.Owner)
-            |
-            # either ally providing repair or owner of ship beign repaired must adopt policy to share repairs
-            (
-                EmpireHasAdoptedPolicy(empire=Source.Owner, name="PLC_ALLIED_REPAIR")
-                | EmpireHasAdoptedPolicy(empire=LocalCandidate.Owner, name="PLC_ALLIED_REPAIR")
+    effectsgroups=[
+        EffectsGroup(
+            scope=Ship
+            & InSystem()
+            & Stationary
+            & (
+                OwnedBy(empire=Source.Owner)
+                |
+                # either ally providing repair or owner of ship beign repaired must adopt policy to share repairs
+                (
+                    EmpireHasAdoptedPolicy(empire=Source.Owner, name="PLC_ALLIED_REPAIR")
+                    | EmpireHasAdoptedPolicy(empire=LocalCandidate.Owner, name="PLC_ALLIED_REPAIR")
+                )
+                & OwnedBy(affiliation=AllyOf, empire=Source.Owner)
             )
-            & OwnedBy(affiliation=AllyOf, empire=Source.Owner)
+            & Turn(low=LocalCandidate.System.LastTurnBattleHere + 1)
+            & Structure(high=LocalCandidate.MaxStructure - 0.001)
+            & ResupplyableBy(empire=Source.Owner),
+            stackinggroup="FLEET_REPAIR",
+            effects=SetStructure(value=Value + (Target.MaxStructure / 10)),
         )
-        & Turn(low=LocalCandidate.System.LastTurnBattleHere + 1)
-        & Structure(high=LocalCandidate.MaxStructure - 0.001)
-        & ResupplyableBy(empire=Source.Owner),
-        stackinggroup="FLEET_REPAIR",
-        effects=SetStructure(value=Value + (Target.MaxStructure / 10)),
-    ),
+    ],
     graphic="icons/tech/fleet_field_repair.png",
 )

--- a/default/scripting/techs/ship_parts/damage_control/SHP_REINFORCED_HULL.focs.py
+++ b/default/scripting/techs/ship_parts/damage_control/SHP_REINFORCED_HULL.focs.py
@@ -9,9 +9,11 @@ Tech(
     researchturns=3,
     tags=["PEDIA_DAMAGE_CONTROL_PART_TECHS"],
     prerequisites=["CON_ARCH_MONOFILS"],
-    effectsgroups=EffectsGroup(
-        scope=Ship & OwnedBy(empire=Source.Owner),
-        effects=SetMaxStructure(value=Value + NamedRealLookup(name="SHP_REINFORCED_HULL_BONUS")),
-    ),
+    effectsgroups=[
+        EffectsGroup(
+            scope=Ship & OwnedBy(empire=Source.Owner),
+            effects=SetMaxStructure(value=Value + NamedRealLookup(name="SHP_REINFORCED_HULL_BONUS")),
+        )
+    ],
     graphic="icons/tech/structural_integrity_fields.png",
 )

--- a/default/scripting/techs/ship_parts/damage_control/SHP_REINFORCED_HULL.focs.py
+++ b/default/scripting/techs/ship_parts/damage_control/SHP_REINFORCED_HULL.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=72 * TECH_COST_MULTIPLIER,
     researchturns=3,
     tags=["PEDIA_DAMAGE_CONTROL_PART_TECHS"],
-    prerequisites="CON_ARCH_MONOFILS",
+    prerequisites=["CON_ARCH_MONOFILS"],
     effectsgroups=EffectsGroup(
         scope=Ship & OwnedBy(empire=Source.Owner),
         effects=SetMaxStructure(value=Value + NamedRealLookup(name="SHP_REINFORCED_HULL_BONUS")),

--- a/default/scripting/techs/ship_parts/shield/SHP_BLACKSHIELD.focs.py
+++ b/default/scripting/techs/ship_parts/shield/SHP_BLACKSHIELD.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=2500 * TECH_COST_MULTIPLIER,
     researchturns=10,
     tags=["PEDIA_SHIELD_PART_TECHS"],
-    prerequisites="SHP_PLASMA_SHIELD",
+    prerequisites=["SHP_PLASMA_SHIELD"],
     unlock=Item(type=UnlockShipPart, name="SH_BLACK"),
     graphic="icons/ship_parts/blackshield.png",
 )

--- a/default/scripting/techs/ship_parts/shield/SHP_DEFLECTOR_SHIELD.focs.py
+++ b/default/scripting/techs/ship_parts/shield/SHP_DEFLECTOR_SHIELD.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=240 * TECH_COST_MULTIPLIER,
     researchturns=10,
     tags=["PEDIA_SHIELD_PART_TECHS"],
-    prerequisites="LRN_FORCE_FIELD",
+    prerequisites=["LRN_FORCE_FIELD"],
     unlock=Item(type=UnlockShipPart, name="SH_DEFLECTOR"),
     graphic="icons/ship_parts/deflector_shield.png",
 )

--- a/default/scripting/techs/ship_parts/shield/SHP_PLASMA_SHIELD.focs.py
+++ b/default/scripting/techs/ship_parts/shield/SHP_PLASMA_SHIELD.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=900 * TECH_COST_MULTIPLIER,
     researchturns=10,
     tags=["PEDIA_SHIELD_PART_TECHS"],
-    prerequisites="SHP_DEFLECTOR_SHIELD",
+    prerequisites=["SHP_DEFLECTOR_SHIELD"],
     unlock=Item(type=UnlockShipPart, name="SH_PLASMA"),
     graphic="icons/ship_parts/plasma_shield.png",
 )

--- a/default/scripting/techs/ship_parts/speed/SHP_IMPROVED_ENGINE_COUPLINGS.focs.py
+++ b/default/scripting/techs/ship_parts/speed/SHP_IMPROVED_ENGINE_COUPLINGS.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=48 * TECH_COST_MULTIPLIER,
     researchturns=3,
     tags=["PEDIA_ENGINE_PART_TECHS"],
-    prerequisites="SHP_GAL_EXPLO",
+    prerequisites=["SHP_GAL_EXPLO"],
     unlock=[Item(type=UnlockShipPart, name="FU_IMPROVED_ENGINE_COUPLINGS"), Item(type=UnlockPolicy, name="PLC_CHARGE")],
     graphic="icons/ship_parts/engine-1.png",
 )

--- a/default/scripting/techs/ship_weapons/SHP_ROOT_AGGRESSION.focs.py
+++ b/default/scripting/techs/ship_weapons/SHP_ROOT_AGGRESSION.focs.py
@@ -13,6 +13,6 @@ Tech(
         Item(type=UnlockShipPart, name="GT_TROOP_POD"),
         Item(type=UnlockShipPart, name="SR_WEAPON_0_1"),
     ],
-    effectsgroups=[WEAPON_BASE_EFFECTS("SR_WEAPON_0_1"), WEAPON_BASE_EFFECTS("SR_WEAPON_1_1")],
+    effectsgroups=[*WEAPON_BASE_EFFECTS("SR_WEAPON_0_1"), *WEAPON_BASE_EFFECTS("SR_WEAPON_1_1")],
     graphic="icons/tech/planetary_colonialism.png",
 )

--- a/default/scripting/techs/ship_weapons/bombard/SHP_BOMBARD.focs.py
+++ b/default/scripting/techs/ship_weapons/bombard/SHP_BOMBARD.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=160 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_BOMBARD_WEAPON_TECHS"],
-    prerequisites="SHP_ROOT_AGGRESSION",
+    prerequisites=["SHP_ROOT_AGGRESSION"],
     unlock=Item(type=UnlockPolicy, name="PLC_TERROR_SUPPRESSION"),
     graphic="",
 )

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_1.focs.py
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_1.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=12 * TECH_COST_MULTIPLIER,
     researchturns=3,
     tags=["PEDIA_FIGHTER_TECHS"],
-    prerequisites="SHP_ROOT_AGGRESSION",
+    prerequisites=["SHP_ROOT_AGGRESSION"],
     unlock=[
         Item(type=UnlockShipPart, name="FT_BAY_1"),
         Item(type=UnlockShipPart, name="FT_HANGAR_1"),

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_2.focs.py
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_2.focs.py
@@ -10,26 +10,28 @@ Tech(
     researchturns=9,
     tags=["PEDIA_FIGHTER_TECHS"],
     prerequisites=["SHP_FIGHTERS_1"],
-    effectsgroups=EffectsGroup(
-        scope=Ship
-        & OwnedBy(empire=Source.Owner)
-        & (
-            DesignHasPart(name="FT_HANGAR_1")
-            | DesignHasPart(name="FT_HANGAR_2")
-            | DesignHasPart(name="FT_HANGAR_3")
-            | DesignHasPart(name="FT_HANGAR_4")
-        ),
-        accountinglabel="SHP_FIGHTERS_2",
-        effects=[
-            # FIXME WTF Target.DesignId is accepted but returns zero while Target.DesignID does the right thing
-            # TODO also test/document (PartOfClassInShipDesign class = FighterWeapon design = Target.DesignID)
-            SetMaxCapacity(
-                partname="FT_HANGAR_1", value=Value + PartsInShipDesign(name="FT_HANGAR_1", design=Target.DesignID)
+    effectsgroups=[
+        EffectsGroup(
+            scope=Ship
+            & OwnedBy(empire=Source.Owner)
+            & (
+                DesignHasPart(name="FT_HANGAR_1")
+                | DesignHasPart(name="FT_HANGAR_2")
+                | DesignHasPart(name="FT_HANGAR_3")
+                | DesignHasPart(name="FT_HANGAR_4")
             ),
-            SetMaxSecondaryStat(partname="FT_HANGAR_2", value=Value + 2 * FIGHTER_DAMAGE_FACTOR),
-            SetMaxSecondaryStat(partname="FT_HANGAR_3", value=Value + 3 * FIGHTER_DAMAGE_FACTOR),
-            SetMaxSecondaryStat(partname="FT_HANGAR_4", value=Value + 6 * FIGHTER_DAMAGE_FACTOR),
-        ],
-    ),
+            accountinglabel="SHP_FIGHTERS_2",
+            effects=[
+                # FIXME WTF Target.DesignId is accepted but returns zero while Target.DesignID does the right thing
+                # TODO also test/document (PartOfClassInShipDesign class = FighterWeapon design = Target.DesignID)
+                SetMaxCapacity(
+                    partname="FT_HANGAR_1", value=Value + PartsInShipDesign(name="FT_HANGAR_1", design=Target.DesignID)
+                ),
+                SetMaxSecondaryStat(partname="FT_HANGAR_2", value=Value + 2 * FIGHTER_DAMAGE_FACTOR),
+                SetMaxSecondaryStat(partname="FT_HANGAR_3", value=Value + 3 * FIGHTER_DAMAGE_FACTOR),
+                SetMaxSecondaryStat(partname="FT_HANGAR_4", value=Value + 6 * FIGHTER_DAMAGE_FACTOR),
+            ],
+        )
+    ],
     graphic="icons/ship_parts/fighter05.png",
 )

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_3.focs.py
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_3.focs.py
@@ -10,24 +10,26 @@ Tech(
     researchturns=9,
     tags=["PEDIA_FIGHTER_TECHS"],
     prerequisites=["SHP_FIGHTERS_2"],
-    effectsgroups=EffectsGroup(
-        scope=Ship
-        & OwnedBy(empire=Source.Owner)
-        & (
-            DesignHasPart(name="FT_HANGAR_1")
-            | DesignHasPart(name="FT_HANGAR_2")
-            | DesignHasPart(name="FT_HANGAR_3")
-            | DesignHasPart(name="FT_HANGAR_4")
-        ),
-        accountinglabel="SHP_FIGHTERS_3",
-        effects=[
-            SetMaxCapacity(
-                partname="FT_HANGAR_1", value=Value + PartsInShipDesign(name="FT_HANGAR_1", design=Target.DesignID)
+    effectsgroups=[
+        EffectsGroup(
+            scope=Ship
+            & OwnedBy(empire=Source.Owner)
+            & (
+                DesignHasPart(name="FT_HANGAR_1")
+                | DesignHasPart(name="FT_HANGAR_2")
+                | DesignHasPart(name="FT_HANGAR_3")
+                | DesignHasPart(name="FT_HANGAR_4")
             ),
-            SetMaxSecondaryStat(partname="FT_HANGAR_2", value=Value + 2 * FIGHTER_DAMAGE_FACTOR),
-            SetMaxSecondaryStat(partname="FT_HANGAR_3", value=Value + 3 * FIGHTER_DAMAGE_FACTOR),
-            SetMaxSecondaryStat(partname="FT_HANGAR_4", value=Value + 6 * FIGHTER_DAMAGE_FACTOR),
-        ],
-    ),
+            accountinglabel="SHP_FIGHTERS_3",
+            effects=[
+                SetMaxCapacity(
+                    partname="FT_HANGAR_1", value=Value + PartsInShipDesign(name="FT_HANGAR_1", design=Target.DesignID)
+                ),
+                SetMaxSecondaryStat(partname="FT_HANGAR_2", value=Value + 2 * FIGHTER_DAMAGE_FACTOR),
+                SetMaxSecondaryStat(partname="FT_HANGAR_3", value=Value + 3 * FIGHTER_DAMAGE_FACTOR),
+                SetMaxSecondaryStat(partname="FT_HANGAR_4", value=Value + 6 * FIGHTER_DAMAGE_FACTOR),
+            ],
+        )
+    ],
     graphic="icons/ship_parts/fighter05.png",
 )

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_4.focs.py
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_4.focs.py
@@ -10,24 +10,26 @@ Tech(
     researchturns=12,
     tags=["PEDIA_FIGHTER_TECHS"],
     prerequisites=["SHP_FIGHTERS_3"],
-    effectsgroups=EffectsGroup(
-        scope=Ship
-        & OwnedBy(empire=Source.Owner)
-        & (
-            DesignHasPart(name="FT_HANGAR_1")
-            | DesignHasPart(name="FT_HANGAR_2")
-            | DesignHasPart(name="FT_HANGAR_3")
-            | DesignHasPart(name="FT_HANGAR_4")
-        ),
-        accountinglabel="SHP_FIGHTERS_3",
-        effects=[
-            SetMaxCapacity(
-                partname="FT_HANGAR_1", value=Value + PartsInShipDesign(name="FT_HANGAR_1", design=Target.DesignID)
+    effectsgroups=[
+        EffectsGroup(
+            scope=Ship
+            & OwnedBy(empire=Source.Owner)
+            & (
+                DesignHasPart(name="FT_HANGAR_1")
+                | DesignHasPart(name="FT_HANGAR_2")
+                | DesignHasPart(name="FT_HANGAR_3")
+                | DesignHasPart(name="FT_HANGAR_4")
             ),
-            SetMaxSecondaryStat(partname="FT_HANGAR_2", value=Value + 2 * FIGHTER_DAMAGE_FACTOR),
-            SetMaxSecondaryStat(partname="FT_HANGAR_3", value=Value + 3 * FIGHTER_DAMAGE_FACTOR),
-            SetMaxSecondaryStat(partname="FT_HANGAR_4", value=Value + 6 * FIGHTER_DAMAGE_FACTOR),
-        ],
-    ),
+            accountinglabel="SHP_FIGHTERS_3",
+            effects=[
+                SetMaxCapacity(
+                    partname="FT_HANGAR_1", value=Value + PartsInShipDesign(name="FT_HANGAR_1", design=Target.DesignID)
+                ),
+                SetMaxSecondaryStat(partname="FT_HANGAR_2", value=Value + 2 * FIGHTER_DAMAGE_FACTOR),
+                SetMaxSecondaryStat(partname="FT_HANGAR_3", value=Value + 3 * FIGHTER_DAMAGE_FACTOR),
+                SetMaxSecondaryStat(partname="FT_HANGAR_4", value=Value + 6 * FIGHTER_DAMAGE_FACTOR),
+            ],
+        )
+    ],
     graphic="icons/ship_parts/fighter05.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_ARC_DISRUPTOR.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_ARC_DISRUPTOR.focs.py
@@ -13,7 +13,7 @@ Tech(
     researchcost=12 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_ROOT_AGGRESSION",
+    prerequisites=["SHP_ROOT_AGGRESSION"],
     unlock=Item(type=UnlockShipPart, name="SR_ARC_DISRUPTOR"),
     effectsgroups=WEAPON_BASE_EFFECTS("SR_ARC_DISRUPTOR"),
     graphic="icons/ship_parts/pulse-laser-1.png",
@@ -27,7 +27,7 @@ Tech(
     researchcost=96 * TECH_COST_MULTIPLIER,
     researchturns=8,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_WEAPON_ARC_DISRUPTOR_1",
+    prerequisites=["SHP_WEAPON_ARC_DISRUPTOR_1"],
     effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_ARC_DISRUPTOR", 2),
     graphic="icons/ship_parts/pulse-laser-2.png",
 )
@@ -41,7 +41,7 @@ Tech(
     researchcost=600 * TECH_COST_MULTIPLIER,
     researchturns=12,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_WEAPON_ARC_DISRUPTOR_2",
+    prerequisites=["SHP_WEAPON_ARC_DISRUPTOR_2"],
     effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_ARC_DISRUPTOR", 3),
     graphic="icons/ship_parts/pulse-laser-3.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_SOLAR_CONNECTION.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_SOLAR_CONNECTION.focs.py
@@ -8,6 +8,6 @@ Tech(
     researchcost=120 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_ORGANIC_WAR_ADAPTION",
+    prerequisites=["SHP_ORGANIC_WAR_ADAPTION"],
     graphic="icons/ship_parts/solarcollector.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_SPACE_FLUX_BASICS.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_SPACE_FLUX_BASICS.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=10 * TECH_COST_MULTIPLIER,
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_ROOT_AGGRESSION",
+    prerequisites=["SHP_ROOT_AGGRESSION"],
     unlock=Item(type=UnlockShipPart, name="SR_FLUX_LANCE"),
     graphic="icons/ship_parts/flux-lance.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_1_2.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_1_2.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=8 * TECH_COST_MULTIPLIER,
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_ROOT_AGGRESSION",
+    prerequisites=["SHP_ROOT_AGGRESSION"],
     effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_1_1", 1),
     graphic="icons/ship_parts/mass-driver-2.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_1_3.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_1_3.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=12 * TECH_COST_MULTIPLIER,
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_WEAPON_1_2",
+    prerequisites=["SHP_WEAPON_1_2"],
     effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_1_1", 1),
     graphic="icons/ship_parts/mass-driver-3.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_1_4.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_1_4.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=20 * TECH_COST_MULTIPLIER,
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_WEAPON_1_3",
+    prerequisites=["SHP_WEAPON_1_3"],
     effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_1_1", 1),
     graphic="icons/ship_parts/mass-driver-4.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_1.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_1.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=64 * TECH_COST_MULTIPLIER,
     researchturns=8,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_ROOT_AGGRESSION",
+    prerequisites=["SHP_ROOT_AGGRESSION"],
     unlock=Item(type=UnlockShipPart, name="SR_WEAPON_2_1"),
     effectsgroups=WEAPON_BASE_EFFECTS("SR_WEAPON_2_1"),
     graphic="icons/ship_parts/laser-1.png",

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_2.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_2.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=40 * TECH_COST_MULTIPLIER,
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_WEAPON_2_1",
+    prerequisites=["SHP_WEAPON_2_1"],
     effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_2_1", 2),
     graphic="icons/ship_parts/laser-2.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_3.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_3.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=60 * TECH_COST_MULTIPLIER,
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_WEAPON_2_2",
+    prerequisites=["SHP_WEAPON_2_2"],
     effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_2_1", 2),
     graphic="icons/ship_parts/laser-3.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_4.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_4.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=100 * TECH_COST_MULTIPLIER,
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_WEAPON_2_3",
+    prerequisites=["SHP_WEAPON_2_3"],
     effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_2_1", 2),
     graphic="icons/ship_parts/laser-4.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_1.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_1.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=280 * TECH_COST_MULTIPLIER,
     researchturns=8,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_WEAPON_2_1",
+    prerequisites=["SHP_WEAPON_2_1"],
     unlock=Item(type=UnlockShipPart, name="SR_WEAPON_3_1"),
     effectsgroups=WEAPON_BASE_EFFECTS("SR_WEAPON_3_1"),
     graphic="icons/ship_parts/plasma-1.png",

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_2.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_2.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=180 * TECH_COST_MULTIPLIER,
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_WEAPON_3_1",
+    prerequisites=["SHP_WEAPON_3_1"],
     effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_3_1", 3),
     graphic="icons/ship_parts/plasma-2.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_3.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_3.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=260 * TECH_COST_MULTIPLIER,
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_WEAPON_3_2",
+    prerequisites=["SHP_WEAPON_3_2"],
     effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_3_1", 3),
     graphic="icons/ship_parts/plasma-3.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_4.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_4.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=400 * TECH_COST_MULTIPLIER,
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_WEAPON_3_3",
+    prerequisites=["SHP_WEAPON_3_3"],
     effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_3_1", 3),
     graphic="icons/ship_parts/plasma-4.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_1.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_1.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=1000 * TECH_COST_MULTIPLIER,
     researchturns=10,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_WEAPON_3_1",
+    prerequisites=["SHP_WEAPON_3_1"],
     unlock=Item(type=UnlockShipPart, name="SR_WEAPON_4_1"),
     effectsgroups=WEAPON_BASE_EFFECTS("SR_WEAPON_4_1"),
     graphic="icons/ship_parts/death-ray-1.png",

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_2.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_2.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=600 * TECH_COST_MULTIPLIER,
     researchturns=3,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_WEAPON_4_1",
+    prerequisites=["SHP_WEAPON_4_1"],
     effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_4_1", 5),
     graphic="icons/ship_parts/death-ray-2.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_3.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_3.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=900 * TECH_COST_MULTIPLIER,
     researchturns=3,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_WEAPON_4_2",
+    prerequisites=["SHP_WEAPON_4_2"],
     effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_4_1", 5),
     graphic="icons/ship_parts/death-ray-3.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_4.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_4.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=1200 * TECH_COST_MULTIPLIER,
     researchturns=3,
     tags=["PEDIA_SR_WEAPON_TECHS"],
-    prerequisites="SHP_WEAPON_4_3",
+    prerequisites=["SHP_WEAPON_4_3"],
     effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_4_1", 5),
     graphic="icons/ship_parts/death-ray-4.png",
 )

--- a/default/scripting/techs/spy/DETECT_1.focs.py
+++ b/default/scripting/techs/spy/DETECT_1.focs.py
@@ -30,22 +30,22 @@ Tech(
             effects=SetDetection(value=Value - 15),
         ),
         EffectsGroup(
-            scope=(Planet() | Ship) & OwnedBy(empire=Source.Owner) & Star(type=White),
+            scope=(Planet() | Ship) & OwnedBy(empire=Source.Owner) & Star(type=[White]),
             accountinglabel="SPY_DETECT_STELLAR_INTERFERENCE",
             effects=SetDetection(value=Value - 10),
         ),
         EffectsGroup(
-            scope=(Planet() | Ship) & OwnedBy(empire=Source.Owner) & Star(type=Yellow),
+            scope=(Planet() | Ship) & OwnedBy(empire=Source.Owner) & Star(type=[Yellow]),
             accountinglabel="SPY_DETECT_STELLAR_INTERFERENCE",
             effects=SetDetection(value=Value - 5),
         ),
         EffectsGroup(
-            scope=(Planet() | Ship) & OwnedBy(empire=Source.Owner) & Star(type=BlackHole),
+            scope=(Planet() | Ship) & OwnedBy(empire=Source.Owner) & Star(type=[BlackHole]),
             accountinglabel="SPY_DETECT_LENSING",
             effects=SetDetection(value=Value + 5),
         ),
         EffectsGroup(
-            scope=(Planet() | Ship) & OwnedBy(empire=Source.Owner) & Star(type=NoStar),
+            scope=(Planet() | Ship) & OwnedBy(empire=Source.Owner) & Star(type=[NoStar]),
             accountinglabel="SPY_DETECT_CLEAN_STELLAR_BACKGROUND",
             effects=SetDetection(value=Value + 10),
         ),

--- a/default/scripting/techs/spy/DETECT_2.focs.py
+++ b/default/scripting/techs/spy/DETECT_2.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=90 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_SPY_CATEGORY"],
-    prerequisites="SHP_GAL_EXPLO",
+    prerequisites=["SHP_GAL_EXPLO"],
     unlock=[Item(type=UnlockShipPart, name="DT_DETECTOR_2"), Item(type=UnlockBuilding, name="BLD_SCANNING_FACILITY")],
     effectsgroups=[
         EffectsGroup(

--- a/default/scripting/techs/spy/DETECT_3.focs.py
+++ b/default/scripting/techs/spy/DETECT_3.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=330 * TECH_COST_MULTIPLIER,
     researchturns=6,
     tags=["PEDIA_SPY_CATEGORY"],
-    prerequisites="SPY_DETECT_2",
+    prerequisites=["SPY_DETECT_2"],
     unlock=Item(type=UnlockShipPart, name="DT_DETECTOR_3"),
     effectsgroups=[
         EffectsGroup(

--- a/default/scripting/techs/spy/DETECT_4.focs.py
+++ b/default/scripting/techs/spy/DETECT_4.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=840 * TECH_COST_MULTIPLIER,
     researchturns=7,
     tags=["PEDIA_SPY_CATEGORY"],
-    prerequisites="SPY_DETECT_3",
+    prerequisites=["SPY_DETECT_3"],
     unlock=Item(type=UnlockShipPart, name="DT_DETECTOR_4"),
     effectsgroups=[
         EffectsGroup(

--- a/default/scripting/techs/spy/DETECT_5.focs.py
+++ b/default/scripting/techs/spy/DETECT_5.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=1600 * TECH_COST_MULTIPLIER,
     researchturns=8,
     tags=["PEDIA_SPY_CATEGORY"],
-    prerequisites="SPY_DETECT_4",
+    prerequisites=["SPY_DETECT_4"],
     effectsgroups=[
         EffectsGroup(
             scope=Planet() & OwnedBy(empire=Source.Owner),

--- a/default/scripting/techs/spy/DISTORT_MODU.focs.py
+++ b/default/scripting/techs/spy/DISTORT_MODU.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=120 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_DETECTION_PART_TECHS"],
-    prerequisites="LRN_EVERYTHING",
+    prerequisites=["LRN_EVERYTHING"],
     unlock=Item(type=UnlockShipPart, name="SP_DISTORTION_MODULATOR"),
     graphic="icons/ship_parts/distortion_modulator.png",
 )

--- a/default/scripting/techs/spy/FORCE_ENERGY_CAMO.focs.py
+++ b/default/scripting/techs/spy/FORCE_ENERGY_CAMO.focs.py
@@ -8,6 +8,6 @@ Tech(
     researchcost=180 * TECH_COST_MULTIPLIER,
     researchturns=3,
     tags=["PEDIA_SPY_CATEGORY"],
-    prerequisites="CON_FRC_ENRG_STRC",
+    prerequisites=["CON_FRC_ENRG_STRC"],
     effectsgroups=EffectsGroup(scope=Building() & OwnedBy(empire=Source.Owner), effects=SetStealth(value=Value + 20)),
 )

--- a/default/scripting/techs/spy/FORCE_ENERGY_CAMO.focs.py
+++ b/default/scripting/techs/spy/FORCE_ENERGY_CAMO.focs.py
@@ -9,5 +9,5 @@ Tech(
     researchturns=3,
     tags=["PEDIA_SPY_CATEGORY"],
     prerequisites=["CON_FRC_ENRG_STRC"],
-    effectsgroups=EffectsGroup(scope=Building() & OwnedBy(empire=Source.Owner), effects=SetStealth(value=Value + 20)),
+    effectsgroups=[EffectsGroup(scope=Building() & OwnedBy(empire=Source.Owner), effects=SetStealth(value=Value + 20))],
 )

--- a/default/scripting/techs/spy/LIGHTHOUSE.focs.py
+++ b/default/scripting/techs/spy/LIGHTHOUSE.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=120 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_SPY_CATEGORY"],
-    prerequisites="SPY_DETECT_2",
+    prerequisites=["SPY_DETECT_2"],
     unlock=Item(type=UnlockBuilding, name="BLD_LIGHTHOUSE"),
     graphic="icons/tech/interstellar_lighthouse.png",
 )

--- a/default/scripting/techs/spy/PLANET_STEALTH_MOD.focs.py
+++ b/default/scripting/techs/spy/PLANET_STEALTH_MOD.focs.py
@@ -7,11 +7,13 @@ Tech(
     researchturns=1,
     researchable=False,
     tags=["PEDIA_SPY_CATEGORY"],
-    effectsgroups=EffectsGroup(
-        scope=Building() | Planet(),
-        stackinggroup="PLANET_STEALTH_MOD_STACK",
-        accountinglabel="BASIC_PLANET_STEALTH",
-        effects=SetStealth(value=Value + NamedReal(name="PLANET_BASIC_STEALTH", value=5.0)),
-    ),
+    effectsgroups=[
+        EffectsGroup(
+            scope=Building() | Planet(),
+            stackinggroup="PLANET_STEALTH_MOD_STACK",
+            accountinglabel="BASIC_PLANET_STEALTH",
+            effects=SetStealth(value=Value + NamedReal(name="PLANET_BASIC_STEALTH", value=5.0)),
+        )
+    ],
     graphic="",
 )

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -8,22 +8,22 @@ Tech(
     tags=["PEDIA_SPY_CATEGORY", "THEORY"],
     effectsgroups=[
         EffectsGroup(
-            scope=Ship & OwnedBy(empire=Source.Owner) & Star(type=NoStar),
+            scope=Ship & OwnedBy(empire=Source.Owner) & Star(type=[NoStar]),
             accountinglabel="SPY_DECEPTION_EMPTY_SPACE_PENALTY",
             effects=SetStealth(value=Value + NamedReal(name="SPY_DECEPTION_EMPTY_SPACE_PENALTY", value=-10.0)),
         ),
         EffectsGroup(
-            scope=Ship & OwnedBy(empire=Source.Owner) & Star(type=Red),
+            scope=Ship & OwnedBy(empire=Source.Owner) & Star(type=[Red]),
             accountinglabel="SPY_DECEPTION_DIM_STAR_PENALTY",
             effects=SetStealth(value=Value + NamedReal(name="SPY_DECEPTION_DIM_STAR_PENALTY", value=-5.0)),
         ),
         EffectsGroup(
-            scope=Ship & OwnedBy(empire=Source.Owner) & Star(type=Neutron),
+            scope=Ship & OwnedBy(empire=Source.Owner) & Star(type=[Neutron]),
             accountinglabel="SPY_DECEPTION_SUBSTELLAR_INTERFERENCE",
             effects=SetStealth(value=Value + NamedReal(name="SPY_DECEPTION_NEUTRON_INTERFERENCE", value=5.0)),
         ),
         EffectsGroup(
-            scope=Ship & OwnedBy(empire=Source.Owner) & Star(type=BlackHole),
+            scope=Ship & OwnedBy(empire=Source.Owner) & Star(type=[BlackHole]),
             accountinglabel="SPY_DECEPTION_SUBSTELLAR_INTERFERENCE",
             effects=SetStealth(value=Value + NamedReal(name="SPY_DECEPTION_BLACK_INTERFERENCE", value=10.0)),
         ),

--- a/default/scripting/techs/spy/STEALTH_1.focs.py
+++ b/default/scripting/techs/spy/STEALTH_1.focs.py
@@ -13,7 +13,7 @@ Tech(
     ),
     researchturns=5,
     tags=["PEDIA_SPY_CATEGORY"],
-    prerequisites="SPY_ROOT_DECEPTION",
+    prerequisites=["SPY_ROOT_DECEPTION"],
     effectsgroups=EffectsGroup(
         scope=OwnedBy(empire=Source.Owner) & Planet(),
         activation=~OwnerHasTech(name="SPY_STEALTH_2")

--- a/default/scripting/techs/spy/STEALTH_1.focs.py
+++ b/default/scripting/techs/spy/STEALTH_1.focs.py
@@ -14,12 +14,14 @@ Tech(
     researchturns=5,
     tags=["PEDIA_SPY_CATEGORY"],
     prerequisites=["SPY_ROOT_DECEPTION"],
-    effectsgroups=EffectsGroup(
-        scope=OwnedBy(empire=Source.Owner) & Planet(),
-        activation=~OwnerHasTech(name="SPY_STEALTH_2")
-        & ~OwnerHasTech(name="SPY_STEALTH_3")
-        & ~OwnerHasTech(name="SPY_STEALTH_4"),
-        effects=AddSpecial(name="CLOUD_COVER_SLAVE_SPECIAL"),
-    ),
+    effectsgroups=[
+        EffectsGroup(
+            scope=OwnedBy(empire=Source.Owner) & Planet(),
+            activation=~OwnerHasTech(name="SPY_STEALTH_2")
+            & ~OwnerHasTech(name="SPY_STEALTH_3")
+            & ~OwnerHasTech(name="SPY_STEALTH_4"),
+            effects=AddSpecial(name="CLOUD_COVER_SLAVE_SPECIAL"),
+        )
+    ],
     graphic="icons/specials_huge/cloud_cover.png",
 )

--- a/default/scripting/techs/spy/STEALTH_2.focs.py
+++ b/default/scripting/techs/spy/STEALTH_2.focs.py
@@ -14,10 +14,12 @@ Tech(
     researchturns=6,
     tags=["PEDIA_SPY_CATEGORY"],
     prerequisites=["SPY_STEALTH_1"],
-    effectsgroups=EffectsGroup(
-        scope=OwnedBy(empire=Source.Owner) & Planet(),
-        activation=~OwnerHasTech(name="SPY_STEALTH_3") & ~OwnerHasTech(name="SPY_STEALTH_4"),
-        effects=[AddSpecial(name="VOLCANIC_ASH_SLAVE_SPECIAL"), RemoveSpecial(name="CLOUD_COVER_SLAVE_SPECIAL")],
-    ),
+    effectsgroups=[
+        EffectsGroup(
+            scope=OwnedBy(empire=Source.Owner) & Planet(),
+            activation=~OwnerHasTech(name="SPY_STEALTH_3") & ~OwnerHasTech(name="SPY_STEALTH_4"),
+            effects=[AddSpecial(name="VOLCANIC_ASH_SLAVE_SPECIAL"), RemoveSpecial(name="CLOUD_COVER_SLAVE_SPECIAL")],
+        )
+    ],
     graphic="icons/specials_huge/volcanic_ash.png",
 )

--- a/default/scripting/techs/spy/STEALTH_2.focs.py
+++ b/default/scripting/techs/spy/STEALTH_2.focs.py
@@ -13,7 +13,7 @@ Tech(
     ),
     researchturns=6,
     tags=["PEDIA_SPY_CATEGORY"],
-    prerequisites="SPY_STEALTH_1",
+    prerequisites=["SPY_STEALTH_1"],
     effectsgroups=EffectsGroup(
         scope=OwnedBy(empire=Source.Owner) & Planet(),
         activation=~OwnerHasTech(name="SPY_STEALTH_3") & ~OwnerHasTech(name="SPY_STEALTH_4"),

--- a/default/scripting/techs/spy/STEALTH_3.focs.py
+++ b/default/scripting/techs/spy/STEALTH_3.focs.py
@@ -13,7 +13,7 @@ Tech(
     ),
     researchturns=7,
     tags=["PEDIA_SPY_CATEGORY"],
-    prerequisites="SPY_STEALTH_2",
+    prerequisites=["SPY_STEALTH_2"],
     effectsgroups=EffectsGroup(
         scope=OwnedBy(empire=Source.Owner) & Planet(),
         activation=~OwnerHasTech(name="SPY_STEALTH_4"),

--- a/default/scripting/techs/spy/STEALTH_3.focs.py
+++ b/default/scripting/techs/spy/STEALTH_3.focs.py
@@ -14,14 +14,16 @@ Tech(
     researchturns=7,
     tags=["PEDIA_SPY_CATEGORY"],
     prerequisites=["SPY_STEALTH_2"],
-    effectsgroups=EffectsGroup(
-        scope=OwnedBy(empire=Source.Owner) & Planet(),
-        activation=~OwnerHasTech(name="SPY_STEALTH_4"),
-        effects=[
-            AddSpecial(name="DIM_RIFT_SLAVE_SPECIAL"),
-            RemoveSpecial(name="VOLCANIC_ASH_SLAVE_SPECIAL"),
-            RemoveSpecial(name="CLOUD_COVER_SLAVE_SPECIAL"),
-        ],
-    ),
+    effectsgroups=[
+        EffectsGroup(
+            scope=OwnedBy(empire=Source.Owner) & Planet(),
+            activation=~OwnerHasTech(name="SPY_STEALTH_4"),
+            effects=[
+                AddSpecial(name="DIM_RIFT_SLAVE_SPECIAL"),
+                RemoveSpecial(name="VOLCANIC_ASH_SLAVE_SPECIAL"),
+                RemoveSpecial(name="CLOUD_COVER_SLAVE_SPECIAL"),
+            ],
+        )
+    ],
     graphic="icons/specials_huge/dim_rift.png",
 )

--- a/default/scripting/techs/spy/STEALTH_4.focs.py
+++ b/default/scripting/techs/spy/STEALTH_4.focs.py
@@ -12,14 +12,16 @@ Tech(
     tags=["PEDIA_SPY_CATEGORY"],
     prerequisites=["SPY_STEALTH_3", "SPY_STEALTH_PART_3"],
     unlock=Item(type=UnlockShipPart, name="ST_CLOAK_4"),
-    effectsgroups=EffectsGroup(
-        scope=OwnedBy(empire=Source.Owner) & Planet(),
-        effects=[
-            AddSpecial(name="VOID_SLAVE_SPECIAL"),
-            RemoveSpecial(name="DIM_RIFT_SLAVE_SPECIAL"),
-            RemoveSpecial(name="VOLCANIC_ASH_SLAVE_SPECIAL"),
-            RemoveSpecial(name="CLOUD_COVER_SLAVE_SPECIAL"),
-        ],
-    ),
+    effectsgroups=[
+        EffectsGroup(
+            scope=OwnedBy(empire=Source.Owner) & Planet(),
+            effects=[
+                AddSpecial(name="VOID_SLAVE_SPECIAL"),
+                RemoveSpecial(name="DIM_RIFT_SLAVE_SPECIAL"),
+                RemoveSpecial(name="VOLCANIC_ASH_SLAVE_SPECIAL"),
+                RemoveSpecial(name="CLOUD_COVER_SLAVE_SPECIAL"),
+            ],
+        )
+    ],
     graphic="icons/specials_huge/void.png",
 )

--- a/default/scripting/techs/spy/STEALTH_PART_1.focs.py
+++ b/default/scripting/techs/spy/STEALTH_PART_1.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=80 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_STEALTH_PART_TECHS"],
-    prerequisites="SPY_DETECT_2",
+    prerequisites=["SPY_DETECT_2"],
     unlock=Item(type=UnlockShipPart, name="ST_CLOAK_1"),
     graphic="icons/ship_parts/cloak-1.png",
 )

--- a/default/scripting/techs/spy/STEALTH_PART_2.focs.py
+++ b/default/scripting/techs/spy/STEALTH_PART_2.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=150 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_STEALTH_PART_TECHS"],
-    prerequisites="SPY_DETECT_3",
+    prerequisites=["SPY_DETECT_3"],
     unlock=Item(type=UnlockShipPart, name="ST_CLOAK_2"),
     graphic="icons/ship_parts/cloak-2.png",
 )

--- a/default/scripting/techs/spy/STEALTH_PART_3.focs.py
+++ b/default/scripting/techs/spy/STEALTH_PART_3.focs.py
@@ -8,7 +8,7 @@ Tech(
     researchcost=350 * TECH_COST_MULTIPLIER,
     researchturns=5,
     tags=["PEDIA_STEALTH_PART_TECHS"],
-    prerequisites="SPY_DETECT_4",
+    prerequisites=["SPY_DETECT_4"],
     unlock=Item(type=UnlockShipPart, name="ST_CLOAK_3"),
     graphic="icons/ship_parts/cloak-3.png",
 )

--- a/parse/ConditionPythonParser.cpp
+++ b/parse/ConditionPythonParser.cpp
@@ -182,14 +182,15 @@ namespace {
             return condition_wrapper(std::make_shared<Condition::PlanetType>(std::move(types)));
         } else if (kw.has_key("size")) {
             std::vector<std::unique_ptr<ValueRef::ValueRef< ::PlanetSize>>> sizes;
-            py_parse::detail::flatten_list<boost::python::object>(kw["size"], [](const boost::python::object& o, std::vector<std::unique_ptr<ValueRef::ValueRef< ::PlanetSize>>>& v) {
-                auto size_arg = boost::python::extract<value_ref_wrapper< ::PlanetSize>>(o);
+            boost::python::stl_input_iterator<boost::python::object> it_begin(kw["size"]), it_end;
+            for (auto it = it_begin; it != it_end; ++it) {
+                auto size_arg = boost::python::extract<value_ref_wrapper< ::PlanetSize>>(*it);
                 if (size_arg.check()) {
-                    v.push_back(ValueRef::CloneUnique(size_arg().value_ref));
+                    sizes.push_back(ValueRef::CloneUnique(size_arg().value_ref));
                 } else {
-                    v.push_back(std::make_unique<ValueRef::Constant< ::PlanetSize>>(boost::python::extract<enum_wrapper< ::PlanetSize>>(o)().value));
+                    sizes.push_back(std::make_unique<ValueRef::Constant< ::PlanetSize>>(boost::python::extract<enum_wrapper< ::PlanetSize>>(*it)().value));
                 }
-            }, sizes);
+            }
             return condition_wrapper(std::make_shared<Condition::PlanetSize>(std::move(sizes)));
         } else if (kw.has_key("environment")) {
             std::vector<std::unique_ptr<ValueRef::ValueRef< ::PlanetEnvironment>>> environments;

--- a/parse/ConditionPythonParser.cpp
+++ b/parse/ConditionPythonParser.cpp
@@ -211,14 +211,15 @@ namespace {
     condition_wrapper insert_homeworld_(const boost::python::tuple& args, const boost::python::dict& kw) {
         if (kw.has_key("name")) {
             std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>> names;
-            py_parse::detail::flatten_list<boost::python::object>(kw["name"], [](const boost::python::object& o, std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>>& v) {
-                auto name_arg = boost::python::extract<value_ref_wrapper<std::string>>(o);
+            boost::python::stl_input_iterator<boost::python::object> it_begin(kw["name"]), it_end;
+            for (auto it = it_begin; it != it_end; ++it) {
+                auto name_arg = boost::python::extract<value_ref_wrapper<std::string>>(*it);
                 if (name_arg.check()) {
-                    v.push_back(ValueRef::CloneUnique(name_arg().value_ref));
+                    names.push_back(ValueRef::CloneUnique(name_arg().value_ref));
                 } else {
-                    v.push_back(std::make_unique<ValueRef::Constant<std::string>>(boost::python::extract<std::string>(o)()));
+                    names.push_back(std::make_unique<ValueRef::Constant<std::string>>(boost::python::extract<std::string>(*it)()));
                 }
-            }, names);
+            }
             return condition_wrapper(std::make_shared<Condition::Homeworld>(std::move(names)));
         }
         return condition_wrapper(std::make_shared<Condition::Homeworld>());

--- a/parse/ConditionPythonParser.cpp
+++ b/parse/ConditionPythonParser.cpp
@@ -194,14 +194,15 @@ namespace {
             return condition_wrapper(std::make_shared<Condition::PlanetSize>(std::move(sizes)));
         } else if (kw.has_key("environment")) {
             std::vector<std::unique_ptr<ValueRef::ValueRef< ::PlanetEnvironment>>> environments;
-            py_parse::detail::flatten_list<boost::python::object>(kw["environment"], [](const boost::python::object& o, std::vector<std::unique_ptr<ValueRef::ValueRef< ::PlanetEnvironment>>>& v) {
-                auto env_arg = boost::python::extract<value_ref_wrapper< ::PlanetEnvironment>>(o);
+            boost::python::stl_input_iterator<boost::python::object> it_begin(kw["environment"]), it_end;
+            for (auto it = it_begin; it != it_end; ++it) {
+                auto env_arg = boost::python::extract<value_ref_wrapper< ::PlanetEnvironment>>(*it);
                 if (env_arg.check()) {
-                    v.push_back(ValueRef::CloneUnique(env_arg().value_ref));
+                    environments.push_back(ValueRef::CloneUnique(env_arg().value_ref));
                 } else {
-                    v.push_back(std::make_unique<ValueRef::Constant< ::PlanetEnvironment>>(boost::python::extract<enum_wrapper< ::PlanetEnvironment>>(o)().value));
+                    environments.push_back(std::make_unique<ValueRef::Constant< ::PlanetEnvironment>>(boost::python::extract<enum_wrapper< ::PlanetEnvironment>>(*it)().value));
                 }
-            }, environments);
+            }
             return condition_wrapper(std::make_shared<Condition::PlanetEnvironment>(std::move(environments)));
         }
         return condition_wrapper(std::make_shared<Condition::Type>(UniverseObjectType::OBJ_PLANET));

--- a/parse/ConditionPythonParser.cpp
+++ b/parse/ConditionPythonParser.cpp
@@ -170,14 +170,15 @@ namespace {
     condition_wrapper insert_planet_(const boost::python::tuple& args, const boost::python::dict& kw) {
         if (kw.has_key("type")) {
             std::vector<std::unique_ptr<ValueRef::ValueRef< ::PlanetType>>> types;
-            py_parse::detail::flatten_list<boost::python::object>(kw["type"], [](const boost::python::object& o, std::vector<std::unique_ptr<ValueRef::ValueRef< ::PlanetType>>>& v) {
-                auto type_arg = boost::python::extract<value_ref_wrapper< ::PlanetType>>(o);
+            boost::python::stl_input_iterator<boost::python::object> it_begin(kw["type"]), it_end;
+            for (auto it = it_begin; it != it_end; ++it) {
+                auto type_arg = boost::python::extract<value_ref_wrapper< ::PlanetType>>(*it);
                 if (type_arg.check()) {
-                    v.push_back(ValueRef::CloneUnique(type_arg().value_ref));
+                    types.push_back(ValueRef::CloneUnique(type_arg().value_ref));
                 } else {
-                    v.push_back(std::make_unique<ValueRef::Constant< ::PlanetType>>(boost::python::extract<enum_wrapper< ::PlanetType>>(o)().value));
+                    types.push_back(std::make_unique<ValueRef::Constant< ::PlanetType>>(boost::python::extract<enum_wrapper< ::PlanetType>>(*it)().value));
                 }
-            }, types);
+            }
             return condition_wrapper(std::make_shared<Condition::PlanetType>(std::move(types)));
         } else if (kw.has_key("size")) {
             std::vector<std::unique_ptr<ValueRef::ValueRef< ::PlanetSize>>> sizes;

--- a/parse/ConditionPythonParser.cpp
+++ b/parse/ConditionPythonParser.cpp
@@ -562,16 +562,15 @@ namespace {
 
     condition_wrapper insert_star_(const boost::python::tuple& args, const boost::python::dict& kw) {
         std::vector<std::unique_ptr<ValueRef::ValueRef< ::StarType>>> types;
-
-        py_parse::detail::flatten_list<boost::python::object>(kw["type"], [](const boost::python::object& o, std::vector<std::unique_ptr<ValueRef::ValueRef< ::StarType>>>& v) {
-            auto type_arg = boost::python::extract<value_ref_wrapper< ::StarType>>(o);
+        boost::python::stl_input_iterator<boost::python::object> it_begin(kw["type"]), it_end;
+        for (auto it = it_begin; it != it_end; ++it) {
+            auto type_arg = boost::python::extract<value_ref_wrapper< ::StarType>>(*it);
             if (type_arg.check()) {
-                v.push_back(ValueRef::CloneUnique(type_arg().value_ref));
+                types.push_back(ValueRef::CloneUnique(type_arg().value_ref));
             } else {
-                v.push_back(std::make_unique<ValueRef::Constant< ::StarType>>(boost::python::extract<enum_wrapper< ::StarType>>(o)().value));
+                types.push_back(std::make_unique<ValueRef::Constant< ::StarType>>(boost::python::extract<enum_wrapper< ::StarType>>(*it)().value));
             }
-        }, types);
-
+        }
         return condition_wrapper(std::make_shared<Condition::StarType>(std::move(types)));
     }
 

--- a/parse/ConditionPythonParser.cpp
+++ b/parse/ConditionPythonParser.cpp
@@ -242,14 +242,15 @@ namespace {
     condition_wrapper insert_has_species_(const boost::python::tuple& args, const boost::python::dict& kw) {
         if (kw.has_key("name")) {
             std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>> names;
-            py_parse::detail::flatten_list<boost::python::object>(kw["name"], [](const boost::python::object& o, std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>>& v) {
-                auto name_arg = boost::python::extract<value_ref_wrapper<std::string>>(o);
+            boost::python::stl_input_iterator<boost::python::object> it_begin(kw["name"]), it_end;
+            for (auto it = it_begin; it != it_end; ++it) {
+                auto name_arg = boost::python::extract<value_ref_wrapper<std::string>>(*it);
                 if (name_arg.check()) {
-                    v.push_back(ValueRef::CloneUnique(name_arg().value_ref));
+                    names.push_back(ValueRef::CloneUnique(name_arg().value_ref));
                 } else {
-                    v.push_back(std::make_unique<ValueRef::Constant<std::string>>(boost::python::extract<std::string>(o)()));
+                    names.push_back(std::make_unique<ValueRef::Constant<std::string>>(boost::python::extract<std::string>(*it)()));
                 }
-            }, names);
+            }
             return condition_wrapper(std::make_shared<Condition::Species>(std::move(names)));
         }
         return condition_wrapper(std::make_shared<Condition::Species>());

--- a/parse/ConditionPythonParser.cpp
+++ b/parse/ConditionPythonParser.cpp
@@ -271,14 +271,15 @@ namespace {
 
     condition_wrapper insert_focus_(const boost::python::tuple& args, const boost::python::dict& kw) {
         std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>> types;
-        py_parse::detail::flatten_list<boost::python::object>(kw["type"], [](const boost::python::object& o, std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>>& v) {
-            auto type_arg = boost::python::extract<value_ref_wrapper<std::string>>(o);
+        boost::python::stl_input_iterator<boost::python::object> it_begin(kw["type"]), it_end;
+        for (auto it = it_begin; it != it_end; ++it) {
+            auto type_arg = boost::python::extract<value_ref_wrapper<std::string>>(*it);
             if (type_arg.check()) {
-                v.push_back(ValueRef::CloneUnique(type_arg().value_ref));
+                types.push_back(ValueRef::CloneUnique(type_arg().value_ref));
             } else {
-                v.push_back(std::make_unique<ValueRef::Constant<std::string>>(boost::python::extract<std::string>(o)()));
+                types.push_back(std::make_unique<ValueRef::Constant<std::string>>(boost::python::extract<std::string>(*it)()));
             }
-        }, types);
+        }
         return condition_wrapper(std::make_shared<Condition::FocusType>(std::move(types)));
     }
 

--- a/parse/ConditionPythonParser.cpp
+++ b/parse/ConditionPythonParser.cpp
@@ -396,14 +396,15 @@ namespace {
         std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>> names;
         
         if (kw.has_key("name")) {
-            py_parse::detail::flatten_list<boost::python::object>(kw["name"], [](const boost::python::object& o, std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>>& v) {
-                auto name_arg = boost::python::extract<value_ref_wrapper<std::string>>(o);
+            boost::python::stl_input_iterator<boost::python::object> it_begin(kw["name"]), it_end;
+            for (auto it = it_begin; it != it_end; ++it) {
+                auto name_arg = boost::python::extract<value_ref_wrapper<std::string>>(*it);
                 if (name_arg.check()) {
-                    v.push_back(ValueRef::CloneUnique(name_arg().value_ref));
+                    names.push_back(ValueRef::CloneUnique(name_arg().value_ref));
                 } else {
-                    v.push_back(std::make_unique<ValueRef::Constant<std::string>>(boost::python::extract<std::string>(o)()));
+                    names.push_back(std::make_unique<ValueRef::Constant<std::string>>(boost::python::extract<std::string>(*it)()));
                 }
-            }, names);
+            }
         }
 
         return condition_wrapper(std::make_shared<Condition::Building>(std::move(names)));

--- a/parse/EffectPythonParser.cpp
+++ b/parse/EffectPythonParser.cpp
@@ -80,15 +80,17 @@ namespace {
         auto condition = ValueRef::CloneUnique(py::extract<condition_wrapper>(kw["condition"])().condition);
 
         std::vector<std::unique_ptr<Effect::Effect>> effects;
-        py_parse::detail::flatten_list<effect_wrapper>(kw["effects"], [](const effect_wrapper& o, std::vector<std::unique_ptr<Effect::Effect>> &v) {
-            v.push_back(ValueRef::CloneUnique(o.effect));
-        }, effects);
+        boost::python::stl_input_iterator<effect_wrapper> effects_begin(kw["effects"]), effects_end;
+        for (auto it = effects_begin; it != effects_end; ++ it) {
+            effects.push_back(ValueRef::CloneUnique(it->effect));
+        }
         
         std::vector<std::unique_ptr<Effect::Effect>> else_;
         if (kw.has_key("else_")) {
-            py_parse::detail::flatten_list<effect_wrapper>(kw["else_"], [](const effect_wrapper& o, std::vector<std::unique_ptr<Effect::Effect>> &v) {
-                v.push_back(ValueRef::CloneUnique(o.effect));
-            }, else_);
+            boost::python::stl_input_iterator<effect_wrapper> else_begin(kw["else_"]);
+            for (auto it = else_begin; it != effects_end; ++ it) {
+                    else_.push_back(ValueRef::CloneUnique(it->effect));
+            }
         }
 
         return effect_wrapper(std::make_shared<Effect::Conditional>(std::move(condition),

--- a/parse/PythonParser.cpp
+++ b/parse/PythonParser.cpp
@@ -326,6 +326,7 @@ bool PythonParser::ParseFileCommon(const boost::filesystem::path& path,
     } catch (const boost::python::error_already_set&) {
         m_current_globals = boost::none;
         m_python.HandleErrorAlreadySet();
+        ErrorLogger() << "Unable to parse data file " << filename;
         if (!m_python.IsPythonRunning()) {
             ErrorLogger() << "Python interpreter is no longer running.  Attempting to restart.";
             if (m_python.Initialize()) {

--- a/parse/PythonParserImpl.h
+++ b/parse/PythonParserImpl.h
@@ -38,22 +38,6 @@ namespace py_parse { namespace detail {
 
         return parser.ParseFileCommon(path, grammar(arg1, arg2), filename, file_contents);
     }
-
-    template <typename T, typename F, typename V>
-    void flatten_list(const boost::python::object& l,
-                      const F& f,
-                      V& retval) {
-        auto args = boost::python::extract<boost::python::list>(l);
-        if (args.check()) {
-            boost::python::stl_input_iterator<boost::python::object> args_begin(args), args_end;
-            for (auto it = args_begin; it != args_end; ++ it) {
-                flatten_list<T, F, V>(*it, f, retval);
-            }
-        } else {
-            f(boost::python::extract<T>(l)(), retval);
-        }
-    }
-
 } }
 
 #endif

--- a/parse/SpeciesParser.cpp
+++ b/parse/SpeciesParser.cpp
@@ -358,10 +358,8 @@ namespace {
         auto name = boost::python::extract<std::string>(kw["name"])();
         auto description = boost::python::extract<std::string>(kw["description"])();
         auto gameplay_description = boost::python::extract<std::string>(kw["gameplay_description"])();
-        std::vector<FocusType> foci;
-        py_parse::detail::flatten_list<FocusType>(kw["foci"], [](const FocusType& o, std::vector<FocusType>& v) {
-            v.push_back(o);
-        }, foci);
+        boost::python::stl_input_iterator<FocusType> foci_begin(kw["foci"]), foci_end;
+        std::vector<FocusType> foci(foci_begin, foci_end);
         auto defaultfocus = boost::python::extract<std::string>(kw["defaultfocus"])();
         std::map<PlanetType, PlanetEnvironment> environments;
         auto environments_args = boost::python::extract<boost::python::dict>(kw["environments"])();
@@ -372,9 +370,10 @@ namespace {
         }
 
         std::vector<std::shared_ptr<Effect::EffectsGroup>> effectsgroups;
-        py_parse::detail::flatten_list<effect_group_wrapper>(kw["effectsgroups"], [](const effect_group_wrapper& o, std::vector<std::shared_ptr<Effect::EffectsGroup>>& v) {
-            v.push_back(o.effects_group);
-        }, effectsgroups);
+        boost::python::stl_input_iterator<effect_group_wrapper> effectsgroups_begin(kw["effectsgroups"]), effectsgroups_end;
+        for (auto it = effectsgroups_begin; it != effectsgroups_end; ++it) {
+            effectsgroups.push_back(it->effects_group);
+        }
         bool playable = false;
         if (kw.has_key("playable")) {
             playable = boost::python::extract<bool>(kw["playable"])();

--- a/parse/TechsParser.cpp
+++ b/parse/TechsParser.cpp
@@ -111,9 +111,10 @@ namespace {
 
         std::vector<std::shared_ptr<Effect::EffectsGroup>> effectsgroups;
         if (kw.has_key("effectsgroups")) {
-            py_parse::detail::flatten_list<effect_group_wrapper>(kw["effectsgroups"], [](const effect_group_wrapper& o, std::vector<std::shared_ptr<Effect::EffectsGroup>>& v) {
-                v.push_back(o.effects_group);
-            }, effectsgroups);
+            boost::python::stl_input_iterator<effect_group_wrapper> effectsgroups_begin(kw["effectsgroups"]), effectsgroups_end;
+            for (auto it = effectsgroups_begin; it != effectsgroups_end; ++it) {
+                effectsgroups.push_back(it->effects_group);
+            }
         }
 
         std::set<std::string> prerequisites;

--- a/parse/TechsParser.cpp
+++ b/parse/TechsParser.cpp
@@ -118,9 +118,8 @@ namespace {
 
         std::set<std::string> prerequisites;
         if (kw.has_key("prerequisites")) {
-            py_parse::detail::flatten_list<std::string>(kw["prerequisites"], [](const std::string& o, std::set<std::string>& v) {
-                v.insert(o);
-            }, prerequisites);
+            prerequisites.insert(boost::python::stl_input_iterator<std::string>(kw["prerequisites"]),
+                boost::python::stl_input_iterator<std::string>());
         }
 
         std::vector<UnlockableItem> unlock;

--- a/test-scripting/techs/growth/ORBITAL_HAB.focs.py
+++ b/test-scripting/techs/growth/ORBITAL_HAB.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=250 * TECH_COST_MULTIPLIER,
     researchturns=7,
     tags=["PEDIA_GROWTH_CATEGORY"],
-    prerequisites="PRO_MICROGRAV_MAN",
+    prerequisites=["PRO_MICROGRAV_MAN"],
     effectsgroups=[
         EffectsGroup(
             scope=HasSpecies() & OwnedBy(empire=Source.Owner),


### PR DESCRIPTION
First I introduced it because I had macros returns lists and I need to concatenate them with other macros and so on. Recently I found unary `*` operator on list and I'm going to use it instead.