### PR TITLE
better flak with direct weapon3 tech

### DIFF
--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -391,9 +391,10 @@ WEAPON_UPGRADE_DICT = {
     }.items()
 }
 
+# ROF == rate of fire == weapon shots
 WEAPON_ROF_UPGRADE_DICT = {
     # "PARTNAME": tuple((tech_name, rof_upgrade), (tech_name2, rof_upgrade2), ...)
-    "SR_WEAPON_0_1": (),
+    "SR_WEAPON_0_1": (("SHP_WEAPON_1_3", 1), ("SHP_WEAPON_2_3", 1), ("SHP_WEAPON_3_3", 1), ("SHP_WEAPON_4_3", 1)),
     "SR_WEAPON_1_1": (),
     "SR_WEAPON_2_1": (),
     "SR_WEAPON_3_1": (),

--- a/default/scripting/focs/_effects.pyi
+++ b/default/scripting/focs/_effects.pyi
@@ -20,6 +20,7 @@ from focs._types import (
     _FloatParam,
     _Focus,
     _IntParam,
+    _MeterType,
     _PlanetEnvironment,
     _PlanetId,
     _PlanetSize,
@@ -32,6 +33,11 @@ from focs._types import (
     _ValueParam,
     _Visibility,
 )
+
+Capacity = _MeterType()
+MaxCapacity = _MeterType()
+SecondaryStat = _MeterType()
+MaxSecondaryStat = _MeterType()
 
 Blue = _StarType()
 White = _StarType()
@@ -91,7 +97,7 @@ class _SystemInfo:
 
 class Source:
     """
-    FOCS Source is IsSource, this class is fpr Source.<something>
+    FOCS Source condition is IsSource, this class is for value ref Source.<something>
     """
 
     Owner: _Empire
@@ -228,6 +234,7 @@ def EmpireStockpile(empire: _EmpireId, resource: _Resource) -> float: ...
 def PartCapacity(*, name: str) -> float: ...
 def PartSecondaryStat(*, name: str) -> float: ...
 def PartsInShipDesign(*, name: str, design: _DesignID) -> float: ...
+def ShipPartMeter(*, part: str, meter: _MeterType, ship: _ID): ...
 def UserString(name: str) -> str: ...
 def EmpireMeterValue(empire: _EmpireId, meter: str) -> float: ...
 def EffectsGroup(

--- a/default/scripting/focs/_types.py
+++ b/default/scripting/focs/_types.py
@@ -11,6 +11,9 @@ try:
 
     from typing_extensions import Self
 
+    class _MeterType:
+        ...
+
     class _Effect:
         ...
 

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_1_3.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_1_3.focs.py
@@ -1,6 +1,6 @@
 from focs._tech import *
 from macros.base_prod import TECH_COST_MULTIPLIER
-from techs.ship_weapons.ship_weapons import WEAPON_UPGRADE_CAPACITY_EFFECTS
+from techs.ship_weapons.ship_weapons import WEAPON_UPGRADE_CAPACITY_EFFECTS, WEAPON_UPGRADE_SECONDARY_STAT_EFFECTS
 
 Tech(
     name="SHP_WEAPON_1_3",
@@ -11,6 +11,9 @@ Tech(
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_1_2"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_1_3", "SR_WEAPON_1_1", 1),
+    effectsgroups=[
+        *WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_1_3", "SR_WEAPON_1_1", 1),
+        *WEAPON_UPGRADE_SECONDARY_STAT_EFFECTS("SHP_WEAPON_1_3", "SR_WEAPON_0_1", 1),
+    ],
     graphic="icons/ship_parts/mass-driver-3.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_3.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_3.focs.py
@@ -1,6 +1,6 @@
 from focs._tech import *
 from macros.base_prod import TECH_COST_MULTIPLIER
-from techs.ship_weapons.ship_weapons import WEAPON_UPGRADE_CAPACITY_EFFECTS
+from techs.ship_weapons.ship_weapons import WEAPON_UPGRADE_CAPACITY_EFFECTS, WEAPON_UPGRADE_SECONDARY_STAT_EFFECTS
 
 Tech(
     name="SHP_WEAPON_2_3",
@@ -11,6 +11,9 @@ Tech(
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_2_2"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_2_3", "SR_WEAPON_2_1", 2),
+    effectsgroups=[
+        *WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_2_3", "SR_WEAPON_1_1", 1),
+        *WEAPON_UPGRADE_SECONDARY_STAT_EFFECTS("SHP_WEAPON_2_3", "SR_WEAPON_0_1", 1),
+    ],
     graphic="icons/ship_parts/laser-3.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_3.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_3.focs.py
@@ -1,6 +1,6 @@
 from focs._tech import *
 from macros.base_prod import TECH_COST_MULTIPLIER
-from techs.ship_weapons.ship_weapons import WEAPON_UPGRADE_CAPACITY_EFFECTS
+from techs.ship_weapons.ship_weapons import WEAPON_UPGRADE_CAPACITY_EFFECTS, WEAPON_UPGRADE_SECONDARY_STAT_EFFECTS
 
 Tech(
     name="SHP_WEAPON_3_3",
@@ -11,6 +11,9 @@ Tech(
     researchturns=2,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_3_2"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_3_3", "SR_WEAPON_3_1", 3),
+    effectsgroups=[
+        *WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_3_3", "SR_WEAPON_1_1", 1),
+        *WEAPON_UPGRADE_SECONDARY_STAT_EFFECTS("SHP_WEAPON_3_3", "SR_WEAPON_0_1", 1),
+    ],
     graphic="icons/ship_parts/plasma-3.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_3.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_3.focs.py
@@ -1,6 +1,6 @@
 from focs._tech import *
 from macros.base_prod import TECH_COST_MULTIPLIER
-from techs.ship_weapons.ship_weapons import WEAPON_UPGRADE_CAPACITY_EFFECTS
+from techs.ship_weapons.ship_weapons import WEAPON_UPGRADE_CAPACITY_EFFECTS, WEAPON_UPGRADE_SECONDARY_STAT_EFFECTS
 
 Tech(
     name="SHP_WEAPON_4_3",
@@ -11,6 +11,9 @@ Tech(
     researchturns=3,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_4_2"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_4_3", "SR_WEAPON_4_1", 5),
+    effectsgroups=[
+        *WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_4_3", "SR_WEAPON_1_1", 1),
+        *WEAPON_UPGRADE_SECONDARY_STAT_EFFECTS("SHP_WEAPON_4_3", "SR_WEAPON_0_1", 1),
+    ],
     graphic="icons/ship_parts/death-ray-3.png",
 )

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -7806,6 +7806,12 @@ All %shippart% weapons on supplied ships have been upgraded to %tech%. Upgraded 
 SITREP_WEAPONS_UPGRADED_LABEL
 Weapon Tech Upgrade
 
+SITREP_WEAPON_SHOTS_UPGRADED
+All %shippart% weapons on supplied ships have been upgraded with %tech% technology. Upgraded weapons do %rawtext:shots% extra shot per bout (%rawtext:shotsum%)
+
+SITREP_WEAPON_SHOTS_UPGRADED_LABEL
+Weapon Tech Upgrade
+
 SITREP_COMBAT_SYSTEM
 At %system%: there was %combat%.
 
@@ -14454,7 +14460,9 @@ SHP_WEAPON_1_3
 Mass Driver 3
 
 SHP_WEAPON_1_3_DESC
-Upgrades [[shippart SR_WEAPON_1_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_1_3_UPGRADED_DAMAGE]].
+'''Upgrades [[shippart SR_WEAPON_1_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_1_3_UPGRADED_DAMAGE]].
+
+Also upgrades [[shippart SR_WEAPON_0_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part fires [[value SHP_WEAPON_1_3_UPGRADE_SHOTS]] extra shots per bout.'''
 
 SHP_WEAPON_1_4
 Mass Driver 4
@@ -14478,7 +14486,9 @@ SHP_WEAPON_2_3
 Laser 3
 
 SHP_WEAPON_2_3_DESC
-Upgrades [[shippart SR_WEAPON_2_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_2_3_UPGRADED_DAMAGE]].
+'''Upgrades [[shippart SR_WEAPON_2_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_2_3_UPGRADED_DAMAGE]].
+
+Also upgrades [[shippart SR_WEAPON_0_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part fires [[value SHP_WEAPON_2_3_UPGRADE_SHOTS]] extra shots per bout.'''
 
 SHP_WEAPON_2_4
 Laser 4
@@ -14502,7 +14512,9 @@ SHP_WEAPON_3_3
 Plasma Cannon 3
 
 SHP_WEAPON_3_3_DESC
-Upgrades [[shippart SR_WEAPON_3_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_3_3_UPGRADED_DAMAGE]].
+'''Upgrades [[shippart SR_WEAPON_3_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_3_3_UPGRADED_DAMAGE]].
+
+Also upgrades [[shippart SR_WEAPON_0_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part fires [[value SHP_WEAPON_3_3_UPGRADE_SHOTS]] extra shots per bout.'''
 
 SHP_WEAPON_3_4
 Plasma Cannon 4
@@ -14526,7 +14538,9 @@ SHP_WEAPON_4_3
 Death Ray 3
 
 SHP_WEAPON_4_3_DESC
-Upgrades [[shippart SR_WEAPON_4_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_4_3_UPGRADED_DAMAGE]].
+'''Upgrades [[shippart SR_WEAPON_4_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part has shot damage of [[value SHP_WEAPON_4_3_UPGRADED_DAMAGE]].
+
+Also upgrades [[shippart SR_WEAPON_0_1]] parts on all ships within [[metertype METER_SUPPLY]] (or after entering it later). The improved weapon part fires [[value SHP_WEAPON_4_3_UPGRADE_SHOTS]] extra shots per bout.'''
 
 SHP_WEAPON_4_4
 Death Ray 4
@@ -15995,7 +16009,13 @@ Flak Cannon
 SR_WEAPON_0_1_DESC
 '''The flak cannon is inexpensive and effective at destroying fighters, but does not target ships or planets.
 
-Each flak cannon on a ship built by a species with the piloting trait will have an additional number of shots equal to 1 per piloting level (-1 shot for Bad Pilots).'''
+Each flak cannon on a ship built by a species with the piloting trait will have an additional number of shots equal to 1 per piloting level (-1 shot for Bad Pilots).
+Researching advanced weapon technologies also gives additional shots
+- [[tech SHP_WEAPON_1_3]] [[value SHP_WEAPON_1_3_UPGRADE_SHOTS]]
+- [[tech SHP_WEAPON_2_3]] [[value SHP_WEAPON_2_3_UPGRADE_SHOTS]]
+- [[tech SHP_WEAPON_3_3]] [[value SHP_WEAPON_3_3_UPGRADE_SHOTS]]
+- [[tech SHP_WEAPON_4_3]] [[value SHP_WEAPON_4_3_UPGRADE_SHOTS]]
+'''
 
 SR_WEAPON_1_1
 Mass Driver

--- a/parse/EnumPythonParser.cpp
+++ b/parse/EnumPythonParser.cpp
@@ -31,7 +31,16 @@ void RegisterGlobalsEnums(boost::python::dict& globals) {
     {
         globals[op.first] = enum_wrapper<EmpireAffiliationType>(op.second);
     }
-                   
+
+// TODO more meter types
+    for (const auto& op : std::initializer_list<std::pair<const char*, MeterType>>{
+            {"Capacity",         MeterType::METER_CAPACITY},
+            {"MaxCapacity",      MeterType::METER_MAX_CAPACITY},
+            {"SecondaryStat",    MeterType::METER_SECONDARY_STAT},
+            {"MaxSecondaryStat", MeterType::METER_MAX_SECONDARY_STAT}})
+    {
+        globals[op.first] = enum_wrapper<MeterType>(op.second);
+    }
 
     for (const auto& op : std::initializer_list<std::pair<const char*, ::PlanetEnvironment>>{
             {"Uninhabitable", PlanetEnvironment::PE_UNINHABITABLE},

--- a/parse/PythonParser.cpp
+++ b/parse/PythonParser.cpp
@@ -165,6 +165,7 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
         py::class_<effect_group_wrapper>("EffectsGroup", py::no_init);
         py::class_<enum_wrapper<UnlockableItemType>>("__UnlockableItemType", py::no_init);
         py::class_<enum_wrapper<EmpireAffiliationType>>("__EmpireAffiliationType", py::no_init);
+        py::class_<enum_wrapper<MeterType>>("__MeterType", py::no_init);
         py::class_<enum_wrapper<ResourceType>>("__ResourceType", py::no_init);
         py::class_<enum_wrapper< ::PlanetEnvironment>>("__PlanetEnvironment", py::no_init);
         py::class_<enum_wrapper<PlanetSize>>("__PlanetSize", py::no_init);

--- a/parse/ValueRefPythonParser.cpp
+++ b/parse/ValueRefPythonParser.cpp
@@ -873,6 +873,38 @@ namespace {
         ));
     }
 
+    value_ref_wrapper<double> insert_ship_part_meter_(const boost::python::tuple& args, const boost::python::dict& kw) {
+        std::unique_ptr<ValueRef::ValueRef<std::string>> part;
+        if (kw.has_key("part")) {
+            auto part_args = boost::python::extract<value_ref_wrapper<std::string>>(kw["part"]);
+            if (part_args.check()) {
+                part = ValueRef::CloneUnique(part_args().value_ref);
+            } else {
+                part = std::make_unique<ValueRef::Constant<std::string>>(boost::python::extract<std::string>(kw["part"])());
+            }
+        }
+
+        auto meter_name = ValueRef::MeterToName(boost::python::extract<enum_wrapper<MeterType>>(kw["meter"])().value);
+        auto meter_type = std::make_unique<ValueRef::Constant<std::string>>(std::string{meter_name});
+
+        std::unique_ptr<ValueRef::ValueRef<int>> ship_id;
+        auto ship_args = boost::python::extract<value_ref_wrapper<int>>(kw["ship"]);
+        if (ship_args.check()) {
+            ship_id = ValueRef::CloneUnique(ship_args().value_ref);
+        } else {
+            ship_id = std::make_unique<ValueRef::Constant<int>>(boost::python::extract<int>(kw["ship"])());
+        }
+
+        return value_ref_wrapper<double>(std::make_shared<ValueRef::ComplexVariable<double>>(
+            "ShipPartMeter",
+            std::move(ship_id),
+            nullptr,
+            nullptr,
+            std::move(part),
+            std::move(meter_type)
+        ));
+    }
+
     value_ref_wrapper<double> insert_empire_meter_value_(const boost::python::tuple& args, const boost::python::dict& kw) {
         std::unique_ptr<ValueRef::ValueRef<int>> empire;
         auto empire_args = boost::python::extract<value_ref_wrapper<int>>(kw["empire"]);
@@ -1051,6 +1083,7 @@ void RegisterGlobalsValueRefs(boost::python::dict& globals, const PythonParser& 
     globals["JumpsBetween"] = insert_jumps_between_;
     globals["UserString"] = insert_user_string;
     globals["PartsInShipDesign"] = boost::python::raw_function(insert_parts_in_ship_design_);
+    globals["ShipPartMeter"] = boost::python::raw_function(insert_ship_part_meter_);
     globals["EmpireMeterValue"] = boost::python::raw_function(insert_empire_meter_value_);
     globals["EmpireStockpile"] = boost::python::raw_function(insert_empire_stockpile_);
 


### PR DESCRIPTION
this is intended to implement a shots+1 boost for flak for  MD3, Laser3, Plasma3 and DR3 techs.

for the UI I try to figure out the highest number of shots, but the necessary ShipPartMeter valueref does not have a python binding.

@o01eg could you have a look at the python binding? it is not working, I get a zero value when i trigger it with mass driver 2 tech; WEAPON_UPGRADE_SECONDARY_STAT_EFFECTS ; focs usage in ship_weapons.py