### PR TITLE
Simplify industry.macros and research.macros

### DIFF
--- a/default/scripting/species/common/industry.macros
+++ b/default/scripting/species/common/industry.macros
@@ -37,7 +37,6 @@ VERY_BAD_INDUSTRY
             activation = And [
                 Planet
                 TargetIndustry low = 0
-                Happiness low = 0
                 Focus type = "FOCUS_INDUSTRY"
             ]
             accountinglabel = "VERY_BAD_INDUSTRY_LABEL"
@@ -56,7 +55,6 @@ BAD_INDUSTRY
             activation = And [
                 Planet
                 TargetIndustry low = 0
-                Happiness low = 0
                 Focus type = "FOCUS_INDUSTRY"
             ]
             accountinglabel = "BAD_INDUSTRY_LABEL"
@@ -79,7 +77,6 @@ GOOD_INDUSTRY
             activation = And [
                 Planet
                 TargetIndustry low = 0
-                Happiness low = 0
                 Focus type = "FOCUS_INDUSTRY"
             ]
             accountinglabel = "GOOD_INDUSTRY_LABEL"
@@ -98,7 +95,6 @@ GREAT_INDUSTRY
             activation = And [
                 Planet
                 TargetIndustry low = 0
-                Happiness low = 0
                 Focus type = "FOCUS_INDUSTRY"
             ]
             accountinglabel = "GREAT_INDUSTRY_LABEL"
@@ -117,7 +113,6 @@ ULTIMATE_INDUSTRY
             activation = And [
                 Planet
                 TargetIndustry low = 0
-                Happiness low = 0
                 Focus type = "FOCUS_INDUSTRY"
             ]
             accountinglabel = "ULTIMATE_INDUSTRY_LABEL"

--- a/default/scripting/species/common/research.macros
+++ b/default/scripting/species/common/research.macros
@@ -68,7 +68,6 @@ GOOD_RESEARCH
             activation = And [
                 Planet
                 Focus type = "FOCUS_RESEARCH"
-                Happiness low = 2
             ]
             accountinglabel = "GOOD_RESEARCH_LABEL"
             priority = [[TARGET_SCALING_PRIORITY]]
@@ -84,7 +83,6 @@ GREAT_RESEARCH
             activation = And [
                 Planet
                 Focus type = "FOCUS_RESEARCH"
-                Happiness low = 0
             ]
             accountinglabel = "GREAT_RESEARCH_LABEL"
             priority = [[TARGET_SCALING_PRIORITY]]


### PR DESCRIPTION
https://github.com/freeorion/freeorion/issues/4400

It is my belief (guess) that the intention of the removed lines was different then the actual effect. This is backed up by an earlier change by Grummel in research.macros

Happiness low = 0 in [BASIC_RESEARCH] and [BASIC_INDUSTRY] sets the actual minimum stability to have research and industry on a colony

Happines low =0 on [VERY_BAD_RESEARCH] and such, sets the minimum stability to obtain the species modifiers to research, in the case of bad and very bad, its placing a minimum stability on receiving the species penalty.

Note with current game state, the change leaves things 99.99% identical, as 1/2 of zero is still zero.