### PR TITLE
restore default capacity effects for Flak

### DIFF
--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_0_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_0_1.focs.txt
@@ -4,7 +4,6 @@ Part
     class = ShortRange
     damage = 1
     shots = 3
-    NoDefaultCapacityEffect
     damageStructurePerBattleMax = 0
     combatTargets = And [
         Fighter


### PR DESCRIPTION
Possibly was omitted from d9015ec26

Might address #4636