### PR TITLE
better indicate detection of ships that launch fighters in combat log

### DIFF
--- a/combat/CombatEvent.h
+++ b/combat/CombatEvent.h
@@ -28,7 +28,6 @@ in the contructor. The descriptions can be expanded on request.
 
 */
 struct FO_COMMON_API CombatEvent {
-    CombatEvent() = default;
     virtual ~CombatEvent() = default;
 
     [[nodiscard]] virtual std::string DebugString(const ScriptingContext& context) const = 0;

--- a/combat/CombatEvents.h
+++ b/combat/CombatEvents.h
@@ -11,6 +11,7 @@
 #include "../util/Export.h"
 #include "../universe/ConstantsFwd.h"
 #include "../universe/EnumsFwd.h"
+#include "../universe/UniverseObject.h"
 
 #include "CombatEvent.h"
 
@@ -126,14 +127,30 @@ struct FO_COMMON_API StealthChangeEvent : public CombatEvent {
     [[nodiscard]] bool AreSubEventsEmpty(int viewing_empire_id) const override;
     void AddEvent(int attacker_id_, int target_id_, int attacker_empire_,
                   int target_empire_, Visibility new_visibility_);
+    void AddEvent(int launcher_id_, int launcher_empire_id_,
+                  int observer_empire_id_, Visibility new_visibility_);
 
     struct StealthChangeEventDetail;
     typedef std::shared_ptr<StealthChangeEventDetail> StealthChangeEventDetailPtr;
     typedef std::shared_ptr<const StealthChangeEventDetail> ConstStealthChangeEventDetailPtr;
     struct StealthChangeEventDetail : public CombatEvent {
-        StealthChangeEventDetail();
-        StealthChangeEventDetail(int attacker_id_, int target_id_, int attacker_empire_,
-                                 int target_empire_, Visibility new_visibility_);
+        constexpr StealthChangeEventDetail() noexcept = default;
+        constexpr StealthChangeEventDetail(int attacker_id_, int target_id_, int attacker_empire_,
+                                           int target_empire_, Visibility new_visibility_) noexcept :
+            attacker_id(attacker_id_),
+            target_id(target_id_),
+            attacker_empire_id(attacker_empire_),
+            target_empire_id(target_empire_),
+            visibility(new_visibility_)
+        {}
+        constexpr StealthChangeEventDetail(int laucher_id_, int laucher_empire_, int observer_empire_,
+                                           Visibility new_visibility_) noexcept :
+            attacker_id(laucher_id_),
+            attacker_empire_id(laucher_empire_),
+            target_empire_id(observer_empire_),
+            visibility(new_visibility_),
+            is_fighter_launch(true)
+        {}
 
         [[nodiscard]] std::string DebugString(const ScriptingContext& context) const override;
         [[nodiscard]] std::string CombatLogDescription(int viewing_empire_id, const ScriptingContext& context) const override;
@@ -142,7 +159,8 @@ struct FO_COMMON_API StealthChangeEvent : public CombatEvent {
         int target_id = INVALID_OBJECT_ID;
         int attacker_empire_id = ALL_EMPIRES;
         int target_empire_id = ALL_EMPIRES;
-        Visibility visibility;
+        Visibility visibility = Visibility::VIS_NO_VISIBILITY;
+        bool is_fighter_launch = false;
     };
 
 private:

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -1875,8 +1875,7 @@ namespace {
 
                     // record visibility change event due to attack
                     // FIXME attacker, TARGET, attacker empire, target empire, visibility
-                    stealth_change_event->AddEvent(attacker->ID(), attacker->ID(),
-                                                   attacker->Owner(), detector_empire_id,
+                    stealth_change_event->AddEvent(attacker->ID(), attacker->Owner(), detector_empire_id,
                                                    Visibility::VIS_BASIC_VISIBILITY);
                 }
             }

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6087,6 +6087,11 @@ ENC_COMBAT_NEUTRAL_INITIAL_STEALTH_LIST
 ENC_COMBAT_STEALTH_DECLOAK_ATTACK
 %2% detects %1% during attack.
 
+# %1 link to the launching unit
+# %2 link to the empire that detects the launcher
+ENC_COMBAT_STEALTH_DECLOAK_LAUNCH
+%2% detects %1% during fighter launch.
+
 # %1% unused
 # %2% name of empire detecting decloacking ship
 ENC_COMBAT_STEALTH_DECLOAK_ATTACK_1_EVENTS

--- a/util/SerializeCombat.cpp
+++ b/util/SerializeCombat.cpp
@@ -122,9 +122,11 @@ void serialize(Archive& ar, StealthChangeEvent::StealthChangeEventDetail& obj, u
         & make_nvp("attacker_empire_id", obj.attacker_empire_id)
         & make_nvp("target_empire_id", obj.target_empire_id)
         & make_nvp("visibility", obj.visibility);
+    if (version >= 5)
+        ar  & make_nvp("is_fighter_launch", obj.is_fighter_launch);
 }
 
-BOOST_CLASS_VERSION(StealthChangeEvent::StealthChangeEventDetail, 4)
+BOOST_CLASS_VERSION(StealthChangeEvent::StealthChangeEventDetail, 5)
 BOOST_CLASS_EXPORT(StealthChangeEvent::StealthChangeEventDetail)
 
 template void serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, StealthChangeEvent::StealthChangeEventDetail&, unsigned int const);


### PR DESCRIPTION
store that a stealth event is a fighter launch and use a dedicated stringtable entry for it