### PR TITLE
Fix alliance victory if diplomacy is forbidden

### DIFF
--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -3877,7 +3877,9 @@ void ServerApp::CheckForEmpireElimination() {
                 auto emp2_it = emp1_it;
                 ++emp2_it;
                 for (; emp2_it != non_eliminated_non_ai_controlled_empires.end(); ++emp2_it) {
-                    if (m_empires.GetDiplomaticStatus((*emp1_it)->EmpireID(), (*emp2_it)->EmpireID()) != DiplomaticStatus::DIPLO_ALLIED)
+                    const auto status = m_empires.GetDiplomaticStatus((*emp1_it)->EmpireID(), (*emp2_it)->EmpireID());
+                    // if diplomacy forbidden then allow peace status
+                    if (status == DiplomaticStatus::DIPLO_WAR || (GetGameRules().Get<std::string>("RULE_DIPLOMACY") != UserStringNop("RULE_DIPLOMACY_FORBIDDEN_FOR_ALL") && status == DiplomaticStatus::DIPLO_PEACE))
                         return;
                 }
             }


### PR DESCRIPTION
If diplomacy is forbidden the empires in peace cannot do anything with it and have to wait for tech victory, experimenters victory or concede of other.