### PR TITLE
Ensure only SDK's Python used on Windows CI

### DIFF
--- a/.github/actions/cmake-build/action.yml
+++ b/.github/actions/cmake-build/action.yml
@@ -32,6 +32,7 @@ runs:
     - name: Configure
       shell: pwsh
       run: |
+        Remove-Item -LiteralPath "C:/hostedtoolcache/windows/Python/" -Force -Recurse # Ensure that system Python is not used
         unzip -q ../${{ steps.download-sdk.outputs.filename }} -d ..
         mkdir build
         pushd build

--- a/.github/workflows/build-windows-msvs.yml
+++ b/.github/workflows/build-windows-msvs.yml
@@ -41,6 +41,7 @@ jobs:
             vs-prerelease: true
       - name: Prepare
         run: |
+          Remove-Item -LiteralPath "C:/hostedtoolcache/windows/Python/" -Force -Recurse # Ensure that system Python is not used
           unzip -q ../${{ steps.download-sdk.outputs.filename }} -d ..
           cp ../bin/* ./
       - name: Build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -717,6 +717,7 @@ if(BUILD_CLIENT_GODOT)
                 -D CMAKE_CONFIGURATION_TYPES=${GODOT_CPP_BUILD_TYPE}
                 -D CMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
                 -D PYTHON_EXECUTABLE=${PYTHON_EXECUTABLE}
+                -D Python3_EXECUTABLE=${PYTHON_EXECUTABLE}
                 ${CL_ARGS}
             INSTALL_COMMAND ""
         )


### PR DESCRIPTION
While I tested SDK update sometimes Github Actions CI chooses incorrect Python so I deleted pre-installed ones. I also fixed godot-cpp project parameters to use same Python version.