### PR TITLE
[CI] Add discord reporting

### DIFF
--- a/.github/workflows/_discord.yml
+++ b/.github/workflows/_discord.yml
@@ -6,6 +6,7 @@ on:
         required: true
     secrets:
       DISCORD_WEBHOOK:
+        required: true
 jobs:
 
   discord:

--- a/.github/workflows/_discord.yml
+++ b/.github/workflows/_discord.yml
@@ -1,14 +1,13 @@
-name: "Snapcraft"
-
 on:
   workflow_call:
+    inputs:
+      title:
+        type: string
+        required: true
+    secrets:
+      DISCORD_WEBHOOK:
 jobs:
-  inputs:
-    title:
-      type: string
-      required: true
-  secrets:
-    DISCORD_WEBHOOK:
+
   discord:
     runs-on: ubuntu-latest
     timeout-minutes: 55
@@ -21,4 +20,3 @@ jobs:
           username: 'FreeOrion Repo'
           url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           avatar_url: https://github.githubassets.com/images/modules/logos_page/Octocat.png
-

--- a/.github/workflows/_discord.yml
+++ b/.github/workflows/_discord.yml
@@ -1,0 +1,24 @@
+name: "Snapcraft"
+
+on:
+  workflow_call:
+jobs:
+  inputs:
+    title:
+      type: string
+      required: true
+  secrets:
+    DISCORD_WEBHOOK:
+  discord:
+    runs-on: ubuntu-latest
+    timeout-minutes: 55
+    steps:
+      - uses: sarisia/actions-status-discord@v1
+        with:
+          title: ${{ title }}
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          color: 0xff0000
+          username: 'FreeOrion Repo'
+          url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          avatar_url: https://github.githubassets.com/images/modules/logos_page/Octocat.png
+

--- a/.github/workflows/_discord.yml
+++ b/.github/workflows/_discord.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: sarisia/actions-status-discord@v1
         with:
-          title: ${{ title }}
+          title: ${{ inputs.title }}
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           color: 0xff0000
           username: 'FreeOrion Repo'

--- a/.github/workflows/_discord.yml
+++ b/.github/workflows/_discord.yml
@@ -5,7 +5,7 @@ on:
         type: string
         required: true
     secrets:
-      DISCORD_WEBHOOK:
+      WEBHOOK:
         required: true
 jobs:
 

--- a/.github/workflows/_discord.yml
+++ b/.github/workflows/_discord.yml
@@ -8,7 +8,6 @@ on:
       WEBHOOK:
         required: true
 jobs:
-
   discord:
     runs-on: ubuntu-latest
     timeout-minutes: 55

--- a/.github/workflows/_discord.yml
+++ b/.github/workflows/_discord.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: sarisia/actions-status-discord@v1
         with:
           title: ${{ inputs.title }}
-          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          webhook: ${{ secrets.WEBHOOK }}
           color: 0xff0000
           username: 'FreeOrion Repo'
           url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}

--- a/.github/workflows/build_on_master.yml
+++ b/.github/workflows/build_on_master.yml
@@ -35,17 +35,17 @@ jobs:
   snapcraft:
     uses: ./.github/workflows/_build_snapcraft.yml
   discord-notify-success: #  sample messages just for demo purposes
-    - uses: ./.github/workflows/_discord.yml
-      needs:
-        - android
-        - macos
-        - ubuntu
-        - windows
-        - docker
-        - snapcraft
-      if: failure()
-      with:
-        title: 'FreeOrion build master'
-        webhook: ${{ secrets.DISCORD_WEBHOOK }}
-        secrets:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+    uses: ./.github/workflows/_discord.yml
+    needs:
+      - android
+      - macos
+      - ubuntu
+      - windows
+      - docker
+      - snapcraft
+    if: failure()
+    with:
+      title: 'FreeOrion build master'
+      webhook: ${{ secrets.DISCORD_WEBHOOK }}
+    secrets:
+      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build_on_master.yml
+++ b/.github/workflows/build_on_master.yml
@@ -46,6 +46,5 @@ jobs:
     if: failure()
     with:
       title: 'FreeOrion build master'
-      webhook: ${{ secrets.DISCORD_WEBHOOK }}
     secrets:
       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build_on_master.yml
+++ b/.github/workflows/build_on_master.yml
@@ -34,3 +34,20 @@ jobs:
     uses: ./.github/workflows/_build-docker.yml
   snapcraft:
     uses: ./.github/workflows/_build_snapcraft.yml
+  discord-notify-failure:
+    - uses: sarisia/actions-status-discord@v1
+      needs:
+        - android
+        - macos
+        - ubuntu
+        - windows
+        - docker
+        - snapcraft
+      if: failure()
+      with:
+        title: 'FreeOrion build master'
+        webhook: ${{ secrets.DISCORD_WEBHOOK }}
+        color: 0xff0000
+        username: 'FreeOrion Repo'
+        url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        avatar_url: https://github.githubassets.com/images/modules/logos_page/Octocat.png

--- a/.github/workflows/build_on_master.yml
+++ b/.github/workflows/build_on_master.yml
@@ -34,8 +34,8 @@ jobs:
     uses: ./.github/workflows/_build-docker.yml
   snapcraft:
     uses: ./.github/workflows/_build_snapcraft.yml
-  discord-notify-failure:
-    - uses: sarisia/actions-status-discord@v1
+  discord-notify-success: #  sample messages just for demo purposes
+    - uses: ./.github/workflows/_discord.yml
       needs:
         - android
         - macos
@@ -47,7 +47,5 @@ jobs:
       with:
         title: 'FreeOrion build master'
         webhook: ${{ secrets.DISCORD_WEBHOOK }}
-        color: 0xff0000
-        username: 'FreeOrion Repo'
-        url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        avatar_url: https://github.githubassets.com/images/modules/logos_page/Octocat.png
+        secrets:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build_on_master.yml
+++ b/.github/workflows/build_on_master.yml
@@ -47,4 +47,4 @@ jobs:
     with:
       title: 'FreeOrion build master'
     secrets:
-      DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+      WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build_on_pull_request.yml
+++ b/.github/workflows/build_on_pull_request.yml
@@ -45,6 +45,5 @@ jobs:
      if: always()
      with:
        title: 'FreeOrion build master'
-       webhook: ${{ secrets.DISCORD_WEBHOOK }}
      secrets:
        DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build_on_pull_request.yml
+++ b/.github/workflows/build_on_pull_request.yml
@@ -34,7 +34,7 @@ jobs:
   docker:
     uses: ./.github/workflows/_build-docker.yml
   discord-notify-success:  #  sample messages just for demo purposes
-    - uses: sarisia/actions-status-discord@v1
+    - uses: ./.github/workflows/_discord.yml
       needs:
         - android
         - macos
@@ -46,7 +46,5 @@ jobs:
       with:
         title: 'FreeOrion build master'
         webhook: ${{ secrets.DISCORD_WEBHOOK }}
-        color: 0x00ff00
-        username: 'FreeOrion Repo'
-        url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-        avatar_url: https://github.githubassets.com/images/modules/logos_page/Octocat.png
+        secrets:
+          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build_on_pull_request.yml
+++ b/.github/workflows/build_on_pull_request.yml
@@ -31,3 +31,22 @@ jobs:
     uses: ./.github/workflows/_build-windows.yml
   windows-msvc:
     uses: ./.github/workflows/_build-windows-msvs.yml
+  docker:
+    uses: ./.github/workflows/_build-docker.yml
+  discord-notify-success:  #  sample messages just for demo purposes
+    - uses: sarisia/actions-status-discord@v1
+      needs:
+        - android
+        - macos
+        - ubuntu
+        - windows
+        - windows-msvc
+        - docker
+      if: always()
+      with:
+        title: 'FreeOrion build master'
+        webhook: ${{ secrets.DISCORD_WEBHOOK }}
+        color: 0x00ff00
+        username: 'FreeOrion Repo'
+        url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        avatar_url: https://github.githubassets.com/images/modules/logos_page/Octocat.png

--- a/.github/workflows/build_on_pull_request.yml
+++ b/.github/workflows/build_on_pull_request.yml
@@ -34,17 +34,17 @@ jobs:
   docker:
     uses: ./.github/workflows/_build-docker.yml
   discord-notify-success:  #  sample messages just for demo purposes
-    - uses: ./.github/workflows/_discord.yml
-      needs:
-        - android
-        - macos
-        - ubuntu
-        - windows
-        - windows-msvc
-        - docker
-      if: always()
-      with:
-        title: 'FreeOrion build master'
-        webhook: ${{ secrets.DISCORD_WEBHOOK }}
-        secrets:
-          DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+     uses: ./.github/workflows/_discord.yml
+     needs:
+      - android
+      - macos
+      - ubuntu
+      - windows
+      - windows-msvc
+      - docker
+     if: always()
+     with:
+       title: 'FreeOrion build master'
+       webhook: ${{ secrets.DISCORD_WEBHOOK }}
+     secrets:
+       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}

--- a/.github/workflows/build_on_pull_request.yml
+++ b/.github/workflows/build_on_pull_request.yml
@@ -46,4 +46,4 @@ jobs:
      with:
        title: 'FreeOrion build master'
      secrets:
-       DISCORD_WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}
+       WEBHOOK: ${{ secrets.DISCORD_WEBHOOK }}


### PR DESCRIPTION
This PR adds reporting to the Discord 

The rationale behind this is to make rich notifications for build failures. 

Current notification limitation:
- There is no way to subscribe to all of them.  For example, the master build fails, but I accidentally noticed this when start doing other things.  https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/notifications-for-workflow-runs
The second part about scheduled workflows is one of the problems. I think a lot of jobs, like Docker and  snapcraft could be run on that event, but I also want to have visibility on the result.
- There is no way to unsubscribe from part of them. (Or I didn't find it)


Solution: 
- Use an external service that could aggregate notifications (Discord, or Slack)
- Put each notification type into a dedicated channel.
- People will mute/subscribe to channels, that are important for them. You almost could not get better flexibility in the notification than that.  


In this PR I have added temporary notification on PR build, just for demo proposes.

Here is the [invitation link to the Discord server](https://discord.gg/NpjmbUjy).  You will need to register.  The browser version is available, no app installation is required. https://discord.com/