### PR TITLE
Reduce Energy Compressor from 200 to 150 PP

### DIFF
--- a/default/scripting/buildings/shipyards/ENERGY_COMP.focs.txt
+++ b/default/scripting/buildings/shipyards/ENERGY_COMP.focs.txt
@@ -1,7 +1,7 @@
 BuildingType
     name = "BLD_SHIPYARD_ENRG_COMP"
     description = "BLD_SHIPYARD_ENRG_COMP_DESC"
-    buildcost = 200 * [[BUILDING_COST_MULTIPLIER]]
+    buildcost = 150 * [[BUILDING_COST_MULTIPLIER]]
     buildtime = 5
     tags = "ORBITAL"
     location = And [


### PR DESCRIPTION
At 150 it's still 2x the cost of an asteroid shipyard. No one uses energy hulls, and the cost of the initial shipyard is part of the problem.

Along with https://github.com/freeorion/freeorion/pull/4525 intends to nudge energy line towards viability.