### PR TITLE
[stringtables] Fix DESC_METER_VALUE_CURRENT_MIN and _MAX entries

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -11680,7 +11680,7 @@ DESC_METER_VALUE_CURRENT_MIN
 # %1% name of the meter.
 # %2% textual description of the lower limit for the meter value.
 DESC_METER_VALUE_CURRENT_MIN_NOT
-''' that has %1% more than %2%'''
+''' that has %1% less than %2%'''
 
 # %1% name of the meter.
 # %2% textual description of the upper limit for the meter value.
@@ -11690,7 +11690,7 @@ DESC_METER_VALUE_CURRENT_MAX
 # %1% name of the meter.
 # %2% textual description of the upper limit for the meter value.
 DESC_METER_VALUE_CURRENT_MAX_NOT
-''' that has %1% less than %2%'''
+''' that has %1% of more than %2%'''
 
 # %1% name of the ship meter.
 # %2% textual description of the ship part.


### PR DESCRIPTION
The targeting condition description was wrong and found the not-versions were non-sensical. The not-version should match the objects which did not match the normal version. So the union of both matches should be all candidates. And the intersection of both matches should be the empty set.

now:
DESC_METER_VALUE_CURRENT
''' that has %1% between %2% and %3%'''
DESC_METER_VALUE_CURRENT_NOT
''' that doesn't have a %1% between %2% and %3%'''

DESC_METER_VALUE_CURRENT_MIN
''' that has %1% of at least %2%'''
DESC_METER_VALUE_CURRENT_MIN_NOT
''' that has %1% less than %2%'''

DESC_METER_VALUE_CURRENT_MAX
''' that has %1% of at most %2%'''
DESC_METER_VALUE_CURRENT_MAX_NOT
''' that has %1% of more than %2%'''

DESC_SHIP_PART_METER_VALUE_CURRENT
''' that has %2% %1% between %3% and %4%'''
DESC_SHIP_PART_METER_VALUE_CURRENT_NOT
''' that doesn't have %2% %1% between %3% and %4%'''