### PR TITLE
workaround for Boost 1.81 Spirit multiple definitions issue in MSVC 

### DIFF
--- a/msvc2019/boost.dependency.props
+++ b/msvc2019/boost.dependency.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>_WINSOCK_DEPRECATED_NO_WARNINGS;BOOST_ALL_DYN_LINK;BOOST_AUTO_LINK_NOMANGLE;BOOST_ZLIB_BINARY=zlib.lib;BOOST_GIL_IO_ENABLE_GRAY_ALPHA;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WINSOCK_DEPRECATED_NO_WARNINGS;BOOST_ALL_DYN_LINK;BOOST_AUTO_LINK_NOMANGLE;BOOST_ZLIB_BINARY=zlib.lib;BOOST_GIL_IO_ENABLE_GRAY_ALPHA;BOOST_PHOENIX_STL_TUPLE_H_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../../include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>

--- a/msvc2022/boost.dependency.props
+++ b/msvc2022/boost.dependency.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <ClCompile>
-      <PreprocessorDefinitions>_WINSOCK_DEPRECATED_NO_WARNINGS;BOOST_ALL_DYN_LINK;BOOST_AUTO_LINK_NOMANGLE;BOOST_ZLIB_BINARY=zlib.lib;BOOST_GIL_IO_ENABLE_GRAY_ALPHA;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>_WINSOCK_DEPRECATED_NO_WARNINGS;BOOST_ALL_DYN_LINK;BOOST_AUTO_LINK_NOMANGLE;BOOST_ZLIB_BINARY=zlib.lib;BOOST_GIL_IO_ENABLE_GRAY_ALPHA;BOOST_PHOENIX_STL_TUPLE_H_;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../../include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>


### PR DESCRIPTION
project files