### PR TITLE
Fix Growth effect on augmentation policy

### DIFF
--- a/default/scripting/macros/misc.macros
+++ b/default/scripting/macros/misc.macros
@@ -54,6 +54,10 @@ MINIMUM_DISTANCE_EMPIRE_CHECK
 UNOWNED_EMPIRE_ID
 '''-1'''
 
+// Range from -0.5(1/2 population growth) to +1(double population growth)
+AUGMENTATION_GROWTH_MODIFIER
+'''(min(2, max(0.5, Target.Construction / (NamedRealLookup name = "AUGMENTATION_FULL_GROWTH_INFRASTRUCTURE_REQUIREMENT"))) - 1)
+'''
 
 GROWTH_RATE_FACTOR
 '''
@@ -61,7 +65,7 @@ GROWTH_RATE_FACTOR
 (1 - (Statistic If condition = And [Target EmpireHasAdoptedPolicy name = "PLC_NO_GROWTH"])) *       // no growth with no-growth policy
 (1 + 0.5*(Statistic If condition = And [Target EmpireHasAdoptedPolicy name = "PLC_POPULATION"])) *  // +50% growth with population policy
 (1 + (Statistic If condition = And [Target EmpireHasAdoptedPolicy name = "PLC_AUGMENTATION"]) *     // slower growth with augmentation on low-infrastructure planets
-      min(1.2, max(0.5, Target.Construction / (NamedRealLookup name = "AUGMENTATION_FULL_GROWTH_INFRASTRUCTURE_REQUIREMENT"))))
+     [[AUGMENTATION_GROWTH_MODIFIER]])
 '''
 
 

--- a/default/scripting/macros/misc.py
+++ b/default/scripting/macros/misc.py
@@ -55,6 +55,19 @@ MINIMUM_DISTANCE_EMPIRE_CHECK = ~WithinStarlaneJumps(
     condition=System & Contains(Planet() & OwnedBy(affiliation=AnyEmpire)),
 )
 
+# Range from -0.5(1/2 population growth) to +1(double population growth)
+AUGMENTATION_GROWTH_MODIFIER = (
+    MinOf(
+        float,
+        2,
+        MaxOf(
+            float,
+            0.5,
+            Target.Construction / NamedRealLookup(name="AUGMENTATION_FULL_GROWTH_INFRASTRUCTURE_REQUIREMENT"),
+        ),
+    )
+    - 1
+)
 
 GROWTH_RATE_FACTOR = (
     0.1
@@ -68,14 +81,6 @@ GROWTH_RATE_FACTOR = (
         1
         + StatisticIf(float, condition=IsTarget & EmpireHasAdoptedPolicy(name="PLC_AUGMENTATION"))
         # slower growth with augmentation on low-infrastructure planets
-        * MinOf(
-            float,
-            1.2,
-            MaxOf(
-                float,
-                0.5,
-                Target.Construction / NamedRealLookup(name="AUGMENTATION_FULL_GROWTH_INFRASTRUCTURE_REQUIREMENT"),
-            ),
-        )
+        * AUGMENTATION_GROWTH_MODIFIER
     )
 )


### PR DESCRIPTION
Pedia description for augmentation claims to slow growth below 40 infrastructure and increase growth above 40 infrastructure. Actual effect was giving 1.5x growth at 20 and below, double growth at 40 and up to 2.2x growth at max.

https://github.com/freeorion/freeorion/issues/4864

tested