### PR TITLE
Prevent copying by using references, also fixes warnings

### DIFF
--- a/Empire/EmpireManager.cpp
+++ b/Empire/EmpireManager.cpp
@@ -172,7 +172,7 @@ boost::container::flat_set<int> EmpireManager::GetEmpireIDsWithDiplomaticStatusW
     retval.reserve(statuses.size()); // probably an overestimate
 
     // find ids of empires with the specified diplomatic status with the specified empire
-    for (auto const [emp1, emp2] : statuses
+    for (auto const &[emp1, emp2] : statuses
          | range_filter([diplo_status](const auto& ids_status) noexcept { return ids_status.second == diplo_status; })
          | range_keys)
     {

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1863,7 +1863,7 @@ void Font::Init(FT_Face& face)
     Y y = Y0;
     X max_x = X0;
     Y max_y = Y0;
-    for (const auto [low, high] : range_vec) {
+    for (const auto &[low, high] : range_vec) {
         for (uint32_t c = low; c < high; ++c) {
             // skip already-existing glphys
             if (std::any_of(temp_glyph_data.begin(), temp_glyph_data.end(),

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -3958,7 +3958,7 @@ namespace {
                     continue;
 
                 // every (blockading fleet) X (blockaded fleet) X (recipient empire) generates a separate sitrep
-                for (const auto [blockading_fleet_id, blockading_empire_id] : blockading_fleets_and_empire_ids) {
+                for (const auto &[blockading_fleet_id, blockading_empire_id] : blockading_fleets_and_empire_ids) {
                     if (context.ContextVis(blockading_fleet_id, recipient_empire_id) >= Visibility::VIS_PARTIAL_VISIBILITY) {
                         // if the blockading fleet is also visible, include that info
                         recipient_empire->AddSitRepEntry(

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -339,7 +339,7 @@ void serialize(Archive& ar, EmpireManager& em, unsigned int const version)
         // erase invalid empire diplomatic statuses
         std::vector<std::pair<int, int>> to_erase;
         to_erase.reserve(em.m_empire_diplomatic_statuses.size());
-        for (const auto [e1, e2] : em.m_empire_diplomatic_statuses | range_keys) {
+        for (const auto &[e1, e2] : em.m_empire_diplomatic_statuses | range_keys) {
             if (!em.m_empire_map.contains(e1) || !em.m_empire_map.contains(e2)) {
                 to_erase.emplace_back(e1, e2);
                 ErrorLogger() << "Erased invalid diplomatic status between empires " << e1 << " and " << e2;


### PR DESCRIPTION
I couldn't run the tests (don't know how) but I think this changes ought to be safe