### PR TITLE
Fix supply disconnected influence malus on start of game

### DIFF
--- a/default/scripting/species/species_macros/influence.py
+++ b/default/scripting/species/species_macros/influence.py
@@ -22,6 +22,7 @@ from focs._effects import (
     Source,
     StatisticCount,
     Target,
+    Turn,
     Unowned,
     Value,
 )
@@ -128,7 +129,8 @@ _BASE_INFLUENCE_COSTS = [
         & ~EmpireHasAdoptedPolicy(empire=Source.Owner, name="PLC_CONFEDERATION")
         & ~ResourceSupplyConnected(
             empire=LocalCandidate.Owner, condition=Planet() & OwnedBy(empire=Source.Owner) & Capital
-        ),
+        )
+        & Turn(low=1),
         accountinglabel="CAPITAL_DISCONNECTION_LABEL",
         priority=TARGET_LAST_BEFORE_OVERRIDE_PRIORITY,
         effects=SetTargetInfluence(


### PR DESCRIPTION
Otherwise capital is treated on turn zero/before the game starts as disconnected from itself, and you start with value=SUPPLY_DISCONNECTED_INFLUENCE_MALUS fewer influence points generation on your capital (e.g. the meter is 2 out of 3 instead of 3 out of 3, if imperial palace generates 3)

Maybe this is a deeper rooted issue on how scripting works on turn zero, but this at least goes around the problem. 

It was discussed as off topic remark on https://freeorion.org/forum/viewtopic.php?p=118946#p118946 where wobbly pointed out that he tested the initial value of 2 influence on capital instead of 3 comes from the disconnected malus. So this is my proposal to fix it, apply Turn(low=1) to the condition so initially you don't get the malus.
