### PR TITLE
Require minimum colony source stability to build colony ships

### DIFF
--- a/default/scripting/ship_parts/Colony/CO_COLONY_POD.focs.txt
+++ b/default/scripting/ship_parts/Colony/CO_COLONY_POD.focs.txt
@@ -11,6 +11,7 @@ Part
         Planet
         OwnedBy empire = Source.Owner
         Population low = [[MIN_RECOLONIZING_SIZE]] high = 999
+        Happiness low = 5
     ]
 // Population consumption is commented out until the discrepancy between outpost
 // population consumption and this consumption is regularized.

--- a/default/scripting/ship_parts/Colony/CO_SUPEND_ANIM_POD.focs.txt
+++ b/default/scripting/ship_parts/Colony/CO_SUPEND_ANIM_POD.focs.txt
@@ -11,6 +11,7 @@ Part
         Planet
         OwnedBy empire = Source.Owner
         Population low = [[MIN_RECOLONIZING_SIZE]] high = 999
+        Happiness low = 5
     ]
 // Population consumption is commented out until the discrepancy between outpost
 // population consumption and this consumption is regularized.


### PR DESCRIPTION
Currently you can build colony ships without the stability to be a colonizing source.

@Grummel7 - does this need any AI changes?