### PR TITLE
NamedValueRefs for pedia for weapon upgrades (AD,MD,Laser,Plasma,DR)

### DIFF
--- a/default/scripting/ship_parts/ShortRange/shortrange.macros
+++ b/default/scripting/ship_parts/ShortRange/shortrange.macros
@@ -10,7 +10,7 @@ WEAPON_BASE_DEFAULT_EFFECTS
             stackinggroup = "WEAPON_BASE_DEFAULT_EFFECTS_@1@"
             accountinglabel = "@1@"
             effects = [
-                SetMaxCapacity partname = "@1@" value = Value + PartCapacity name = "@1@"
-                SetMaxSecondaryStat partname = "@1@" value = Value + PartSecondaryStat name = "@1@"
+                SetMaxCapacity partname = "@1@" value = Value + NamedReal name = "@1@_CAPACITY" value = PartCapacity name = "@1@"
+                SetMaxSecondaryStat partname = "@1@" value = Value + NamedReal name = "@1@_SECONDARY" value = PartSecondaryStat name = "@1@"
             ]
 '''

--- a/default/scripting/techs/ship_weapons/short_range/SHP_ARC_DISRUPTOR.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_ARC_DISRUPTOR.focs.py
@@ -28,7 +28,7 @@ Tech(
     researchturns=8,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_ARC_DISRUPTOR_1"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_ARC_DISRUPTOR", 2),
+    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_ARC_DISRUPTOR_2", "SR_ARC_DISRUPTOR", 2),
     graphic="icons/ship_parts/pulse-laser-2.png",
 )
 
@@ -42,6 +42,6 @@ Tech(
     researchturns=12,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_ARC_DISRUPTOR_2"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_ARC_DISRUPTOR", 3),
+    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_ARC_DISRUPTOR_3", "SR_ARC_DISRUPTOR", 3, 5),
     graphic="icons/ship_parts/pulse-laser-3.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_1_2.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_1_2.focs.py
@@ -10,6 +10,6 @@ Tech(
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_ROOT_AGGRESSION"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_1_1", 1),
+    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_1_2", "SR_WEAPON_1_1", 1),
     graphic="icons/ship_parts/mass-driver-2.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_1_3.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_1_3.focs.py
@@ -10,6 +10,6 @@ Tech(
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_1_2"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_1_1", 1),
+    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_1_3", "SR_WEAPON_1_1", 1),
     graphic="icons/ship_parts/mass-driver-3.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_1_4.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_1_4.focs.py
@@ -10,6 +10,6 @@ Tech(
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_1_3"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_1_1", 1),
+    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_1_4", "SR_WEAPON_1_1", 1),
     graphic="icons/ship_parts/mass-driver-4.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_2.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_2.focs.py
@@ -10,6 +10,6 @@ Tech(
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_2_1"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_2_1", 2),
+    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_2_2", "SR_WEAPON_2_1", 2),
     graphic="icons/ship_parts/laser-2.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_3.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_3.focs.py
@@ -10,6 +10,6 @@ Tech(
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_2_2"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_2_1", 2),
+    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_2_3", "SR_WEAPON_2_1", 2),
     graphic="icons/ship_parts/laser-3.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_4.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_4.focs.py
@@ -10,6 +10,6 @@ Tech(
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_2_3"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_2_1", 2),
+    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_2_4", "SR_WEAPON_2_1", 2),
     graphic="icons/ship_parts/laser-4.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_2.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_2.focs.py
@@ -10,6 +10,6 @@ Tech(
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_3_1"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_3_1", 3),
+    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_3_2", "SR_WEAPON_3_1", 3),
     graphic="icons/ship_parts/plasma-2.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_3.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_3.focs.py
@@ -10,6 +10,6 @@ Tech(
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_3_2"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_3_1", 3),
+    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_3_3", "SR_WEAPON_3_1", 3),
     graphic="icons/ship_parts/plasma-3.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_4.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_4.focs.py
@@ -10,6 +10,6 @@ Tech(
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_3_3"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_3_1", 3),
+    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_3_4", "SR_WEAPON_3_1", 3),
     graphic="icons/ship_parts/plasma-4.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_2.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_2.focs.py
@@ -10,6 +10,6 @@ Tech(
     researchturns=3,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_4_1"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_4_1", 5),
+    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_4_2", "SR_WEAPON_4_1", 5),
     graphic="icons/ship_parts/death-ray-2.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_3.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_3.focs.py
@@ -10,6 +10,6 @@ Tech(
     researchturns=3,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_4_2"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_4_1", 5),
+    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_4_3", "SR_WEAPON_4_1", 5),
     graphic="icons/ship_parts/death-ray-3.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_4.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_4.focs.py
@@ -10,6 +10,6 @@ Tech(
     researchturns=3,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_4_3"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SR_WEAPON_4_1", 5),
+    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_4_4", "SR_WEAPON_4_1", 5),
     graphic="icons/ship_parts/death-ray-4.png",
 )

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -14076,19 +14076,19 @@ SHP_WEAPON_1_2
 Mass Driver 2
 
 SHP_WEAPON_1_2_DESC
-Upgrades [[shippart SR_WEAPON_1_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of 24.
+Upgrades [[shippart SR_WEAPON_1_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_1_2_UPGRADED_DAMAGE]].
 
 SHP_WEAPON_1_3
 Mass Driver 3
 
 SHP_WEAPON_1_3_DESC
-Upgrades [[shippart SR_WEAPON_1_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of 30.
+Upgrades [[shippart SR_WEAPON_1_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_1_3_UPGRADED_DAMAGE]].
 
 SHP_WEAPON_1_4
 Mass Driver 4
 
 SHP_WEAPON_1_4_DESC
-Upgrades [[shippart SR_WEAPON_1_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of 36.
+Upgrades [[shippart SR_WEAPON_1_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_1_4_UPGRADED_DAMAGE]].
 
 SHP_WEAPON_2_1
 Laser Weapons
@@ -14100,19 +14100,19 @@ SHP_WEAPON_2_2
 Laser 2
 
 SHP_WEAPON_2_2_DESC
-Upgrades [[shippart SR_WEAPON_2_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of 42.
+Upgrades [[shippart SR_WEAPON_2_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_2_2_UPGRADED_DAMAGE]].
 
 SHP_WEAPON_2_3
 Laser 3
 
 SHP_WEAPON_2_3_DESC
-Upgrades [[shippart SR_WEAPON_2_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of 54.
+Upgrades [[shippart SR_WEAPON_2_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_2_3_UPGRADED_DAMAGE]].
 
 SHP_WEAPON_2_4
 Laser 4
 
 SHP_WEAPON_2_4_DESC
-Upgrades [[shippart SR_WEAPON_2_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of 66.
+Upgrades [[shippart SR_WEAPON_2_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_2_4_UPGRADED_DAMAGE]].
 
 SHP_WEAPON_3_1
 Plasma Cannons
@@ -14124,19 +14124,19 @@ SHP_WEAPON_3_2
 Plasma Cannon 2
 
 SHP_WEAPON_3_2_DESC
-Upgrades [[shippart SR_WEAPON_3_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of 72.
+Upgrades [[shippart SR_WEAPON_3_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_3_2_UPGRADED_DAMAGE]].
 
 SHP_WEAPON_3_3
 Plasma Cannon 3
 
 SHP_WEAPON_3_3_DESC
-Upgrades [[shippart SR_WEAPON_3_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of 90.
+Upgrades [[shippart SR_WEAPON_3_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_3_3_UPGRADED_DAMAGE]].
 
 SHP_WEAPON_3_4
 Plasma Cannon 4
 
 SHP_WEAPON_3_4_DESC
-Upgrades [[shippart SR_WEAPON_3_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of 108.
+Upgrades [[shippart SR_WEAPON_3_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_3_4_UPGRADED_DAMAGE]].
 
 SHP_WEAPON_4_1
 Death Rays
@@ -14148,37 +14148,37 @@ SHP_WEAPON_4_2
 Death Ray 2
 
 SHP_WEAPON_4_2_DESC
-Upgrades [[shippart SR_WEAPON_4_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of 120.
+Upgrades [[shippart SR_WEAPON_4_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_4_2_UPGRADED_DAMAGE]].
 
 SHP_WEAPON_4_3
 Death Ray 3
 
 SHP_WEAPON_4_3_DESC
-Upgrades [[shippart SR_WEAPON_4_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of 150.
+Upgrades [[shippart SR_WEAPON_4_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_4_3_UPGRADED_DAMAGE]].
 
 SHP_WEAPON_4_4
 Death Ray 4
 
 SHP_WEAPON_4_4_DESC
-Upgrades [[shippart SR_WEAPON_4_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of 180.
+Upgrades [[shippart SR_WEAPON_4_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_4_4_UPGRADED_DAMAGE]].
 
 SHP_WEAPON_ARC_DISRUPTOR_1
 Arc Disruptors
 
 SHP_WEAPON_ARC_DISRUPTOR_1_DESC
-Unlocks the [[shippart SR_ARC_DISRUPTOR]], an automated weapon system doing low damage to multiple targets. The base weapon part has shot damage 12.
+Unlocks the [[shippart SR_ARC_DISRUPTOR]], an automated weapon system doing low damage to multiple targets. The base weapon part has shot damage [[value SR_ARC_DISRUPTOR_PART_CAPACITY]].
 
 SHP_WEAPON_ARC_DISRUPTOR_2
 Arc Disruptor 2
 
 SHP_WEAPON_ARC_DISRUPTOR_2_DESC
-Upgrades [[shippart SR_ARC_DISRUPTOR]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of 24.
+Upgrades [[shippart SR_ARC_DISRUPTOR]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_ARC_DISRUPTOR_2_UPGRADED_DAMAGE]].
 
 SHP_WEAPON_ARC_DISRUPTOR_3
 Arc Disruptor 3
 
 SHP_WEAPON_ARC_DISRUPTOR_3_DESC
-Upgrades [[shippart SR_ARC_DISRUPTOR]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of 42.
+Upgrades [[shippart SR_ARC_DISRUPTOR]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_ARC_DISRUPTOR_3_UPGRADED_DAMAGE]].
 
 SHP_ION_CANNON
 Ion Cannon
@@ -15633,7 +15633,7 @@ SR_WEAPON_1_1_DESC
 
 Upgrading the weapon technology will increase the shot damage.
 
-The weapon's [[encyclopedia DAMAGE_TITLE]] is a combination of the shot damage and any active modifiers. Each mass driver on a ship built by a species with the piloting trait will do an additional 6 damage per piloting level (-6 for Bad Pilots).'''
+The weapon's [[encyclopedia DAMAGE_TITLE]] is a combination of the shot damage and any active modifiers. Each mass driver on a ship built by a species with the piloting trait will do an additional 6 damage per piloting level (-6 for Bad Pilots). The Mass Driver has [[value SR_WEAPON_1_1_PART_CAPACITY]] basic shot damage. Upgrade tech [[tech SHP_WEAPON_1_2]] increases this by [[value SHP_WEAPON_1_2_UPGRADE_DAMAGE]].'''
 
 SR_WEAPON_2_1
 Laser Weapon
@@ -15643,7 +15643,7 @@ SR_WEAPON_2_1_DESC
 
 Upgrading the weapon technology will increase the shot damage.
 
-The weapon's [[encyclopedia DAMAGE_TITLE]] is a combination of the shot damage and any active modifiers. Each laser weapon on a ship built by a species with the piloting trait will do an additional 12 damage per piloting level (-12 for Bad Pilots). Laser weapon damage can also be enhanced on [[shiphull SH_ORGANIC]] ships with a [[shippart SP_SOLAR_CONCENTRATOR]].'''
+The weapon's [[encyclopedia DAMAGE_TITLE]] is a combination of the shot damage and any active modifiers. Each laser weapon on a ship built by a species with the piloting trait will do an additional 12 damage per piloting level (-12 for Bad Pilots). The Laser has [[value SR_WEAPON_2_1_PART_CAPACITY]] basic shot damage. Upgrade tech [[tech SHP_WEAPON_2_2]] increases this by [[value SHP_WEAPON_2_2_UPGRADE_DAMAGE]]. Laser weapon damage can also be enhanced on [[shiphull SH_ORGANIC]] ships with a [[shippart SP_SOLAR_CONCENTRATOR]].'''
 
 SR_WEAPON_3_1
 Plasma Cannons
@@ -15653,7 +15653,7 @@ SR_WEAPON_3_1_DESC
 
 Upgrading the weapon technology will increase the shot damage.
 
-The weapon's [[encyclopedia DAMAGE_TITLE]] is a combination of the shot damage and any active modifiers. Each plasma cannon on a ship built by a species with the piloting trait will do an additional 18 damage per piloting level (-18 for Bad Pilots).'''
+The weapon's [[encyclopedia DAMAGE_TITLE]] is a combination of the shot damage and any active modifiers. Each plasma cannon on a ship built by a species with the piloting trait will do an additional 18 damage per piloting level (-18 for Bad Pilots). The Plasma Cannon has [[value SR_WEAPON_3_1_PART_CAPACITY]] basic shot damage. Upgrade tech [[tech SHP_WEAPON_3_2]] increases this by [[value SHP_WEAPON_3_2_UPGRADE_DAMAGE]].'''
 
 SR_WEAPON_4_1
 Death Ray
@@ -15663,7 +15663,7 @@ SR_WEAPON_4_1_DESC
 
 Upgrading the weapon technology will increase the shot damage.
 
-The weapon's [[encyclopedia DAMAGE_TITLE]] is a combination of the shot damage and any active modifiers. Each death ray on a ship built by a species with the piloting trait will do an additional 30 damage per piloting level (-30 for Bad Pilots).'''
+The weapon's [[encyclopedia DAMAGE_TITLE]] is a combination of the shot damage and any active modifiers. Each death ray on a ship built by a species with the piloting trait will do an additional 30 damage per piloting level (-30 for Bad Pilots). The Death Ray has [[value SR_WEAPON_4_1_PART_CAPACITY]] basic shot damage. Upgrade tech [[tech SHP_WEAPON_4_2]] increases this by [[value SHP_WEAPON_4_2_UPGRADE_DAMAGE]].'''
 
 SR_ARC_DISRUPTOR
 Arc Disruptor
@@ -15675,7 +15675,7 @@ Charged polaron capacitors generate a molecular disruption flux wave that arcs t
 
 Upgrading the weapon technology will increase the shot damage.
 
-The weapon's [[encyclopedia DAMAGE_TITLE]] is a combination of the shot damage and any active modifiers. Piloting trait does not affect damage.'''
+The weapon's [[encyclopedia DAMAGE_TITLE]] is a combination of the shot damage and any active modifiers. Piloting trait does not affect damage. The Arc Disruptor has [[value SR_ARC_DISRUPTOR_PART_CAPACITY]] basic shot damage. Upgrade tech [[tech SHP_WEAPON_ARC_DISRUPTOR_2]] increases this by [[value SHP_WEAPON_ARC_DISRUPTOR_2_UPGRADE_DAMAGE]].'''
 
 SR_SPINAL_ANTIMATTER
 Spinal Antimatter Cannon


### PR DESCRIPTION
this takes values from content for upgradable ship weapon parts und the upgrade techs.

the part shows the basic value, the difference the next upgrade tech would make and links to the upgrade tech 

the upgrade tech shows the effective damage for that tech level. the techs are anyway linked, so one can see all the values easily by clicking links

this  fixes issue #4283 

this makes the pedia much better, but the implementation is very ugly, so i would rather not merge this into the master, ONLY into release-v0.5