### PR TITLE
make snap run freeoriond find python lib from gnome extension

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,7 +22,7 @@ apps:
     environment:
       LD_LIBRARY_PATH: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}/freeorion:$SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}
       LIBGL_DRIVERS_PATH: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}/dri
-      # PYTHONPATH: $SNAP/usr/lib/python3.6
+      # PYTHONPATH: $SNAP_DESKTOP_RUNTIME/usr/lib/python3.10
   freeorion-godot:
     # LD_LIBRARY_PATH=$SNAP/usr/lib/x86_64-linux-gnu/freeorion:$SNAP/usr/lib/x86_64-linux-gnu/:$SNAP/usr/lib/x86_64-linux-gnu/pulseaudio LIBGL_DRIVERS_PATH=$SNAP/usr/lib/x86_64-linux-gnu/dri godot3-runner   --resource.path $SNAP/usr/share/freeorion/default/ -S $SNAP_USER_COMMON/save
     command: usr/bin/godot3-runner --main-pack $SNAP/usr/share/freeorion/freeorion.pck --resource.path $SNAP/usr/share/freeorion/default/ -S $SNAP_USER_COMMON/save
@@ -32,19 +32,19 @@ apps:
     environment:
       LD_LIBRARY_PATH: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}/freeorion:$SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}
       LIBGL_DRIVERS_PATH: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}/dri
-      #PYTHONPATH: $SNAP/usr/lib/python3.6
+      #PYTHONPATH: $SNAP_DESKTOP_RUNTIME/usr/lib/python3.10
   freeoriond:
     command: usr/bin/freeoriond
     plugs: [home, network, network-bind]
     environment:
-      LD_LIBRARY_PATH: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}/freeorion:$SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}
-      #PYTHONPATH: $SNAP/usr/lib/python3.6
+      LD_LIBRARY_PATH: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}/freeorion:$SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}:$SNAP_DESKTOP_RUNTIME/usr/lib/${CRAFT_ARCH_TRIPLET}
+      #PYTHONPATH: $SNAP_DESKTOP_RUNTIME/usr/lib/python3.10
   freeoriond-dedicated:
     command: usr/bin/freeoriond --hostless --network.server.unconn-human-empire-players.max 0 --network.server.conn-human-empire-players.min 0
     plugs: [home, network, network-bind]
     environment:
-      LD_LIBRARY_PATH: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}/freeorion:$SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}
-      #PYTHONPATH: $SNAP/usr/lib/python3.6
+      LD_LIBRARY_PATH: $SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}/freeorion:$SNAP/usr/lib/${CRAFT_ARCH_TRIPLET}:$SNAP_DESKTOP_RUNTIME/usr/lib/${CRAFT_ARCH_TRIPLET}
+      #PYTHONPATH: $SNAP_DESKTOP_RUNTIME/usr/lib/python3.10
 
 layout:
   # the path to the freeorion libs has to be known when snapcraft exports the godot client


### PR DESCRIPTION
Fixes snap run for freeoriond and freeoriond-dedicated.

```
$ freeorion.freeoriond-dedicated
/snap/freeorion/352/usr/bin/freeoriond: error while loading shared libraries: libpython3.8.so.1.0: cannot open shared object file: No such file or directory
```

was reported in 

https://freeorion.org/forum/viewtopic.php?p=116230&sid=7eed0ef856c4e0da07d89075e18b29d7#p116230
