### PR TITLE
Remove MacOS 10.15 build action and add MacOS 13 build action

### DIFF
--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -43,10 +43,6 @@ jobs:
         uses: actions/checkout@v3
       - name: Clean up Mono
         run: sudo ./.github/workflows/mono-uninstall.sh
-      - name: Setup - Xcode
-        if: matrix.os == 'macos-11'
-        run: |
-          sudo xcode-select -s /Applications/Xcode_11.7.app
       - name: Prepare ccache timestamp
         id: build-macos-ccache-timestamp
         shell: cmake -P {0}

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -43,6 +43,10 @@ jobs:
         uses: actions/checkout@v3
       - name: Clean up Mono
         run: sudo ./.github/workflows/mono-uninstall.sh
+      - name: Setup - Xcode
+        if: matrix.os == 'macos-11'
+        run: |
+          sudo xcode-select -s /Applications/Xcode_11.7.app
       - name: Prepare ccache timestamp
         id: build-macos-ccache-timestamp
         shell: cmake -P {0}
@@ -77,6 +81,7 @@ jobs:
           cd build
           cmake --build . --config Release -- -parallelizeTargets
       - name: Generate binaries
+        if: matrix.os != 'macos-13'
         run: |
           export PATH="/usr/local/opt/ccache/libexec:$PATH"
           alias cmake="/usr/local/bin/gtimeout 40m /usr/local/bin/cmake"

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-10.15, macos-11, macos-12]
+        os: [macos-11, macos-12, macos-13]
     env:
       CACHE_NAME: macos-full
       CMAKE_BUILD_PARALLEL_LEVEL: 2

--- a/BUILD.md
+++ b/BUILD.md
@@ -27,9 +27,9 @@ FreeOrion depends on the following software to build:
   * [Visual Studio] - 2022 for Windows Desktop ; Windows only
   * [Xcode] - 13.2 or later ; MacOS only
   * [CMake] - 3.8 or 3.16 (Windows) or later
-  * A C++17 compliant compiler - Other Operating Systems
-    * [GNU GCC] - 8.0 or later
-    * [Clang] - 5 or later
+  * A C++20 compliant compiler - Other Operating Systems
+    * [GNU GCC] - 11 or later
+    * [Clang] - 10 or later
   * [Python] - 3.9 or later
   * [Git]
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -8,7 +8,7 @@ corresponding release branch, eg. [FreeOrion v0.5 BUILD.md]
 Hardware and OS Requirements
 ----------------------------
 
-FreeOrion should compile on Windows 8.1 (or later), macOS 10.12 (or later) and
+FreeOrion should compile on Windows 8.1 (or later), macOS 11 (or later) and
 Linux operating systems. Other operating systems have reported to work, but
 support is not actively maintained by the FreeOrion developers. FreeOrion is
 developed for x86 compatible processor architectures; other architectures
@@ -25,7 +25,7 @@ Required Software Dependencies
 FreeOrion depends on the following software to build:
 
   * [Visual Studio] - 2022 for Windows Desktop ; Windows only
-  * [Xcode] - 10.1 or later ; MacOS only
+  * [Xcode] - 13.2 or later ; MacOS only
   * [CMake] - 3.8 or 3.16 (Windows) or later
   * A C++17 compliant compiler - Other Operating Systems
     * [GNU GCC] - 8.0 or later


### PR DESCRIPTION
GitHub has apparently removed 10.15 as a hosted runner option https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners