### PR TITLE
Update Arch Linux package URL in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,6 @@ accompanying license file.
 [Gentoo package]: https://packages.gentoo.org/packages/games-strategy/freeorion
 [openSUSE Package]: https://build.opensuse.org/package/show/games/freeorion
 [Void package]: https://github.com/voidlinux/void-packages/tree/master/srcpkgs/freeorion
-[ArchLinux Package]: https://archlinux.org/packages/community/x86_64/freeorion/
+[ArchLinux Package]: https://archlinux.org/packages/extra/x86_64/freeorion/
 [GPL v2]: https://www.gnu.org/licenses/gpl-2.0.txt
 [CC-BY-SA-3.0]: https://creativecommons.org/licenses/by-sa/3.0/legalcode


### PR DESCRIPTION
The old URL returns 404 now.