### PR TITLE
Move pre-commit instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,13 +59,43 @@ To ensure your PR won't be rejected, please make sure that:
 To build FreeOrion please refer to the [Build Instructions](BUILD.md).
 
 
+Installing pre-commit hooks (optional)
+--------------------------------------
+Pre-commit hook is a good way to get feedback fast.
+Hooks implement a subset of checks that run on the CI, so it will jus save your time.
+
+Hooks work on all operating systems.
+You need to install them once, pre-commit will track config file and update itself in case of changes.
+
+- install git
+- install Python
+- [Install pre-commit](https://pre-commit.com/#install)
+   ```shell
+    pip install pre-commit
+    ```
+- install hooks from the project root
+    ```sh
+    pre-commit install
+    ```
+
+Notes:
+- Hooks might change your files, you will need to add (`git add`) changes to commit.
+- First commit after installation/update of hooks may take some time for installing tools.
+- You can skip checks by adding `-n, --no-verify` to `git commit`. This is useful when you commit partial done job.
+
+When you commit, hooks are run only on the changed files, if you want to run an all files:
+```shell
+pre-commit run --all-files
+```
+
+
 Further documentation
 ---------------------
 
 There are further specialized documents available that should be considered
 when working within the FreeOrion project.  Those are:
 
-* [GitHub Issue/PR Labels] - How to properly label Issues/PRs on Github.
+* [GitHub Issue/PR Labels] - How to properly label Issues/PRs on GitHub.
 * [Release Issue template] - Template for release checklist Issues.
 
 

--- a/default/python/README.md
+++ b/default/python/README.md
@@ -55,37 +55,12 @@ Add `default\python\` as content root.
 pip install -r default\python\requirements-dev.txt
 ```
 
-### Automate check with pre commit hooks
-Git could run a script
-([hook](https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks)) 
-when you commit changes.  
-
-This feature could be used as duplication of the CI actions.
-The main difference are that hooks are optional 
-(a developer made a decision if they should be run) 
-and that hooks gives you feedback much faster 
-because they are run on developer machine.
-
-Hooks work on all operating systems.
-You need to install them once.
-Hook will track config file and update itself in case of changes. 
-
-- install git
-- install Python
-- [Install pre-commit](https://pre-commit.com/#install) 
-    ```sh
-    pip install pre-commit
-    ```
-- install hooks from the project root
-    ```sh
-    pre-commit install 
-    ```
-
-Notes:
-- First commit after installation/update of hooks may take some time.
-- You can skip checks by adding `-n, --no-verify` to `git commit`.
 
 ## Developers routine
+
+### It's recommended to install pre-commit hooks, see: [CONTRIBUTING.md](CONTRIBUTING.md)
+
+
 ### Manual code style check
 You don't need to run this script manually, pre-commit hooks and CI will do it fo you.
 


### PR DESCRIPTION
Move pre-commit instructions from the AI folder to the root.  

Pre-commit is a nice tool that is really helpful.  After I adopted it, I almost stopped to run linters manually. 
This tool could be beneficial not only for the Python developers but other code could be processed as well.

If you know a tool that is popular, it probably already has hooks created, so you'll need a couple of lines to enable it.  
If we use any C++ tools, we could take a look if we could integrate them.
 
@o01eg @geoffthemedio @Vezzra 

