### PR TITLE
Add supply traversals for borders for common allies of both suppliers

### DIFF
--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -825,14 +825,9 @@ void SupplyManager::Update(const ScriptingContext& context) {
 
 
     for (const auto& [supply_empire_id, empire] : empires) {
-    //for (const auto& [supply_empire_id, empire_obstructed_traversals] : m_supply_starlane_obstructed_traversals) {
-        //for (empire_id : empires.GetEmpireIDsWithDiplomaticStatusWithEmpire(DiplomaticStatus::DIPLO_ALLIED)) {
         const auto allies_of_empire = allies_of(supply_empire_id);
         if (allies_of_empire.empty())
             continue;
-        auto& empire_supply_traversals = ally_merged_supply_starlane_traversals[supply_empire_id];
-        const auto& supply_empire_baseline_unobstructed_systems =
-            empires.GetEmpire(supply_empire_id)->SupplyUnobstructedSystems();
         const auto& empire_directly_supplied = m_empire_propagated_supply_ranges[supply_empire_id];
         const auto& empire_obstructed_traversals = m_supply_starlane_obstructed_traversals[supply_empire_id];
         TraceLogger(supply) << " CHECK BORDERS of empire " << supply_empire_id << "";
@@ -846,14 +841,14 @@ void SupplyManager::Update(const ScriptingContext& context) {
                 //TraceLogger(supply) << "Check if (empire " << b_empire_id << ") " << " is supplier of " << sys_B;
                 if (!m_empire_propagated_supply_ranges[b_empire_id].count(sys_B))
                     continue;
-                TraceLogger(supply) << "(empire " << supply_empire_id << ") " << sys_A << " - " << sys_B << " (empire " << b_empire_id << ")";
+                TraceLogger(supply) << " ... empire " << supply_empire_id << ") " << sys_A << " - " << sys_B << " (empire " << b_empire_id << ")";
                 // all allies of a_empire which are allies of b_empire may use this traversal
                 for (int a_ally_id : allies_of_empire) {
-                    TraceLogger(supply) << "Check if (empire " << a_ally_id << ") " << " is allied to supplier of " << sys_B << " (empire " << b_empire_id << ")";
+                    TraceLogger(supply) << " ... Check if (empire " << a_ally_id << ") " << " is allied to supplier of " << sys_B << " (empire " << b_empire_id << ")";
                     if (a_ally_id == b_empire_id)
                         continue;
                     if (empires.GetDiplomaticStatus(a_ally_id, b_empire_id) >= DiplomaticStatus::DIPLO_ALLIED) {
-                        TraceLogger(supply) << "Empire " << a_ally_id << " may use (empire " << supply_empire_id << ")" << sys_A << " - " << sys_B << " (empire " << b_empire_id << ") as its allied with " << b_empire_id;
+                        TraceLogger(supply) << " ... ... Empire " << a_ally_id << " may use (empire " << supply_empire_id << ")" << sys_A << " - " << sys_B << " (empire " << b_empire_id << ") as its allied with " << b_empire_id;
                         auto& a_ally_supply_traversals = ally_merged_supply_starlane_traversals[a_ally_id]; // output
                         a_ally_supply_traversals.emplace(sys_A, sys_B);
                         a_ally_supply_traversals.emplace(sys_B, sys_A);

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -822,6 +822,49 @@ void SupplyManager::Update(const ScriptingContext& context) {
             }
         }
     }
+
+
+    for (const auto& [supply_empire_id, empire] : empires) {
+    //for (const auto& [supply_empire_id, empire_obstructed_traversals] : m_supply_starlane_obstructed_traversals) {
+        //for (empire_id : empires.GetEmpireIDsWithDiplomaticStatusWithEmpire(DiplomaticStatus::DIPLO_ALLIED)) {
+        const auto allies_of_empire = allies_of(supply_empire_id);
+        if (allies_of_empire.empty())
+            continue;
+        auto& empire_supply_traversals = ally_merged_supply_starlane_traversals[supply_empire_id];
+        const auto& supply_empire_baseline_unobstructed_systems =
+            empires.GetEmpire(supply_empire_id)->SupplyUnobstructedSystems();
+        const auto& empire_directly_supplied = m_empire_propagated_supply_ranges[supply_empire_id];
+        const auto& empire_obstructed_traversals = m_supply_starlane_obstructed_traversals[supply_empire_id];
+        TraceLogger(supply) << " CHECK BORDERS of empire " << supply_empire_id << "";
+        for (auto const& [sys_A, sys_B] : empire_obstructed_traversals) {
+            //TraceLogger(supply) << "(?empire " << supply_empire_id << "?) " << sys_A << " - " << sys_B << " (empire ?)";
+            if (!empire_directly_supplied.count(sys_A)) {
+                ErrorLogger(supply) << "Error: system " << sys_A << " is NOT directly supplied by empire " << supply_empire_id << ", but it should";
+            }
+            // Find the supplier of B and find the intersection of allies between the B supplier and the A supplier
+            for (const auto& [b_empire_id, b_empire] : empires) {
+                //TraceLogger(supply) << "Check if (empire " << b_empire_id << ") " << " is supplier of " << sys_B;
+                if (!m_empire_propagated_supply_ranges[b_empire_id].count(sys_B))
+                    continue;
+                TraceLogger(supply) << "(empire " << supply_empire_id << ") " << sys_A << " - " << sys_B << " (empire " << b_empire_id << ")";
+                // all allies of a_empire which are allies of b_empire may use this traversal
+                for (int a_ally_id : allies_of_empire) {
+                    TraceLogger(supply) << "Check if (empire " << a_ally_id << ") " << " is allied to supplier of " << sys_B << " (empire " << b_empire_id << ")";
+                    if (a_ally_id == b_empire_id)
+                        continue;
+                    if (empires.GetDiplomaticStatus(a_ally_id, b_empire_id) >= DiplomaticStatus::DIPLO_ALLIED) {
+                        TraceLogger(supply) << "Empire " << a_ally_id << " may use (empire " << supply_empire_id << ")" << sys_A << " - " << sys_B << " (empire " << b_empire_id << ") as its allied with " << b_empire_id;
+                        auto& a_ally_supply_traversals = ally_merged_supply_starlane_traversals[a_ally_id]; // output
+                        a_ally_supply_traversals.emplace(sys_A, sys_B);
+                        a_ally_supply_traversals.emplace(sys_B, sys_A);
+                    }
+                }
+                break; // stop after finding the one supplier of B
+            }
+        }
+        TraceLogger(supply) << " DONE CHECK BORDERS of empire " << supply_empire_id;
+    }
+
     for (auto& [empire_id, traversals] : ally_merged_supply_starlane_traversals) {
         TraceLogger(supply) << "Empire " << empire_id << " supply traversals after ally connections:";
         for (auto const& [a, b] : traversals)


### PR DESCRIPTION
in order to fix transitive use of allied supply this adds supply traversals for borders for common allies of both suppliers

PHASE1: make it work (probably done)
* [x] check logs CHECK BORDERS, supply traversals after ally connections, supply traversals after merging allies

PHASE2: make it right
* [ ] functional code review (does this introduce bugs)
* [~] thorough code review 
* [~] maybe code needs a bit clean up
* [~] maybe better debug output
* [~] change stringtables 

PHASE3: make it fast (probably not in this PR)
* [~] probably can be sped up moving code into the previous loop
* [~] probably can be sped up by removing visited empires

@geoffthemedio can you have a look if I broke anything? i would like to merge a working version before the weekly build; i suggest I fix secondary concerns (style, refactoring for speed, ...) in a followup-PR if the time runs out

Note: as a follow-up there is also a discussion if traversal between warring empires should be allowed or not. but that needs some more thought (e.g. consistency with military ships etc) before introducing extra case switches.