### PR TITLE
Implement Value as separate entity in Python FOCS parser

### DIFF
--- a/parse/PythonParser.cpp
+++ b/parse/PythonParser.cpp
@@ -101,6 +101,7 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
             .def(py::self_ns::self - int())
             .def(int() - py::self_ns::self)
             .def(py::self_ns::self + py::self_ns::self)
+            .def(py::other<value_placeholder>() + py::self_ns::self)
             .def(py::self_ns::self + int())
             .def(double() + py::self_ns::self)
             .def(py::self_ns::self < py::self_ns::self)
@@ -115,7 +116,6 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
             .def(py::self_ns::self | py::self_ns::self)
             .def(py::self_ns::pow(py::self_ns::self, double()));
         py::class_<value_ref_wrapper<double>>("ValueRefDouble", py::no_init)
-            .def("__call__", &value_ref_wrapper<double>::call)
             .def(int() * py::self_ns::self)
             .def(py::other<value_ref_wrapper<int>>() * py::self_ns::self)
             .def(py::self_ns::self * py::other<value_ref_wrapper<int>>())
@@ -128,9 +128,11 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
             .def(py::self_ns::self + int())
             .def(py::self_ns::self + double())
             .def(py::self_ns::self + py::self_ns::self)
+            .def(py::other<value_placeholder>() + py::self_ns::self)
             .def(py::self_ns::self + py::other<value_ref_wrapper<int>>())
             .def(py::self_ns::self - double())
             .def(py::self_ns::self - py::self_ns::self)
+            .def(py::other<value_placeholder>() - py::self_ns::self)
             .def(py::self_ns::self - py::other<value_ref_wrapper<int>>())
             .def(int() + py::self_ns::self)
             .def(int() - py::self_ns::self)
@@ -153,6 +155,15 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
             .def(py::self_ns::self + std::string())
             .def(std::string() + py::self_ns::self);
         py::class_<value_ref_wrapper<Visibility>>("ValueRefVisibility", py::no_init);
+        py::class_<value_placeholder>("ValuePlaceHolder", py::no_init)
+            .def("__call__", &value_placeholder::call<double>)
+            .def(py::self_ns::self + double())
+            .def(py::self_ns::self * double())
+            .def(py::self_ns::self / double())
+            .def(py::self_ns::self - int())
+            .def(int() - py::self_ns::self)
+            .def(py::self_ns::self * int())
+            .def(py::self_ns::self / int());
         py::class_<condition_wrapper>("Condition", py::no_init)
             .def(py::self_ns::self & py::self_ns::self)
             .def(py::self_ns::self & py::other<value_ref_wrapper<double>>())
@@ -299,6 +310,10 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
 
         py::implicitly_convertible<value_ref_wrapper<double>, condition_wrapper>();
         py::implicitly_convertible<value_ref_wrapper<int>, condition_wrapper>();
+
+        py::implicitly_convertible<value_placeholder, value_ref_wrapper<double>>();
+        py::implicitly_convertible<value_placeholder, value_ref_wrapper<int>>();
+        py::implicitly_convertible<value_placeholder, value_ref_wrapper<Visibility>>();
 
         m_meta_path = py::extract<py::list>(py::import("sys").attr("meta_path"));
         const int meta_path_len = py::len(m_meta_path);

--- a/parse/ValueRefPythonParser.cpp
+++ b/parse/ValueRefPythonParser.cpp
@@ -103,6 +103,26 @@ value_ref_wrapper<double> operator*(const value_ref_wrapper<double>& lhs, const 
     );
 }
 
+value_ref_wrapper<double> operator*(value_placeholder, int rhs) {
+    return value_ref_wrapper<double>(
+        std::make_shared<ValueRef::Operation<double>>(
+            ValueRef::OpType::TIMES,
+            std::make_unique<ValueRef::Variable<double>>(ValueRef::ReferenceType::EFFECT_TARGET_VALUE_REFERENCE),
+            std::make_unique<ValueRef::Constant<double>>(rhs)
+        )
+    );
+}
+
+value_ref_wrapper<double> operator*(value_placeholder, double rhs) {
+    return value_ref_wrapper<double>(
+        std::make_shared<ValueRef::Operation<double>>(
+            ValueRef::OpType::TIMES,
+            std::make_unique<ValueRef::Variable<double>>(ValueRef::ReferenceType::EFFECT_TARGET_VALUE_REFERENCE),
+            std::make_unique<ValueRef::Constant<double>>(rhs)
+        )
+    );
+}
+
 value_ref_wrapper<double> operator/(const value_ref_wrapper<double>& lhs, const value_ref_wrapper<double>& rhs) {
     return value_ref_wrapper<double>(
         std::make_shared<ValueRef::Operation<double>>(
@@ -128,6 +148,26 @@ value_ref_wrapper<double> operator/(const value_ref_wrapper<double>& lhs, double
         std::make_shared<ValueRef::Operation<double>>(
             ValueRef::OpType::DIVIDE,
             ValueRef::CloneUnique(lhs.value_ref),
+            std::make_unique<ValueRef::Constant<double>>(rhs)
+        )
+    );
+}
+
+value_ref_wrapper<double> operator/(value_placeholder, int rhs) {
+    return value_ref_wrapper<double>(
+        std::make_shared<ValueRef::Operation<double>>(
+            ValueRef::OpType::DIVIDE,
+            std::make_unique<ValueRef::Variable<double>>(ValueRef::ReferenceType::EFFECT_TARGET_VALUE_REFERENCE),
+            std::make_unique<ValueRef::Constant<double>>(rhs)
+        )
+    );
+}
+
+value_ref_wrapper<double> operator/(value_placeholder, double rhs) {
+    return value_ref_wrapper<double>(
+        std::make_shared<ValueRef::Operation<double>>(
+            ValueRef::OpType::DIVIDE,
+            std::make_unique<ValueRef::Variable<double>>(ValueRef::ReferenceType::EFFECT_TARGET_VALUE_REFERENCE),
             std::make_unique<ValueRef::Constant<double>>(rhs)
         )
     );
@@ -192,6 +232,36 @@ value_ref_wrapper<double> operator+(const value_ref_wrapper<double>& lhs, const 
     );
 }
 
+value_ref_wrapper<double> operator+(value_placeholder, const value_ref_wrapper<double>& rhs) {
+    return value_ref_wrapper<double>(
+        std::make_shared<ValueRef::Operation<double>>(
+            ValueRef::OpType::PLUS,
+            std::make_unique<ValueRef::Variable<double>>(ValueRef::ReferenceType::EFFECT_TARGET_VALUE_REFERENCE),
+            ValueRef::CloneUnique(rhs.value_ref)
+        )
+    );
+}
+
+value_ref_wrapper<double> operator+(value_placeholder, const value_ref_wrapper<int>& rhs) {
+    return value_ref_wrapper<double>(
+        std::make_shared<ValueRef::Operation<double>>(
+            ValueRef::OpType::PLUS,
+            std::make_unique<ValueRef::Variable<double>>(ValueRef::ReferenceType::EFFECT_TARGET_VALUE_REFERENCE),
+            std::make_unique<ValueRef::StaticCast<int, double>>(ValueRef::CloneUnique(rhs.value_ref))
+        )
+    );
+}
+
+value_ref_wrapper<double> operator+(value_placeholder, double rhs) {
+    return value_ref_wrapper<double>(
+        std::make_shared<ValueRef::Operation<double>>(
+            ValueRef::OpType::PLUS,
+            std::make_unique<ValueRef::Variable<double>>(ValueRef::ReferenceType::EFFECT_TARGET_VALUE_REFERENCE),
+            std::make_unique<ValueRef::Constant<double>>(rhs)
+        )
+    );
+}
+
 value_ref_wrapper<double> operator+(const value_ref_wrapper<double>& lhs, const value_ref_wrapper<int>& rhs) {
     return value_ref_wrapper<double>(
         std::make_shared<ValueRef::Operation<double>>(
@@ -228,6 +298,36 @@ value_ref_wrapper<double> operator-(const value_ref_wrapper<double>& lhs, const 
             ValueRef::OpType::MINUS,
             ValueRef::CloneUnique(lhs.value_ref),
             ValueRef::CloneUnique(rhs.value_ref)
+        )
+    );
+}
+
+value_ref_wrapper<double> operator-(value_placeholder, const value_ref_wrapper<double>& rhs) {
+    return value_ref_wrapper<double>(
+        std::make_shared<ValueRef::Operation<double>>(
+            ValueRef::OpType::MINUS,
+            std::make_unique<ValueRef::Variable<double>>(ValueRef::ReferenceType::EFFECT_TARGET_VALUE_REFERENCE),
+            ValueRef::CloneUnique(rhs.value_ref)
+        )
+    );
+}
+
+value_ref_wrapper<double> operator-(value_placeholder, int rhs) {
+    return value_ref_wrapper<double>(
+        std::make_shared<ValueRef::Operation<double>>(
+            ValueRef::OpType::MINUS,
+            std::make_unique<ValueRef::Variable<double>>(ValueRef::ReferenceType::EFFECT_TARGET_VALUE_REFERENCE),
+            std::make_unique<ValueRef::Constant<double>>(static_cast<double>(rhs))
+        )
+    );
+}
+
+value_ref_wrapper<double> operator-(int lhs, value_placeholder) {
+    return value_ref_wrapper<double>(
+        std::make_shared<ValueRef::Operation<double>>(
+            ValueRef::OpType::MINUS,
+            std::make_unique<ValueRef::Constant<double>>(static_cast<double>(lhs)),
+            std::make_unique<ValueRef::Variable<double>>(ValueRef::ReferenceType::EFFECT_TARGET_VALUE_REFERENCE)
         )
     );
 }
@@ -920,7 +1020,7 @@ void RegisterGlobalsValueRefs(boost::python::dict& globals, const PythonParser& 
     globals["NamedIntegerLookup"] = boost::python::raw_function(insert_named_lookup_<int>);
     globals["NamedReal"] = boost::python::raw_function(insert_named_<double>);
     globals["NamedRealLookup"] = boost::python::raw_function(insert_named_lookup_<double>);
-    globals["Value"] = value_ref_wrapper<double>(std::make_shared<ValueRef::Variable<double>>(ValueRef::ReferenceType::EFFECT_TARGET_VALUE_REFERENCE));
+    globals["Value"] = value_placeholder();
 
     // free variable name
     for (const char* variable : {"CombatBout",

--- a/parse/ValueRefPythonParser.h
+++ b/parse/ValueRefPythonParser.h
@@ -20,21 +20,6 @@ struct value_ref_wrapper {
         value_ref(ref)
     {}
 
-    value_ref_wrapper<T> call(const value_ref_wrapper<T>& var_) const {
-        auto var = std::dynamic_pointer_cast<const ValueRef::Variable<T>>(var_.value_ref);
-        if (var) {
-            return value_ref_wrapper<T>(std::make_shared<ValueRef::Variable<T>>(
-                                            var->GetReferenceType(),
-                                            var->PropertyName(),
-                                            true
-                                        ));
-        } else if(var_.value_ref) {
-            throw std::runtime_error(std::string("Unknown type of Value.__call__ ") + typeid(*var_.value_ref).name());
-        } else {
-            throw std::runtime_error("Empty value in Value.__call__");
-        }
-    }
-
     operator condition_wrapper() const {
         auto op = std::dynamic_pointer_cast<const ValueRef::Operation<T>>(value_ref);
 
@@ -74,6 +59,29 @@ struct value_ref_wrapper {
     const std::shared_ptr<const ValueRef::ValueRef<T>> value_ref;
 };
 
+struct value_placeholder {
+    template<typename T>
+    operator value_ref_wrapper<T>() const {
+        return value_ref_wrapper<T>(std::make_shared<ValueRef::Variable<T>>(ValueRef::ReferenceType::EFFECT_TARGET_VALUE_REFERENCE));
+    }
+
+    template<typename T>
+    value_ref_wrapper<T> call(const value_ref_wrapper<T>& var_) const {
+        auto var = std::dynamic_pointer_cast<const ValueRef::Variable<T>>(var_.value_ref);
+        if (var) {
+            return value_ref_wrapper<T>(std::make_shared<ValueRef::Variable<T>>(
+                                            var->GetReferenceType(),
+                                            var->PropertyName(),
+                                            true
+                                        ));
+        } else if(var_.value_ref) {
+            throw std::runtime_error(std::string("Unknown type of Value.__call__ ") + typeid(*var_.value_ref).name());
+        } else {
+            throw std::runtime_error("Empty value in Value.__call__");
+        }
+    }
+};
+
 value_ref_wrapper<double> pow(const value_ref_wrapper<int>& lhs, double rhs);
 value_ref_wrapper<double> pow(const value_ref_wrapper<double>& lhs, double rhs);
 value_ref_wrapper<double> pow(double lhs, const value_ref_wrapper<double>& rhs);
@@ -86,17 +94,27 @@ value_ref_wrapper<double> operator*(const value_ref_wrapper<double>&, double);
 value_ref_wrapper<double> operator*(double, const value_ref_wrapper<double>&);
 value_ref_wrapper<double> operator*(double, const value_ref_wrapper<int>&);
 value_ref_wrapper<double> operator*(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
+value_ref_wrapper<double> operator*(value_placeholder, int);
+value_ref_wrapper<double> operator*(value_placeholder, double);
 value_ref_wrapper<double> operator/(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
 value_ref_wrapper<double> operator/(const value_ref_wrapper<double>&, int);
 value_ref_wrapper<double> operator/(const value_ref_wrapper<double>&, double);
+value_ref_wrapper<double> operator/(value_placeholder, int);
+value_ref_wrapper<double> operator/(value_placeholder, double);
 value_ref_wrapper<double> operator+(int, const value_ref_wrapper<double>&);
 value_ref_wrapper<double> operator+(const value_ref_wrapper<double>&, int);
 value_ref_wrapper<double> operator+(const value_ref_wrapper<double>&, double);
 value_ref_wrapper<double> operator+(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
+value_ref_wrapper<double> operator+(value_placeholder, const value_ref_wrapper<double>&);
+value_ref_wrapper<double> operator+(value_placeholder, const value_ref_wrapper<int>&);
+value_ref_wrapper<double> operator+(value_placeholder, double);
 value_ref_wrapper<double> operator+(const value_ref_wrapper<double>&, const value_ref_wrapper<int>&);
 value_ref_wrapper<double> operator+(double, const value_ref_wrapper<int>&);
 value_ref_wrapper<double> operator-(const value_ref_wrapper<double>&, double);
 value_ref_wrapper<double> operator-(const value_ref_wrapper<double>&, const value_ref_wrapper<double>&);
+value_ref_wrapper<double> operator-(value_placeholder, const value_ref_wrapper<double>&);
+value_ref_wrapper<double> operator-(value_placeholder, int);
+value_ref_wrapper<double> operator-(int, value_placeholder);
 value_ref_wrapper<double> operator-(int, const value_ref_wrapper<double>&);
 value_ref_wrapper<double> operator-(double, const value_ref_wrapper<int>&);
 value_ref_wrapper<double> operator-(const value_ref_wrapper<double>&, int);


### PR DESCRIPTION
Known issue:

```
                SetStockpile value = Value + min(abs(Value(Target.MaxStockpile) - Value), 1.000000) * (1.000000 - 2.000000 * Value ? Value(Target.MaxStockpile))
```
became
```
                SetStockpile value = Value + min(abs(Value(Target.MaxStockpile) - (Value) // StaticCast{i,d}
                    ), 1.000000) * (1.000000 - 2.000000 * Value(Target.MaxStockpile) ? Value)
```