### PR TITLE
allow resonant moon on gas giants

### DIFF
--- a/default/scripting/buildings/ART_MOON.focs.py
+++ b/default/scripting/buildings/ART_MOON.focs.py
@@ -4,7 +4,6 @@ from focs._effects import (
     Contains,
     Destroy,
     EffectsGroup,
-    GasGiantType,
     HasSpecial,
     IsBuilding,
     IsSource,
@@ -30,7 +29,7 @@ BuildingType(  # type: ignore[reportUnboundVariable]
         Planet()
         & ~Contains(IsBuilding(name=["BLD_ART_MOON"]))
         & OwnedBy(empire=Source.Owner)
-        & ~Planet(type=[AsteroidsType, GasGiantType])
+        & ~Planet(type=[AsteroidsType])
         & ~HasSpecial(name="RESONANT_MOON_SPECIAL")
     ),
     enqueuelocation=ENQUEUE_BUILD_ONE_PER_PLANET,

--- a/default/scripting/specials/planet/RESONANT_MOON.focs.txt
+++ b/default/scripting/specials/planet/RESONANT_MOON.focs.txt
@@ -7,7 +7,7 @@ Special
     location = And [
         Planet
         Not Capital
-        Not Planet type = [Asteroids GasGiant]
+        Not Planet type = [Asteroids]
     ]
     effectsgroups = [
         EffectsGroup


### PR DESCRIPTION
Discussion threads:

https://www.freeorion.org/forum/viewtopic.php?t=13005
https://www.freeorion.org/forum/viewtopic.php?p=109633

Gas giants never had specials, but they also never had colonisable species. Moons are the most natural fit for gas giants, but most are too powerful, unless you have enough eligible specials in the pool to dilute them.

Adding just resonant moon means any special on a gas giant will be resonant moon, I've looked in game, its noticeable but not bad (in my opinion). Resonant moon is mostly no effect, but can hide some buildings (e.g. shipyards), its got some natural synergy with Sly.

My belief is long term Gas giants need enough of a unique pool of specials to add in other specials, and this would be a "1st step" or "trial". 