### PR TITLE
Fix Scrap Popup v0.5

### DIFF
--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -403,7 +403,7 @@ void BuildingIndicator::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys)
 
     auto popup = GG::Wnd::Create<CUIPopupMenu>(pt.x, pt.y);
 
-    if (m_order_issuing_enabled) {
+    if (m_order_issuing_enabled && ScrapOrder::Check(empire_id, m_building_id, context)) {
         if (!building->OrderedScrapped()) {
             // create popup menu with "Scrap" option
             popup->AddMenuItem(GG::MenuItem(UserString("ORDER_BUIDLING_SCRAP"), false, false,


### PR DESCRIPTION
Only show scrap building popup if a scrap order could be issued for that building by the client empire.

Should fix #4746