### PR TITLE
Swap order of monster and special placement in universe generation

### DIFF
--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -176,13 +176,13 @@ def create_universe(psd_map):  # noqa: C901
     seed_rng(seed_pool.pop())
     generate_natives(gsd.native_frequency, systems, home_systems)
 
-    print("Generating Space Monsters")
-    seed_rng(seed_pool.pop())
-    generate_monsters(gsd.monster_frequency, systems)
-
     print("Distributing Starting Specials")
     seed_rng(seed_pool.pop())
     distribute_specials(gsd.specials_frequency, fo.get_all_objects())
+
+    print("Generating Space Monsters")
+    seed_rng(seed_pool.pop())
+    generate_monsters(gsd.monster_frequency, systems)
 
     # finally, write some statistics to the log file
     print("############################################################")


### PR DESCRIPTION
These location condition lines were doing nothing, as specials currently don't exist at the time of experimentor placement:

https://github.com/freeorion/freeorion/blob/master/default/scripting/monster_fleets.inf#L193-L197

More generally I believe it's more useful to already know where the specials are when placing monsters, rather then know where the monsters are when placing specials.

Specifically I'd like to move the following to within universe generation:

https://github.com/freeorion/freeorion/blob/master/default/scripting/specials/planet/monster_guard.macros

and then add a check in universe generation to prevent stationary monsters from increasing the path length between 2 empires by more then a specifiable jump distance.