### PR TITLE
packaging: Update releases in appdata metainfo

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -51,7 +51,8 @@ doing the actual release.
 * [ ] Create a new GitHub Issue from `.github/RELEASE_TEMPLATE.md` and follow
       instructions. :wink:
 * [ ] Determine initial milestones and dates for release.
-* [ ] Update `packaging/org.freeorion.FreeOrion.metainfo.xml` and linked screenshots if necessary
+* [ ] Add the new release in `packaging/org.freeorion.FreeOrion.metainfo.xml`
+* [ ] Update the screenshots in `packaging/org.freeorion.FreeOrion.metainfo.xml` if necessary
 * [ ] Create release branch from development branch master by using:
 ```
 git checkout -b release-vX.Y.Z master
@@ -105,7 +106,7 @@ git tag --annotate --message="X.Y.Z Stable Release"  vX.Y.Z
 
 #### Cleanup
 
-* [ ] Cherry-pick updates of `ChangeLog.md` to master. 
+* [ ] Cherry-pick updates of `ChangeLog.md` to master.
 * [ ] Prune release candidate tags.
 * [ ] Prune release branch.
 

--- a/packaging/org.freeorion.FreeOrion.metainfo.xml
+++ b/packaging/org.freeorion.FreeOrion.metainfo.xml
@@ -39,6 +39,9 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="0.5" date="2023-04-02"/>
+    <release version="0.4.10.2" date="2021-08-15"/>
+    <release version="0.4.10.1" date="2020-09-13"/>
     <release version="0.4.10" date="2020-07-26"/>
     <release version="0.4.9" date="2020-02-09"/>
     <release version="0.4.8" date="2018-08-30"/>


### PR DESCRIPTION
packaging: Update releases in appdata metainfo

---

github/ISSUE_TEMPLATE/release: Clarify metadata release update

Clarify that new releases have to be added to the metadata independently
of screenshots updates.