### PR TITLE
 Change speed requirement on charge to 120 uu / Make energy hulls an alternative unlock for charge policy (current unlock improved couplings)

### DIFF
--- a/default/scripting/policies/CHARGE.focs.txt
+++ b/default/scripting/policies/CHARGE.focs.txt
@@ -14,7 +14,7 @@ Policy
                 Ship
                 OwnedBy empire = Source.Owner
                 Armed
-                Speed low = NamedReal name = "PLC_CHARGE_MINIMUM_SPEED" value = 100.0
+                Speed low = NamedReal name = "PLC_CHARGE_MINIMUM_SPEED" value = 120.0
             ]
             priority = [[TARGET_AFTER_SCALING_PRIORITY]]
             effects = [

--- a/default/scripting/techs/ship_hulls/energy/SHP_FRC_ENRG_COMP.focs.py
+++ b/default/scripting/techs/ship_hulls/energy/SHP_FRC_ENRG_COMP.focs.py
@@ -12,6 +12,7 @@ Tech(
     unlock=[
         Item(type=UnlockShipHull, name="SH_COMPRESSED_ENERGY"),
         Item(type=UnlockBuilding, name="BLD_SHIPYARD_ENRG_COMP"),
+        Item(type=UnlockPolicy, name="PLC_CHARGE"),
     ],
     graphic="icons/ship_hulls/compressed_energy_hull_small.png",
 )


### PR DESCRIPTION
https://freeorion.org/forum/viewtopic.php?t=12776&sid=9dc1a2841c355597aecdb3d725ec7fb9

Aimed at restoring balance between robotic and organic hulls, while encouraging the use of energy hulls