### PR TITLE
Add changlog labels

### DIFF
--- a/.github/project-labels.yml
+++ b/.github/project-labels.yml
@@ -138,3 +138,11 @@
   description: >
     The Issue can't be reproduced or it doesn't contain sufficient information
     to reproduce it.
+- name: changlelog:yes
+  color: "cccccc"
+  description: >
+    The PR contains changes that are worth to be mention in the changelog
+- name: changlelog:no
+  color: "cccccc"
+  description: >
+    The PR contains changes that should not be reflected in change log


### PR DESCRIPTION
This PR purpose is to raise a discussion. 

The idea is to add two labels related to the changelog.  This should split the job for changelog creation into small steps and make a decision about that when the feature is in progress. 

In short, each PR will be in one of 3 states:  we want to add changes to this PR to the changelog, we don't want it, and not sure (the label is not set).   This kind of decision is much easier to do during the development phase than at the end.  Also, it could be done by the person who is involved in the review/merge process.

On top of that, we could build some simple automation.  If the label is `category:feature` set it automatically to yes.  If this is some technical staff, or refactoring, tweak, make it no. 

Another automation could be to check if the change log file was updated. If we want to have a changelog entry, it's good to write it now.

@Vezzra what do you think? 

