### PR TITLE
Use sub-interpeters to isolate Python FOCS parser context

### DIFF
--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -138,7 +138,7 @@ void AIClientApp::Run() {
         // Start parsing content
         std::promise<void> barrier;
         std::future<void> barrier_future = barrier.get_future();
-        StartBackgroundParsing(PythonParser(*m_AI, GetResourceDir() / "scripting", false), std::move(barrier));
+        StartBackgroundParsing(PythonParser(*m_AI, GetResourceDir() / "scripting"), std::move(barrier));
         barrier_future.wait();
 
         // Import python main module only after game content has been parsed, allowing

--- a/client/godot/GodotClientApp.cpp
+++ b/client/godot/GodotClientApp.cpp
@@ -79,7 +79,7 @@ GodotClientApp::GodotClientApp() {
         DebugLogger() << "Started background parser thread";
         PythonCommon python;
         python.Initialize();
-        StartBackgroundParsing(PythonParser(python, GetResourceDir() / "scripting", false), std::move(b));
+        StartBackgroundParsing(PythonParser(python, GetResourceDir() / "scripting"), std::move(b));
     }, std::move(barrier));
     background.detach();
     barrier_future.wait();

--- a/client/human/GGHumanClientApp.cpp
+++ b/client/human/GGHumanClientApp.cpp
@@ -363,7 +363,7 @@ GGHumanClientApp::GGHumanClientApp(int width, int height, bool calculate_fps, st
         DebugLogger() << "Started background parser thread";
         PythonCommon python;
         python.Initialize();
-        StartBackgroundParsing(PythonParser(python, GetResourceDir() / "scripting", false), std::move(b));
+        StartBackgroundParsing(PythonParser(python, GetResourceDir() / "scripting"), std::move(b));
     }, std::move(barrier));
     background.detach();
     barrier_future.wait();
@@ -1612,7 +1612,7 @@ void GGHumanClientApp::HandleResoureDirChange() {
             DebugLogger() << "Started background parser thread";
             PythonCommon python;
             python.Initialize();
-            StartBackgroundParsing(PythonParser(python, GetResourceDir() / "scripting", false), std::move(b));
+            StartBackgroundParsing(PythonParser(python, GetResourceDir() / "scripting"), std::move(b));
         }, std::move(barrier));
         background.detach();
         barrier_future.wait();

--- a/parse/DummyParsers.cpp
+++ b/parse/DummyParsers.cpp
@@ -87,10 +87,9 @@ template FO_PARSE_API TechManager::TechParseTuple parse::techs<TechManager::Tech
 
 template FO_PARSE_API std::vector<Policy> parse::policies<std::vector<Policy>>(const boost::filesystem::path& path);
 
-PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path& scripting_dir, bool clean_modules) :
+PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path& scripting_dir) :
     m_python(_python),
-    m_scripting_dir(scripting_dir),
-    m_clean_modules(clean_modules)
+    m_scripting_dir(scripting_dir)
 { }
 
 PythonParser::~PythonParser() = default;

--- a/parse/PythonParser.cpp
+++ b/parse/PythonParser.cpp
@@ -55,10 +55,9 @@ struct module_spec {
     const PythonParser& parser;
 };
 
-PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path& scripting_dir, bool clean_modules) :
+PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path& scripting_dir) :
     m_python(_python),
-    m_scripting_dir(scripting_dir),
-    m_clean_modules(clean_modules)
+    m_scripting_dir(scripting_dir)
 {
     if (!m_python.IsPythonRunning()) {
         ErrorLogger() << "Python parse given non-initialized python!";
@@ -289,7 +288,6 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
         m_meta_path = py::extract<py::list>(py::import("sys").attr("meta_path"));
         m_meta_path.append(boost::cref(*this));
 
-        m_modules = py::extract<py::dict>(py::import("sys").attr("modules"))().copy();
     } catch (const boost::python::error_already_set&) {
         m_python.HandleErrorAlreadySet();
         if (!m_python.IsPythonRunning()) {
@@ -309,9 +307,6 @@ PythonParser::~PythonParser() {
         m_meta_path.pop(py::len(m_meta_path) - 1);
         // ToDo: ensure type of removed parser
         // ToDo: clean up sys.modules
-        if (m_clean_modules) {
-            py::import("sys").attr("modules") = m_modules;
-        }
     } catch (const py::error_already_set&) {
         ErrorLogger() << "Python parser destructor throw exception";
         m_python.HandleErrorAlreadySet();

--- a/parse/PythonParser.h
+++ b/parse/PythonParser.h
@@ -41,6 +41,8 @@ private:
     PythonCommon&                  m_python;
     const boost::filesystem::path& m_scripting_dir;
     boost::python::list            m_meta_path;
+    PyThreadState*                 m_parser_thread_state = nullptr;
+    PyThreadState*                 m_main_thread_state = nullptr;
 };
 
 #endif

--- a/parse/PythonParser.h
+++ b/parse/PythonParser.h
@@ -14,7 +14,7 @@ struct module_spec;
 
 class FO_PARSE_API PythonParser {
 public:
-    PythonParser(PythonCommon& _python, const boost::filesystem::path& scripting_dir, bool clean_modules);
+    PythonParser(PythonCommon& _python, const boost::filesystem::path& scripting_dir);
     ~PythonParser();
 
     PythonParser(const PythonParser&) = delete;
@@ -40,9 +40,7 @@ private:
 
     PythonCommon&                  m_python;
     const boost::filesystem::path& m_scripting_dir;
-    const bool                     m_clean_modules;
     boost::python::list            m_meta_path;
-    boost::python::dict            m_modules;
 };
 
 #endif

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -130,7 +130,7 @@ ServerApp::ServerApp() :
     // to have data initialized before autostart execution
     std::promise<void> barrier;
     std::future<void> barrier_future = barrier.get_future();
-    StartBackgroundParsing(PythonParser(m_python_server, GetResourceDir() / "scripting", false), std::move(barrier));
+    StartBackgroundParsing(PythonParser(m_python_server, GetResourceDir() / "scripting"), std::move(barrier));
     barrier_future.wait();
 
     m_fsm->initiate();

--- a/test/parse/TestPythonParser.cpp
+++ b/test/parse/TestPythonParser.cpp
@@ -26,7 +26,7 @@ namespace {
 BOOST_FIXTURE_TEST_SUITE(TestPythonParser, ParserAppFixture)
 
 BOOST_AUTO_TEST_CASE(parse_game_rules) {
-    PythonParser parser(m_python, m_scripting_dir, true);
+    PythonParser parser(m_python, m_scripting_dir);
 
     auto game_rules_p = Pending::ParseSynchronously(parse::game_rules, parser,  m_scripting_dir / "game_rules.focs.py");
     auto game_rules = *Pending::WaitForPendingUnlocked(std::move(game_rules_p));
@@ -36,7 +36,7 @@ BOOST_AUTO_TEST_CASE(parse_game_rules) {
 }
 
 BOOST_AUTO_TEST_CASE(parse_techs) {
-    PythonParser parser(m_python, m_scripting_dir, true);
+    PythonParser parser(m_python, m_scripting_dir);
 
     auto techs_p = Pending::ParseSynchronously(parse::techs<TechManager::TechParseTuple>, parser, m_scripting_dir / "techs");
     auto [techs, tech_categories, categories_seen] = *Pending::WaitForPendingUnlocked(std::move(techs_p));
@@ -207,7 +207,7 @@ BOOST_AUTO_TEST_CASE(parse_techs) {
 }
 
 BOOST_AUTO_TEST_CASE(parse_species) {
-    PythonParser parser(m_python, m_scripting_dir, true);
+    PythonParser parser(m_python, m_scripting_dir);
 
     auto species_p = Pending::ParseSynchronously(parse::species, parser, m_scripting_dir / "species");
     const auto [species_map, ordering] = *Pending::WaitForPendingUnlocked(std::move(species_p));
@@ -434,7 +434,7 @@ BOOST_AUTO_TEST_CASE(parse_techs_full) {
     BOOST_REQUIRE(boost::filesystem::exists(scripting_dir));
     BOOST_REQUIRE(boost::filesystem::is_directory(scripting_dir));
 
-    PythonParser parser(m_python, scripting_dir, true);
+    PythonParser parser(m_python, scripting_dir);
 
     auto named_values = Pending::ParseSynchronously(parse::named_value_refs, scripting_dir / "common");
 
@@ -477,7 +477,7 @@ BOOST_AUTO_TEST_CASE(parse_species_full) {
     BOOST_REQUIRE(boost::filesystem::exists(scripting_dir));
     BOOST_REQUIRE(boost::filesystem::is_directory(scripting_dir));
 
-    PythonParser parser(m_python, scripting_dir, true);
+    PythonParser parser(m_python, scripting_dir);
 
     auto named_values = Pending::ParseSynchronously(parse::named_value_refs, scripting_dir / "common");
 

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -52,7 +52,7 @@ ClientAppFixture::ClientAppFixture() :
         DebugLogger() << "Started background parser thread";
         PythonCommon python;
         python.Initialize();
-        StartBackgroundParsing(PythonParser(python, GetResourceDir() / "scripting", false), std::move(b));
+        StartBackgroundParsing(PythonParser(python, GetResourceDir() / "scripting"), std::move(b));
     }, std::move(barrier));
     background.detach();
     barrier_future.wait();


### PR DESCRIPTION
Solves issue with modules loaded by Python FOCS parser by isolating them in sub-interpreter.

It could be used later to parse content in parallel to main python scripts of the server and AI.

Would be nice to test on MacOS as we don't have unit tests working.