### PR TITLE
[v0.5][snap] brute remove godot build from snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -23,16 +23,16 @@ apps:
       LD_LIBRARY_PATH: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/freeorion
       LIBGL_DRIVERS_PATH: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
       # PYTHONPATH: $SNAP/usr/lib/python3.6
-  freeorion-godot:
-    # LD_LIBRARY_PATH=$SNAP/usr/lib/x86_64-linux-gnu/freeorion:$SNAP/usr/lib/x86_64-linux-gnu/:$SNAP/usr/lib/x86_64-linux-gnu/pulseaudio LIBGL_DRIVERS_PATH=$SNAP/usr/lib/x86_64-linux-gnu/dri godot3-runner   --resource.path $SNAP/usr/share/freeorion/default/ -S $SNAP_USER_COMMON/save
-    command: usr/bin/godot3-runner --main-pack $SNAP/usr/share/freeorion/freeorion.pck --resource.path $SNAP/usr/share/freeorion/default/ -S $SNAP_USER_COMMON/save
-    extensions: [gnome-3-38]
-    plugs: [home, pulseaudio, opengl, network, screen-inhibit-control, browser-support, x11]
-    desktop: usr/share/applications/org.freeorion.FreeOrion.desktop
-    environment:
-      LD_LIBRARY_PATH: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/freeorion
-      LIBGL_DRIVERS_PATH: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
-      #PYTHONPATH: $SNAP/usr/lib/python3.6
+  ### freeorion-godot:
+    ### LD_LIBRARY_PATH=$SNAP/usr/lib/x86_64-linux-gnu/freeorion:$SNAP/usr/lib/x86_64-linux-gnu/:$SNAP/usr/lib/x86_64-linux-gnu/pulseaudio LIBGL_DRIVERS_PATH=$SNAP/usr/lib/x86_64-linux-gnu/dri godot3-runner   --resource.path $SNAP/usr/share/freeorion/default/ -S $SNAP_USER_COMMON/save
+    ### command: usr/bin/godot3-runner --main-pack $SNAP/usr/share/freeorion/freeorion.pck --resource.path $SNAP/usr/share/freeorion/default/ -S $SNAP_USER_COMMON/save
+    ### extensions: [gnome-3-38]
+    ### plugs: [home, pulseaudio, opengl, network, screen-inhibit-control, browser-support, x11]
+    ### desktop: usr/share/applications/org.freeorion.FreeOrion.desktop
+    ### environment:
+    ###   LD_LIBRARY_PATH: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/freeorion
+    ###   LIBGL_DRIVERS_PATH: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
+    ###   #PYTHONPATH: $SNAP/usr/lib/python3.6
   freeoriond:
     command: usr/bin/freeoriond
     plugs: [home, network, network-bind]
@@ -58,17 +58,18 @@ parts:
     override-build: |
       # Icon paths in the desktop file will be rewritten to use ${SNAP}/<file> if specified as desktop file in snapcraft.yaml
       sed -i.bak -e "s|Icon=freeorion$|Icon=meta/gui/icon.png|g" ../src/packaging/org.freeorion.FreeOrion.desktop
-      sed -i.bak -e 's|="res://bin/linux.*/libfreeoriongodot.so"|="/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/freeorion/libfreeoriongodot.so"|g' ../src/godot/freeoriongodot.gdnlib
+      ### sed -i.bak -e 's|="res://bin/linux.*/libfreeoriongodot.so"|="/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/freeorion/libfreeoriongodot.so"|g' ../src/godot/freeoriongodot.gdnlib
       snapcraftctl build
       # godot-headless wants a writable homedir, simulate it
       mkdir -p home/
       mkdir -p "${SNAPCRAFT_PART_INSTALL}/usr/share/freeorion/"
       # Note: we use godot3-headless really
-      HOME=$(pwd)/home godot3-server --path ../src/godot --export-pack "Linux/X11" "${SNAPCRAFT_PART_INSTALL}/usr/share/freeorion/freeorion.pck"
+      ### HOME=$(pwd)/home godot3-server --path ../src/godot --export-pack "Linux/X11" "${SNAPCRAFT_PART_INSTALL}/usr/share/freeorion/freeorion.pck"
     plugin: cmake
     cmake-parameters:
-      - -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_CLIENT_GODOT=ON
-    #cmake-parameters: [-DBUILD_TESTING=ON]
+      ### - -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_CLIENT_GODOT=ON
+      - -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_CLIENT_GODOT=OFF
+    # cmake-parameters: [-DBUILD_TESTING=ON]
     override-pull: |
       snapcraftctl pull
       # this versioning works for e.g. weekly-test-builds
@@ -103,7 +104,7 @@ parts:
       - libtiff-dev
       - libvorbis-dev
       - pkg-config
-      - godot3-server
+      ### - godot3-server
       # - python
     stage-packages:
       - mesa-utils
@@ -129,5 +130,4 @@ parts:
       - libvorbisfile3
       - libpng16-16
       - libfreetype6
-      - godot3-runner
-
+      ### - godot3-runner


### PR DESCRIPTION
NOT FOR MASTER, only for 0.5

this removes godot build and dependencies from snapcraft build (and saves about 190MB)