### PR TITLE
Generate better version name for release & candidates in snapcraft

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -73,7 +73,7 @@ parts:
       snapcraftctl pull
       branchn="$(git rev-parse --abbrev-ref HEAD)"
       daterev="$(git log -n1 --date=short --format='%cd.%h' $branchn)"
-      longtagn="$(git describe --tags)"
+      longtagn="$(git describe --tags || echo none)"
       case $longtagn in
         v*) version=${longtagn} ;;
         *) case $daterev in

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -71,14 +71,17 @@ parts:
     #cmake-parameters: [-DBUILD_TESTING=ON]
     override-pull: |
       snapcraftctl pull
-      # this versioning works for e.g. weekly-test-builds
       branchn="$(git rev-parse --abbrev-ref HEAD)"
-      version="$(git log -n1 --date=short --format='%cd.%h' $branchn)"
-      case $version in
-        v*) version=$(echo $version | tail -c +2) ;;
-        *)  version=$(echo $version | head -c 32) ;;
+      daterev="$(git log -n1 --date=short --format='%cd.%h' $branchn)"
+      longtagn="$(git describe --tags)"
+      case $longtagn in
+        v*) version=${longtagn} ;;
+        *) case $daterev in
+          v*) version=$(echo $daterev | tail -c +2) ;;
+          *)  version=$(echo $daterev | head -c 32) ;;
+        esac ;;
       esac
-      [ -n "$(echo $version | grep '-')" ] && grade=devel || grade=stable
+      [ -n "$(echo $version | grep '^[0-9]+-')" ] && grade=devel || grade=stable
       snapcraftctl set-version "$version"
       snapcraftctl set-grade "$grade"
     override-prime: |


### PR DESCRIPTION
Generate better version name for release & candidates in snapcraft - e.g. v0.5-rc1.abcdef012

building a candidate works for me if i kick off the snapcraft build in launchpad via the github trigger.

still need to figure out how to automatically determine that we are not building a release/candidate.
maybe consider a normal edge build if the last release tag is further away than three commits