### PR TITLE
Allow independence decree only to be built on populated planets

### DIFF
--- a/default/scripting/buildings/COLONY_INDEPENDENCE_DECREE.focs.txt
+++ b/default/scripting/buildings/COLONY_INDEPENDENCE_DECREE.focs.txt
@@ -7,7 +7,7 @@ BuildingType
     location = And [
         Planet
         OwnedBy empire = Source.Owner
-        Population
+        Population low = 0.001
         Not Capital
     ]
 


### PR DESCRIPTION
this prevents it from being built on outposts; for that purposes exists the "abandon outpost" building