### PR TITLE
Fix exception handle on Python 3.11 or older

### DIFF
--- a/util/PythonCommon.cpp
+++ b/util/PythonCommon.cpp
@@ -82,7 +82,6 @@ void PythonCommon::HandleErrorAlreadySet() {
         return;
     }
 
-    PyErr_Print();
 #if PY_VERSION_HEX < 0x030c0000
     PyObject *extype, *value, *traceback;
     PyErr_Fetch(&extype, &value, &traceback);
@@ -102,6 +101,8 @@ void PythonCommon::HandleErrorAlreadySet() {
         boost::algorithm::trim_right(line);
         ErrorLogger() << line;
     }
+#else
+    PyErr_Print();
 #endif
     return;
 }


### PR DESCRIPTION
Maybe fix #4844 