### PR TITLE
fix compile error with GCC 13

### DIFF
--- a/GG/GG/Clr.h
+++ b/GG/GG/Clr.h
@@ -15,6 +15,7 @@
 #define _GG_Clr_h_
 
 #include <array>
+#include <cstdint>
 #include <sstream>
 #include <string>
 #include <GG/Export.h>

--- a/GG/GG/Enum.h
+++ b/GG/GG/Enum.h
@@ -17,6 +17,7 @@
 
 
 #include <climits>
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <map>

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2967,8 +2967,7 @@ namespace {
         cost_units = UserString("ENC_PP");
 
 
-        const bool insert_success = universe.InsertShipDesignID(
-            *incomplete_design, client_empire_id, incomplete_design->ID());
+        universe.InsertShipDesignID(*incomplete_design, client_empire_id, incomplete_design->ID());
         detailed_description = GetDetailedDescriptionBase(*incomplete_design);
 
         // baseline values, may be overridden

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -1988,7 +1988,7 @@ void MapWnd::RenderSystems() {
     // distance between inner and outer system circle
     const double circle_distance = GetOptionsDB().Get<double>("ui.map.system.circle.distance");
     // width of outer...
-    const double outer_circle_width = GetOptionsDB().Get<double>("ui.map.system.circle.outer.width");
+    //const double outer_circle_width = GetOptionsDB().Get<double>("ui.map.system.circle.outer.width");
     // ... and inner circle line at close zoom
     const double inner_circle_width = GetOptionsDB().Get<double>("ui.map.system.circle.inner.width");
     // width of inner circle line when map is zoomed out
@@ -2343,8 +2343,6 @@ void MapWnd::RenderFleetMovementLines() {
     glEnableClientState(GL_TEXTURE_COORD_ARRAY);
 
     glBindTexture(GL_TEXTURE_2D, move_line_dot_texture->OpenGLId());
-
-    const float dot_half_sz = dot_size / 2.0f;
 
     const auto sz = (m_fleet_lines.size() + m_projected_fleet_lines.size()) * 4;
     m_fleet_move_dot_vertices.clear();

--- a/network/Networking.h
+++ b/network/Networking.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <bitset>
+#include <cstdint>
 
 #include "../util/Enum.h"
 #include "../util/Export.h"

--- a/parse/ConditionPythonParser.cpp
+++ b/parse/ConditionPythonParser.cpp
@@ -623,7 +623,7 @@ namespace {
 
         auto condition = boost::python::extract<condition_wrapper>(kw["condition"])();
         return condition_wrapper(std::make_shared<Condition::ResourceSupplyConnectedByEmpire>(std::move(empire),
-            std::move(ValueRef::CloneUnique(condition.condition))));
+            ValueRef::CloneUnique(condition.condition)));
     }
 
     condition_wrapper insert_within_starlane_jumps_(const boost::python::tuple& args, const boost::python::dict& kw) {
@@ -638,7 +638,7 @@ namespace {
         }
 
         return condition_wrapper(std::make_shared<Condition::WithinStarlaneJumps>(std::move(jumps),
-            std::move(ValueRef::CloneUnique(condition.condition))));
+            ValueRef::CloneUnique(condition.condition)));
     }
 
     condition_wrapper insert_within_distance_(const boost::python::tuple& args, const boost::python::dict& kw) {
@@ -653,7 +653,7 @@ namespace {
         }
 
         return condition_wrapper(std::make_shared<Condition::WithinDistance>(std::move(distance),
-            std::move(ValueRef::CloneUnique(condition.condition))));
+            ValueRef::CloneUnique(condition.condition)));
     }
 
     condition_wrapper insert_object_id_(const boost::python::tuple& args, const boost::python::dict& kw) {

--- a/parse/EffectPythonParser.cpp
+++ b/parse/EffectPythonParser.cpp
@@ -360,7 +360,7 @@ namespace {
 
         return {std::move(name),
             std::move(description),
-            std::move(ValueRef::CloneUnique(location.condition)),
+            ValueRef::CloneUnique(location.condition),
             std::move(graphic)};
     }
 }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -3247,7 +3247,6 @@ namespace {
             for (auto& [recipient_empire_id, objs] : recipients_objs) {
                 for (auto* gifted_obj : objs) {
                     const auto initial_owner_empire_id = gifted_obj->Owner();
-                    const auto obj_type = gifted_obj->ObjectType();
                     const auto gifted_obj_id = gifted_obj->ID();
                     gifted_object_ids.push_back(gifted_obj_id);
 

--- a/test/system/SmokeTestGame.cpp
+++ b/test/system/SmokeTestGame.cpp
@@ -139,7 +139,7 @@ BOOST_AUTO_TEST_CASE(host_server) {
         // output sitreps
         const auto& my_empire = m_empires.GetEmpire(m_empire_id);
         BOOST_REQUIRE(my_empire != nullptr);
-        for (const auto sitrep : my_empire->SitReps()) {
+        for (const auto& sitrep : my_empire->SitReps()) {
             if (sitrep.GetTurn() == m_current_turn) {
                 BOOST_TEST_MESSAGE("Sitrep: " << sitrep.Dump());
             }

--- a/universe/BuildingType.cpp
+++ b/universe/BuildingType.cpp
@@ -68,7 +68,7 @@ BuildingType::BuildingType(std::string&& name, std::string&& description,
 
         // store views into concatenated tags string
         std::for_each(common_params.tags.begin(), common_params.tags.end(),
-                      [&next_idx, &retval, this, sv](const auto& t)
+                      [&next_idx, &retval, sv](const auto& t)
         {
             retval.push_back(sv.substr(next_idx, t.size()));
             next_idx += t.size();

--- a/universe/FieldType.cpp
+++ b/universe/FieldType.cpp
@@ -56,7 +56,7 @@ FieldType::FieldType(std::string&& name, std::string&& description,
         std::string_view sv{m_tags_concatenated};
 
         // store views into concatenated tags string
-        std::for_each(tags.begin(), tags.end(), [&next_idx, &retval, this, sv](const auto& t) {
+        std::for_each(tags.begin(), tags.end(), [&next_idx, &retval, sv](const auto& t) {
             std::string upper_t = boost::to_upper_copy<std::string>(t);
             retval.push_back(sv.substr(next_idx, upper_t.size()));
             next_idx += upper_t.size();

--- a/universe/Meter.h
+++ b/universe/Meter.h
@@ -6,6 +6,7 @@
 #endif
 
 #include <array>
+#include <cstdint>
 #include <string>
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/nvp.hpp>

--- a/universe/ShipHull.cpp
+++ b/universe/ShipHull.cpp
@@ -136,7 +136,7 @@ ShipHull::ShipHull(float fuel, float speed, float stealth, float structure,
 
         // store views into concatenated tags string
         std::for_each(common_params.tags.begin(), common_params.tags.end(),
-                      [&next_idx, &retval, this, sv](const auto& t)
+                      [&next_idx, &retval, sv](const auto& t)
         {
             retval.push_back(sv.substr(next_idx, t.size()));
             next_idx += t.size();

--- a/universe/Species.cpp
+++ b/universe/Species.cpp
@@ -180,7 +180,7 @@ Species::Species(std::string&& name, std::string&& desc,
         std::for_each(m_tags.begin(), m_tags.end(), [&next_idx](const auto& t) { next_idx += t.size(); });
 
         // store views into concatenated tags/likes string
-        std::for_each(likes.begin(), likes.end(), [&next_idx, &retval, this, sv](const auto& t) {
+        std::for_each(likes.begin(), likes.end(), [&next_idx, &retval, sv](const auto& t) {
             std::string upper_t = boost::to_upper_copy<std::string>(t);
             retval.push_back(sv.substr(next_idx, upper_t.size()));
             next_idx += upper_t.size();
@@ -199,7 +199,7 @@ Species::Species(std::string&& name, std::string&& desc,
         std::for_each(m_likes.begin(), m_likes.end(), [&next_idx](const auto& t) { next_idx += t.size(); });
 
         // store views into concatenated tags/likes string
-        std::for_each(dislikes.begin(), dislikes.end(), [&next_idx, &retval, this, sv](const auto& t) {
+        std::for_each(dislikes.begin(), dislikes.end(), [&next_idx, &retval, sv](const auto& t) {
             std::string upper_t = boost::to_upper_copy<std::string>(t);
             retval.push_back(sv.substr(next_idx, upper_t.size()));
             next_idx += upper_t.size();

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2139,10 +2139,10 @@ Universe::GetEmpiresPositionNextTurnFleetDetectionRanges(const ScriptingContext&
 
 
         // get next turn position of fleet
-        auto path = fleet->MovePath(false, context);
+        const auto path = fleet->MovePath(false, context);
         if (path.empty())
             continue;
-        auto& next_turn_end_position = [&path]() -> const MovePathNode& {
+        const auto next_turn_end_position = [&path]() -> MovePathNode {
             for (const auto& node : path) {
                 if (node.turn_end)
                     return node;
@@ -2156,9 +2156,9 @@ Universe::GetEmpiresPositionNextTurnFleetDetectionRanges(const ScriptingContext&
         { continue; }
 
         // add detection at next position
-        auto object_owner_empire_id = fleet->Owner();
+        const auto object_owner_empire_id = fleet->Owner();
         auto& retval_empire_pos_range = retval[object_owner_empire_id];
-        std::pair<double, double> object_pos{next_turn_end_position.x, next_turn_end_position.y};
+        const std::pair<double, double> object_pos{next_turn_end_position.x, next_turn_end_position.y};
 
         // store range in output map (if new for location or larger than any
         // previously-found range at this location)

--- a/universe/UnlockableItem.h
+++ b/universe/UnlockableItem.h
@@ -4,6 +4,7 @@
 
 #include "../util/Enum.h"
 #include "../util/Export.h"
+#include <cstdint>
 
 
 /** types of items that can be unlocked for empires */

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -2191,9 +2191,9 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
     std::function<const std::map<int, float>& ()> property_int_key{nullptr};
 
     if (variable_name == "PropagatedSystemSupplyRange") // int_ref2 is system ID
-        property_int_key = [&context]() { return context.supply.PropagatedSupplyRanges(); };
+        property_int_key = [&context]() -> const auto& { return context.supply.PropagatedSupplyRanges(); };
     else if (variable_name == "PropagatedSystemSupplyDistance") // int_ref2 is system ID
-        property_int_key = [&context]() { return context.supply.PropagatedSupplyDistances(); };
+        property_int_key = [&context]() -> const auto& { return context.supply.PropagatedSupplyDistances(); };
 
     if (property_int_key) {
         if (!m_int_ref2)

--- a/util/Pending.h
+++ b/util/Pending.h
@@ -74,9 +74,7 @@ namespace Pending {
                 return boost::none;
             }
             DebugLogger() << "Retrieve result of parsing \"" << pending.filename << "\".";
-            auto x = std::move(pending.pending->get());
-            DebugLogger() << "Retrieved result of parsing \"" << pending.filename << "\".";
-            return std::move(x);
+            return pending.pending->get();
         } catch (const std::exception& e) {
             ErrorLogger() << "Parsing of \"" << pending.filename << "\" failed with error: " << e.what();
         }

--- a/util/i18n.cpp
+++ b/util/i18n.cpp
@@ -294,7 +294,7 @@ void FlushLoadedStringTables() {
     stringtables.clear();
 }
 
-const AllStringsResultT& AllStringtableEntries(bool default_table) {
+AllStringsResultT& AllStringtableEntries(bool default_table) {
     std::shared_lock stringtable_lock(stringtable_access_mutex);
     if (default_table)
         return GetDevDefaultStringTable(stringtable_lock).AllStrings();

--- a/util/i18n.h
+++ b/util/i18n.h
@@ -24,8 +24,8 @@
 [[nodiscard]] FO_COMMON_API const std::string& UserString(const char* str);
 
 /** Returns all entries in current stringtable */
-using AllStringsResultT = decltype(std::declval<StringTable>().AllStrings());
-[[nodiscard]] FO_COMMON_API const AllStringsResultT& AllStringtableEntries(bool default_table = false);
+using AllStringsResultT = const decltype(std::declval<StringTable>().AllStrings());
+[[nodiscard]] FO_COMMON_API AllStringsResultT& AllStringtableEntries(bool default_table = false);
 
 /** Returns a language-specific vector of strings for given @a key. */
 [[nodiscard]] FO_COMMON_API std::vector<std::string> UserStringList(const std::string& key);


### PR DESCRIPTION
fedora-rawhide bumped GCC from 12.2 to 13 which lead to compile errors:
````
 /freeorion/universe/ValueRefs.cpp:2197:91: error: no match for 'operator=' (operand types are 'std::function<const std::map<int, float>&()>' and 'ValueRef::ComplexVariable<double>::Eval(const ScriptingContext&) const::<lambda()>')
 2197 |         property_int_key = [&context]() { return context.supply.PropagatedSupplyRanges(); };
      |                                                                                           ^
````

and also various missing #includes and warning reductions.