### PR TITLE
Add parser_context attribute to Python FOCS parser builtins

### DIFF
--- a/parse/PythonParser.cpp
+++ b/parse/PythonParser.cpp
@@ -77,6 +77,7 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
         type_float = py::import("builtins").attr("float");
         type_bool = py::import("builtins").attr("bool");
         type_str = py::import("builtins").attr("str");
+        py::import("builtins").attr("parser_context") = true;
 
         py::register_exception_translator<import_error>(&translate);
 


### PR DESCRIPTION
Allows to use code like:

```python
import builtins

if not hasattr(builtins, "parser_context"):
```

to exclude unneeded code for parser.
