### PR TITLE
Quickfix weapon base effects also working for monsters

### DIFF
--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_0_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_0_1.focs.txt
@@ -18,6 +18,7 @@ Part
         Planet
         OwnedBy empire = Source.Owner
     ]
+    effectsgroups = [[SET_BOTH_MAX_CAPACITIES_FROM_PART_CAPACITIES]]
     icon = "icons/ship_parts/flak.png"
 
 #include "shortrange.macros"

--- a/default/scripting/ship_parts/ShortRange/shortrange.macros
+++ b/default/scripting/ship_parts/ShortRange/shortrange.macros
@@ -1,1 +1,24 @@
-// shortrange.macros has currently no effects
+# shortrange.macros basic functionality for direct weapon ship parts
+
+# Set the max meters for damage and number of shots to the base value from the ship part specification.
+# So direct weapon parts with NoDefaultCapacityEffect will not have the damage/PartCapacity scaled by SHIP_DAMAGE_WEAPON_FACTOR.
+# NB: The default effects of a direct weapon part
+#     increases the part's Capacity MaxMeter by the PartCapacity (which is the capacity from the part definition scaled by the game rule)
+#     increases the part's SecondarStat MaxMeter by the PartSecondaryStat
+# The standard/default effect happen at default priority, before any scripted ones happen
+# In order for this tech effect to also happen first, we make it happen slightly earlier
+SET_BOTH_MAX_CAPACITIES_FROM_PART_CAPACITIES
+'''EffectsGroup
+    description = "SET_BOTH_MAX_CAPACITIES_FROM_PART_CAPACITIES_DESC"
+    scope = Source
+
+    priority = [[TARGET_EARLY_BEFORE_SCALING_PRIORITY]]
+    effects = [
+       SetMaxCapacity partname = CurrentContent value = (PartCapacity name = CurrentContent)
+       SetMaxSecondaryStat partname = CurrentContent value = (PartSecondaryStat name = CurrentContent)
+    ]
+'''
+
+#include "/scripting/common/priorities.macros"
+
+#include "/scripting/common/misc.macros"

--- a/default/scripting/techs/ship_weapons/SHP_ROOT_AGGRESSION.focs.py
+++ b/default/scripting/techs/ship_weapons/SHP_ROOT_AGGRESSION.focs.py
@@ -1,5 +1,5 @@
 from focs._tech import *
-from techs.ship_weapons.ship_weapons import SET_BOTH_MAX_CAPACITIES_FROM_PART_CAPACITIES, WEAPON_BASE_EFFECTS
+from techs.ship_weapons.ship_weapons import WEAPON_BASE_EFFECTS
 
 Tech(
     name="SHP_ROOT_AGGRESSION",
@@ -16,7 +16,6 @@ Tech(
     ],
     effectsgroups=[
         # TODO move at least the flak effect to the part definition
-        SET_BOTH_MAX_CAPACITIES_FROM_PART_CAPACITIES("SR_WEAPON_0_1"),
         *WEAPON_BASE_EFFECTS("SR_WEAPON_0_1"),
         *WEAPON_BASE_EFFECTS("SR_WEAPON_1_1"),
     ],

--- a/default/scripting/techs/ship_weapons/ship_weapons.py
+++ b/default/scripting/techs/ship_weapons/ship_weapons.py
@@ -11,7 +11,6 @@ from focs._effects import (
     PartSecondaryStat,
     SetCapacity,
     SetMaxCapacity,
-    SetMaxSecondaryStat,
     SetSecondaryStat,
     Source,
     Target,
@@ -23,7 +22,6 @@ from techs.techs import (
     EMPIRE_OWNED_SHIP_WITH_PART,
     SHIP_PART_UPGRADE_RESUPPLY_CHECK,
 )
-
 
 # Tech based setting of damage and number of shots of a weapon. Registers named reals for use in the pedia.
 # Be careful the effect does not show in the ship damage/shot estimates in the ship designer UI if the tech is not researched yet.

--- a/default/scripting/techs/ship_weapons/ship_weapons.py
+++ b/default/scripting/techs/ship_weapons/ship_weapons.py
@@ -32,7 +32,7 @@ from techs.techs import (
 #     increases the part's SecondarStat MaxMeter by the PartSecondaryStat
 def SET_BOTH_MAX_CAPACITIES_FROM_PART_CAPACITIES(part_name: str):
     return EffectsGroup(
-        scope=EMPIRE_OWNED_SHIP_WITH_PART(part_name),
+        scope=Ship & (OwnedBy(empire=Source.Owner) | Unowned) & DesignHasPart(name=part_name),
         accountinglabel=part_name,
         # The standard/default effect happen at default priority, before any scripted ones happen
         # In order for this tech effect to also happen first, we make it happen slightly earlier

--- a/default/scripting/techs/ship_weapons/ship_weapons.py
+++ b/default/scripting/techs/ship_weapons/ship_weapons.py
@@ -1,5 +1,5 @@
 from common.misc import SHIP_WEAPON_DAMAGE_FACTOR
-from common.priorities import AFTER_ALL_TARGET_MAX_METERS_PRIORITY, TARGET_EARLY_BEFORE_SCALING_PRIORITY
+from common.priorities import AFTER_ALL_TARGET_MAX_METERS_PRIORITY
 from focs._effects import (
     CurrentContent,
     CurrentTurn,
@@ -23,25 +23,6 @@ from techs.techs import (
     EMPIRE_OWNED_SHIP_WITH_PART,
     SHIP_PART_UPGRADE_RESUPPLY_CHECK,
 )
-
-
-# Set the max meters for damage and number of shots to the base value from the ship part specification.
-# So direct weapon parts with NoDefaultCapacityEffect will not have the damage/PartCapacity scaled by SHIP_DAMAGE_WEAPON_FACTOR.
-# NB: The default effects of a direct weapon part
-#     increases the part's Capacity MaxMeter by the PartCapacity (which is the capacity from the part definition scaled by the game rule)
-#     increases the part's SecondarStat MaxMeter by the PartSecondaryStat
-def SET_BOTH_MAX_CAPACITIES_FROM_PART_CAPACITIES(part_name: str):
-    return EffectsGroup(
-        scope=Ship & (OwnedBy(empire=Source.Owner) | Unowned) & DesignHasPart(name=part_name),
-        accountinglabel=part_name,
-        # The standard/default effect happen at default priority, before any scripted ones happen
-        # In order for this tech effect to also happen first, we make it happen slightly earlier
-        priority=TARGET_EARLY_BEFORE_SCALING_PRIORITY,
-        effects=[
-            SetMaxCapacity(partname=part_name, value=PartCapacity(name=part_name)),
-            SetMaxSecondaryStat(partname=part_name, value=PartSecondaryStat(name=part_name)),
-        ],
-    )
 
 
 # Tech based setting of damage and number of shots of a weapon. Registers named reals for use in the pedia.


### PR DESCRIPTION
quickfix for #4636 

* this will apply the base effect of standard weapons: setting capacatiy/2nd to max_* also on monsters (before only on ships of the tech owner)
* this will fix e.g. flak on drone factories

* actually the effect will apply too often (updates unowned ships once per empire)
* the correct fix would probably be moving this effect out of tech to the ship part ** it would be nice to measure the performance of both approaches (tech vs part based)
* if I am not mistaken the default effects also do this setting correctly, so the problems only exist with NoDefaultCapacity parts
* also for current content, the fix could be to split NoDefaultCapacity and NoDefaultSecondaryStat