### PR TITLE
Fix godot version on CI

### DIFF
--- a/.github/fedora-32/Dockerfile
+++ b/.github/fedora-32/Dockerfile
@@ -15,5 +15,5 @@ RUN dnf install -y cmake \
 	libogg-devel \
 	libvorbis-devel \
 	glew-devel \
-    godot-headless
+	godot-headless
 

--- a/.github/fedora-rawhide/Dockerfile
+++ b/.github/fedora-rawhide/Dockerfile
@@ -15,5 +15,5 @@ RUN dnf install -y cmake \
 	libogg-devel \
 	libvorbis-devel \
 	glew-devel \
-    godot-headless
+	godot3-headless
 

--- a/.github/godot-detect.cmake
+++ b/.github/godot-detect.cmake
@@ -1,4 +1,4 @@
-find_program(GODOT_EXECUTABLE NAMES godot3-server godot-headless godot3 godot godot3-runner REQUIRED)
+find_program(GODOT_EXECUTABLE NAMES godot3-server godot3-headless godot-headless godot3 godot godot3-runner REQUIRED)
 execute_process(COMMAND ${GODOT_EXECUTABLE} --version OUTPUT_VARIABLE GODOT_VERSION)
 string(STRIP "${GODOT_VERSION}" GODOT_VERSION)
 message("Found godot at ${GODOT_EXECUTABLE} version ${GODOT_VERSION}")

--- a/.github/workflows/godot-check.yml
+++ b/.github/workflows/godot-check.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install development dependencies
         run: |
-          pip install gdtoolkit
+          pip install "gdtoolkit==3.*"
       - name: Check format
         run: |
           find godot/ -iname "*.gd" -not -path "godot/addons/*" | xargs gdformat -c


### PR DESCRIPTION
Fix #4433 and #4434

Default Godot on Fedora Rawhide suddenly became 4.0 so this PR pins 3.x versions. Same for gdtoolkit versions.