### PR TITLE
Restore modules after Python FOCS parser

### DIFF
--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -138,7 +138,7 @@ void AIClientApp::Run() {
         // Start parsing content
         std::promise<void> barrier;
         std::future<void> barrier_future = barrier.get_future();
-        StartBackgroundParsing(PythonParser(*m_AI, GetResourceDir() / "scripting"), std::move(barrier));
+        StartBackgroundParsing(PythonParser(*m_AI, GetResourceDir() / "scripting", false), std::move(barrier));
         barrier_future.wait();
 
         // Import python main module only after game content has been parsed, allowing

--- a/client/godot/GodotClientApp.cpp
+++ b/client/godot/GodotClientApp.cpp
@@ -79,7 +79,7 @@ GodotClientApp::GodotClientApp() {
         DebugLogger() << "Started background parser thread";
         PythonCommon python;
         python.Initialize();
-        StartBackgroundParsing(PythonParser(python, GetResourceDir() / "scripting"), std::move(b));
+        StartBackgroundParsing(PythonParser(python, GetResourceDir() / "scripting", false), std::move(b));
     }, std::move(barrier));
     background.detach();
     barrier_future.wait();

--- a/client/human/GGHumanClientApp.cpp
+++ b/client/human/GGHumanClientApp.cpp
@@ -363,7 +363,7 @@ GGHumanClientApp::GGHumanClientApp(int width, int height, bool calculate_fps, st
         DebugLogger() << "Started background parser thread";
         PythonCommon python;
         python.Initialize();
-        StartBackgroundParsing(PythonParser(python, GetResourceDir() / "scripting"), std::move(b));
+        StartBackgroundParsing(PythonParser(python, GetResourceDir() / "scripting", false), std::move(b));
     }, std::move(barrier));
     background.detach();
     barrier_future.wait();
@@ -1612,7 +1612,7 @@ void GGHumanClientApp::HandleResoureDirChange() {
             DebugLogger() << "Started background parser thread";
             PythonCommon python;
             python.Initialize();
-            StartBackgroundParsing(PythonParser(python, GetResourceDir() / "scripting"), std::move(b));
+            StartBackgroundParsing(PythonParser(python, GetResourceDir() / "scripting", false), std::move(b));
         }, std::move(barrier));
         background.detach();
         barrier_future.wait();

--- a/parse/DummyParsers.cpp
+++ b/parse/DummyParsers.cpp
@@ -84,9 +84,10 @@ namespace parse {
 
 template FO_PARSE_API TechManager::TechParseTuple parse::techs<TechManager::TechParseTuple>(const PythonParser& parser, const boost::filesystem::path& path);
 
-PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path& scripting_dir) 
+PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path& scripting_dir, bool clean_modules) 
     : m_python(_python)
     , m_scripting_dir(scripting_dir)
+    , m_clean_modules(clean_modules)
 { }
 
 PythonParser::~PythonParser()

--- a/parse/PythonParser.h
+++ b/parse/PythonParser.h
@@ -14,7 +14,7 @@ struct module_spec;
 
 class FO_PARSE_API PythonParser {
 public:
-    PythonParser(PythonCommon& _python, const boost::filesystem::path& scripting_dir);
+    PythonParser(PythonCommon& _python, const boost::filesystem::path& scripting_dir, bool clean_modules);
     ~PythonParser();
 
     PythonParser(const PythonParser&) = delete;
@@ -40,7 +40,9 @@ private:
 
     PythonCommon&                  m_python;
     const boost::filesystem::path& m_scripting_dir;
+    const bool                     m_clean_modules;
     boost::python::list            m_meta_path;
+    boost::python::dict            m_modules;
 };
 
 #endif

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -130,7 +130,7 @@ ServerApp::ServerApp() :
     // to have data initialized before autostart execution
     std::promise<void> barrier;
     std::future<void> barrier_future = barrier.get_future();
-    StartBackgroundParsing(PythonParser(m_python_server, GetResourceDir() / "scripting"), std::move(barrier));
+    StartBackgroundParsing(PythonParser(m_python_server, GetResourceDir() / "scripting", false), std::move(barrier));
     barrier_future.wait();
 
     m_fsm->initiate();

--- a/test/parse/TestPythonParser.cpp
+++ b/test/parse/TestPythonParser.cpp
@@ -26,7 +26,7 @@ namespace {
 BOOST_FIXTURE_TEST_SUITE(TestPythonParser, ParserAppFixture)
 
 BOOST_AUTO_TEST_CASE(parse_game_rules) {
-    PythonParser parser(m_python, m_scripting_dir);
+    PythonParser parser(m_python, m_scripting_dir, true);
 
     auto game_rules_p = Pending::ParseSynchronously(parse::game_rules, parser,  m_scripting_dir / "game_rules.focs.py");
     auto game_rules = *Pending::WaitForPendingUnlocked(std::move(game_rules_p));
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(parse_game_rules) {
 }
 
 BOOST_AUTO_TEST_CASE(parse_techs) {
-    PythonParser parser(m_python, m_scripting_dir);
+    PythonParser parser(m_python, m_scripting_dir, true);
 
     auto techs_p = Pending::ParseSynchronously(parse::techs<TechManager::TechParseTuple>, parser, m_scripting_dir / "techs");
     auto [techs, tech_categories, categories_seen] = *Pending::WaitForPendingUnlocked(std::move(techs_p));
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE(parse_techs) {
 }
 
 BOOST_AUTO_TEST_CASE(parse_species) {
-    PythonParser parser(m_python, m_scripting_dir);
+    PythonParser parser(m_python, m_scripting_dir, true);
 
     auto species_p = Pending::ParseSynchronously(parse::species, parser, m_scripting_dir / "species");
     const auto [species_map, ordering] = *Pending::WaitForPendingUnlocked(std::move(species_p));
@@ -434,7 +434,7 @@ BOOST_AUTO_TEST_CASE(parse_techs_full) {
     BOOST_REQUIRE(boost::filesystem::exists(scripting_dir));
     BOOST_REQUIRE(boost::filesystem::is_directory(scripting_dir));
 
-    PythonParser parser(m_python, scripting_dir);
+    PythonParser parser(m_python, scripting_dir, true);
 
     auto named_values = Pending::ParseSynchronously(parse::named_value_refs, scripting_dir / "common");
 
@@ -477,7 +477,7 @@ BOOST_AUTO_TEST_CASE(parse_species_full) {
     BOOST_REQUIRE(boost::filesystem::exists(scripting_dir));
     BOOST_REQUIRE(boost::filesystem::is_directory(scripting_dir));
 
-    PythonParser parser(m_python, scripting_dir);
+    PythonParser parser(m_python, scripting_dir, true);
 
     auto named_values = Pending::ParseSynchronously(parse::named_value_refs, scripting_dir / "common");
 

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -52,7 +52,7 @@ ClientAppFixture::ClientAppFixture() :
         DebugLogger() << "Started background parser thread";
         PythonCommon python;
         python.Initialize();
-        StartBackgroundParsing(PythonParser(python, GetResourceDir() / "scripting"), std::move(b));
+        StartBackgroundParsing(PythonParser(python, GetResourceDir() / "scripting", false), std::move(b));
     }, std::move(barrier));
     background.detach();
     barrier_future.wait();


### PR DESCRIPTION
Should fix failure in #4421 

Test process re-initializes parser multiple times and use same modules from both test-scripting and default/scripting so each call should clean previously imported modules