### PR TITLE
Fix annex sitrep

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -7919,7 +7919,7 @@ SITREP_PLANET_ANNEXED_LABEL
 Neutral Planet Annexed
 
 SITREP_PLANET_ANNEXED_FROM_OTHER_EMPIRE
-%planet% has been annexed by %empire% from %empire%.
+%planet% has been annexed by %empire:annexer% from %empire:original%.
 
 SITREP_PLANET_ANNEXED_FROM_OTHER_EMPIRE_LABEL
 Empire Planet Annexed

--- a/util/SitRepEntry.cpp
+++ b/util/SitRepEntry.cpp
@@ -391,10 +391,10 @@ SitRepEntry CreatePlanetAnnexedSitRep(int planet_id, int original_owner_id, int 
     const auto msg = (original_owner_id == ALL_EMPIRES) ? neutral_annex_txt : other_empire_annex_txt;
     const auto label = (original_owner_id == ALL_EMPIRES) ? neutral_annex_label : other_empire_annex_label;
     SitRepEntry sitrep{msg.data(), current_turn + 1, "icons/sitrep/annexed.png", label.data(), true};
-    sitrep.AddVariable(VarText::PLANET_ID_TAG,     std::to_string(planet_id));
-    sitrep.AddVariable(VarText::EMPIRE_ID_TAG,     std::to_string(annexer_empire_id));
+    sitrep.AddVariable(VarText::PLANET_ID_TAG,  std::to_string(planet_id));
+    sitrep.AddVariable("annexer",               std::to_string(annexer_empire_id));
     if (original_owner_id != ALL_EMPIRES)
-        sitrep.AddVariable(VarText::EMPIRE_ID_TAG, std::to_string(original_owner_id));
+        sitrep.AddVariable("original",          std::to_string(original_owner_id));
     return sitrep;
 }
 

--- a/util/VarText.h
+++ b/util/VarText.h
@@ -117,6 +117,7 @@ public:
     //! @param  data
     //!     Data value of the #m_variables set.
     void AddVariable(std::string tag, std::string data);
+    void AddVariable(const char* tag, std::string data) { AddVariable(std::string{tag}, std::move(data)); }
     void AddVariable(std::string_view tag, std::string data) { AddVariable(std::string{tag}, std::move(data)); }
 
     //! Assign @p data as tags. Does not overwrite or replace data of existing tags.


### PR DESCRIPTION
Should fix #4902 for newly generated sitreps, but may break previously-generated sitreps of this type for saved games.