### PR TITLE
Snap core22 migration (necessitated by boost 1.74)     

### DIFF
--- a/.github/snap-xvfb-launch.sh
+++ b/.github/snap-xvfb-launch.sh
@@ -4,7 +4,19 @@ LIBGL_DEBUG=verbose glxinfo
 
 ps auxx | grep 'Xvfb' | grep -v grep
 
+export SDL_VIDEODRIVER=x11
+
 echo = Launching freeorion =
+
+LIBGL_DEBUG=verbose freeorion.freeorion &
+FOPID=$!
+sleep 10
+kill ${FOPID}
+wait ${FOPID}
+echo Freeorion return code $?
+cat ~/.local/share/freeorion/freeorion.log || echo No log file
+
+echo = Launching freeorion godot =
 
 export SDL_VIDEODRIVER=x11
 
@@ -13,6 +25,6 @@ FOPID=$!
 sleep 10
 kill ${FOPID}
 wait ${FOPID}
-echo Freeorion return code $?
-cat ~/.local/share/freeorion/freeorion.log || echo No log file
+echo Freeorion Godot return code $?
+cat ~/.local/share/freeorion/freeorion-godot.log || echo No log file
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,6 +1,6 @@
 ---
 name: freeorion
-base: core20
+base: core22
 summary: turn-based space empire and galactic conquest (4X) computer game
 description: |
   FreeOrion is a free, open source, turn-based space empire and galactic
@@ -16,7 +16,7 @@ architectures:
 apps:
   freeorion:
     command: usr/bin/freeorion -S $SNAP_USER_COMMON/save
-    extensions: [gnome-3-38]
+    extensions: [gnome]
     plugs: [home, pulseaudio, opengl, network, screen-inhibit-control, browser-support, x11]
     desktop: usr/share/applications/org.freeorion.FreeOrion.desktop
     environment:
@@ -26,7 +26,7 @@ apps:
   freeorion-godot:
     # LD_LIBRARY_PATH=$SNAP/usr/lib/x86_64-linux-gnu/freeorion:$SNAP/usr/lib/x86_64-linux-gnu/:$SNAP/usr/lib/x86_64-linux-gnu/pulseaudio LIBGL_DRIVERS_PATH=$SNAP/usr/lib/x86_64-linux-gnu/dri godot3-runner   --resource.path $SNAP/usr/share/freeorion/default/ -S $SNAP_USER_COMMON/save
     command: usr/bin/godot3-runner --main-pack $SNAP/usr/share/freeorion/freeorion.pck --resource.path $SNAP/usr/share/freeorion/default/ -S $SNAP_USER_COMMON/save
-    extensions: [gnome-3-38]
+    extensions: [gnome]
     plugs: [home, pulseaudio, opengl, network, screen-inhibit-control, browser-support, x11]
     desktop: usr/share/applications/org.freeorion.FreeOrion.desktop
     environment:
@@ -94,7 +94,7 @@ parts:
       - dpkg-dev
       - git
       - libalut-dev
-      - libboost1.71-all-dev
+      - libboost1.74-all-dev
       - libfreetype6-dev
       - libgl1-mesa-dev
       - libglew-dev
@@ -113,18 +113,18 @@ parts:
       - libgl1-mesa-dri
       # - python3
       # - libpython3.8
-      - libboost-date-time1.71.0
-      - libboost-filesystem1.71.0
-      - libboost-iostreams1.71.0
-      - libboost-locale1.71.0
-      - libboost-log1.71.0
-      - libboost-python1.71.0
-      - libboost-regex1.71.0
-      - libboost-serialization1.71.0
-      - libboost-system1.71.0
-      - libboost-thread1.71.0
-      - libboost-test1.71.0
-      - libglew2.1
+      - libboost-date-time1.74.0
+      - libboost-filesystem1.74.0
+      - libboost-iostreams1.74.0
+      - libboost-locale1.74.0
+      - libboost-log1.74.0
+      - libboost-python1.74.0
+      - libboost-regex1.74.0
+      - libboost-serialization1.74.0
+      - libboost-system1.74.0
+      - libboost-thread1.74.0
+      - libboost-test1.74.0
+      - libglew2.2
       - libglu1-mesa
       - libopenal1
       - libsdl2-2.0-0
@@ -133,4 +133,5 @@ parts:
       - libpng16-16
       - libfreetype6
       - godot3-runner
+      - libenet7
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -20,8 +20,8 @@ apps:
     plugs: [home, pulseaudio, opengl, network, screen-inhibit-control, browser-support, x11]
     desktop: usr/share/applications/org.freeorion.FreeOrion.desktop
     environment:
-      LD_LIBRARY_PATH: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/freeorion
-      LIBGL_DRIVERS_PATH: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
+      LD_LIBRARY_PATH: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}/freeorion:$SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}
+      LIBGL_DRIVERS_PATH: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}/dri
       # PYTHONPATH: $SNAP/usr/lib/python3.6
   freeorion-godot:
     # LD_LIBRARY_PATH=$SNAP/usr/lib/x86_64-linux-gnu/freeorion:$SNAP/usr/lib/x86_64-linux-gnu/:$SNAP/usr/lib/x86_64-linux-gnu/pulseaudio LIBGL_DRIVERS_PATH=$SNAP/usr/lib/x86_64-linux-gnu/dri godot3-runner   --resource.path $SNAP/usr/share/freeorion/default/ -S $SNAP_USER_COMMON/save
@@ -30,27 +30,27 @@ apps:
     plugs: [home, pulseaudio, opengl, network, screen-inhibit-control, browser-support, x11]
     desktop: usr/share/applications/org.freeorion.FreeOrion.desktop
     environment:
-      LD_LIBRARY_PATH: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/freeorion
-      LIBGL_DRIVERS_PATH: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/dri
+      LD_LIBRARY_PATH: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}/freeorion:$SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}
+      LIBGL_DRIVERS_PATH: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}/dri
       #PYTHONPATH: $SNAP/usr/lib/python3.6
   freeoriond:
     command: usr/bin/freeoriond
     plugs: [home, network, network-bind]
     environment:
-      LD_LIBRARY_PATH: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/freeorion
+      LD_LIBRARY_PATH: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}/freeorion:$SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}
       #PYTHONPATH: $SNAP/usr/lib/python3.6
   freeoriond-dedicated:
     command: usr/bin/freeoriond --hostless --network.server.unconn-human-empire-players.max 0 --network.server.conn-human-empire-players.min 0
     plugs: [home, network, network-bind]
     environment:
-      LD_LIBRARY_PATH: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/freeorion
+      LD_LIBRARY_PATH: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}/freeorion:$SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}
       #PYTHONPATH: $SNAP/usr/lib/python3.6
 
 layout:
   # the path to the freeorion libs has to be known when snapcraft exports the godot client
   # $SNAP depends on the release number so it is unknown/wrong/different in the build step
-  /usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/freeorion:
-    symlink: $SNAP/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/freeorion
+  /usr/lib/${CRAFT_ARCH_TRIPLET}/freeorion:
+    symlink: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}/freeorion
 
 parts:
   freeorion:
@@ -58,19 +58,19 @@ parts:
     override-build: |
       # Icon paths in the desktop file will be rewritten to use ${SNAP}/<file> if specified as desktop file in snapcraft.yaml
       sed -i.bak -e "s|Icon=freeorion$|Icon=meta/gui/icon.png|g" ../src/packaging/org.freeorion.FreeOrion.desktop
-      sed -i.bak -e 's|="res://bin/linux.*/libfreeoriongodot.so"|="/usr/lib/${SNAPCRAFT_ARCH_TRIPLET}/freeorion/libfreeoriongodot.so"|g' ../src/godot/freeoriongodot.gdnlib
-      snapcraftctl build
+      sed -i.bak -e 's|="res://bin/linux.*/libfreeoriongodot.so"|="/usr/lib/${CRAFT_ARCH_TRIPLET}/freeorion/libfreeoriongodot.so"|g' ../src/godot/freeoriongodot.gdnlib
+      craftctl default
       # godot-headless wants a writable homedir, simulate it
       mkdir -p home/
-      mkdir -p "${SNAPCRAFT_PART_INSTALL}/usr/share/freeorion/"
+      mkdir -p "${CRAFT_PART_INSTALL}/usr/share/freeorion/"
       # Note: we use godot3-headless really
-      HOME=$(pwd)/home godot3-server --path ../src/godot --export-pack "Linux/X11" "${SNAPCRAFT_PART_INSTALL}/usr/share/freeorion/freeorion.pck"
+      HOME=$(pwd)/home godot3-server --path ../src/godot --export-pack "Linux/X11" "${CRAFT_PART_INSTALL}/usr/share/freeorion/freeorion.pck"
     plugin: cmake
     cmake-parameters:
       - -DCMAKE_INSTALL_PREFIX=/usr -DBUILD_CLIENT_GODOT=ON
     #cmake-parameters: [-DBUILD_TESTING=ON]
     override-pull: |
-      snapcraftctl pull
+      craftctl default
       branchn="$(git rev-parse --abbrev-ref HEAD)"
       daterev="$(git log -n1 --date=short --format='%cd.%h' $branchn)"
       longtagn="$(git describe --tags || echo none)"
@@ -82,12 +82,12 @@ parts:
         esac ;;
       esac
       [ -n "$(echo $version | grep '^[0-9]+-')" ] && grade=devel || grade=stable
-      snapcraftctl set-version "$version"
-      snapcraftctl set-grade "$grade"
+      craftctl set version="$version"
+      craftctl set grade="$grade"
     override-prime: |
-      snapcraftctl prime
-      mkdir -p ${SNAPCRAFT_PRIME}/meta/gui
-      cp ${SNAPCRAFT_PART_SRC}/default/data/art/icons/FO_Icon_256x256.png ${SNAPCRAFT_PRIME}/meta/gui/icon.png
+      craftctl default
+      mkdir -p ${CRAFT_PRIME}/meta/gui
+      cp ${CRAFT_PART_SRC}/default/data/art/icons/FO_Icon_256x256.png ${CRAFT_PRIME}/meta/gui/icon.png
     build-packages:
       - cmake
       - debhelper


### PR DESCRIPTION
* o01eg already updated dependencies; newer boost version is available
* command renames
* LD_LIBRARY_PATH fixes (could probably also prepend $LD_LIBRARY_PATH: )
