### PR TITLE
Tweak probability of Ancient Guardians

### DIFF
--- a/default/scripting/game_rules.focs.py
+++ b/default/scripting/game_rules.focs.py
@@ -312,7 +312,7 @@ GameRule(
     description="RULE_MINIMUM_MONSTER_DISTANCE_CAPITAL_DESC",
     category="BALANCE",
     type=int,
-    default=4,
+    default=3,
     min=1,
     max=10,
 )

--- a/default/scripting/specials/planet/monster_guard.macros
+++ b/default/scripting/specials/planet/monster_guard.macros
@@ -14,7 +14,7 @@ CHANCE_OF_GUARD_1
             ]
             effects = [
                 If condition = And [
-                        Random probability = 0.6
+                        Random probability = 0.5
                         [[MINIMUM_DISTANCE_EMPIRE_CHECK]]
                     ]
                     effects = [
@@ -26,7 +26,7 @@ CHANCE_OF_GUARD_1
                     ]
                 else = [
                     If condition = And [
-                            Random probability = 0.7
+                            Random probability = 0.5
                             Not Homeworld
                         ]
                         effects = [
@@ -34,7 +34,7 @@ CHANCE_OF_GUARD_1
                             SetPopulation value = Target.TargetPopulation
                         ]
                     else = [
-                        AddSpecial name = "CLOUD_COVER_MASTER_SPECIAL"
+                        AddSpecial name = OneOf("CLOUD_COVER_MASTER_SPECIAL", "VOLCANIC_ASH_MASTER_SPECIAL")
                     ]
                 ]
             ]


### PR DESCRIPTION
Ancient Guardians became too common near empires after RULE_MINIMUM_MONSTER_DISTANCE_CAPITAL was added.

default value for RULE_MINIMUM_MONSTER_DISTANCE_CAPITAL too high for "recommended" galaxy size.