### PR TITLE
Fix Compile Error in Apple Clang 15

### DIFF
--- a/universe/ScriptingContext.h
+++ b/universe/ScriptingContext.h
@@ -7,13 +7,21 @@
 #include "../util/AppInterface.h"
 #include <variant>
 
+#if !defined(CONSTEXPR_VEC_AND_STRING)
+#  if defined(__cpp_lib_constexpr_vector) && defined(__cpp_lib_constexpr_string) && ((!defined(__GNUC__) || (__GNUC__ > 12) || (__GNUC__ == 12 && __GNUC_MINOR__ >= 2))) && ((!defined(_MSC_VER) || (_MSC_VER >= 1934))) && ((!defined(__clang_major__) || (__clang_major__ >= 17)))
+#    define CONSTEXPR_VEC_AND_STRING constexpr
+#  else
+#    define CONSTEXPR_VEC_AND_STRING
+#  endif
+#endif
+
 struct CombatInfo;
 
 struct [[nodiscard]] ScriptingContext {
     using CurrentValueVariant = std::variant<
         int, double, PlanetType, PlanetSize, ::PlanetEnvironment, StarType,
         UniverseObjectType, Visibility, std::string, std::vector<std::string>>;
-    inline static CONSTEXPR_VEC const CurrentValueVariant DEFAULT_CURRENT_VALUE{0};
+    inline static CONSTEXPR_VEC_AND_STRING const CurrentValueVariant DEFAULT_CURRENT_VALUE{0};
 
     ScriptingContext() noexcept :
         ScriptingContext(GetUniverse(), ::Empires(), GetGalaxySetupData(),


### PR DESCRIPTION
Previously working code has suddenly stopped working, possibly due to an XCode version bump from 14 to 15.
https://github.com/freeorion/freeorion/actions/runs/7856911504/job/21440187996

````
/Users/runner/work/freeorion/freeorion/parse/../universe/ScriptingContext.h:16:59: error: constexpr variable cannot have non-literal type 'const CurrentValueVariant' (aka 'const variant<int, double, PlanetType, PlanetSize, PlanetEnvironment, StarType, UniverseObjectType, Visibility, basic_string<char>, vector<basic_string<char>>>')
    inline static CONSTEXPR_VEC const CurrentValueVariant DEFAULT_CURRENT_VALUE{0};
````