### PR TITLE
Render smaller fields on top of larger ones

### DIFF
--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -529,11 +529,8 @@ private:
     GG::GL2DVertexBuffer    m_system_circle_vertices;
     GG::GLRGBAColorBuffer   m_system_circle_colours;
 
-    /** First buffer is visible fields, second buffer is not visible (scanlined)
-        fields for each texture. */
-    std::map<std::shared_ptr<GG::Texture>,
-             std::pair<GG::GL2DVertexBuffer, GG::GL2DVertexBuffer>>
-                                    m_field_vertices;
+    std::vector<std::pair<std::shared_ptr<GG::Texture>, GG::GL2DVertexBuffer>> m_field_vertices_visible;
+    std::vector<std::pair<std::shared_ptr<GG::Texture>, GG::GL2DVertexBuffer>> m_field_vertices_not_visible;
 
     GG::GL2DVertexBuffer            m_field_scanline_circles;
     GG::GLTexCoordBuffer            m_field_texture_coords;

--- a/util/ranges.h
+++ b/util/ranges.h
@@ -9,6 +9,7 @@ static constexpr auto& range_values = std::views::values;
 static constexpr auto& range_transform = std::views::transform;
 static constexpr auto& range_filter = std::views::filter;
 //static constexpr auto& range_join = std::views::join; // no equivalent in boost ranges
+static constexpr auto& range_reverse = std::views::reverse;
 static constexpr auto& range_find_if = std::ranges::find_if;
 static constexpr auto& range_any_of = std::ranges::any_of;
 static constexpr auto& range_copy = std::ranges::copy;
@@ -20,6 +21,7 @@ static constexpr auto& range_end = std::ranges::end;
 # include <boost/range/adaptor/map.hpp>
 # include <boost/range/adaptor/filtered.hpp>
 # include <boost/range/adaptor/transformed.hpp>
+# include <boost/range/adaptor/reversed.hpp>
 # include <boost/range/algorithm.hpp>
 # include <boost/range/end.hpp>
 # include <boost/algorithm/cxx11/any_of.hpp>
@@ -28,6 +30,7 @@ static const auto& range_keys = boost::adaptors::map_keys;
 static const auto& range_values = boost::adaptors::map_values;
 static const auto& range_filter = boost::adaptors::filtered;
 static const auto& range_transform = boost::adaptors::transformed;
+static const auto& range_reverse = boost::adaptors::reversed;
 template <typename... Args>
 inline auto range_find_if(Args... args) { return boost::range::find_if(std::forward<Args>(args)...); }
 template <typename... Args>


### PR DESCRIPTION
Per discussion at https://freeorion.org/forum/viewtopic.php?p=116994#p116994 smaller fields could "hide" under bigger ones and it could be hard to fish them out with a mouse.

https://github.com/freeorion/freeorion/pull/4739 improved functional aspect of that, putting the fields in z-order according to their size, so as far as mouse events are concerned, smaller fields are on top of larger ones.

However, I've uncovered that visual aspect of this is separate. Field icons don't render themselves, they are rendered by galaxy map window. And this is separate processing, grouped by field texture. So e.g. all ion storms would be rendered before molecular clouds, or vice versa (depending on somewhat random factors).

So, a smaller field could still get rendered visually under a bigger one, and moreover, due to grouping by texture, it's not even possible to avoid this situation in general case as is (a smaller ion storm could be rendered on top of larger molecular cloud, but in other place in the galaxy, smaller molecular cloud would be rendered under bigger ion storm... or vice versa)

Seems to me the grouping by texture is not necessary, even if it ends up with fewer GL calls. I propose to render fields more individually, largest to smallest, so smaller ones get painted over larger ones. While still grouping by texture as much as possible.

Following picture shows situation from MP25, where an ion storm is between two molecular clouds... Ion storm is on top of larger molecular cloud, but the smaller molecular cloud is visually rendered under ion storm (it could also happen that the ion storm is rendered under both the larger molecular cloud and smaller molecular cloud).

After this change, all three fields in this configuration are rendered per their size, matching the improved mouse behavior

![spot_the_difference](https://github.com/freeorion/freeorion/assets/110989598/5e7905f9-1d55-4524-b629-780d0ee397b7)
