### PR TITLE
remove seemingly unneeded #include that is removed from Boost 1.85

### DIFF
--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -4,7 +4,6 @@
 #include "i18n.h"
 
 #include <boost/algorithm/string/trim.hpp>
-#include <boost/filesystem/convenience.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 


### PR DESCRIPTION
hopefully fixes #4897 for master