### PR TITLE
Do not overriding species pilot trait effects by tech (Fix #4604)

### DIFF
--- a/default/scripting/techs/ship_weapons/SHP_ROOT_AGGRESSION.focs.py
+++ b/default/scripting/techs/ship_weapons/SHP_ROOT_AGGRESSION.focs.py
@@ -1,4 +1,4 @@
-from techs.ship_weapons.ship_weapons import WEAPON_BASE_EFFECTS
+from techs.ship_weapons.ship_weapons import SET_BOTH_MAX_CAPACITIES_FROM_PART_CAPACITIES, WEAPON_BASE_EFFECTS
 
 Tech(
     name="SHP_ROOT_AGGRESSION",
@@ -13,6 +13,11 @@ Tech(
         Item(type=UnlockShipPart, name="GT_TROOP_POD"),
         Item(type=UnlockShipPart, name="SR_WEAPON_0_1"),
     ],
-    effectsgroups=[*WEAPON_BASE_EFFECTS("SR_WEAPON_0_1"), *WEAPON_BASE_EFFECTS("SR_WEAPON_1_1")],
+    effectsgroups=[
+        # TODO move at least the flak effect to the part definition
+        SET_BOTH_MAX_CAPACITIES_FROM_PART_CAPACITIES("SR_WEAPON_0_1"),
+        *WEAPON_BASE_EFFECTS("SR_WEAPON_0_1"),
+        *WEAPON_BASE_EFFECTS("SR_WEAPON_1_1"),
+    ],
     graphic="icons/tech/planetary_colonialism.png",
 )

--- a/default/scripting/techs/ship_weapons/ship_weapons.py
+++ b/default/scripting/techs/ship_weapons/ship_weapons.py
@@ -16,6 +16,8 @@ def SET_BOTH_MAX_CAPACITIES_FROM_PART_CAPACITIES(part_name: str):
     return EffectsGroup(
         scope=EMPIRE_OWNED_SHIP_WITH_PART(part_name),
         accountinglabel=part_name,
+        # The standard/default effect happen at default priority, before any scripted ones happen
+        # In order for this tech effect to also happen first, we make it happen slightly earlier with a lower priority value
         priority=DEFAULT_PRIORITY - 1,
         effects=[
             SetMaxCapacity(partname=part_name, value=PartCapacity(name=part_name)),

--- a/default/scripting/techs/ship_weapons/ship_weapons.py
+++ b/default/scripting/techs/ship_weapons/ship_weapons.py
@@ -31,8 +31,8 @@ def SET_BOTH_MAX_CAPACITIES_FROM_PART_CAPACITIES(part_name: str):
 # @1@ part name
 def WEAPON_BASE_EFFECTS(part_name: str):
     # these NamedReals need to be parsed to be registered in the pedia. XXX remove this when the pedia can look up ship meters/part capacity
-    NamedReal(name=part_name + "_PART_CAPACITY", value=PartCapacity(name=part_name))
-    NamedReal(name=part_name + "_PART_SECONDARY_STAT", value=PartSecondaryStat(name=part_name))
+    NamedReal(name=f"{part_name}_PART_CAPACITY", value=PartCapacity(name=part_name))
+    NamedReal(name=f"{part_name}_PART_SECONDARY_STAT", value=PartSecondaryStat(name=part_name))
 
     # Set the damage and shot meters to the max values every turn.
     # The topup_effects_group is necessary..

--- a/default/scripting/techs/ship_weapons/ship_weapons.py
+++ b/default/scripting/techs/ship_weapons/ship_weapons.py
@@ -1,5 +1,5 @@
 from common.misc import SHIP_WEAPON_DAMAGE_FACTOR
-from common.priorities import AFTER_ALL_TARGET_MAX_METERS_PRIORITY, DEFAULT_PRIORITY
+from common.priorities import AFTER_ALL_TARGET_MAX_METERS_PRIORITY, TARGET_EARLY_BEFORE_SCALING_PRIORITY
 from techs.techs import (
     ARBITRARY_BIG_NUMBER_FOR_METER_TOPUP,
     EMPIRE_OWNED_SHIP_WITH_PART,
@@ -17,8 +17,8 @@ def SET_BOTH_MAX_CAPACITIES_FROM_PART_CAPACITIES(part_name: str):
         scope=EMPIRE_OWNED_SHIP_WITH_PART(part_name),
         accountinglabel=part_name,
         # The standard/default effect happen at default priority, before any scripted ones happen
-        # In order for this tech effect to also happen first, we make it happen slightly earlier with a lower priority value
-        priority=DEFAULT_PRIORITY - 1,
+        # In order for this tech effect to also happen first, we make it happen slightly earlier
+        priority=TARGET_EARLY_BEFORE_SCALING_PRIORITY,
         effects=[
             SetMaxCapacity(partname=part_name, value=PartCapacity(name=part_name)),
             SetMaxSecondaryStat(partname=part_name, value=PartSecondaryStat(name=part_name)),


### PR DESCRIPTION
fixes #4604 by resetting the max capacity meters only for NoDefaultCapacityEffects parts (i.e. flak )

the problem was overriding the capacities' max meters, but the effect evaluation order concerning those was like this:

- default cumulative effects from backend (if not NoDefaultCapacityEffects) (prio 100, i think these are always executed first)
- cumulative effects from species trait (prio 100, species)
- overriding (prio 100, tech)
- so basically i erased the species' effects . My effects result in the same value from the backend, so that was not a problem just not necessary. After this fix this does only apply to flak (see below)

After this fix for flak it works like this:
- overriding (prio 99, tech)
- No DefaultCapacityEffects
- cumulative effects from species trait (prio 100, species)

[slow game 025 thread in forum](https://freeorion.org/forum/viewtopic.php?p=116753#p116753)