### PR TITLE
allow targeted terraforming on outpost

### DIFF
--- a/default/scripting/buildings/TERRAFORM.focs.txt
+++ b/default/scripting/buildings/TERRAFORM.focs.txt
@@ -25,7 +25,6 @@ TARGET_TERRAFORMING
     location = And [
         Planet
         OwnedBy empire = Source.Owner
-        TargetPopulation low = 1
         Not Planet type = [Asteroids GasGiant]
         Or [
             Planet type = @1@


### PR DESCRIPTION
fix #4727 

    Outposts should be directly terraformable (without exobot intermediate)
    
    as discussed in wobbly's Complete rework of Terraforming
    
    https://freeorion.org/forum/viewtopic.php?p=109108&sid=9afce0093bf451f01f37d111356781e0#p109108
