### PR TITLE
Force const for Python FOCS parser wrapper structures

### DIFF
--- a/parse/ConditionPythonParser.cpp
+++ b/parse/ConditionPythonParser.cpp
@@ -10,8 +10,8 @@
 #include "ValueRefPythonParser.h"
 
 condition_wrapper operator&(const condition_wrapper& lhs, const condition_wrapper& rhs) {
-    std::shared_ptr<Condition::ValueTest> lhs_cond = std::dynamic_pointer_cast<Condition::ValueTest>(lhs.condition);
-    std::shared_ptr<Condition::ValueTest> rhs_cond = std::dynamic_pointer_cast<Condition::ValueTest>(rhs.condition);
+    auto lhs_cond = std::dynamic_pointer_cast<const Condition::ValueTest>(lhs.condition);
+    auto rhs_cond = std::dynamic_pointer_cast<const Condition::ValueTest>(rhs.condition);
 
     if (lhs_cond && rhs_cond) {
         const auto lhs_vals = lhs_cond->ValuesDouble();

--- a/parse/ConditionPythonParser.h
+++ b/parse/ConditionPythonParser.h
@@ -16,7 +16,7 @@ struct condition_wrapper {
     condition_wrapper(std::shared_ptr<Condition::Condition>&& ref) : condition(std::move(ref)) {}
     condition_wrapper(const std::shared_ptr<Condition::Condition>& ref) : condition(ref) {}
 
-    std::shared_ptr<Condition::Condition> condition;
+    const std::shared_ptr<const Condition::Condition> condition;
 };
 
 condition_wrapper operator&(const condition_wrapper&, const condition_wrapper&);

--- a/parse/EffectPythonParser.h
+++ b/parse/EffectPythonParser.h
@@ -19,7 +19,7 @@ struct effect_wrapper {
         : effect(ref)
     { }
 
-    std::shared_ptr<Effect::Effect> effect;
+    const std::shared_ptr<const Effect::Effect> effect;
 };
 
 struct effect_group_wrapper {
@@ -31,7 +31,7 @@ struct effect_group_wrapper {
         : effects_group(ref)
     { }
 
-    std::shared_ptr<Effect::EffectsGroup> effects_group;
+    const std::shared_ptr<const Effect::EffectsGroup> effects_group;
 };
 
 struct unlockable_item_wrapper {
@@ -43,7 +43,7 @@ struct unlockable_item_wrapper {
         : item(item_)
     { }
 
-    UnlockableItem item;
+    const UnlockableItem item;
 };
 
 void RegisterGlobalsEffects(boost::python::dict& globals);

--- a/parse/EnumPythonParser.h
+++ b/parse/EnumPythonParser.h
@@ -11,7 +11,7 @@ template<typename E>
 struct enum_wrapper {
     enum_wrapper(E value_) : value(value_) { }
 
-    E value;
+    const E value;
 
     bool operator==(const enum_wrapper<E>& rhs) {
         return this->value == rhs.value;

--- a/parse/SourcePythonParser.cpp
+++ b/parse/SourcePythonParser.cpp
@@ -78,7 +78,7 @@ condition_wrapper operator&(const variable_wrapper& lhs, const value_ref_wrapper
             throw std::runtime_error(std::string("Not implemented in ") + __func__ + " type " + std::to_string(static_cast<int>(lhs.m_reference_type)) + rhs.value_ref->Dump());
     }
 
-    std::shared_ptr<ValueRef::Operation<double>> rhs_op = std::dynamic_pointer_cast<ValueRef::Operation<double>>(rhs.value_ref);
+    auto rhs_op = std::dynamic_pointer_cast<const ValueRef::Operation<double>>(rhs.value_ref);
 
     if (rhs_op && rhs_op->LHS() && rhs_op->RHS()) {
         Condition::ComparisonType cmp_type;

--- a/parse/SpeciesParser.cpp
+++ b/parse/SpeciesParser.cpp
@@ -379,9 +379,9 @@ namespace {
         for (auto it = effectsgroups_begin; it != effectsgroups_end; ++it) {
             const auto& effects_group = *it->effects_group;
             effectsgroups.push_back(std::make_unique<Effect::EffectsGroup>(
-                std::move(ValueRef::CloneUnique(effects_group.Scope())),
-                std::move(ValueRef::CloneUnique(effects_group.Activation())),
-                std::move(ValueRef::CloneUnique(effects_group.Effects())),
+                ValueRef::CloneUnique(effects_group.Scope()),
+                ValueRef::CloneUnique(effects_group.Activation()),
+                ValueRef::CloneUnique(effects_group.Effects()),
                 effects_group.AccountingLabel(),
                 effects_group.StackingGroup(),
                 effects_group.Priority(),

--- a/parse/TechsParser.cpp
+++ b/parse/TechsParser.cpp
@@ -105,8 +105,19 @@ namespace {
         std::vector<std::shared_ptr<Effect::EffectsGroup>> effectsgroups;
         if (kw.has_key("effectsgroups")) {
             boost::python::stl_input_iterator<effect_group_wrapper> effectsgroups_begin(kw["effectsgroups"]), effectsgroups_end;
-            for (auto it = effectsgroups_begin; it != effectsgroups_end; ++it)
-                effectsgroups.push_back(it->effects_group);
+            for (auto it = effectsgroups_begin; it != effectsgroups_end; ++it) {
+                const auto& effects_group = *it->effects_group;
+                effectsgroups.push_back(std::make_shared<Effect::EffectsGroup>(
+                    ValueRef::CloneUnique(effects_group.Scope()),
+                    ValueRef::CloneUnique(effects_group.Activation()),
+                    ValueRef::CloneUnique(effects_group.Effects()),
+                    effects_group.AccountingLabel(),
+                    effects_group.StackingGroup(),
+                    effects_group.Priority(),
+                    effects_group.GetDescription(),
+                    effects_group.TopLevelContent()
+                ));
+            }
         }
 
         std::set<std::string> prerequisites;

--- a/parse/ValueRefPythonParser.h
+++ b/parse/ValueRefPythonParser.h
@@ -21,8 +21,7 @@ struct value_ref_wrapper {
     {}
 
     value_ref_wrapper<T> call(const value_ref_wrapper<T>& var_) const {
-        std::shared_ptr<ValueRef::Variable<T>> var =
-            std::dynamic_pointer_cast<ValueRef::Variable<T>>(var_.value_ref);
+        auto var = std::dynamic_pointer_cast<const ValueRef::Variable<T>>(var_.value_ref);
         if (var) {
             return value_ref_wrapper<T>(std::make_shared<ValueRef::Variable<T>>(
                                             var->GetReferenceType(),
@@ -37,8 +36,7 @@ struct value_ref_wrapper {
     }
 
     operator condition_wrapper() const {
-        std::shared_ptr<ValueRef::Operation<T>> op =
-            std::dynamic_pointer_cast<ValueRef::Operation<T>>(value_ref);
+        auto op = std::dynamic_pointer_cast<const ValueRef::Operation<T>>(value_ref);
 
         if (op && op->LHS() && op->RHS()) {
             Condition::ComparisonType cmp_type;
@@ -73,7 +71,7 @@ struct value_ref_wrapper {
         }
     }
 
-    std::shared_ptr<ValueRef::ValueRef<T>> value_ref;
+    const std::shared_ptr<const ValueRef::ValueRef<T>> value_ref;
 };
 
 value_ref_wrapper<double> pow(const value_ref_wrapper<double>& lhs, double rhs);

--- a/universe/ValueRef.h
+++ b/universe/ValueRef.h
@@ -163,15 +163,15 @@ FO_ENUM(
 )
 
 template<typename T>
-[[nodiscard]] inline std::unique_ptr<T> CloneUnique(const T* ptr)
+[[nodiscard]] inline std::unique_ptr<std::remove_const_t<T>> CloneUnique(const T* ptr)
 { return ptr ? ptr->Clone() : nullptr; }
 
 template<typename T>
-[[nodiscard]] inline std::unique_ptr<T> CloneUnique(const std::unique_ptr<T>& ptr)
+[[nodiscard]] inline std::unique_ptr<std::remove_const_t<T>> CloneUnique(const std::unique_ptr<T>& ptr)
 { return ptr ? ptr->Clone() : nullptr; }
 
 template<typename T>
-[[nodiscard]] inline std::unique_ptr<T> CloneUnique(const std::shared_ptr<T>& ptr)
+[[nodiscard]] inline std::unique_ptr<std::remove_const_t<T>> CloneUnique(const std::shared_ptr<T>& ptr)
 { return ptr ? ptr->Clone() : nullptr; }
 
 template<typename T>


### PR DESCRIPTION
Prevents moving out values stored in Python.