### PR TITLE
Update actions/cache versions

### DIFF
--- a/.github/godot-detect.cmake
+++ b/.github/godot-detect.cmake
@@ -2,6 +2,5 @@ find_program(GODOT_EXECUTABLE NAMES godot3-server godot-headless godot3 godot go
 execute_process(COMMAND ${GODOT_EXECUTABLE} --version OUTPUT_VARIABLE GODOT_VERSION)
 string(STRIP "${GODOT_VERSION}" GODOT_VERSION)
 message("Found godot at ${GODOT_EXECUTABLE} version ${GODOT_VERSION}")
-message("::set-output name=godot::${GODOT_EXECUTABLE}")
-message("::set-output name=version::${GODOT_VERSION}")
-
+file(APPEND "$ENV{GITHUB_OUTPUT}" "godot=${GODOT_EXECUTABLE}\n")
+file(APPEND "$ENV{GITHUB_OUTPUT}" "version=${GODOT_VERSION}\n")

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -39,8 +39,8 @@ jobs:
         run: |
           TAG=$(echo $GITHUB_SHA | head -c7)
           IMAGE="freeorion/freeorion"
-          echo ::set-output name=tagged_image::${IMAGE}:${TAG}
-          echo ::set-output name=tag::${TAG}
+          echo tagged_image=${IMAGE}:${TAG} >> $GITHUB_OUTPUT
+          echo tag=${TAG} >> $GITHUB_OUTPUT
       - uses: satackey/action-docker-layer-caching@v0.0.11
         # Ignore the failure of a step and avoid terminating the job.
         continue-on-error: true
@@ -52,7 +52,7 @@ jobs:
         shell: cmake -P {0}
         run: |
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+          file(APPEND "$ENV{GITHUB_OUTPUT}" "timestamp=${current_date}")
       - name: Cache files with ccache
         uses: actions/cache@v3
         with:
@@ -63,7 +63,8 @@ jobs:
       - name: Detect godot
         id: detect-godot
         run: |
-          docker run -v "$(pwd):/freeorion" -v "${{ runner.temp }}/ccache:/ccache_dir" -e CCACHE_DIR='/ccache_dir' -w /freeorion ${{ steps.prep.outputs.tagged_image }} /usr/bin/cmake -P /freeorion/.github/godot-detect.cmake
+          touch ${GITHUB_OUTPUT}
+          docker run -v "$(pwd):/freeorion" -v "${{ runner.temp }}/ccache:/ccache_dir" --mount type=bind,source=${GITHUB_OUTPUT},target=/github-output.file -e CCACHE_DIR='/ccache_dir' -e GITHUB_OUTPUT=/github-output.file -w /freeorion ${{ steps.prep.outputs.tagged_image }} /usr/bin/cmake -P /freeorion/.github/godot-detect.cmake
       - name: Copy godot
         run: |
           mkdir build

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -54,7 +54,7 @@ jobs:
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
           message("::set-output name=timestamp::${current_date}")
       - name: Cache files with ccache
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v3
         with:
           path: ${{ runner.temp }}/ccache
           key: build-${{ matrix.image }}-docker-ccache-${{ steps.build-docker-ccache-timestamp.outputs.timestamp }}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -45,7 +45,7 @@ jobs:
         shell: cmake -P {0}
         run: |
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+          file(APPEND "$ENV{GITHUB_OUTPUT}" "timestamp=${current_date}")
       - name: Cache compilation
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -47,7 +47,7 @@ jobs:
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
           message("::set-output name=timestamp::${current_date}")
       - name: Cache compilation
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ~/Library/Caches/
           key: build-${{ matrix.os }}-ccache-${{ steps.build-macos-ccache-timestamp.outputs.timestamp }}

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -61,7 +61,7 @@ jobs:
         shell: cmake -P {0}
         run: |
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
-          message("::set-output name=timestamp::${current_date}")
+          file(APPEND "$ENV{GITHUB_OUTPUT}" "timestamp=${current_date}")
       - name: Cache files with ccache
         uses: actions/cache@v2
         with:

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -44,7 +44,7 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
-      - uses: actions/cache@v2
+      - uses: actions/cache@v3
         id: build-ubuntu-install-cache-id
         with:
           path: ${{ runner.temp }}/cache-build-linux-install
@@ -63,7 +63,7 @@ jobs:
           string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
           message("::set-output name=timestamp::${current_date}")
       - name: Cache files with ccache
-        uses: actions/cache@v1.1.0
+        uses: actions/cache@v2
         with:
           path: ${{ runner.temp }}/ccache
           key: build-${{ matrix.os }}-${{ matrix.compiler }}-ccache-${{ steps.build-ubuntu-ccache-timestamp.outputs.timestamp }}

--- a/.github/workflows/build-windows-msvs.yml
+++ b/.github/workflows/build-windows-msvs.yml
@@ -36,7 +36,7 @@ jobs:
           url: https://github.com/freeorion/freeorion-sdk/releases/download/v13/FreeOrionSDK_13_MSVC-v141-Win32.zip
           target: ../
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v1.0.3
+        uses: microsoft/setup-msbuild@v1.1.3
         with:
             vs-prerelease: true
       - name: Prepare


### PR DESCRIPTION
Updates actions version to mitigate Node 12 deprecation https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
Also removes deprecated set-output command https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/