### PR TITLE
Add rank to game rules and option to sort them by rank; use that for GUI

### DIFF
--- a/Empire/Diplomacy.cpp
+++ b/Empire/Diplomacy.cpp
@@ -2,14 +2,17 @@
 
 #include "../universe/ConstantsFwd.h"
 #include "../util/GameRules.h"
+#include "../util/GameRuleRanks.h"
 #include "../util/i18n.h"
 
 namespace {
     void AddRules(GameRules& rules) {
         // determine if diplomacy allowed
         rules.Add<std::string>(UserStringNop("RULE_DIPLOMACY"), UserStringNop("RULE_DIPLOMACY_DESC"),
-                               UserStringNop("MULTIPLAYER"), UserStringNop("RULE_DIPLOMACY_ALLOWED_FOR_ALL"),
+                               GameRuleCategories::GameRuleCategory::MULTIPLAYER,
+                               UserStringNop("RULE_DIPLOMACY_ALLOWED_FOR_ALL"),
                                true,
+                               GameRuleRanks::RULE_DIPLOMACY_RANK,
                                DiscreteValidator<std::string>(std::array{
                                    "RULE_DIPLOMACY_ALLOWED_FOR_ALL",
                                    "RULE_DIPLOMACY_FORBIDDEN_FOR_ALL"

--- a/Empire/Government.cpp
+++ b/Empire/Government.cpp
@@ -10,6 +10,7 @@
 #include "../util/GameRules.h"
 #include "../util/MultiplayerCommon.h"
 #include "../util/GameRules.h"
+#include "../util/GameRuleRanks.h"
 #include "../util/CheckSums.h"
 #include "../util/ScopedTimer.h"
 #include "../Empire/Empire.h"
@@ -23,7 +24,8 @@ namespace {
     void AddRules(GameRules& rules) {
         // makes all policies cost 1 influence to adopt
         rules.Add<bool>(UserStringNop("RULE_CHEAP_POLICIES"), UserStringNop("RULE_CHEAP_POLICIES_DESC"),
-                        "TEST", false, true);
+                        GameRuleCategories::GameRuleCategory::TEST, false, true,
+                        GameRuleRanks::RULE_CHEAP_POLICIES_RANK);
     }
     bool temp_bool = RegisterGameRules(&AddRules);
 }

--- a/Empire/ProductionQueue.cpp
+++ b/Empire/ProductionQueue.cpp
@@ -10,6 +10,7 @@
 #include "../universe/ValueRef.h"
 #include "../util/AppInterface.h"
 #include "../util/GameRules.h"
+#include "../util/GameRuleRanks.h"
 #include "../util/ranges.h"
 #include "../util/ScopedTimer.h"
 #include "../util/i18n.h"
@@ -25,14 +26,21 @@ namespace {
         // limits amount of PP per turn that can be imported into the stockpile
         rules.Add<bool>(UserStringNop("RULE_STOCKPILE_IMPORT_LIMITED"),
                         UserStringNop("RULE_STOCKPILE_IMPORT_LIMITED_DESC"),
-                        "", false, true);
-
+                        GameRuleCategories::GameRuleCategory::GENERAL,
+                        false, true,
+                        GameRuleRanks::RULE_STOCKPILE_IMPORT_LIMITED_RANK);
         rules.Add<double>(UserStringNop("RULE_PRODUCTION_QUEUE_FRONTLOAD_FACTOR"),
                           UserStringNop("RULE_PRODUCTION_QUEUE_FRONTLOAD_FACTOR_DESC"),
-                          "", 0.0, true, RangedValidator<double>(0.0, 30.0));
+                          GameRuleCategories::GameRuleCategory::GENERAL,
+                          0.0, true,
+                          GameRuleRanks::RULE_PRODUCTION_QUEUE_FRONTLOAD_FACTOR_RANK,
+                          RangedValidator<double>(0.0, 30.0));
         rules.Add<double>(UserStringNop("RULE_PRODUCTION_QUEUE_TOPPING_UP_FACTOR"),
                           UserStringNop("RULE_PRODUCTION_QUEUE_TOPPING_UP_FACTOR_DESC"),
-                          "", 0.0, true, RangedValidator<double>(0.0, 30.0));
+                          GameRuleCategories::GameRuleCategory::GENERAL,
+                          0.0, true,
+                          GameRuleRanks::RULE_PRODUCTION_QUEUE_TOPPING_UP_FACTOR_RANK,
+                          RangedValidator<double>(0.0, 30.0));
     }
     bool temp_bool = RegisterGameRules(&AddRules);
 

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -1397,11 +1397,17 @@ namespace {
             return;
         }
         else if (item_name == "ENC_GAME_RULES") {
-            for (auto& [rule_name, rule] : GetGameRules()) {
-                if (rule.ValueIsDefault())
-                    detailed_description += UserString(rule_name) + " : " + rule.ValueToString() + "\n";
+            std::string last_category;
+            detailed_description += UserString("GENERAL") + ":\n";
+            for (const auto* rule : GetGameRules().GetSortedByCategoryAndRank()) {
+                if (last_category != rule->category) {
+                    last_category = rule->category;
+                    detailed_description += "\n\n" + UserString(last_category == "" ? "GENERAL" : last_category) + ":\n";
+                }
+                if (rule->ValueIsDefault())
+                    detailed_description += "    " + UserString(rule->name) + " : " + rule->ValueToString() + "\n";
                 else
-                    detailed_description += "<u>" + UserString(rule_name) + " : " + rule.ValueToString() + "</u>\n";
+                    detailed_description += "    <u>" + UserString(rule->name) + " : " + rule->ValueToString() + "</u>\n";
             }
             return;
         }

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -1397,12 +1397,12 @@ namespace {
             return;
         }
         else if (item_name == "ENC_GAME_RULES") {
-            std::string last_category;
+            std::string_view last_category;
             detailed_description += UserString("GENERAL") + ":\n";
             for (const auto* rule : GetGameRules().GetSortedByCategoryAndRank()) {
                 if (last_category != rule->category) {
                     last_category = rule->category;
-                    detailed_description += "\n\n" + UserString(last_category == "" ? "GENERAL" : last_category) + ":\n";
+                    detailed_description += "\n\n" + UserString(last_category.empty() ? "GENERAL" : last_category) + ":\n";
                 }
                 if (rule->ValueIsDefault())
                     detailed_description += "    " + UserString(rule->name) + " : " + rule->ValueToString() + "\n";

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -175,12 +175,12 @@ void GameRulesPanel::CompleteConstruction() {
     indexed_pages[""] = CreatePage(UserString("GENERAL"));
 
     // for all rules, add to page
-    for (const auto& rule : GetGameRules()) {
+    for (const auto* rule : GetGameRules().GetSortedByCategoryAndRank()) {
         // get or create page for rule
-        auto itr = indexed_pages.find(rule.second.category);
+        auto itr = indexed_pages.find(rule->category);
         if (itr == indexed_pages.end()) {
-            indexed_pages[rule.second.category] = CreatePage(UserString(rule.second.category));
-            itr = indexed_pages.find(rule.second.category);
+            indexed_pages[rule->category] = CreatePage(UserString(rule->category));
+            itr = indexed_pages.find(rule->category);
         }
         if (itr == indexed_pages.end()) {
             ErrorLogger() << "Unable to create and insert and then find new rule page";
@@ -189,18 +189,18 @@ void GameRulesPanel::CompleteConstruction() {
         auto current_page = itr->second;
 
         // add rule to page
-        switch (rule.second.type) {
+        switch (rule->type) {
         case GameRule::Type::TOGGLE:
-            BoolRuleWidget(current_page, 0, rule.first);
+            BoolRuleWidget(current_page, 0, rule->name);
             break;
         case GameRule::Type::INT:
-            IntRuleWidget(current_page, 0, rule.first);
+            IntRuleWidget(current_page, 0, rule->name);
             break;
         case GameRule::Type::DOUBLE:
-            DoubleRuleWidget(current_page, 0, rule.first);
+            DoubleRuleWidget(current_page, 0, rule->name);
             break;
         case GameRule::Type::STRING:
-            StringRuleWidget(current_page, 0, rule.first);
+            StringRuleWidget(current_page, 0, rule->name);
             break;
         default:
             break;

--- a/combat/CombatEvents.cpp
+++ b/combat/CombatEvents.cpp
@@ -7,6 +7,7 @@
 #include "../util/AppInterface.h"
 #include "../util/VarText.h"
 #include "../util/GameRules.h"
+#include "../util/GameRuleRanks.h"
 
 #include "../Empire/Empire.h"
 
@@ -21,10 +22,15 @@ namespace {
     void AddRules(GameRules& rules) {
         rules.Add<int>(UserStringNop("RULE_NUM_COMBAT_ROUNDS"),
                        UserStringNop("RULE_NUM_COMBAT_ROUNDS_DESC"),
-                       "", 4, true, RangedValidator<int>(2, 20));
+                       GameRuleCategories::GameRuleCategory::GENERAL,
+                       4, true,
+                       GameRuleRanks::RULE_NUM_COMBAT_ROUNDS_RANK,
+                       RangedValidator<int>(2, 20));
         rules.Add<bool>(UserStringNop("RULE_AGGRESSIVE_SHIPS_COMBAT_VISIBLE"),
                         UserStringNop("RULE_AGGRESSIVE_SHIPS_COMBAT_VISIBLE_DESC"),
-                        "", false, true);
+                        GameRuleCategories::GameRuleCategory::GENERAL,
+                        false, true,
+                        GameRuleRanks::RULE_AGGRESSIVE_SHIPS_COMBAT_VISIBLE_RANK);
 
     }
     bool temp_bool = RegisterGameRules(&AddRules);

--- a/default/scripting/game_rules.focs.py
+++ b/default/scripting/game_rules.focs.py
@@ -1,51 +1,51 @@
+# comments hold info about internal engine rules defined in c++ side, but this was manually created in some effort to bring the two together
+# and holds no power over what is on the C++ side
+# for proper ordering ranks need to make sense together with GameRuleRanks.h
+# categories are ranked by definitions in GameRuleCategories.h - add new category there in expected order, along with stringtable entry
+
+
+def count(start=0, step=1):
+    n = start
+    while True:
+        yield n
+        n += step
+
+
+#########################################
+# Category "" aka "GENERAL"
+#########################################
+# -> only internal rules so far
+#   internal RULE_RESEED_PRNG_SERVER
+#   internal RULE_EXTRASOLAR_SHIP_DETECTION
+#   internal RULE_BASIC_VIS_SYSTEM_INFO_SHOWN
+#   internal RULE_NUM_COMBAT_ROUNDS
+#   internal RULE_AGGRESSIVE_SHIPS_COMBAT_VISIBLE
+#   internal RULE_STOCKPILE_IMPORT_LIMITED
+#   internal RULE_PRODUCTION_QUEUE_FRONTLOAD_FACTOR
+#   internal RULE_PRODUCTION_QUEUE_TOPPING_UP_FACTOR
+
+
+#########################################
+# Category "CONTENT"
+#########################################
+ranker = count(start=100, step=100)
+
 GameRule(
-    name="RULE_SHIP_HULL_COST_FACTOR",
-    description="RULE_SHIP_HULL_COST_FACTOR_DESC",
-    category="BALANCE",
-    type=float,
-    default=1.0,
-    min=0.1,
-    max=10.0,
+    name="RULE_ALLOW_REPEATED_SPECIES",
+    description="RULE_ALLOW_REPEATED_SPECIES_DESC",
+    category="CONTENT",
+    type=bool,
+    default=False,
+    rank=next(ranker),
 )
 
 GameRule(
-    name="RULE_SHIP_PART_COST_FACTOR",
-    description="RULE_SHIP_PART_COST_FACTOR_DESC",
-    category="BALANCE",
-    type=float,
-    default=1.0,
-    min=0.1,
-    max=10.0,
-)
-
-GameRule(
-    name="RULE_TECH_COST_FACTOR",
-    description="RULE_TECH_COST_FACTOR_DESC",
-    category="BALANCE",
-    type=float,
-    default=1.0,
-    min=0.1,
-    max=10.0,
-)
-
-GameRule(
-    name="RULE_BUILDING_COST_FACTOR",
-    description="RULE_BUILDING_COST_FACTOR_DESC",
-    category="BALANCE",
-    type=float,
-    default=1.0,
-    min=0.1,
-    max=10.0,
-)
-
-GameRule(
-    name="RULE_SINGULARITY_COST_FACTOR",
-    description="RULE_SINGULARITY_COST_FACTOR_DESC",
-    category="BALANCE",
-    type=float,
-    default=1.0,
-    min=0.1,
-    max=10.0,
+    name="RULE_ENSURE_HABITABLE_PLANET_HW_VICINITY",
+    description="RULE_ENSURE_HABITABLE_PLANET_HW_VICINITY_DESC",
+    category="CONTENT",
+    type=bool,
+    default=False,
+    rank=next(ranker),
 )
 
 GameRule(
@@ -54,6 +54,7 @@ GameRule(
     category="CONTENT",
     type=bool,
     default=True,
+    rank=next(ranker),
 )
 
 GameRule(
@@ -64,6 +65,7 @@ GameRule(
     default=250,
     min=0,
     max=500,
+    rank=next(ranker),
 )
 
 GameRule(
@@ -72,6 +74,7 @@ GameRule(
     category="CONTENT",
     type=bool,
     default=False,
+    rank=next(ranker),
 )
 
 GameRule(
@@ -80,6 +83,7 @@ GameRule(
     category="CONTENT",
     type=bool,
     default=False,
+    rank=next(ranker),
 )
 
 GameRule(
@@ -90,6 +94,7 @@ GameRule(
     default=1.0,
     min=0.0,
     max=10.0,
+    rank=next(ranker),
 )
 
 GameRule(
@@ -100,297 +105,67 @@ GameRule(
     default=1.0,
     min=0.0,
     max=10.0,
+    rank=next(ranker),
 )
 
-GameRule(
-    name="RULE_ENABLE_SUPER_TESTER",
-    description="RULE_ENABLE_SUPER_TESTER_DESC",
-    category="CONTENT",
-    type=bool,
-    default=True,
-)
+#########################################
+# Category "BALANCE"
+#########################################
+ranker = count(start=100, step=100)
 
 GameRule(
-    name="RULE_TEST_STRING",
-    description="RULE_TEST_STRING_DESC",
-    category="TEST",
-    type=str,
-    default="PLAYER",
-    allowed=["MODERATOR", "OBSERVER", "PLAYER", "AI_PLAYER"],
-)
-
-GameRule(
-    name="RULE_HABITABLE_SIZE_TINY",
-    description="RULE_HABITABLE_SIZE_DESC",
-    category="PLANET_SIZE",
-    type=int,
-    default=1,
-    min=0,
-    max=999,
-)
-
-GameRule(
-    name="RULE_HABITABLE_SIZE_SMALL",
-    description="RULE_HABITABLE_SIZE_DESC",
-    category="PLANET_SIZE",
-    type=int,
-    default=2,
-    min=0,
-    max=999,
-)
-
-GameRule(
-    name="RULE_HABITABLE_SIZE_MEDIUM",
-    description="RULE_HABITABLE_SIZE_DESC",
-    category="PLANET_SIZE",
-    type=int,
-    default=3,
-    min=0,
-    max=999,
-)
-
-GameRule(
-    name="RULE_HABITABLE_SIZE_LARGE",
-    description="RULE_HABITABLE_SIZE_DESC",
-    category="PLANET_SIZE",
-    type=int,
-    default=4,
-    min=0,
-    max=999,
-)
-
-GameRule(
-    name="RULE_HABITABLE_SIZE_HUGE",
-    description="RULE_HABITABLE_SIZE_DESC",
-    category="PLANET_SIZE",
-    type=int,
-    default=5,
-    min=0,
-    max=999,
-)
-
-GameRule(
-    name="RULE_HABITABLE_SIZE_ASTEROIDS",
-    description="RULE_HABITABLE_SIZE_DESC",
-    category="PLANET_SIZE",
-    type=int,
-    default=3,
-    min=0,
-    max=999,
-)
-
-GameRule(
-    name="RULE_HABITABLE_SIZE_GASGIANT",
-    description="RULE_HABITABLE_SIZE_DESC",
-    category="PLANET_SIZE",
-    type=int,
-    default=6,
-    min=0,
-    max=999,
-)
-
-GameRule(
-    name="RULE_BASELINE_PLANET_STABILITY",
-    description="RULE_BASELINE_PLANET_STABILITY_DESC",
-    category="BALANCE_STABILITY",
-    type=int,
-    default=0,
-    min=-20,
-    max=20,
-)
-
-GameRule(
-    name="RULE_BASELINE_SPECIES_EMPIRE_OPINION",
-    description="RULE_BASELINE_SPECIES_EMPIRE_OPINION_DESC",
-    category="BALANCE_STABILITY",
-    type=int,
-    default=0,
-    min=-20,
-    max=20,
-)
-
-GameRule(
-    name="RULE_INVASION_OPINION_PENALTY_SCALING",
-    description="RULE_INVASION_OPINION_PENALTY_SCALING_DESC",
-    category="BALANCE_STABILITY",
-    type=float,
-    default=-2.0,
-    min=-50.0,
-    max=25.0,
-)
-
-GameRule(
-    name="RULE_SHIPS_LOST_DESTROYED_PENALTY_SCALING",
-    description="RULE_SHIPS_LOST_DESTROYED_PENALTY_SCALING_DESC",
-    category="BALANCE_STABILITY",
-    type=float,
-    default=-0.5,
-    min=-50.0,
-    max=25.0,
-)
-
-GameRule(
-    name="RULE_COLONIES_FOUNDED_BONUS_SCALING",
-    description="RULE_COLONIES_FOUNDED_BONUS_SCALING_DESC",
-    category="BALANCE_STABILITY",
+    name="RULE_SHIP_HULL_COST_FACTOR",
+    description="RULE_SHIP_HULL_COST_FACTOR_DESC",
+    category="BALANCE",
     type=float,
     default=1.0,
-    min=-25.0,
-    max=50.0,
+    min=0.1,
+    max=10.0,
+    rank=next(ranker),
 )
 
 GameRule(
-    name="RULE_PROTECTION_FOCUS_STABILITY",
-    description="RULE_PROTECTION_FOCUS_STABILITY_DESC",
-    category="BALANCE_STABILITY",
-    type=int,
-    default=15,
-    min=-20,
-    max=20,
-)
-
-GameRule(
-    name="RULE_IMPERIAL_PALACE_INFLUENCE",
-    description="RULE_IMPERIAL_PALACE_INFLUENCE_DESC",
-    category="BALANCE_STABILITY",
-    type=int,
-    default=3,
-    min=-20,
-    max=20,
-)
-
-GameRule(
-    name="RULE_GOOD_ENVIRONMENT_STABILITY",
-    description="RULE_GOOD_ENVIRONMENT_STABILITY_DESC",
-    category="BALANCE_STABILITY",
-    type=int,
-    default=2,
-    min=-20,
-    max=20,
-)
-
-GameRule(
-    name="RULE_ADEQUATE_ENVIRONMENT_STABILITY",
-    description="RULE_ADEQUATE_ENVIRONMENT_STABILITY_DESC",
-    category="BALANCE_STABILITY",
-    type=int,
-    default=1,
-    min=-20,
-    max=20,
-)
-
-GameRule(
-    name="RULE_POOR_ENVIRONMENT_STABILITY",
-    description="RULE_POOR_ENVIRONMENT_STABILITY_DESC",
-    category="BALANCE_STABILITY",
-    type=int,
-    default=0,
-    min=-20,
-    max=20,
-)
-
-GameRule(
-    name="RULE_HOSTILE_ENVIRONMENT_STABILITY",
-    description="RULE_HOSTILE_ENVIRONMENT_STABILITY_DESC",
-    category="BALANCE_STABILITY",
-    type=int,
-    default=-1,
-    min=-20,
-    max=20,
-)
-
-GameRule(
-    name="RULE_TINY_SIZE_STABILITY",
-    description="RULE_TINY_SIZE_STABILITY_DESC",
-    category="BALANCE_STABILITY",
-    type=int,
-    default=2,
-    min=-20,
-    max=20,
-)
-
-GameRule(
-    name="RULE_SMALL_SIZE_STABILITY",
-    description="RULE_SMALL_SIZE_STABILITY_DESC",
-    category="BALANCE_STABILITY",
-    type=int,
-    default=1,
-    min=-20,
-    max=20,
-)
-
-GameRule(
-    name="RULE_MEDIUM_SIZE_STABILITY",
-    description="RULE_MEDIUM_SIZE_STABILITY_DESC",
-    category="BALANCE_STABILITY",
-    type=int,
-    default=0,
-    min=-20,
-    max=20,
-)
-
-GameRule(
-    name="RULE_LARGE_SIZE_STABILITY",
-    description="RULE_LARGE_SIZE_STABILITY_DESC",
-    category="BALANCE_STABILITY",
-    type=int,
-    default=-1,
-    min=-20,
-    max=20,
-)
-
-GameRule(
-    name="RULE_HUGE_SIZE_STABILITY",
-    description="RULE_HUGE_SIZE_STABILITY_DESC",
-    category="BALANCE_STABILITY",
-    type=int,
-    default=-2,
-    min=-20,
-    max=20,
-)
-
-GameRule(
-    name="RULE_GAS_GIANT_SIZE_STABILITY",
-    description="RULE_GAS_GIANT_SIZE_STABILITY_DESC",
-    category="BALANCE_STABILITY",
-    type=int,
-    default=0,
-    min=-20,
-    max=20,
-)
-
-GameRule(
-    name="RULE_SHIP_PART_BASED_UPKEEP",
-    description="RULE_SHIP_PART_BASED_UPKEEP_DESC",
+    name="RULE_SHIP_PART_COST_FACTOR",
+    description="RULE_SHIP_PART_COST_FACTOR_DESC",
     category="BALANCE",
-    type=bool,
-    default=False,
+    type=float,
+    default=1.0,
+    min=0.1,
+    max=10.0,
+    rank=next(ranker),
 )
 
 GameRule(
-    name="RULE_FIRST_COMBAT_ROUND_IN_CLOSE_TARGETING_RANGE",
-    description="RULE_FIRST_COMBAT_ROUND_IN_CLOSE_TARGETING_RANGE_DESC",
+    name="RULE_BUILDING_COST_FACTOR",
+    description="RULE_BUILDING_COST_FACTOR_DESC",
     category="BALANCE",
-    type=int,
-    default=3,
-    min=1,
-    max=20,
+    type=float,
+    default=1.0,
+    min=0.1,
+    max=10.0,
+    rank=next(ranker),
 )
 
 GameRule(
-    name="RULE_ALLOW_REPEATED_SPECIES",
-    description="RULE_ALLOW_REPEATED_SPECIES_DESC",
-    category="CONTENT",
-    type=bool,
-    default=False,
+    name="RULE_TECH_COST_FACTOR",
+    description="RULE_TECH_COST_FACTOR_DESC",
+    category="BALANCE",
+    type=float,
+    default=1.0,
+    min=0.1,
+    max=10.0,
+    rank=next(ranker),
 )
 
 GameRule(
-    name="RULE_ENSURE_HABITABLE_PLANET_HW_VICINITY",
-    description="RULE_ENSURE_HABITABLE_PLANET_HW_VICINITY_DESC",
-    category="CONTENT",
-    type=bool,
-    default=False,
+    name="RULE_SINGULARITY_COST_FACTOR",
+    description="RULE_SINGULARITY_COST_FACTOR_DESC",
+    category="BALANCE",
+    type=float,
+    default=1.0,
+    min=0.1,
+    max=10.0,
+    rank=next(ranker),
 )
 
 GameRule(
@@ -401,4 +176,356 @@ GameRule(
     default=3,
     min=1,
     max=10,
+    rank=next(ranker),
 )
+
+GameRule(
+    name="RULE_SHIP_PART_BASED_UPKEEP",
+    description="RULE_SHIP_PART_BASED_UPKEEP_DESC",
+    category="BALANCE",
+    type=bool,
+    default=False,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_FIRST_COMBAT_ROUND_IN_CLOSE_TARGETING_RANGE",
+    description="RULE_FIRST_COMBAT_ROUND_IN_CLOSE_TARGETING_RANGE_DESC",
+    category="BALANCE",
+    type=int,
+    default=3,
+    min=1,
+    max=20,
+    rank=next(ranker),
+)
+
+# internal RULE_SHIP_WEAPON_DAMAGE_FACTOR rank = 1100,
+# internal RULE_FIGHTER_DAMAGE_FACTOR rank = 1200,
+# internal RULE_SHIP_STRUCTURE_FACTOR rank = 1300,
+# internal RULE_SHIP_SPEED_FACTOR rank = 1400,
+
+
+#########################################
+# category "TEST"
+#########################################
+ranker = count(start=100, step=100)
+
+GameRule(
+    name="RULE_ENABLE_SUPER_TESTER",
+    description="RULE_ENABLE_SUPER_TESTER_DESC",
+    category="TEST",
+    type=bool,
+    default=False,
+    rank=next(ranker),
+)
+
+# internal RULE_CHEAP_AND_FAST_BUILDING_PRODUCTION, rank = 110,
+# internal RULE_CHEAP_AND_FAST_SHIP_PRODUCTION, rank = 111,
+# internal RULE_CHEAP_AND_FAST_TECH_RESEARCH, rank = 112,
+# internal RULE_CHEAP_POLICIES, rank = 113,
+# internal RULE_ALL_OBJECTS_VISIBLE, rank = 130,
+# internal RULE_ALL_SYSTEMS_VISIBLE, rank = 131,
+# internal RULE_UNSEEN_STEALTHY_PLANETS_INVISIBLE, rank = 132,
+# internal RULE_STARLANES_EVERYWHERE, rank = 135,
+
+GameRule(
+    name="RULE_TEST_STRING",
+    description="RULE_TEST_STRING_DESC",
+    category="TEST",
+    type=str,
+    default="PLAYER",
+    allowed=["MODERATOR", "OBSERVER", "PLAYER", "AI_PLAYER"],
+    rank=next(ranker),
+)
+
+
+#########################################
+# category "BALANCE_STABILITY"
+#########################################
+ranker = count(start=100, step=100)
+
+GameRule(
+    name="RULE_BASELINE_PLANET_STABILITY",
+    description="RULE_BASELINE_PLANET_STABILITY_DESC",
+    category="BALANCE_STABILITY",
+    type=int,
+    default=0,
+    min=-20,
+    max=20,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_PROTECTION_FOCUS_STABILITY",
+    description="RULE_PROTECTION_FOCUS_STABILITY_DESC",
+    category="BALANCE_STABILITY",
+    type=int,
+    default=15,
+    min=-20,
+    max=20,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_IMPERIAL_PALACE_INFLUENCE",
+    description="RULE_IMPERIAL_PALACE_INFLUENCE_DESC",
+    category="BALANCE_STABILITY",
+    type=int,
+    default=3,
+    min=-20,
+    max=20,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_GOOD_ENVIRONMENT_STABILITY",
+    description="RULE_GOOD_ENVIRONMENT_STABILITY_DESC",
+    category="BALANCE_STABILITY",
+    type=int,
+    default=2,
+    min=-20,
+    max=20,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_ADEQUATE_ENVIRONMENT_STABILITY",
+    description="RULE_ADEQUATE_ENVIRONMENT_STABILITY_DESC",
+    category="BALANCE_STABILITY",
+    type=int,
+    default=1,
+    min=-20,
+    max=20,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_POOR_ENVIRONMENT_STABILITY",
+    description="RULE_POOR_ENVIRONMENT_STABILITY_DESC",
+    category="BALANCE_STABILITY",
+    type=int,
+    default=0,
+    min=-20,
+    max=20,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_HOSTILE_ENVIRONMENT_STABILITY",
+    description="RULE_HOSTILE_ENVIRONMENT_STABILITY_DESC",
+    category="BALANCE_STABILITY",
+    type=int,
+    default=-1,
+    min=-20,
+    max=20,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_TINY_SIZE_STABILITY",
+    description="RULE_TINY_SIZE_STABILITY_DESC",
+    category="BALANCE_STABILITY",
+    type=int,
+    default=2,
+    min=-20,
+    max=20,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_SMALL_SIZE_STABILITY",
+    description="RULE_SMALL_SIZE_STABILITY_DESC",
+    category="BALANCE_STABILITY",
+    type=int,
+    default=1,
+    min=-20,
+    max=20,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_MEDIUM_SIZE_STABILITY",
+    description="RULE_MEDIUM_SIZE_STABILITY_DESC",
+    category="BALANCE_STABILITY",
+    type=int,
+    default=0,
+    min=-20,
+    max=20,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_LARGE_SIZE_STABILITY",
+    description="RULE_LARGE_SIZE_STABILITY_DESC",
+    category="BALANCE_STABILITY",
+    type=int,
+    default=-1,
+    min=-20,
+    max=20,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_HUGE_SIZE_STABILITY",
+    description="RULE_HUGE_SIZE_STABILITY_DESC",
+    category="BALANCE_STABILITY",
+    type=int,
+    default=-2,
+    min=-20,
+    max=20,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_GAS_GIANT_SIZE_STABILITY",
+    description="RULE_GAS_GIANT_SIZE_STABILITY_DESC",
+    category="BALANCE_STABILITY",
+    type=int,
+    default=0,
+    min=-20,
+    max=20,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_BASELINE_SPECIES_EMPIRE_OPINION",
+    description="RULE_BASELINE_SPECIES_EMPIRE_OPINION_DESC",
+    category="BALANCE_STABILITY",
+    type=int,
+    default=0,
+    min=-20,
+    max=20,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_INVASION_OPINION_PENALTY_SCALING",
+    description="RULE_INVASION_OPINION_PENALTY_SCALING_DESC",
+    category="BALANCE_STABILITY",
+    type=float,
+    default=-2.0,
+    min=-50.0,
+    max=25.0,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_SHIPS_LOST_DESTROYED_PENALTY_SCALING",
+    description="RULE_SHIPS_LOST_DESTROYED_PENALTY_SCALING_DESC",
+    category="BALANCE_STABILITY",
+    type=float,
+    default=-0.5,
+    min=-50.0,
+    max=25.0,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_COLONIES_FOUNDED_BONUS_SCALING",
+    description="RULE_COLONIES_FOUNDED_BONUS_SCALING_DESC",
+    category="BALANCE_STABILITY",
+    type=float,
+    default=1.0,
+    min=-25.0,
+    max=50.0,
+    rank=next(ranker),
+)
+
+# internal RULE_ANNEX_COST_OPINION_EXP_BASE, rank = 5500,
+# internal RULE_ANNEX_COST_STABILITY_EXP_BASE, rank = 5510,
+# internal RULE_ANNEX_COST_SCALING, rank = 5520,
+# internal RULE_BUILDING_ANNEX_COST_SCALING, rank = 5530,
+# internal RULE_ANNEX_COST_MINIMUM, rank = 5540,
+
+#########################################
+# category "PLANET_SIZE"
+#########################################
+ranker = count(start=100, step=100)
+
+GameRule(
+    name="RULE_HABITABLE_SIZE_TINY",
+    description="RULE_HABITABLE_SIZE_DESC",
+    category="PLANET_SIZE",
+    type=int,
+    default=1,
+    min=0,
+    max=999,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_HABITABLE_SIZE_SMALL",
+    description="RULE_HABITABLE_SIZE_DESC",
+    category="PLANET_SIZE",
+    type=int,
+    default=2,
+    min=0,
+    max=999,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_HABITABLE_SIZE_MEDIUM",
+    description="RULE_HABITABLE_SIZE_DESC",
+    category="PLANET_SIZE",
+    type=int,
+    default=3,
+    min=0,
+    max=999,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_HABITABLE_SIZE_LARGE",
+    description="RULE_HABITABLE_SIZE_DESC",
+    category="PLANET_SIZE",
+    type=int,
+    default=4,
+    min=0,
+    max=999,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_HABITABLE_SIZE_HUGE",
+    description="RULE_HABITABLE_SIZE_DESC",
+    category="PLANET_SIZE",
+    type=int,
+    default=5,
+    min=0,
+    max=999,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_HABITABLE_SIZE_ASTEROIDS",
+    description="RULE_HABITABLE_SIZE_DESC",
+    category="PLANET_SIZE",
+    type=int,
+    default=3,
+    min=0,
+    max=999,
+    rank=next(ranker),
+)
+
+GameRule(
+    name="RULE_HABITABLE_SIZE_GASGIANT",
+    description="RULE_HABITABLE_SIZE_DESC",
+    category="PLANET_SIZE",
+    type=int,
+    default=6,
+    min=0,
+    max=999,
+    rank=next(ranker),
+)
+
+
+#########################################
+# Category "MULTIPLAYER"
+#########################################
+# -> only internal rules so far
+# internal RULE_DIPLOMACY, rank = 90000000,
+# internal RULE_THRESHOLD_HUMAN_PLAYER_WIN, rank = 90000010,
+# internal RULE_ONLY_ALLIANCE_WIN, rank = 90000020,
+# internal RULE_ALLOW_CONCEDE, rank = 90000030,
+# internal RULE_CONCEDE_COLONIES_THRESHOLD, rank = 90000040,

--- a/msvc2022/Common/Common.vcxproj
+++ b/msvc2022/Common/Common.vcxproj
@@ -255,6 +255,8 @@
     <ClInclude Include="..\..\util\ModeratorAction.h" />
     <ClInclude Include="..\..\util\MultiplayerCommon.h" />
     <ClInclude Include="..\..\util\GameRules.h" />
+    <ClInclude Include="..\..\util\GameRuleCategories.h" />
+    <ClInclude Include="..\..\util\GameRuleRanks.h" />
     <ClInclude Include="..\..\util\i18n.h" />
     <ClInclude Include="..\..\util\Logger.h" />
     <ClInclude Include="..\..\util\LoggerWithOptionsDB.h" />

--- a/msvc2022/Common/Common.vcxproj.filters
+++ b/msvc2022/Common/Common.vcxproj.filters
@@ -178,6 +178,12 @@
     <ClInclude Include="..\..\util\GameRules.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\util\GameRuleCategories.h">
+      <Filter>Header Files\util</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\util\GameRuleRanks.h">
+      <Filter>Header Files\util</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\util\i18n.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>

--- a/parse/GameRulesParser.cpp
+++ b/parse/GameRulesParser.cpp
@@ -39,6 +39,8 @@ object insert_rule_(const grammar& g, GameRulesTypeMap& game_rules, const tuple&
     auto desc{extract<std::string>(kw["description"])()};
     auto category{extract<std::string>(kw["category"])()};
     auto type_ = kw["type"];
+    uint32_t rank{extract<uint32_t>(kw["rank"])()};
+
 
     if (type_ == g.m_parser.type_int) {
         int default_value{extract<int>(kw["default"])()};
@@ -49,7 +51,7 @@ object insert_rule_(const grammar& g, GameRulesTypeMap& game_rules, const tuple&
                       << ", min: " << min << ", max: " << max;
         game_rules.insert_or_assign(name, GameRule{GameRule::Type::INT, name, default_value, default_value,
                                                    std::move(desc), std::make_unique<RangedValidator<int>>(min, max),
-                                                   false, std::move(category)});
+                                                   false, rank, std::move(category)});
 
     } else if (type_ == g.m_parser.type_float) {
         double default_value{extract<double>(kw["default"])()};
@@ -60,7 +62,7 @@ object insert_rule_(const grammar& g, GameRulesTypeMap& game_rules, const tuple&
                       << ", min: " << min << ", max: " << max;
         game_rules.insert_or_assign(name, GameRule{GameRule::Type::DOUBLE, name, default_value, default_value,
                                                    std::move(desc), std::make_unique<RangedValidator<double>>(min, max),
-                                                   false, std::move(category)});
+                                                   false, rank, std::move(category)});
 
     } else if (type_ == g.m_parser.type_bool) {
         bool default_value{extract<bool>(kw["default"])()};
@@ -68,7 +70,7 @@ object insert_rule_(const grammar& g, GameRulesTypeMap& game_rules, const tuple&
                       << ", desc: " << desc << ", default: " << default_value;
         game_rules.insert_or_assign(name, GameRule{GameRule::Type::TOGGLE, name, default_value, default_value,
                                                    std::move(desc), std::make_unique<Validator<bool>>(),
-                                                   false, std::move(category)});
+                                                   false, rank, std::move(category)});
 
     } else if (type_ == g.m_parser.type_str) {
         auto default_value{extract<std::string>(kw["default"])()};
@@ -87,7 +89,7 @@ object insert_rule_(const grammar& g, GameRulesTypeMap& game_rules, const tuple&
                                                    allowed.empty() ?
                                                         nullptr :
                                                         std::make_unique<DiscreteValidator<std::string>>(std::move(allowed)),
-                                                   false, std::move(category)});
+                                                   false, rank, std::move(category)});
 
     } else {
         ErrorLogger() << "Unsupported type for rule " << name << ": " << extract<std::string>(str(type_))();

--- a/test-scripting/game_rules.focs.py
+++ b/test-scripting/game_rules.focs.py
@@ -6,6 +6,7 @@ GameRule(
     default=1.0,
     min=0.1,
     max=10.0,
+    rank=20,
 )
 
 GameRule(
@@ -16,6 +17,7 @@ GameRule(
     default=1.0,
     min=0.1,
     max=10.0,
+    rank=10,
 )
 
 GameRule(
@@ -26,6 +28,7 @@ GameRule(
     default=2.0,
     min=0.1,
     max=10.0,
+    rank=666,
 )
 
 GameRule(
@@ -36,6 +39,7 @@ GameRule(
     default=1.0,
     min=0.1,
     max=10.0,
+    rank=1337,
 )
 
 GameRule(
@@ -44,6 +48,7 @@ GameRule(
     category="CONTENT",
     type=bool,
     default=True,
+    rank=1,
 )
 
 GameRule(
@@ -52,6 +57,7 @@ GameRule(
     category="CONTENT",
     type=bool,
     default=True,
+    rank=2,
 )
 
 GameRule(
@@ -61,6 +67,7 @@ GameRule(
     type=str,
     default="PLAYER",
     allowed=["MODERATOR", "OBSERVER", "PLAYER", "AI_PLAYER"],
+    rank=999,
 )
 
 GameRule(
@@ -71,6 +78,7 @@ GameRule(
     default=1,
     min=0,
     max=999,
+    rank=900000,
 )
 
 GameRule(
@@ -81,6 +89,7 @@ GameRule(
     default=2,
     min=0,
     max=999,
+    rank=900001,
 )
 
 GameRule(
@@ -91,6 +100,7 @@ GameRule(
     default=3,
     min=0,
     max=999,
+    rank=900002,
 )
 
 GameRule(
@@ -101,6 +111,7 @@ GameRule(
     default=4,
     min=0,
     max=999,
+    rank=900003,
 )
 
 GameRule(
@@ -111,6 +122,7 @@ GameRule(
     default=5,
     min=0,
     max=999,
+    rank=900004,
 )
 
 GameRule(
@@ -121,6 +133,7 @@ GameRule(
     default=3,
     min=0,
     max=999,
+    rank=900005,
 )
 
 GameRule(
@@ -131,6 +144,7 @@ GameRule(
     default=6,
     min=0,
     max=999,
+    rank=900006,
 )
 
 GameRule(
@@ -139,6 +153,7 @@ GameRule(
     category="BALANCE",
     type=bool,
     default=False,
+    rank=1234567,
 )
 
 GameRule(
@@ -147,6 +162,7 @@ GameRule(
     category="MULTIPLAYER",
     type=bool,
     default=False,
+    rank=3001,
 )
 
 GameRule(
@@ -157,4 +173,5 @@ GameRule(
     default=3,
     min=1,
     max=20,
+    rank=42,
 )

--- a/universe/BuildingType.cpp
+++ b/universe/BuildingType.cpp
@@ -3,6 +3,7 @@
 #include <boost/algorithm/string/case_conv.hpp>
 #include "../util/CheckSums.h"
 #include "../util/GameRules.h"
+#include "../util/GameRuleRanks.h"
 #include "../util/Logger.h"
 #include "../util/ScopedTimer.h"
 #include "../Empire/Empire.h"
@@ -26,7 +27,9 @@ namespace {
         // makes all buildings cost 1 PP and take 1 turn to produce
         rules.Add<bool>(UserStringNop("RULE_CHEAP_AND_FAST_BUILDING_PRODUCTION"),
                         UserStringNop("RULE_CHEAP_AND_FAST_BUILDING_PRODUCTION_DESC"),
-                        "TEST", false, true);
+                        GameRuleCategories::GameRuleCategory::TEST,
+                        false, true,
+                        GameRuleRanks::RULE_CHEAP_AND_FAST_BUILDING_PRODUCTION_RANK);
     }
     bool temp_bool = RegisterGameRules(&AddRules);
 }

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -14,6 +14,7 @@
 #include "../util/AppInterface.h"
 #include "../util/CheckSums.h"
 #include "../util/GameRules.h"
+#include "../util/GameRuleRanks.h"
 #include "../util/i18n.h"
 #include <numeric>
 
@@ -23,7 +24,8 @@ namespace {
         // makes all ships cost 1 PP and take 1 turn to produce
         rules.Add<bool>(UserStringNop("RULE_CHEAP_AND_FAST_SHIP_PRODUCTION"),
                         UserStringNop("RULE_CHEAP_AND_FAST_SHIP_PRODUCTION_DESC"),
-                        "TEST", false, true);
+                        GameRuleCategories::GameRuleCategory::TEST, false, true,
+                        GameRuleRanks::RULE_CHEAP_AND_FAST_SHIP_PRODUCTION_RANK);
     }
     bool temp_bool = RegisterGameRules(&AddRules);
 

--- a/universe/ShipHull.cpp
+++ b/universe/ShipHull.cpp
@@ -7,6 +7,7 @@
 #include "../Empire/Empire.h"
 #include "../Empire/EmpireManager.h"
 #include "../util/GameRules.h"
+#include "../util/GameRuleRanks.h"
 
 #define CHECK_COND_VREF_MEMBER(m_ptr) { if (m_ptr == rhs.m_ptr) {           \
                                             /* check next member */         \
@@ -21,16 +22,24 @@ namespace {
     void AddRules(GameRules& rules) {
         rules.Add<double>(UserStringNop("RULE_SHIP_SPEED_FACTOR"),
                           UserStringNop("RULE_SHIP_SPEED_FACTOR_DESC"),
-                          UserStringNop("BALANCE"), 1.0, true, RangedValidator<double>(0.1, 10.0));
+                          GameRuleCategories::GameRuleCategory::BALANCE, 1.0, true,
+                          GameRuleRanks::RULE_SHIP_SPEED_FACTOR_RANK,
+                          RangedValidator<double>(0.1, 10.0));
         rules.Add<double>(UserStringNop("RULE_SHIP_STRUCTURE_FACTOR"),
                           UserStringNop("RULE_SHIP_STRUCTURE_FACTOR_DESC"),
-                          UserStringNop("BALANCE"), 8.0, true, RangedValidator<double>(0.1, 80.0));
+                          GameRuleCategories::GameRuleCategory::BALANCE, 8.0, true,
+                          GameRuleRanks::RULE_SHIP_STRUCTURE_FACTOR_RANK,
+                          RangedValidator<double>(0.1, 80.0));
         rules.Add<double>(UserStringNop("RULE_SHIP_WEAPON_DAMAGE_FACTOR"),
                           UserStringNop("RULE_SHIP_WEAPON_DAMAGE_FACTOR_DESC"),
-                          UserStringNop("BALANCE"), 6.0, true, RangedValidator<double>(0.1, 60.0));
+                          GameRuleCategories::GameRuleCategory::BALANCE, 6.0, true,
+                          GameRuleRanks::RULE_SHIP_WEAPON_DAMAGE_FACTOR_RANK,
+                          RangedValidator<double>(0.1, 60.0));
         rules.Add<double>(UserStringNop("RULE_FIGHTER_DAMAGE_FACTOR"),
                           UserStringNop("RULE_FIGHTER_DAMAGE_FACTOR_DESC"),
-                          UserStringNop("BALANCE"), 6.0, true, RangedValidator<double>(0.1, 60.0));
+                          GameRuleCategories::GameRuleCategory::BALANCE, 6.0, true,
+                          GameRuleRanks::RULE_FIGHTER_DAMAGE_FACTOR_RANK,
+                          RangedValidator<double>(0.1, 60.0));
     }
     bool temp_bool = RegisterGameRules(&AddRules);
 

--- a/universe/Species.cpp
+++ b/universe/Species.cpp
@@ -12,6 +12,7 @@
 #include "../util/AppInterface.h"
 #include "../util/CheckSums.h"
 #include "../util/GameRules.h"
+#include "../util/GameRuleRanks.h"
 #include "../util/Logger.h"
 #include "../util/OptionsDB.h"
 #include "../util/Random.h"
@@ -80,19 +81,29 @@ namespace {
     void AddRules(GameRules& rules) {
         rules.Add<double>(UserStringNop("RULE_ANNEX_COST_OPINION_EXP_BASE"),
                           UserStringNop("RULE_ANNEX_COST_OPINION_EXP_BASE_DESC"),
-                          "BALANCE_STABILITY", 1.2, true, RangedValidator<double>(0.0, 3.0));
+                          GameRuleCategories::GameRuleCategory::BALANCE_STABILITY, 1.2, true,
+                          GameRuleRanks::RULE_ANNEX_COST_OPINION_EXP_BASE_RANK,
+                          RangedValidator<double>(0.0, 3.0));
         rules.Add<double>(UserStringNop("RULE_ANNEX_COST_STABILITY_EXP_BASE"),
                           UserStringNop("RULE_ANNEX_COST_STABILITY_EXP_BASE_DESC"),
-                          "BALANCE_STABILITY", 1.1, true, RangedValidator<double>(0.0, 3.0));
+                          GameRuleCategories::GameRuleCategory::BALANCE_STABILITY, 1.1, true,
+                          GameRuleRanks::RULE_ANNEX_COST_STABILITY_EXP_BASE_RANK,
+                          RangedValidator<double>(0.0, 3.0));
         rules.Add<double>(UserStringNop("RULE_ANNEX_COST_SCALING"),
                           UserStringNop("RULE_ANNEX_COST_SCALING_DESC"),
-                          "BALANCE_STABILITY", 5.0, true, RangedValidator<double>(0.0, 50.0));
+                          GameRuleCategories::GameRuleCategory::BALANCE_STABILITY, 5.0, true,
+                          GameRuleRanks::RULE_ANNEX_COST_SCALING_RANK,
+                          RangedValidator<double>(0.0, 50.0));
         rules.Add<double>(UserStringNop("RULE_BUILDING_ANNEX_COST_SCALING"),
                           UserStringNop("RULE_BUILDING_ANNEX_COST_SCALING_DESC"),
-                          "BALANCE_STABILITY", 0.25, true, RangedValidator<double>(0.0, 5.0));
+                          GameRuleCategories::GameRuleCategory::BALANCE_STABILITY, 0.25, true,
+                          GameRuleRanks::RULE_BUILDING_ANNEX_COST_SCALING_RANK,
+                          RangedValidator<double>(0.0, 5.0));
         rules.Add<double>(UserStringNop("RULE_ANNEX_COST_MINIMUM"),
                           UserStringNop("RULE_ANNEX_COST_MINIMUM_DESC"),
-                          "BALANCE_STABILITY", 5.0, true, RangedValidator<double>(0.0, 50.0));
+                          GameRuleCategories::GameRuleCategory::BALANCE_STABILITY, 5.0, true,
+                          GameRuleRanks::RULE_ANNEX_COST_MINIMUM_RANK,
+                          RangedValidator<double>(0.0, 50.0));
     }
     bool temp_bool = RegisterGameRules(&AddRules);
 

--- a/universe/System.cpp
+++ b/universe/System.cpp
@@ -12,15 +12,17 @@
 #include "../util/Logger.h"
 #include "../util/OptionsDB.h"
 #include "../util/GameRules.h"
+#include "../util/GameRuleRanks.h"
 #include "../util/i18n.h"
 
 
 namespace {
     void AddRules(GameRules& rules) {
-        // makes all PRNG be reseeded frequently
+        // whether systems detected only at basic visibility have their name and star type revealed or not
         rules.Add<bool>(UserStringNop("RULE_BASIC_VIS_SYSTEM_INFO_SHOWN"),
                         UserStringNop("RULE_BASIC_VIS_SYSTEM_INFO_SHOWN_DESC"),
-                        "", false, true);
+                        GameRuleCategories::GameRuleCategory::GENERAL, false, true,
+                        GameRuleRanks::RULE_BASIC_VIS_SYSTEM_INFO_SHOWN_RANK);
     }
     bool temp_bool = RegisterGameRules(&AddRules);
 }

--- a/universe/Tech.cpp
+++ b/universe/Tech.cpp
@@ -12,6 +12,7 @@
 #include "../util/AppInterface.h"
 #include "../util/CheckSums.h"
 #include "../util/GameRules.h"
+#include "../util/GameRuleRanks.h"
 #include "../util/Logger.h"
 #include "../util/OptionsDB.h"
 #include "../util/ScopedTimer.h"
@@ -24,7 +25,8 @@ namespace {
         // makes all techs cost 1 RP and take 1 turn to research
         rules.Add<bool>(UserStringNop("RULE_CHEAP_AND_FAST_TECH_RESEARCH"),
                         UserStringNop("RULE_CHEAP_AND_FAST_TECH_RESEARCH_DESC"),
-                        "TEST", false, true);
+                        GameRuleCategories::GameRuleCategory::TEST, false, true,
+                        GameRuleRanks::RULE_CHEAP_AND_FAST_TECH_RESEARCH_RANK);
     }
     bool temp_bool = RegisterGameRules(&AddRules);
 }

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -33,6 +33,7 @@
 #include "../Empire/Government.h"
 #include "../util/CheckSums.h"
 #include "../util/GameRules.h"
+#include "../util/GameRuleRanks.h"
 #include "../util/Logger.h"
 #include "../util/OptionsDB.h"
 #include "../util/Random.h"
@@ -68,22 +69,44 @@ namespace {
         // makes all PRNG be reseeded frequently
         rules.Add<bool>(UserStringNop("RULE_RESEED_PRNG_SERVER"),
                         UserStringNop("RULE_RESEED_PRNG_SERVER_DESC"),
-                        "", true, true);
+                        GameRuleCategories::GameRuleCategory::GENERAL,
+                        true, true,
+                        GameRuleRanks::RULE_RESEED_PRNG_SERVER_RANK);
+
         rules.Add<bool>(UserStringNop("RULE_STARLANES_EVERYWHERE"),
                         UserStringNop("RULE_STARLANES_EVERYWHERE_DESC"),
-                        "TEST", false, true);
+                        GameRuleCategories::GameRuleCategory::TEST,
+                        false,
+                        true,
+                        GameRuleRanks::RULE_STARLANES_EVERYWHERE_RANK);
+
         rules.Add<bool>(UserStringNop("RULE_ALL_OBJECTS_VISIBLE"),
                         UserStringNop("RULE_ALL_OBJECTS_VISIBLE_DESC"),
-                        "TEST", false, true);
+                        GameRuleCategories::GameRuleCategory::TEST,
+                        false,
+                        true,
+                        GameRuleRanks::RULE_ALL_OBJECTS_VISIBLE_RANK);
+
         rules.Add<bool>(UserStringNop("RULE_UNSEEN_STEALTHY_PLANETS_INVISIBLE"),
                         UserStringNop("RULE_UNSEEN_STEALTHY_PLANETS_INVISIBLE_DESC"),
-                        "TEST", false, true);
+                        GameRuleCategories::GameRuleCategory::TEST,
+                        false,
+                        true,
+                        GameRuleRanks::RULE_UNSEEN_STEALTHY_PLANETS_INVISIBLE_RANK);
+
         rules.Add<bool>(UserStringNop("RULE_ALL_SYSTEMS_VISIBLE"),
                         UserStringNop("RULE_ALL_SYSTEMS_VISIBLE_DESC"),
-                        "TEST", false, true);
+                        GameRuleCategories::GameRuleCategory::TEST,
+                        false,
+                        true,
+                        GameRuleRanks::RULE_ALL_SYSTEMS_VISIBLE_RANK);
+
         rules.Add<bool>(UserStringNop("RULE_EXTRASOLAR_SHIP_DETECTION"),
                         UserStringNop("RULE_EXTRASOLAR_SHIP_DETECTION_DESC"),
-                        "", false, true);
+                        GameRuleCategories::GameRuleCategory::GENERAL,
+                        false,
+                        true,
+                        GameRuleRanks::RULE_EXTRASOLAR_SHIP_DETECTION_RANK);
     }
     bool temp_bool2 = RegisterGameRules(&AddRules);
 

--- a/util/GameRuleCategories.h
+++ b/util/GameRuleCategories.h
@@ -1,0 +1,20 @@
+#ifndef _GameRuleCategories_h_
+#define _GameRuleCategories_h_
+
+#include "Enum.h"
+
+namespace GameRuleCategories {
+    FO_ENUM(
+        (GameRuleCategory),
+        ((GENERAL, 0))
+        ((CONTENT))
+        ((BALANCE))
+        ((TEST))
+        ((BALANCE_STABILITY))
+        ((PLANET_SIZE))
+        ((MULTIPLAYER))
+        ((UNDEFINED, std::numeric_limits<int8_t>::max()))
+    )
+}
+
+#endif

--- a/util/GameRuleRanks.h
+++ b/util/GameRuleRanks.h
@@ -1,0 +1,54 @@
+#ifndef _GameRuleRanks_h_
+#define _GameRuleRanks_h_
+
+/** This file is to keep internal engine game rules' ranks in one place for easier re-ordering,
+    though still needs to be manually synchronized with game_rules.focs.py
+    */
+
+namespace GameRuleRanks {
+    enum GameRuleRanks : uint32_t {
+
+        // "" aka "GENERAL" category
+        RULE_RESEED_PRNG_SERVER_RANK = 1,
+        RULE_EXTRASOLAR_SHIP_DETECTION_RANK = 2,
+        RULE_BASIC_VIS_SYSTEM_INFO_SHOWN_RANK = 10,
+        RULE_NUM_COMBAT_ROUNDS_RANK = 30,
+        RULE_AGGRESSIVE_SHIPS_COMBAT_VISIBLE_RANK = 35,
+        RULE_STOCKPILE_IMPORT_LIMITED_RANK = 50,
+        RULE_PRODUCTION_QUEUE_FRONTLOAD_FACTOR_RANK = 51,
+        RULE_PRODUCTION_QUEUE_TOPPING_UP_FACTOR_RANK = 52,
+
+        // "BALANCE" category
+        RULE_SHIP_WEAPON_DAMAGE_FACTOR_RANK = 1100,
+        RULE_FIGHTER_DAMAGE_FACTOR_RANK = 1200,
+        RULE_SHIP_STRUCTURE_FACTOR_RANK = 1300,
+        RULE_SHIP_SPEED_FACTOR_RANK = 1400,
+
+        // "TEST" category
+        RULE_CHEAP_AND_FAST_BUILDING_PRODUCTION_RANK = 110,
+        RULE_CHEAP_AND_FAST_SHIP_PRODUCTION_RANK = 111,
+        RULE_CHEAP_AND_FAST_TECH_RESEARCH_RANK = 112,
+        RULE_CHEAP_POLICIES_RANK = 113,
+        RULE_ALL_OBJECTS_VISIBLE_RANK = 130,
+        RULE_ALL_SYSTEMS_VISIBLE_RANK = 131,
+        RULE_UNSEEN_STEALTHY_PLANETS_INVISIBLE_RANK = 132,
+        RULE_STARLANES_EVERYWHERE_RANK = 135,
+
+        // "BALANCE_STABILITY" category (should there be a separate opinion and annexation group?)
+        RULE_ANNEX_COST_OPINION_EXP_BASE_RANK = 5500,
+        RULE_ANNEX_COST_STABILITY_EXP_BASE_RANK = 5510,
+        RULE_ANNEX_COST_SCALING_RANK = 5520,
+        RULE_BUILDING_ANNEX_COST_SCALING_RANK = 5530,
+        RULE_ANNEX_COST_MINIMUM_RANK = 5540,
+
+
+        // "MULTIPLAYER" category
+        RULE_DIPLOMACY_RANK = 90000000,
+        RULE_THRESHOLD_HUMAN_PLAYER_WIN_RANK = 90000010,
+        RULE_ONLY_ALLIANCE_WIN_RANK = 90000020,
+        RULE_ALLOW_CONCEDE_RANK = 90000030,
+        RULE_CONCEDE_COLONIES_THRESHOLD_RANK = 90000040,
+    };
+}
+
+#endif

--- a/util/GameRules.cpp
+++ b/util/GameRules.cpp
@@ -152,16 +152,20 @@ std::map<std::string, std::string> GameRules::GetRulesAsStrings() {
 
 std::vector<const GameRule*> GameRules::GetSortedByCategoryAndRank() {
     CheckPendingGameRules();
-    std::vector<const GameRule*> sorted_rules(m_game_rules.size(), nullptr);
-    std::transform(m_game_rules.begin(), m_game_rules.end(), sorted_rules.begin(), [](const auto& rule_pair) { return &rule_pair.second; });
-    std::sort(sorted_rules.begin(), sorted_rules.end(), [](const GameRule* lhs, const GameRule* rhs) {
-        auto lhs_category_rank = GetCategoryRank(lhs->category);
-        auto rhs_category_rank = GetCategoryRank(rhs->category);
-        return lhs_category_rank == rhs_category_rank ? lhs->rank < rhs->rank : lhs_category_rank < rhs_category_rank;
+    std::vector<const GameRule*> sorted_rules;
+    sorted_rules.reserve(m_game_rules.size());
+    std::transform(m_game_rules.begin(), m_game_rules.end(), std::back_inserter(sorted_rules),
+                   [](const auto& rule_pair) { return &rule_pair.second; });
+    std::sort(sorted_rules.begin(), sorted_rules.end(),
+              [](const GameRule* lhs, const GameRule* rhs) {
+                auto lhs_category_rank = GetCategoryRank(lhs->category);
+                auto rhs_category_rank = GetCategoryRank(rhs->category);
+                return lhs_category_rank == rhs_category_rank ?
+                    lhs->rank < rhs->rank :
+                    lhs_category_rank < rhs_category_rank;
     });
     return sorted_rules;
 }
-
 void GameRules::Add(Pending::Pending<GameRulesTypeMap>&& future)
 { m_pending_rules = std::move(future); }
 

--- a/util/GameRules.cpp
+++ b/util/GameRules.cpp
@@ -33,6 +33,9 @@ namespace {
     constexpr auto category_ranks = GameRuleCategories::GameRuleCategoryValues();
 
     constexpr int8_t GetCategoryRank(std::string_view category) {
+        if (category.empty())
+            return static_cast<int8_t>(GameRuleCategories::GameRuleCategory::GENERAL);
+
         const auto it = std::find_if(category_ranks.begin(), category_ranks.end(),
                                      [category](auto entry) { return entry.second == category; });
         return static_cast<int8_t>(

--- a/util/GameRules.cpp
+++ b/util/GameRules.cpp
@@ -29,24 +29,15 @@ GameRules& GetGameRules() {
     return game_rules;
 }
 
-static std::unordered_map<std::string, int8_t> AssignCategoryRanks()
-{
-    std::unordered_map<std::string, int8_t> category_ranks;
-    category_ranks[""] = static_cast<int8_t>(GameRuleCategories::GameRuleCategory::GENERAL);
-    for (const auto& [category, str_view] : GameRuleCategories::GameRuleCategoryValues()) {
-        category_ranks[std::string(str_view)] = static_cast<int8_t>(category);
-    }
-    return category_ranks;
-}
+namespace {
+    constexpr auto category_ranks = GameRuleCategories::GameRuleCategoryValues();
 
-static int8_t GetCategoryRank(const std::string& category)
-{
-    static auto category_ranks = AssignCategoryRanks();
-    const auto& it = category_ranks.find(category);
-    if (it != category_ranks.end()) {
-        return it->second;
+    constexpr int8_t GetCategoryRank(std::string_view category) {
+        const auto it = std::find_if(category_ranks.begin(), category_ranks.end(),
+                                     [category](auto entry) { return entry.second == category; });
+        return static_cast<int8_t>(
+            (it == category_ranks.end() ? GameRuleCategories::GameRuleCategory::UNDEFINED : it->first));
     }
-    return static_cast<int8_t>(GameRuleCategories::GameRuleCategory::UNDEFINED);
 }
 
 /////////////////////////////////////////////////////

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -2,6 +2,7 @@
 
 #include "Directories.h"
 #include "GameRules.h"
+#include "GameRuleRanks.h"
 #include "i18n.h"
 #include "LoggerWithOptionsDB.h"
 #include "OptionsDB.h"
@@ -68,19 +69,29 @@ namespace {
     void AddRules(GameRules& rules) {
         rules.Add<int>(UserStringNop("RULE_THRESHOLD_HUMAN_PLAYER_WIN"),
                        UserStringNop("RULE_THRESHOLD_HUMAN_PLAYER_WIN_DESC"),
-                       UserStringNop("MULTIPLAYER"), 0, true, RangedValidator<int>(0, 999));
+                       GameRuleCategories::GameRuleCategory::MULTIPLAYER,
+                       0, true,
+                       GameRuleRanks::RULE_THRESHOLD_HUMAN_PLAYER_WIN_RANK,
+                       RangedValidator<int>(0, 999));
 
         rules.Add<bool>(UserStringNop("RULE_ONLY_ALLIANCE_WIN"),
                         UserStringNop("RULE_ONLY_ALLIANCE_WIN_DESC"),
-                        UserStringNop("MULTIPLAYER"), true, true);
+                        GameRuleCategories::GameRuleCategory::MULTIPLAYER,
+                        true, true,
+                        GameRuleRanks::RULE_ONLY_ALLIANCE_WIN_RANK);
 
         rules.Add<bool>(UserStringNop("RULE_ALLOW_CONCEDE"),
                         UserStringNop("RULE_ALLOW_CONCEDE_DESC"),
-                        UserStringNop("MULTIPLAYER"), false, true);
+                        GameRuleCategories::GameRuleCategory::MULTIPLAYER,
+                        false, true,
+                        GameRuleRanks::RULE_ALLOW_CONCEDE_RANK);
 
         rules.Add<int>(UserStringNop("RULE_CONCEDE_COLONIES_THRESHOLD"),
                        UserStringNop("RULE_CONCEDE_COLONIES_THRESHOLD_DESC"),
-                       UserStringNop("MULTIPLAYER"), 1, true,  RangedValidator<int>(0, 9999));
+                       GameRuleCategories::GameRuleCategory::MULTIPLAYER,
+                       1, true,
+                       GameRuleRanks::RULE_CONCEDE_COLONIES_THRESHOLD_RANK,
+                       RangedValidator<int>(0, 9999));
     }
     bool temp_bool2 = RegisterGameRules(&AddRules);
 


### PR DESCRIPTION
Autogenerated GUI for Game Rules is a great feature, however the way it iterates over unordered_map means there's practically no control over order of the items in the GUI.

This means galaxy setup on single player game start is bit of a mess. Similarly impacted is pedia article about game rules

Changing unordered_map to an ordered collection seems not worth the performance hit, plus it would be not obvious how to sort them either right of the bat (add ranking prefixes to game rule names? sounds clunky)

I propose adding a rank to each GameRule and a helper method that returns collection sorted by rank. Then, use that for ordered GUI.

I took liberty to arrange the rules as I saw fit, hopefully it makes sense (though I would probably still make separate tabs/groups/categories for annexation and opinion stuff as opposed to lumping them with stability, but I did not go that far)
![GalaxySetupWindow](https://github.com/freeorion/freeorion/assets/110989598/123f3438-6f06-4577-ba43-fb6e349675d0)
![GameRulesPedia](https://github.com/freeorion/freeorion/assets/110989598/18a40a84-6c13-480a-b55e-3ab7aedd90a8)


