### PR TITLE
Run CI build only to push into specific branches

### DIFF
--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -15,6 +15,7 @@ on:
       - 'test-scripting/**'
   pull_request:
     branches: [ 'master' ]
+    types: ['opened', 'reopened', 'synchronize']
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'

--- a/.github/workflows/build-android.yml
+++ b/.github/workflows/build-android.yml
@@ -2,6 +2,7 @@ name: "Android build"
 
 on:
   push:
+    branches: [ 'master' ]
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'
@@ -13,6 +14,7 @@ on:
       - 'default/**'
       - 'test-scripting/**'
   pull_request:
+    branches: [ 'master' ]
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -15,6 +15,7 @@ on:
       - 'test-scripting/**'
   pull_request:
     branches: [ 'master' ]
+    types: ['opened', 'reopened', 'synchronize']
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'

--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -2,6 +2,7 @@ name: "Dockerized Linux"
 
 on:
   push:
+    branches: [ 'master' ]
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'
@@ -13,6 +14,7 @@ on:
       - 'default/**'
       - 'test-scripting/**'
   pull_request:
+    branches: [ 'master' ]
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -2,6 +2,7 @@ name: "MacOS"
 
 on:
   push:
+    branches: [ 'master', 'weekly-test-builds' ]
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'
@@ -13,6 +14,7 @@ on:
       - 'default/**'
       - 'test-scripting/**'
   pull_request:
+    branches: [ 'master' ]
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -15,6 +15,7 @@ on:
       - 'test-scripting/**'
   pull_request:
     branches: [ 'master' ]
+    types: ['opened', 'reopened', 'synchronize']
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -2,6 +2,7 @@ name: "Ubuntu"
 
 on:
   push:
+    branches: [ 'master' ]
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'
@@ -13,6 +14,7 @@ on:
       - 'default/**'
       - 'test-scripting/**'
   pull_request:
+    branches: [ 'master' ]
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -15,6 +15,7 @@ on:
       - 'test-scripting/**'
   pull_request:
     branches: [ 'master' ]
+    types: ['opened', 'reopened', 'synchronize']
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'

--- a/.github/workflows/build-windows-msvs.yml
+++ b/.github/workflows/build-windows-msvs.yml
@@ -14,6 +14,7 @@ on:
       - 'test-scripting/**'
   pull_request:
     branches: [ 'master' ]
+    types: ['opened', 'reopened', 'synchronize']
     paths-ignore:
       - 'check/**'
       - 'doc/**'

--- a/.github/workflows/build-windows-msvs.yml
+++ b/.github/workflows/build-windows-msvs.yml
@@ -2,6 +2,7 @@ name: "Windows MS VS build"
 
 on:
   push:
+    branches: [ 'master', 'weekly-test-builds']
     paths-ignore:
       - 'check/**'
       - 'doc/**'
@@ -12,6 +13,7 @@ on:
       - 'default/**'
       - 'test-scripting/**'
   pull_request:
+    branches: [ 'master' ]
     paths-ignore:
       - 'check/**'
       - 'doc/**'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -2,6 +2,7 @@ name: "Windows build"
 
 on:
   push:
+    branches: [ 'master', 'weekly-test-builds' ]
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'
@@ -13,6 +14,7 @@ on:
       - 'default/**'
       - 'test-scripting/**'
   pull_request:
+    branches: [ 'master' ]
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -15,6 +15,7 @@ on:
       - 'test-scripting/**'
   pull_request:
     branches: [ 'master' ]
+    types: ['opened', 'reopened', 'synchronize']
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,10 +2,9 @@ name: "CodeQL C++"
 
 on:
   push:
-    branches: [ master ]
+    branches: [ 'master' ]
   pull_request:
-    # The branches below must be a subset of the branches above
-    branches: [ master ]
+    branches: [ 'master' ]
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,7 @@ on:
     branches: [ 'master' ]
   pull_request:
     branches: [ 'master' ]
+    types: ['opened', 'reopened', 'synchronize']
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'

--- a/.github/workflows/godot-check.yml
+++ b/.github/workflows/godot-check.yml
@@ -2,9 +2,11 @@ name: GDScript linters and formatting
 
 on:
   push:
+    branches: [ 'master' ]
     paths:
       - 'godot/**.gd'
   pull_request:
+    branches: [ 'master' ]
     paths:
       - 'godot/**.gd'
 

--- a/.github/workflows/godot-check.yml
+++ b/.github/workflows/godot-check.yml
@@ -7,6 +7,7 @@ on:
       - 'godot/**.gd'
   pull_request:
     branches: [ 'master' ]
+    types: ['opened', 'reopened', 'synchronize']
     paths:
       - 'godot/**.gd'
 

--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -1,6 +1,7 @@
 name: AI linters and tests
 on:
   pull_request:
+    branches: [ 'master' ]
     types: ['opened', 'reopened', 'synchronize']
     paths:
       - '.github/**'

--- a/.github/workflows/python-check.yml
+++ b/.github/workflows/python-check.yml
@@ -1,17 +1,13 @@
 name: AI linters and tests
 on:
   pull_request:
+    types: ['opened', 'reopened', 'synchronize']
     paths:
       - '.github/**'
       - 'check/st-tool.py'
       - 'default/python/**'
       - 'default/scripting/**'
       - 'test-scripting/**'
-    types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/snapcraft.yml
+++ b/.github/workflows/snapcraft.yml
@@ -14,6 +14,7 @@ on:
       - 'test-scripting/**'
   pull_request:
     branches: [ 'master' ]
+    types: ['opened', 'reopened', 'synchronize']
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'

--- a/.github/workflows/snapcraft.yml
+++ b/.github/workflows/snapcraft.yml
@@ -2,6 +2,7 @@ name: "Snapcraft build"
 
 on:
   push:
+    branches: [ 'master' ]
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'
@@ -12,6 +13,7 @@ on:
       - 'default/**'
       - 'test-scripting/**'
   pull_request:
+    branches: [ 'master' ]
     paths-ignore:
       - 'msvc*/**'
       - 'check/**'

--- a/.github/workflows/string-tables-check.yml
+++ b/.github/workflows/string-tables-check.yml
@@ -1,15 +1,12 @@
 name: String tables checks
 on:
   pull_request:
+    types: ['opened', 'reopened', 'synchronize']
     paths:
       - '.github/**'
       - 'check/st-tool.py'
       - 'default/stringtables/**'
-    types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
+
 jobs:
   lint-string-tables:
     runs-on: ubuntu-latest

--- a/.github/workflows/string-tables-check.yml
+++ b/.github/workflows/string-tables-check.yml
@@ -1,6 +1,7 @@
 name: String tables checks
 on:
   pull_request:
+    branches: [ 'master' ]
     types: ['opened', 'reopened', 'synchronize']
     paths:
       - '.github/**'


### PR DESCRIPTION
@o01eg , could you review, please? Please estimate possible conflicts with your other changes on CI,  this branch should have the least priority, I could rebase or wait until something will be merged.
@geoffthemedio , as I recall you have some personal workflow, so this might break something for you. Workflow is pretty flexible, so I could adapt it to your needs.
@Vezzra , I don't expect any input from you but want to keep you in the loop. For example, you could just add a smile to this description, that you have seen it.


This PR is reducing the number of events that trigger CI.

Reasons to do it:
- Reduce the number of queued builds, since we have a limited number of simultaneous workers when exceeding jobs will be queued. This will slow down overall check time.
- Reduce the GitHub of resources Freeorion consumes
- Reduce carbon footprint

Change log:
- Workflows that runs on push are triggered only for `master` and sometimes `weekly-test-builds` if it's mentioned in the workflow
- Workflow with heavy jobs is triggered on pull-request only when it targets to master
- Reduce the number of events that trigger the workflow
  - [opened][opened]
  - [reopened][reopened]
  - [synchronize][synchronize]


[opened]: https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=opened#pull_request
[reopened]: https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=reopened#pull_request
[synchronize]: https://docs.github.com/en/webhooks-and-events/webhooks/webhook-events-and-payloads?actionType=synchronize#pull_request



