### PR TITLE
Fix estimated monster fighter damage by introducing DUMMY_EVIL_EMPIRE id

### DIFF
--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -612,7 +612,7 @@ namespace {
     ////////////////////////////////////////////////
     // ShipDataPanel
     ////////////////////////////////////////////////
-    /** Shows info about a single ship. */
+    /** Shows stats of a single ship. Used in ShipRows in the FleetWnd to show ships of a fleet. */
     class ShipDataPanel : public GG::Control {
     public:
         ShipDataPanel(GG::X w, GG::Y h, int ship_id);

--- a/combat/CombatDamage.cpp
+++ b/combat/CombatDamage.cpp
@@ -128,9 +128,9 @@ namespace {
         // use the given design and species as default enemy.
         std::shared_ptr<Ship> target;
         try {
-            target = std::make_shared<Ship>(ALL_EMPIRES, template_ship->DesignID(),
+            target = std::make_shared<Ship>(DUMMY_EVIL_EMPIRE, template_ship->DesignID(),
                                             template_ship->SpeciesName(), context.ContextUniverse(),
-                                            context.species, ALL_EMPIRES, context.current_turn);
+                                            context.species, DUMMY_EVIL_EMPIRE, context.current_turn);
         } catch (...) {
             ErrorLogger() << "Couldn't create temporary ship from template ship: " << template_ship->Dump();
             return nullptr;
@@ -150,7 +150,7 @@ namespace {
                                    const ScriptingContext& context)
     {
         static constexpr auto combat_targets = nullptr;
-        auto target = std::make_shared<Fighter>(ALL_EMPIRES, template_ship->ID(),
+        auto target = std::make_shared<Fighter>(DUMMY_EVIL_EMPIRE, template_ship->ID(),
                                                 template_ship->SpeciesName(), 1.0f, combat_targets);
         target->SetID(TEMPORARY_OBJECT_ID);
         return target;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1219,6 +1219,8 @@ namespace {
                     return true;
                 if (m_empire_id == candidate->Owner())
                     return false;
+                if (candidate->Owner() == DUMMY_EVIL_EMPIRE)
+                    return true;
                 DiplomaticStatus status = m_context.ContextDiploStatus(m_empire_id, candidate->Owner());
                 return (status == DiplomaticStatus::DIPLO_WAR);
                 break;
@@ -1229,6 +1231,8 @@ namespace {
                     return false;
                 if (m_empire_id == candidate->Owner())
                     return false;
+                if (candidate->Owner() == DUMMY_EVIL_EMPIRE)
+                    return false;
                 DiplomaticStatus status = m_context.ContextDiploStatus(m_empire_id, candidate->Owner());
                 return (status == DiplomaticStatus::DIPLO_PEACE);
                 break;
@@ -1238,6 +1242,8 @@ namespace {
                 if (m_empire_id == ALL_EMPIRES)
                     return false;
                 if (m_empire_id == candidate->Owner())
+                    return false;
+                if (m_empire_id == DUMMY_EVIL_EMPIRE)
                     return false;
                 DiplomaticStatus status = m_context.ContextDiploStatus(m_empire_id, candidate->Owner());
                 return (status >= DiplomaticStatus::DIPLO_ALLIED);
@@ -1258,7 +1264,7 @@ namespace {
             }
 
             case EmpireAffiliationType::AFFIL_HUMAN: {
-                if (candidate->Unowned())
+                if (candidate->Unowned() || candidate->Owner() == DUMMY_EVIL_EMPIRE)
                     return false;
                 if (GetEmpireClientType(candidate->Owner()) == Networking::ClientType::CLIENT_TYPE_HUMAN_PLAYER)
                     return true;

--- a/universe/ConstantsFwd.h
+++ b/universe/ConstantsFwd.h
@@ -5,6 +5,7 @@ constexpr int INVALID_DESIGN_ID = -1;
 constexpr int INCOMPLETE_DESIGN_ID = -4;
 constexpr int INVALID_OBJECT_ID = -1; // The ID number assigned to a UniverseObject upon construction; It is assigned an ID later when it is placed in the universe
 constexpr int ALL_EMPIRES = -1;
+constexpr int DUMMY_EVIL_EMPIRE = -2; // non-existent "Empire" which is enemy of all empires and also of neutral objects
 
 // sentinel values returned by CurrentTurn().  Can't be an enum since
 // CurrentGameTurn() needs to return an integer game turn number


### PR DESCRIPTION
The shown ship damage estimates for fleets, ships and fighter per bout take the targeting condition into account. This did not work for monsters as the target candidate was not an enemy of neutral.

This adds DUMMY_EVIL_EMPIRE -2 to dummy ships used for determining valid targets. For the targeting condition, the empire affiliations are checked. The DUMMY_EVIL_EMPIRE is at war with every real empire and also neutral forces. It is not at peace/alliance with anyone. It is not a human player empire.

While currently irrelevant, it is not completely clear what the right values for AFFIL_ANY and AFFIL_NONE should be. Currently for those, it is treated like a normal empire.