### PR TITLE
boostrapping stability growth happen at AFTER_ALL_TARGET_MAX_METERS_PRIORITY

### DIFF
--- a/default/scripting/policies/BOOTSTRAPPING.focs.txt
+++ b/default/scripting/policies/BOOTSTRAPPING.focs.txt
@@ -15,20 +15,32 @@ Policy
                 OwnedBy empire = Source.Owner
             ]
             effects = [
+                // increase target stability by 10 on first turn, decreasing each turn to 0 at turn 20
+                SetTargetHappiness value = Value + 
+                    0.5 * max(0.0, (NamedReal name = "PLC_BOOTSTRAPPING_MAX_TURNS" value = 20.0) - Target.TurnsSinceColonization)
+            ]
+
+        EffectsGroup
+            scope = And [
+                Species
+                Population high = NamedRealLookup name = "PLC_BOOTSTRAPPING_MAX_POP"
+                OwnedBy empire = Source.Owner
+            ]
+            priority = [[AFTER_ALL_TARGET_MAX_METERS_PRIORITY]]
+            effects = [
+                // increase normal meter growth rate
                 SetIndustry value = min(Target.TargetIndustry, Value + 1.0)
                 SetResearch value = min(Target.TargetResearch, Value + 1.0)
                 SetInfluence value = min(Target.TargetInfluence, Value + 1.0)
 
-                // increase target stability by 10 on first turn, decreasing each turn to 0 at turn 20
-                SetTargetHappiness value = Value + 
-                    0.5 * max(0.0, (NamedReal name = "PLC_BOOTSTRAPPING_MAX_TURNS" value = 20.0) - Target.TurnsSinceColonization)
-
-                // increase stability growth rate
+                // increase growth rate for meteres which could be negative; i.e. stability
                 SetHappiness value = Value + min(abs(Value(Target.TargetHappiness) - Value), 1) *
                     (Value < Value(Target.TargetHappiness))
             ]
+
     ]
     graphic = "icons/policies/economic_colonial_bootstrapping.png"
 
 #include "/scripting/macros/base_prod.macros"
 #include "/scripting/policies/policies.macros"
+#include "/scripting/macros/priorities.macros"

--- a/default/scripting/policies/BOOTSTRAPPING.focs.txt
+++ b/default/scripting/policies/BOOTSTRAPPING.focs.txt
@@ -28,12 +28,12 @@ Policy
             ]
             priority = [[AFTER_ALL_TARGET_MAX_METERS_PRIORITY]]
             effects = [
-                // increase normal meter growth rate
-                SetIndustry value = min(Target.TargetIndustry, Value + 1.0)
-                SetResearch value = min(Target.TargetResearch, Value + 1.0)
-                SetInfluence value = min(Target.TargetInfluence, Value + 1.0)
+                // increase normal meter growth rate (where the target is at least zero)
+                SetIndustry value = max(Value, min(Target.TargetIndustry, Value + 1.0))
+                SetResearch value = max(Value, min(Target.TargetResearch, Value + 1.0))
+                SetInfluence value = max(Value, min(Target.TargetInfluence, Value + 1.0))
 
-                // increase growth rate for meteres which could be negative; i.e. stability
+                // increase growth rate for meters which could be negative; i.e. stability
                 SetHappiness value = Value + min(abs(Value(Target.TargetHappiness) - Value), 1) *
                     (Value < Value(Target.TargetHappiness))
             ]


### PR DESCRIPTION
Stability growth of bootstrapping depends on TargetHappiness, so it should happen after all effects on that.
hopefully fixes https://www.freeorion.org/forum/viewtopic.php?p=118215#p118215

also the policy is supposed to boost other meters (i.e. add extra growth); now the meters are not decreased by this policy in case of falling target meters