### PR TITLE
Do not deny any FOCUS to Exobot based on Racial Purity policy

### DIFF
--- a/default/scripting/species/common/focus.py
+++ b/default/scripting/species/common/focus.py
@@ -27,6 +27,7 @@ HAS_RESEARCH_FOCUS = FocusType(
     location=Planet()
     & (
         ~EmpireHasAdoptedPolicy(empire=Source.Owner, name="PLC_RACIAL_PURITY")
+        | HasSpecies(name=["SP_EXOBOT"])
         | HasSpecies(
             name=[Statistic(str, Mode, value=LocalCandidate.Species, condition=Capital & OwnedBy(empire=Source.Owner))]
         )
@@ -40,6 +41,7 @@ HAS_INFLUENCE_FOCUS = FocusType(
     location=Planet()
     & (
         ~EmpireHasAdoptedPolicy(empire=Source.Owner, name="PLC_RACIAL_PURITY")
+        | HasSpecies(name=["SP_EXOBOT"])
         | HasSpecies(
             name=[Statistic(str, Mode, value=LocalCandidate.Species, condition=Capital & OwnedBy(empire=Source.Owner))]
         )


### PR DESCRIPTION
fixes #4728 , good to go if the checks are green, I playtested it 
allowing influence focus does not do anything as exobot currently does not have that, but this spares us a bug in case exobot get changed