### PR TITLE
extend copysign workaround

### DIFF
--- a/msvc2022/Parsers/StdAfx.h
+++ b/msvc2022/Parsers/StdAfx.h
@@ -19,10 +19,11 @@
 #include <vector>
 
 #include <boost/version.hpp>
-#if BOOST_VERSION == 107900 && defined(_MSC_VER)
+#if BOOST_VERSION >= 107900 && defined(_MSC_VER)
 #include <cmath>
 namespace boost::core {
     // workaround for error in boost/lexical_cast/detail/inf_nan.hpp : error C2039: '_copysign': is not a member of 'boost::core'
+    // this seems to occur because the Python pyconfig.h #defines copysign as _copysign
     inline float _copysign(float x, float y)
     { return std::copysignf(x, y); }
 }


### PR DESCRIPTION
rework workaround for pyconfig.h `#define`ing copysign as _copysign by `#undef` instead of declaring a function