### PR TITLE
Increase research and build costs for carriers

### DIFF
--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -10,7 +10,7 @@ Part
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
     ]
     mountableSlotTypes = Internal
-    buildcost = 10 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 15 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1
     tags = [ "PEDIA_PC_FIGHTER_HANGAR" ]
     location = And [

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_2.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_2.focs.txt
@@ -13,7 +13,7 @@ Part
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
     ]
     mountableSlotTypes = Internal
-    buildcost = 15 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1
     tags = [ "PEDIA_PC_FIGHTER_HANGAR" ]
     location = And [

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_3.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_3.focs.txt
@@ -10,7 +10,7 @@ Part
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
     ]
     mountableSlotTypes = Internal
-    buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 25 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1
     tags = [ "PEDIA_PC_FIGHTER_HANGAR" ]
     location = And [

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
@@ -13,7 +13,7 @@ Part
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
     ]
     mountableSlotTypes = Internal
-    buildcost = 25 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 30 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1
     tags = [ "PEDIA_PC_FIGHTER_HANGAR" ]
     location = And [

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_1.focs.py
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_1.focs.py
@@ -6,7 +6,7 @@ Tech(
     description="SHP_FIGHTERS_1_DESC",
     short_description="SHIP_WEAPON_UNLOCK_SHORT_DESC",
     category="SHIP_WEAPONS_CATEGORY",
-    researchcost=12 * TECH_COST_MULTIPLIER,
+    researchcost=15 * TECH_COST_MULTIPLIER,
     researchturns=3,
     tags=["PEDIA_FIGHTER_TECHS"],
     prerequisites=["SHP_ROOT_AGGRESSION"],

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_2.focs.py
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_2.focs.py
@@ -19,7 +19,7 @@ Tech(
     description="SHP_FIGHTERS_2_DESC",
     short_description="SHIP_WEAPON_IMPROVE_SHORT_DESC",
     category="SHIP_WEAPONS_CATEGORY",
-    researchcost=90 * TECH_COST_MULTIPLIER,
+    researchcost=108 * TECH_COST_MULTIPLIER,
     researchturns=9,
     tags=["PEDIA_FIGHTER_TECHS"],
     prerequisites=["SHP_FIGHTERS_1"],

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_3.focs.py
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_3.focs.py
@@ -19,7 +19,7 @@ Tech(
     description="SHP_FIGHTERS_3_DESC",
     short_description="SHIP_WEAPON_IMPROVE_SHORT_DESC",
     category="SHIP_WEAPONS_CATEGORY",
-    researchcost=360 * TECH_COST_MULTIPLIER,
+    researchcost=396 * TECH_COST_MULTIPLIER,
     researchturns=9,
     tags=["PEDIA_FIGHTER_TECHS"],
     prerequisites=["SHP_FIGHTERS_2"],


### PR DESCRIPTION
Unfortunately the forum is down and I can't open a discussion thread, hopefully people with an opinion will see it here.

This started with a question in my head about robotic interference shields, but when I compared them to other shields they seemed to be good value (12 robotics will match a plasma shield with less cost/shield). Then I asked whether shields are too expensive? Maybe, maybe not, but reducing their cost would just make direct weapons weaker and push more people towards carriers.

Carriers are the dominant choice in MP, it seems most players feel they are the best value for PP and RP. Proposed change is +5 PP/hanger. +25% RP on the base hanger tech, +20% RP on fighter 2, +10% RP on fighter 3 and no change to fighter 4. 