### PR TITLE
Fix reference to invalidated element

### DIFF
--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1338,7 +1338,7 @@ void StatisticIcon::SetValue(double value, std::size_t index) {
     }
 
     auto& entry0 = m_values[0];
-    auto& [value0, precision0, show_sign0] = entry0;
+    auto [value0, precision0, show_sign0] = entry0;
 
     if (index >= m_values.size()) {
         value0 = value;


### PR DESCRIPTION
Fix #4837

Resize of `m_values` in next lines could invalidate reference to `m_values[0]`.