### PR TITLE
Add build limit

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -24,6 +24,7 @@ on:
 
 jobs:
   build-docker:
+    timeout-minutes: 45
     name: Docker ${{ matrix.image }}
     runs-on: ubuntu-latest
     strategy:


### PR DESCRIPTION
Add time limit for Dockerised builds. 

I take the last successful build and add +10 minutes to the max build time. https://github.com/freeorion/freeorion/actions/runs/4567980309/jobs/8062459458

Initially the problem was that the job failed on default timeout: 
https://github.com/freeorion/freeorion/actions/runs/4579157041/jobs/8086619851

> The job running on runner GitHub Actions 10 has exceeded the maximum execution time of 360 minutes.


Not sure what was happen.  Maybe this is some problem with the latest base image or maybe some GitHub things. Anyway having shorter limits will help us keep things under control.

```
Run docker run -v "$(pwd):/freeorion" -v "/home/runner/work/_temp/ccache:/ccache_dir" -e CCACHE_DIR='/ccache_dir' -w /freeorion/build freeorion/freeorion:c26f772 /usr/bin/xvfb-run /freeorion/build/godot --no-window --disable-render-loop --video-driver GLES2 --gdnative-generate-json-api /freeorion/build/godot-api.json
libfontconfig.so.1: cannot open shared object file: No such file or directory
Godot Engine v4.0.1.stable.arch_linux - https://godotengine.org/
libxkbcommon.so.0: cannot open shared object file: No such file or directory
OpenGL API 4.5 (Core Profile) Mesa 23.0.1 - Compatibility - Using Device: Mesa - llvmpipe (LLVM 15.0.7, 256 bits)
libasound.so.2: cannot open shared object file: No such file or directory
libpulse.so.0: cannot open shared object file: No such file or directory
libpulse.so.0: cannot open shared object file: No such file or directory
libasound.so.2: cannot open shared object file: No such file or directory
WARNING: All audio drivers failed, falling back to the dummy driver.
     at: initialize (servers/audio_server.cpp:218)
```