### PR TITLE
Fix Ship Part Meter Serialization and Add Sitrep

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -7789,6 +7789,12 @@ Ship %ship% failed to establish a colony or outpost on %planet% because the %emp
 SITREP_PLANET_ESTABLISH_FAILED_ARMED_LABEL
 Ship Failed to Esablish on Planet
 
+SITREP_PLANET_ESTABLISH_FAILED_NEUTRAL_ARMED
+Ship %ship% failed to establish a colony or outpost on %planet% because there are neutral armed ships in system.
+
+SITREP_PLANET_ESTABLISH_FAILED_ARMED_NEUTRAL_LABEL
+Ship Failed to Esablish on Planet
+
 SITREP_OUTPOST_ABANDONED_PREPARATION
 Outpost on %planet% prepares to be abandoned in turn %rawtext%.
 

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -589,6 +589,7 @@ namespace {
             std::string part_name{next, part_name_end_it};
             if (part_name.empty())
                 return;
+            next = part_name_end_it;
 
             // skip whitespace
             while (std::distance(next, buffer_end) > 0 && *next == ' ')
@@ -617,7 +618,8 @@ namespace {
 
                 // get meter values
                 Meter meter;
-                const auto consumed = meter.SetFromChars(std::string_view(next, std::distance(next, buffer_end)));
+                const std::string_view meter_view(next, std::distance(next, buffer_end));
+                const auto consumed = meter.SetFromChars(meter_view);
                 if (consumed < 1)
                     return;
                 next += consumed;

--- a/util/SitRepEntry.cpp
+++ b/util/SitRepEntry.cpp
@@ -424,15 +424,27 @@ SitRepEntry CreatePlanetEstablishFailedVisibleOtherSitRep(int planet_id, int shi
 SitRepEntry CreatePlanetEstablishFailedArmedSitRep(int planet_id, int ship_id, int other_empire_id,
                                                    int current_turn)
 {
-    SitRepEntry sitrep(
-        UserStringNop("SITREP_PLANET_ESTABLISH_FAILED_ARMED"),
-        current_turn + 1,
-        "icons/sitrep/planet_colonized.png",
-        UserStringNop("SITREP_PLANET_ESTABLISH_FAILED_ARMED_LABEL"), true);
-    sitrep.AddVariable(VarText::PLANET_ID_TAG,     std::to_string(planet_id));
-    sitrep.AddVariable(VarText::SHIP_ID_TAG,       std::to_string(ship_id));
-    sitrep.AddVariable(VarText::EMPIRE_ID_TAG,     std::to_string(other_empire_id));
-    return sitrep;
+    if (other_empire_id == ALL_EMPIRES) {
+        SitRepEntry sitrep(
+            UserStringNop("SITREP_PLANET_ESTABLISH_FAILED_NEUTRAL_ARMED"),
+            current_turn + 1,
+            "icons/sitrep/planet_colonized.png",
+            UserStringNop("SITREP_PLANET_ESTABLISH_FAILED_ARMED_NEUTRAL_LABEL"), true);
+        sitrep.AddVariable(VarText::PLANET_ID_TAG,     std::to_string(planet_id));
+        sitrep.AddVariable(VarText::SHIP_ID_TAG,       std::to_string(ship_id));
+        return sitrep;
+
+    } else {
+        SitRepEntry sitrep(
+            UserStringNop("SITREP_PLANET_ESTABLISH_FAILED_ARMED"),
+            current_turn + 1,
+            "icons/sitrep/planet_colonized.png",
+            UserStringNop("SITREP_PLANET_ESTABLISH_FAILED_ARMED_LABEL"), true);
+        sitrep.AddVariable(VarText::PLANET_ID_TAG,     std::to_string(planet_id));
+        sitrep.AddVariable(VarText::SHIP_ID_TAG,       std::to_string(ship_id));
+        sitrep.AddVariable(VarText::EMPIRE_ID_TAG,     std::to_string(other_empire_id));
+        return sitrep;
+    }
 }
 
 SitRepEntry CreatePlanetGiftedSitRep(int planet_id, int empire_id, int current_turn) {


### PR DESCRIPTION
-fixes ship part meter deserialization from XML
-adds a variant of the colonization failed sitrep for a neutral armed ship