### PR TITLE
(0.5) Cap xeno frenzy malus with self-sustain bonus

### DIFF
--- a/default/scripting/species/common/xenophobic.macros
+++ b/default/scripting/species/common/xenophobic.macros
@@ -36,7 +36,7 @@ XENOPHOBIC_SELF
         EffectsGroup
             scope = Source
             activation = And [
-                Planet
+                Planet environment = Good
                 HasTag name = "SELF_SUSTAINING"
                 (0 < [[XENOPHOBIC_SELFSUSTAINING_QUALIFYING_PLANET_COUNT]])
             ]


### PR DESCRIPTION
Apply self-sustaining xenophobic malus only where self-sustaining bonus applies
Fixes #4836 for release 0.5.0.1

*EDIT by Vezzra: fixed release version number: 0.5.1 -> 0.5.0.1*