### PR TITLE
Try to force Boost from SDK on MacOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,7 @@ if(APPLE)
     set(CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}/dep/")
     set(CMAKE_FRAMEWORK_PATH "${CMAKE_BINARY_DIR}/dep/Frameworks")
     set(CMAKE_PROGRAM_PATH "${CMAKE_FRAMEWORK_PATH}/Python.framework/Versions/3.7/bin")
+    set(BOOST_ROOT "${CMAKE_BINARY_DIR}/dep/")
 endif()
 
 if(UNIX)


### PR DESCRIPTION
Should fix https://github.com/freeorion/freeorion/issues/4383

I've set `v0.5` as it's seemed to be useful here too and there still time before RC3 but shouldn't be blocking for it.