### PR TITLE
Enable CMAKE_CXX_EXTENSIONS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,6 @@ include(CPackComponent)
 
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_CXX_VISIBILITY_PRESET hidden)
 
 option(BUILD_SHARED_LIBS "Build project as shared libraries." ON)

--- a/GG/CMakeLists.txt
+++ b/GG/CMakeLists.txt
@@ -30,7 +30,6 @@ include(Util)
 set(GIGI_VERSION 0.8.0)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
-set(CMAKE_CXX_EXTENSIONS OFF)
 
 option(ENABLE_PNG_TEXTURES "Enable PNG texture support." ON)
 option(ENABLE_TIFF_TEXTURES "Enable TIFF texture support." OFF)


### PR DESCRIPTION
This avoids excess precision on i386/m68/s390x with gcc >= 13.

@apoleon This fixes #4699 and addresses the root cause of what #4702 attempted to address.

If enabling compiler extensions is not wanted, the alternative would be to pass `-fexcess-precision=fast` to `g++` (either upstream or in Debian for all architectures in `DEB_CXXFLAGS_MAINT_APPEND`).

For background see the `Excess precision support` bullet point at https://gcc.gnu.org/gcc-13/changes.html