### PR TITLE
Move artefact generation to the cmake-2022

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -41,6 +41,18 @@ jobs:
         run: bash .github/pre-deploy.sh
         env:
           DEPLOY_SSH_PASSWORD: ${{ secrets.DEPLOY_SSH_PASSWORD }}
+  build-windows-2022-cmake:
+    name: MSVS 2022 on Windows CMake
+    runs-on: windows-2022
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v3
+      - name: Build with CMake 2022
+        uses: ./.github/actions/cmake-build
+        with:
+          mvc: '2022'
+          generator-name: 'Visual Studio 17 2022'
+          toolset-spec: 'v143'
       - name: Generate binaries only
         run: |
           pushd build
@@ -55,15 +67,3 @@ jobs:
           name: freeorion-binaries-win32-build-${{ github.run_number }}
           path: build/FreeOrion_*.zip
           retention-days: 7
-  build-windows-2022-cmake:
-    name: MSVS 2022 on Windows CMake
-    runs-on: windows-2022
-    steps:
-      - name: Checkout sources
-        uses: actions/checkout@v3
-      - name: Build with CMake 2022
-        uses: ./.github/actions/cmake-build
-        with:
-          mvc: '2022'
-          generator-name: 'Visual Studio 17 2022'
-          toolset-spec: 'v143'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -36,11 +36,6 @@ jobs:
           mvc: '2019'
           generator-name: 'Visual Studio 16 2019'
           toolset-spec: 'v142'
-      - name: Decrypt deploy SSH key
-        if: github.ref == 'refs/heads/weekly-test-builds' && github.event_name == 'push'
-        run: bash .github/pre-deploy.sh
-        env:
-          DEPLOY_SSH_PASSWORD: ${{ secrets.DEPLOY_SSH_PASSWORD }}
   build-windows-2022-cmake:
     name: MSVS 2022 on Windows CMake
     runs-on: windows-2022
@@ -53,6 +48,11 @@ jobs:
           mvc: '2022'
           generator-name: 'Visual Studio 17 2022'
           toolset-spec: 'v143'
+      - name: Decrypt deploy SSH key
+        if: github.ref == 'refs/heads/weekly-test-builds' && github.event_name == 'push'
+        run: bash .github/pre-deploy.sh
+        env:
+          DEPLOY_SSH_PASSWORD: ${{ secrets.DEPLOY_SSH_PASSWORD }}
       - name: Generate binaries only
         run: |
           pushd build


### PR DESCRIPTION
I move the section that builds binaries from 2019 to 2020.

At some point, we will decide to remove 2019 and this change will make it easier. 

FYI: @o01eg @geoffthemedio

PS. If you use `unified` diff view it's look vired, please use `split`.
![изображение](https://user-images.githubusercontent.com/171597/232197838-b477cf0a-49f2-4c6f-af7a-d65b317afff3.png)
