### PR TITLE
fix build (boost<1.79,missing include)

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1300,7 +1300,7 @@ Empire::IntSet Empire::ExploredSystems() const {
     const auto rng = m_explored_systems | range_keys;
     static_assert(std::is_same_v<std::decay_t<decltype(m_explored_systems)>, std::map<int, int>>,
                   "make sure m_explored_systems is sorted for use of ordered_unique_range below");
-#if BOOST_VERSION > 107400
+#if BOOST_VERSION > 107800
     return {boost::container::ordered_unique_range, rng.begin(), rng.end()};
 #else
     Empire::IntSet::sequence_type scratch;

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -419,7 +419,7 @@ void SupplyManager::Update(const ScriptingContext& context) {
                           std::map<int, std::pair<float, float>>>,
                           "make sure supply ranges are sorted for use with ordered_unique_range below");
             auto sys_ids_rng = supply_ranges | range_keys;
-#if BOOST_VERSION > 107400
+#if BOOST_VERSION > 107800
             systems_with_supply_in_them.insert(boost::container::ordered_unique_range,
                                                sys_ids_rng.begin(), sys_ids_rng.end());
 #else

--- a/UI/Sound.cpp
+++ b/UI/Sound.cpp
@@ -15,6 +15,7 @@
 
 #include <atomic>
 #include <map>
+#include <mutex>
 
 class Sound::Impl {
 public:

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -310,7 +310,7 @@ Universe::IDSet Universe::EmpireVisibleObjectIDs(int empire_id, const EmpireMana
 
     auto ids_rng = m_objects->allWithIDs() | range_keys | range_filter(is_visible_to_an_empire);
     Universe::IDSet retval;
-#if BOOST_VERSION > 107400
+#if BOOST_VERSION > 107800
     retval.reserve(m_objects->size());
     retval.insert(boost::container::ordered_unique_range, ids_rng.begin(), ids_rng.end());
 #else


### PR DESCRIPTION
with this current master compiles on my fedora 36/gcc

this applies the boost version check for boost ranges from #4720  (and deprecates that PR)

it also adds a missing <mutex> header, else UI/Sound.cpp would not compile


forum discussion at https://freeorion.org/forum/viewtopic.php?t=12859


