### PR TITLE
Increase Charge bonus with speed

### DIFF
--- a/default/scripting/policies/CHARGE.focs.txt
+++ b/default/scripting/policies/CHARGE.focs.txt
@@ -14,16 +14,16 @@ Policy
                 Ship
                 OwnedBy empire = Source.Owner
                 Armed
-                Speed low = NamedReal name = "PLC_CHARGE_MINIMUM_SPEED" value = 120.0
+                Speed low = NamedReal name = "PLC_CHARGE_MINIMUM_SPEED" value = 110.0
             ]
             priority = [[TARGET_AFTER_SCALING_PRIORITY]]
             effects = [
                 // fluff-wise: a charge bonus could interact with "range", so e.g. a charging vessel could shoot a bout earlier.
                 // fluff-wise: a charge bonus probably should wear off when already in close combat range
-                SetMaxDamage partname = "SR_WEAPON_1_1" value = Value + (NamedReal name = "PLC_CHARGE_DAMAGE_BOOST" value = 1.0 * [[SHIP_WEAPON_DAMAGE_FACTOR]] )
-                SetMaxDamage partname = "SR_WEAPON_2_1" value = Value + NamedRealLookup name = "PLC_CHARGE_DAMAGE_BOOST"
-                SetMaxDamage partname = "SR_WEAPON_3_1" value = Value + NamedRealLookup name = "PLC_CHARGE_DAMAGE_BOOST"
-                SetMaxDamage partname = "SR_WEAPON_4_1" value = Value + NamedRealLookup name = "PLC_CHARGE_DAMAGE_BOOST"
+                SetMaxDamage partname = "SR_WEAPON_1_1" value = Value + (NamedReal name = "PLC_CHARGE_BASE_DAMAGE_BOOST" value = 1.0 * [[SHIP_WEAPON_DAMAGE_FACTOR]] ) * [[PLC_CHARGE_SPEED_FACTOR]]
+                SetMaxDamage partname = "SR_WEAPON_2_1" value = Value + NamedRealLookup name = "PLC_CHARGE_BASE_DAMAGE_BOOST" * [[PLC_CHARGE_SPEED_FACTOR]]
+                SetMaxDamage partname = "SR_WEAPON_3_1" value = Value + NamedRealLookup name = "PLC_CHARGE_BASE_DAMAGE_BOOST" * [[PLC_CHARGE_SPEED_FACTOR]]
+                SetMaxDamage partname = "SR_WEAPON_4_1" value = Value + NamedRealLookup name = "PLC_CHARGE_BASE_DAMAGE_BOOST" * [[PLC_CHARGE_SPEED_FACTOR]]
                 SetMaxSecondaryStat partname = "SR_ARC_DISRUPTOR" value = (Value + NamedReal name = "PLC_CHARGE_ARC_DISRUPTOR_SHOT_BONUS" value = 1.0)
                 // TODO check monster weapons
                 // fluff-wise: Fighters should not get a charge bonus for fighters from carriers as the carrier speed does not give combat advantage to the fighters.
@@ -33,11 +33,22 @@ Policy
                 SetMaxCapacity partname = "FT_BAY_1" value = Value + (NamedInteger name = "PLC_CHARGE_BAY_LAUNCH_BONUS" value = 1)
                 // Point defense and shields are less efficient when charging:
                 SetMaxDamage partname = "SR_WEAPON_0_1" value = Value - (NamedReal name = "PLC_CHARGE_FLAK_SHOT_REDUCTION" value = 1.0)
-                SetMaxShield value = Value - (NamedReal name = "PLC_CHARGE_SHIELD_REDUCTION" value = 3.0 * [[SHIP_SHIELD_FACTOR]] )
+                SetMaxShield value = max(Value / 2,
+                    Value - (NamedReal name = "PLC_CHARGE_SHIELD_REDUCTION" value = 1.0 * [[SHIP_SHIELD_FACTOR]] ) * [[PLC_CHARGE_SPEED_FACTOR]]
+                    )
             ]
 
     ]
     graphic = "icons/policies/military_charge.png"
+
+PLC_CHARGE_SPEED_FACTOR
+'''min(NamedReal name = "PLC_CHARGE_MAXIMUM_SPEED_FACTOR" value = 5,
+    floor(
+        (Target.Speed - NamedReal name = "PLC_CHARGE_BASE_SPEED" value = 100) /
+        NamedReal name = "PLC_CHARGE_STEP_SIZE" value = 10
+    )
+)
+'''
 
 #include "/scripting/policies/policies.macros"
 #include "/scripting/macros/priorities.macros"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -13062,12 +13062,12 @@ Charge
 
 PLC_CHARGE_DESC
 '''For armed ships with at least [[value PLC_CHARGE_MINIMUM_SPEED]] [[metertype METER_SPEED]]:
-• Weapon damage for ship weapons is increased by [[value PLC_CHARGE_DAMAGE_BOOST]] (i.e. for [[shippart SR_WEAPON_1_1]], [[shippart SR_WEAPON_2_1]], [[shippart SR_WEAPON_3_1]], or [[shippart SR_WEAPON_4_1]])
+• Weapon damage for ship weapons (i.e. for [[shippart SR_WEAPON_1_1]], [[shippart SR_WEAPON_2_1]], [[shippart SR_WEAPON_3_1]], or [[shippart SR_WEAPON_4_1]]) is increased by [[value PLC_CHARGE_BASE_DAMAGE_BOOST]] for every [[value PLC_CHARGE_STEP_SIZE]] uu over [[value PLC_CHARGE_BASE_SPEED]] up to a maximum of [[value PLC_CHARGE_MAXIMUM_SPEED_FACTOR]] * [[value PLC_CHARGE_BASE_DAMAGE_BOOST]]
 • Number of fighters launched per [[FT_BAY_1]] is increased by [[value PLC_CHARGE_BAY_LAUNCH_BONUS]]
 • Number of shots for [[shippart SR_ARC_DISRUPTOR]] is increased by [[value PLC_CHARGE_ARC_DISRUPTOR_SHOT_BONUS]]
 • A charging [[shippart SR_FLUX_LANCE]] can attack ships starting one combat round earlier
 • Number of shots for [[shippart SR_WEAPON_0_1]] is decreased by [[value PLC_CHARGE_FLAK_SHOT_REDUCTION]]
-• [[metertype METER_MAX_SHIELD]] is reduced by [[value PLC_CHARGE_SHIELD_REDUCTION]] '''
+• [[metertype METER_MAX_SHIELD]] is reduced by [[value PLC_CHARGE_SHIELD_REDUCTION]] for every [[value PLC_CHARGE_STEP_SIZE]] uu over [[value PLC_CHARGE_BASE_SPEED]] maxing at half shields'''
 
 PLC_CHARGE_SHORT_DESC
 Boosts Fast Ship Damage


### PR DESCRIPTION
Its been commented that charge policy scales poorly with upgraded weapons. I've expressed a view that the policy favouring mass drivers is a strength. This is a "middle ground" where the boost scales with ship speed instead of weapon type.

Discussion thread:

https://www.freeorion.org/forum/viewtopic.php?t=12850&sid=7b21ef90c5571d8e779b915813906d05

Updated Pedia:

![charge](https://github.com/freeorion/freeorion/assets/43386669/26fa9528-8dea-428d-b885-a74fb53a044b)

Tested.

