### PR TITLE
Don't alter planet type for philosopher special

### DIFF
--- a/default/scripting/specials/planet/PHILOSOPHER.focs.txt
+++ b/default/scripting/specials/planet/PHILOSOPHER.focs.txt
@@ -2,12 +2,12 @@ Special
     name = "PHILOSOPHER_SPECIAL"
     description = "PHILOSOPHER_SPECIAL_DESC"
     stealth = 0
-    spawnrate = 2.0
+    spawnrate = 25.0
     spawnlimit = 1
     location = And [
         Planet
         Planet size = Tiny
-        Not Planet type = [Asteroids GasGiant]
+        Planet type = Radiated
         Not Species
         ContainedBy And [
             System 
@@ -25,16 +25,6 @@ Special
         ]
     ]
     effectsgroups = [
-        EffectsGroup
-            scope = Source
-            activation = Turn high = 0
-            stackinggroup = "GAME_START_MOD_STACK"
-            priority = [[BEFORE_ANYTHING_ELSE_PRIORITY]]
-            effects = [
-                SetPlanetType type = Radiated
-                SetOriginalType type = Radiated
-            ]
-
         EffectsGroup
             scope = And [
                 Planet


### PR DESCRIPTION
Tested

I'm not seeing the reason for changing planet type, rather then checking planet type. What if 2 specials change a planet type? Also the planet statistics? 