### PR TITLE
Add property to empire of which turn it received game state

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1001,6 +1001,9 @@ void Empire::AutoTurnSetReady() {
 void Empire::SetAutoTurn(int turns_count)
 { m_auto_turn_count = turns_count; }
 
+void Empire::SetLastTurnReceived(int last_turn_received) noexcept
+{ m_last_turn_received = last_turn_received; }
+
 void Empire::UpdateSystemSupplyRanges(const std::set<int>& known_objects, const ObjectMap& objects) {
     TraceLogger(supply) << "Empire::UpdateSystemSupplyRanges() for empire " << this->Name();
     m_supply_system_ranges.clear();

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -297,6 +297,7 @@ public:
     void SetReady(bool ready);               ///< Marks this empire with readiness status
     void AutoTurnSetReady();                 ///< Decreases auto-turn counter and set empire ready if not expired or set unready
     void SetAutoTurn(int turns_count);       ///< Set auto-turn counter
+    void SetLastTurnReceived(int last_turn_received) noexcept; ///< Set last turn received
 
     /** Inserts the given SitRep entry into the empire's sitrep list. */
     void AddSitRepEntry(const SitRepEntry& entry);
@@ -439,6 +440,7 @@ public:
     [[nodiscard]] auto& BuildingTypesProduced() const noexcept { return m_building_types_produced; }
     [[nodiscard]] auto& BuildingTypesScrapped() const noexcept { return m_building_types_scrapped; }
     [[nodiscard]] auto& TurnsSystemsExplored() const noexcept { return m_explored_systems; }
+    [[nodiscard]] auto LastTurnReceived() const noexcept { return m_last_turn_received; }
 
     /** Processes Builditems on queues of empires other than the indicated
       * empires, at the location with id \a location_id and, as appropriate,
@@ -558,6 +560,7 @@ private:
     std::map<int, std::set<int>>    m_preserved_system_exit_lanes;  ///< for each system known to this empire, the set of exit lanes preserved for fleet travel even if otherwise blockaded
     std::map<int, std::set<int>>    m_pending_system_exit_lanes;    ///< pending updates to m_preserved_system_exit_lanes
     int                             m_auto_turn_count = 0;          ///< auto-turn counter value
+    int                             m_last_turn_received = INVALID_GAME_TURN; ///< last turn empire completedly received game state
 
     /** The source id is the id of any object owned by the empire.  It is
         mutable so that Source() can be const and still cache its result. */

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -370,6 +370,7 @@ namespace FreeOrionPython {
             .def("getMeter",                        +[](const Empire& empire, const std::string& name) -> const Meter* { return empire.GetMeter(name); },
                                                     py::return_internal_reference<>(),
                                                     "Returns the empire meter with the indicated name (string).")
+            .add_property("lastTurnReceived",       &Empire::LastTurnReceived);
         ;
 
         //////////////////////

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -379,6 +379,14 @@ void ServerApp::AsyncIOTimedoutHandler(const boost::system::error_code& error) {
     }
 }
 
+void ServerApp::UpdateEmpireTurnReceived(int empire_id, int turn, bool success) {
+    if (success) {
+        if (auto empire = m_empires.GetEmpire(empire_id)) {
+            empire->SetLastTurnReceived(turn);
+        }
+    }
+}
+
 void ServerApp::CleanupAIs() {
     if (m_ai_client_processes.empty() && m_networking.empty())
         return;

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -307,6 +307,9 @@ private:
     /** Called when asyncio timer ends. Executes Python asyncio callbacks if any was generated. */
     void AsyncIOTimedoutHandler(const boost::system::error_code& error);
 
+    /** Called when new \a turn state received by player playing \a empire_id. */
+    void UpdateEmpireTurnReceived(int empire_id, int turn, bool success);
+
     boost::asio::io_context m_io_context;
     boost::asio::signal_set m_signals;
     boost::asio::high_resolution_timer m_timer;

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -398,9 +398,16 @@ void Empire::serialize(Archive& ar, const unsigned int version)
     ar  & BOOST_SERIALIZATION_NVP(m_authenticated);
     ar  & BOOST_SERIALIZATION_NVP(m_ready);
     ar  & BOOST_SERIALIZATION_NVP(m_auto_turn_count);
+
+    if (Archive::is_loading::value && version < 13) {
+        m_last_turn_received = INVALID_GAME_TURN;
+    } else {
+        ar  & BOOST_SERIALIZATION_NVP(m_last_turn_received);
+    }
+
 }
 
-BOOST_CLASS_VERSION(Empire, 12)
+BOOST_CLASS_VERSION(Empire, 13)
 
 template void Empire::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
 template void Empire::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);


### PR DESCRIPTION
For better notifications to players I need info which turn they received game state.