### PR TITLE
Make Military Command cheaper

### DIFF
--- a/default/scripting/buildings/MILITARY_COMMAND.focs.txt
+++ b/default/scripting/buildings/MILITARY_COMMAND.focs.txt
@@ -2,8 +2,8 @@ BuildingType
     name = "BLD_MILITARY_COMMAND"
     description = "BLD_MILITARY_COMMAND_DESC"
     captureresult = Destroy
-    buildcost = 80 * [[BUILDING_COST_MULTIPLIER]]
-    buildtime = 6
+    buildcost = 60 * [[BUILDING_COST_MULTIPLIER]]
+    buildtime = 5
     location = And [
         Planet
         OwnedBy empire = Source.Owner


### PR DESCRIPTION
https://www.freeorion.org/forum/viewtopic.php?t=13017&sid=ddfa55fe1ba53cc24ec5cf0b294cd440

Exploration Policy is gated behind the slot from this building. On top of that the production spent on the building is production that can't be used to build scouts.