### PR TITLE
NoDefault..Effects PartCapacity/HullStructure should return unscaled values

### DIFF
--- a/universe/ShipHull.cpp
+++ b/universe/ShipHull.cpp
@@ -259,11 +259,14 @@ void ShipHull::Init(std::vector<std::unique_ptr<Effect::EffectsGroup>>&& effects
         m_effects.push_back(IncreaseMeter(MeterType::METER_MAX_FUEL,      m_fuel));
     if (default_stealth_effects && m_stealth != 0)
         m_effects.push_back(IncreaseMeter(MeterType::METER_STEALTH,       m_stealth));
-    if (default_structure_effects && m_structure != 0)
+    if (default_structure_effects && m_structure != 0) {
+        m_default_structure_effects = default_structure_effects;
         m_effects.push_back(IncreaseMeter(MeterType::METER_MAX_STRUCTURE, m_structure, "RULE_SHIP_STRUCTURE_FACTOR"));
-    if (default_speed_effects && m_speed != 0)
+    }
+    if (default_speed_effects && m_speed != 0) {
+        m_default_speed_effects = default_speed_effects;
         m_effects.push_back(IncreaseMeter(MeterType::METER_SPEED,         m_speed,     "RULE_SHIP_SPEED_FACTOR"));
-
+    }
     if (m_production_cost)
         m_production_cost->SetTopLevelContent(m_name);
     if (m_production_time)
@@ -277,10 +280,10 @@ void ShipHull::Init(std::vector<std::unique_ptr<Effect::EffectsGroup>>&& effects
 }
 
 float ShipHull::Speed() const
-{ return m_speed * GetGameRules().Get<double>("RULE_SHIP_SPEED_FACTOR"); }
+{ return m_speed * (m_default_speed_effects ? GetGameRules().Get<double>("RULE_SHIP_SPEED_FACTOR") : 1.0f); }
 
 float ShipHull::Structure() const
-{ return m_structure * GetGameRules().Get<double>("RULE_SHIP_STRUCTURE_FACTOR"); }
+{ return m_structure * (m_default_structure_effects ? GetGameRules().Get<double>("RULE_SHIP_STRUCTURE_FACTOR") : 1.0f); }
 
 uint32_t ShipHull::NumSlots(ShipSlotType slot_type) const {
     uint32_t count = 0;

--- a/universe/ShipHull.h
+++ b/universe/ShipHull.h
@@ -161,10 +161,13 @@ private:
     float       m_fuel = 0.0f;
     float       m_stealth = 0.0f;
     float       m_structure = 0.0f;
+    bool        m_default_speed_effects = false;
+    bool        m_default_structure_effects = false;
 
+    bool                                                m_producible = false;
     std::unique_ptr<ValueRef::ValueRef<double>>         m_production_cost;
     std::unique_ptr<ValueRef::ValueRef<int>>            m_production_time;
-    bool                                                m_producible = false;
+
     std::vector<Slot>                                   m_slots;
     const std::string                                   m_tags_concatenated;
     const std::vector<std::string_view>                 m_tags;
@@ -175,6 +178,7 @@ private:
     std::vector<std::shared_ptr<Effect::EffectsGroup>>  m_effects;
     std::string                                         m_graphic;
     std::string                                         m_icon;
+
 };
 
 

--- a/universe/ShipPart.cpp
+++ b/universe/ShipPart.cpp
@@ -408,14 +408,14 @@ bool ShipPart::operator==(const ShipPart& rhs) const {
 float ShipPart::Capacity() const {
     switch (m_class) {
     case ShipPartClass::PC_ARMOUR:
-        return m_capacity * GetGameRules().Get<double>("RULE_SHIP_STRUCTURE_FACTOR");
+        return m_capacity * (m_add_standard_capacity_effect ? GetGameRules().Get<double>("RULE_SHIP_STRUCTURE_FACTOR") : 1.0f);
         break;
     case ShipPartClass::PC_DIRECT_WEAPON:
     case ShipPartClass::PC_SHIELD:
-        return m_capacity * GetGameRules().Get<double>("RULE_SHIP_WEAPON_DAMAGE_FACTOR");
+        return m_capacity * (m_add_standard_capacity_effect ? GetGameRules().Get<double>("RULE_SHIP_WEAPON_DAMAGE_FACTOR") : 1.0f);
         break;
     case ShipPartClass::PC_SPEED:
-        return m_capacity * GetGameRules().Get<double>("RULE_SHIP_SPEED_FACTOR");
+        return m_capacity * (m_add_standard_capacity_effect ? GetGameRules().Get<double>("RULE_SHIP_SPEED_FACTOR") : 1.0f);
         break;
     default:
         return m_capacity;
@@ -425,7 +425,7 @@ float ShipPart::Capacity() const {
 float ShipPart::SecondaryStat() const {
     switch (m_class) {
     case ShipPartClass::PC_FIGHTER_HANGAR:
-        return m_secondary_stat * GetGameRules().Get<double>("RULE_FIGHTER_DAMAGE_FACTOR");
+        return m_secondary_stat * (m_add_standard_capacity_effect ? GetGameRules().Get<double>("RULE_FIGHTER_DAMAGE_FACTOR") : 1.0f);
         break;
     default:
         return m_secondary_stat;


### PR DESCRIPTION
Fix PartCapacity and HullStructure/HullSpeed to return unscaled values if default effects are disabled
    
https://www.freeorion.org/forum/viewtopic.php?p=115134#p115134

this is completely untested, testers

for testing one needs to disable default effects for some ship part/ship hull contents and query those values with PartCapacity and HullStructure/HullSpeed 

without this PR, the values should be scaled by the corresponding game rules; with this PR, the values should be unscaled