### PR TITLE
[AI] Another attempt to handle focus switches via target ratio

### DIFF
--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -582,8 +582,14 @@ class PlanetFocusManager:
         Calculate ratios of planned PP / industry priority and RP / research priority.
         It uses future_focus of all planets, setting this value without baking it can be used to check alternatives.
         """
-        planned_pp_target = sum(pi.possible_output[pi.future_focus].industry for pi in self.planet_info.values())
-        planned_rp_target = sum(pi.possible_output[pi.future_focus].research for pi in self.planet_info.values())
+        planned_pp_target = sum(
+            pi.possible_output[pi.future_focus].industry
+            for pi in chain(self.baked_planet_info.values(), self.planet_info.values())
+        )
+        planned_rp_target = sum(
+            pi.possible_output[pi.future_focus].research
+            for pi in chain(self.baked_planet_info.values(), self.planet_info.values())
+        )
         pp_per_priority = planned_pp_target / self.priority_industry
         rp_per_priority = planned_rp_target / self.priority_research
         debug(

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -134,17 +134,23 @@ class PlanetFocusInfo:
     def best_over_second(self) -> float:
         return self.rated_foci.best.rating - self.rated_foci.second.rating
 
+    def difference(self, focus1: str, focus2: str) -> float:
+        """How much is the output of focus1 better or worse than output of focus2."""
+        return self.possible_output[focus1].rating - self.possible_output[focus2].rating
+
     def evaluate(self, focus: str) -> float:
         """
         Compare focus with best alternative.
         If focus produces best, return a positive rating, giving how much its output is better than second best.
         If another focus produces better, returns a negative rating, giving how much it is worse than best.
+        Result is divided by sqrt(population) to prefer switching smaller planets.
         """
-        sqrt_population = min(1.0, self.planet.currentMeterValue(fo.meterType.population)) ** 0.5
+        sqrt_population = max(1.0, self.planet.currentMeterValue(fo.meterType.population)) ** 0.5
         if sqrt_population == 0:
             sqrt_population = 0.0001  # prevent Zero division
 
         if focus == self.rated_foci.best.focus:
+            # TBD replace division by using immediate_lost...
             return self.best_over_second() / sqrt_population
         else:
             return self.rating_below_best(focus) / sqrt_population
@@ -442,7 +448,7 @@ class PlanetFocusManager:
 
     def evaluate_computronium(self, pid: PlanetId, loss: float) -> bool:
         """
-        Determine whether switching the given planet with a computronium to research focus is worse the loss.
+        Determine whether switching the given planet with a computronium to research focus is worth the loss.
         """
         researchers = 0.0  # amount of people that would profit from the special
         min_stability = get_named_real("COMPUTRONIUM_MIN_STABILITY")
@@ -520,55 +526,149 @@ class PlanetFocusManager:
                         self.bake_future_focus(capital.id, INDUSTRY)
                     # else: don't do anything special, standard handling will likely switch to RESEARCH
 
+    def immediate_loss_on_switch_to(self, pinfo: PlanetFocusInfo, focus: str) -> float:
+        """
+        When switching to focus, how much would the current production go down?
+        E.g. when switching from research to production, how much does research go down?
+        Since it may take several turns until we reach the new targets, this can be used as an indicator how
+        'expensive' the switch would be.
+        """
+        # This is not totally correct, since it won't go down to the minimum immediately. but it should be a good
+        # enough estimate to compare how expensive a different switches would be.
+        low_rating = self.rate_output(
+            pp=min(pinfo.current_output.industry, pinfo.possible_output[focus].industry),
+            rp=min(pinfo.current_output.research, pinfo.possible_output[focus].research),
+            ip=min(pinfo.current_output.influence, pinfo.possible_output[focus].influence),
+            stability=min(pinfo.current_output.stability, pinfo.possible_output[focus].stability),
+            focus=focus,
+        )
+        current_rating = self.rate_output(
+            pp=pinfo.current_output.industry,
+            rp=pinfo.current_output.research,
+            ip=pinfo.current_output.influence,
+            stability=pinfo.current_output.stability,
+            focus=pinfo.current_focus,
+        )
+
+        # note that this may be zero, e.g. for a newly conquered planet or one that currently has negative stability
+        return current_rating - low_rating
+
+    def change_candidate(
+        self, best_so_far: PlanetFocusInfo | None, candidate: PlanetFocusInfo, from_focus: str, to_focus: str
+    ) -> PlanetFocusInfo:
+        """
+        Returns either candidate or best_so_far (if not None), depending on which one should rather do the
+        given focus switch.
+        """
+        if best_so_far is None:
+            return candidate
+        best_val = best_so_far.possible_output[to_focus].rating - best_so_far.possible_output[from_focus].rating
+        cand_val = candidate.possible_output[to_focus].rating - candidate.possible_output[from_focus].rating
+        if best_val > 0:
+            # to_focus would be an improvement for best_so_far, chose candidate if it gains even more
+            return candidate if cand_val > best_val else best_so_far
+        elif cand_val > 0:
+            # to_focus would be an improvement for candidate
+            return candidate
+        else:
+            # Neither would be better, prefer planets with a smaller immediate and long term loss
+            # Small offsets, since both values may be zero
+            best_val = (best_val - 0.1) * (self.immediate_loss_on_switch_to(best_so_far, to_focus) ** 0.5 + 0.1)
+            cand_val = (cand_val - 0.1) * (self.immediate_loss_on_switch_to(candidate, to_focus) ** 0.5 + 0.1)
+            return candidate if cand_val > best_val else best_so_far
+
+    def get_planned_pp_rp_per_prio(self) -> (float, float):
+        """
+        Calculate ratios of planned PP / industry priority and RP / research priority.
+        It uses future_focus of all planets, setting this value without baking it can be used to check alternatives.
+        """
+        planned_pp_target = sum(pi.possible_output[pi.future_focus].industry for pi in self.planet_info.values())
+        planned_rp_target = sum(pi.possible_output[pi.future_focus].research for pi in self.planet_info.values())
+        pp_per_priority = planned_pp_target / self.priority_industry
+        rp_per_priority = planned_rp_target / self.priority_research
+        debug(
+            f"pp: {planned_pp_target}/{self.priority_industry}={pp_per_priority}, "
+            f"rp: {planned_rp_target}/{self.priority_research}={rp_per_priority}"
+        )
+        return pp_per_priority, rp_per_priority
+
     def set_other_foci(self):
         """
         Set remaining planet's foci.
-        If best focus is protection, it is set.
-        Others are set to industry or research, aiming for a production ratio like the ratio of the priorities.
+        If best focus is protection, set it, else if only one of industry and research is possible, set it.
+        All others are set to industry or research, aiming for a production ratio like the ratio of the priorities.
+        If we have one or more candidates currently set to neither industry nor research, we assign these, otherwise
+        we may switch one planet from industry to research or vice versa, or let two planets swap their foci.
         """
         debug("set_other_foci...")
-        industry_or_research = []
+        may_switch_to_research = None
+        may_switch_to_industry = None
+        set_to_neither = []
         for pid, pinfo in dict(self.planet_info).items():
             # Note that if focus hasn't been baked as INFLUENCE yet, it shouldn't be.
             if pinfo.rated_foci.best.focus in (INDUSTRY, RESEARCH, INFLUENCE) and {INDUSTRY, RESEARCH} <= pinfo.options:
-                # sort planets:
-                # - negative values, if research is better
-                # - ratio of delta research / delta industry or vice versa as absolute value
-                # So, best research planets are at the beginning, and best industry planets are at the end.
-                # Note that first criteria is better rating, so e.g. a planet that is happier and gets flat bonuses
-                # with research, but not with industry, should be set to research before any with a better rating
-                # for industry.
-                industry_rating = pinfo.possible_output[INDUSTRY].rating
-                research_rating = pinfo.possible_output[RESEARCH].rating
-                # adding 0.001 to make sure we never divide by zero, shouldn't affect normal values much
-                pp_delta = pinfo.possible_output[INDUSTRY].industry - pinfo.possible_output[RESEARCH].industry + 0.001
-                rp_delta = pinfo.possible_output[RESEARCH].research - pinfo.possible_output[INDUSTRY].research + 0.001
-                sort_value = -rp_delta / pp_delta if research_rating > industry_rating else pp_delta / rp_delta
-                industry_or_research.append((sort_value, pinfo))
+                if pinfo.current_focus == INDUSTRY:
+                    may_switch_to_research = self.change_candidate(may_switch_to_research, pinfo, INDUSTRY, RESEARCH)
+                elif pinfo.current_focus == RESEARCH:
+                    may_switch_to_industry = self.change_candidate(may_switch_to_industry, pinfo, RESEARCH, INDUSTRY)
+                else:
+                    set_to_neither.append(pinfo)
             else:
                 # Either protection due to stability, or planet does not support both foci
                 self.bake_future_focus(pid, pinfo.rated_foci.best.focus)
-        industry_or_research.sort()
-        debug(f"Assigning ind/res, candidates: {industry_or_research}")
-        current_pp_target = sum(pi.possible_output[pi.current_focus].industry for pi in self.baked_planet_info.values())
-        current_rp_target = sum(pi.possible_output[pi.current_focus].research for pi in self.baked_planet_info.values())
-        while industry_or_research:
-            # Mini offset to avoid comparing 0 vs 0, so higher priority wins if we have not baked anything yet.
-            pp_per_priority = (current_pp_target + 0.1) / self.priority_industry
-            ip_per_priority = (current_rp_target + 0.1) / self.priority_research
-            debug(
-                f"pp: {current_pp_target}/{self.priority_industry}={pp_per_priority}, "
-                f"rp: {current_rp_target}/{self.priority_research}={ip_per_priority}"
-            )
-            if pp_per_priority > ip_per_priority:
-                # set one to research, best research (or worst industry) planets are at the beginning
-                _, pinfo = industry_or_research.pop(0)
-                self.bake_future_focus(pinfo.planet.id, RESEARCH)
+        if set_to_neither:
+            self.chose_industry_or_research(set_to_neither)
+        else:
+            self.chose_switches(may_switch_to_research, may_switch_to_industry)
+
+    def chose_industry_or_research(self, set_to_neither: list[PlanetFocusInfo]) -> None:
+        """Assign planets in set_to_neither to industry or research focus."""
+        set_to_neither.sort()
+        debug(f"chose_industry_or_research set_to_neither={set_to_neither}")
+        while set_to_neither:
+            pp_per_priority, rp_per_priority = self.get_planned_pp_rp_per_prio()
+            # sorting is best research to best industry
+            if pp_per_priority > rp_per_priority:
+                self.bake_future_focus(set_to_neither[0].planet.id, RESEARCH)
+                set_to_neither.pop(0)
             else:
-                _, pinfo = industry_or_research.pop(-1)
-                self.bake_future_focus(pinfo.planet.id, INDUSTRY)
-            current_pp_target += pinfo.possible_output[pinfo.future_focus].industry
-            current_rp_target += pinfo.possible_output[pinfo.future_focus].research
+                self.bake_future_focus(set_to_neither[-1].planet.id, INDUSTRY)
+                set_to_neither.pop()
+
+    def chose_switches(self, to_research: PlanetFocusInfo, to_industry: PlanetFocusInfo) -> None:
+        """
+        Decide which of the two candidates should switch between industry and research, if any.
+        """
+        debug(f"chose_switches, candidates: research={to_research or '-'}, industry={to_industry or '-'}")
+        tr_gain = to_research.difference(RESEARCH, INDUSTRY) if to_research else USELESS_RATING
+        ti_gain = to_industry.difference(INDUSTRY, RESEARCH) if to_industry else USELESS_RATING
+        if tr_gain > 0 and ti_gain > 0:
+            debug("both are better with the new focus")
+            self.bake_future_focus(to_research.planet.id, RESEARCH)
+            self.bake_future_focus(to_industry.planet.id, INDUSTRY)
+        else:
+            pp_per_priority, rp_per_priority = self.get_planned_pp_rp_per_prio()
+            debug(f"current: PP/prio={pp_per_priority:.4f}, RP/prio={rp_per_priority:.4f}")
+            # For an AI without a capital numbers may be 0. But if one is bigger than the other,
+            # at least this one cannot be, so it is safe ot use it as a divisor.
+            if to_research and pp_per_priority > rp_per_priority:
+                self.check_switch_for_ratio(to_research, RESEARCH, rp_per_priority / pp_per_priority)
+            elif to_industry and rp_per_priority > pp_per_priority:
+                self.check_switch_for_ratio(to_industry, INDUSTRY, pp_per_priority / rp_per_priority)
+
+    def check_switch_for_ratio(self, candidate: PlanetFocusInfo, new_focus: str, old_ratio: float) -> None:
+        candidate.future_focus = new_focus
+        new_ppp, new_rpp = self.get_planned_pp_rp_per_prio()
+        # if the targeted value is 0 after the switch, we surely want to revert
+        if new_focus == RESEARCH:
+            new_ratio = new_ppp / new_rpp if new_rpp else -1
+        else:
+            new_ratio = new_rpp / new_ppp if new_ppp else -1
+        debug(f"With switch: PP/prio={new_ppp:.4f}, RP/prio={new_rpp:.4f}")
+        # ideal ratio would be 1.0, the smaller, the worse
+        if new_ratio < old_ratio:
+            candidate.future_focus = candidate.current_focus
+        self.bake_future_focus(candidate.planet.id, candidate.future_focus)
 
 
 class Reporter:


### PR DESCRIPTION
This should work better than the old code, but on its own still produces weird decisions. Often it would be better to simply chose always the best focus. That however has two problems:
- Large empires will do almost no research, because when the research priority is low, industry is considered "better" for almost all planets
- When having a lot of similar planets, e.g. mostly starting species without any specials that affect industry or research, a small change in the priorities may make the AI switch all planets at once.

@MichaelCourtney Please have a look at this. The stupid decisions at the beginning could probably be avoided by using more selective priorities. Or perhaps we could use the best only up until some point (minimum number of planets to chose from? Other ideas?)

Also, in general, we should work on the priorities. At least the first point could also be solve in a much simpler way by avoiding extremely low research priorities.
