### PR TITLE
Let ShipDesignAI considers flak, distractions for multi-target weapons

### DIFF
--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -424,6 +424,14 @@ class AIstate:
 
         e_f_dict = cur_e_fighters or old_e_fighters
         self.__empire_standard_enemy = max(e_f_dict, key=e_f_dict.get)
+        # tweak standard enemy, simulate an extra weak striker hangar
+        if self.__empire_standard_enemy._fighter_capacity < 1:
+            self.__empire_standard_enemy._fighter_capacity = 3
+        if self.__empire_standard_enemy._fighter_launch_rate < 1:
+            self.__empire_standard_enemy._fighter_launch_rate = 2
+        # XXX actually consider upgradability to next level
+        if self.__empire_standard_enemy._fighter_damage < 1:
+            self.__empire_standard_enemy._fighter_damage = 2
         self.empire_standard_enemy_rating = self.get_standard_enemy().get_rating()
 
     def __update_system_status(self):  # noqa: C901
@@ -942,7 +950,7 @@ class AIstate:
         debug(
             dict_to_table(
                 CombatRatingsAI.get_empire_standard_military_ship_stats().__getstate__(),
-                name="Empire standard fighter summary",
+                name="Empire standard military ship summary",
             )
         )
 

--- a/default/python/AI/CombatRatingsAI/__init__.py
+++ b/default/python/AI/CombatRatingsAI/__init__.py
@@ -10,4 +10,4 @@ from CombatRatingsAI._ratings import (
     species_shield_bonus,
 )
 from CombatRatingsAI._ship_combat_stats import ShipCombatStats, get_ship_combat_stats
-from CombatRatingsAI._targets import get_allowed_targets
+from CombatRatingsAI._targets import get_allowed_targets, get_multi_target_split_damage_factor

--- a/default/python/AI/CombatRatingsAI/_ratings.py
+++ b/default/python/AI/CombatRatingsAI/_ratings.py
@@ -38,13 +38,13 @@ def default_ship_stats() -> ShipCombatStats:
     return ShipCombatStats(
         attacks={AttackDamage(6.0): AttackCount(1)},
         structure=15,
-        shields=0,
+        shields=0.0,
         fighter_capacity=0,
         fighter_launch_rate=0,
         fighter_damage=0,
         flak_shots=0,
         has_interceptors=False,
-        damage_vs_planets=0,
+        damage_vs_planets=6,
         has_bomber=False,
     )
 

--- a/default/python/AI/CombatRatingsAI/_ship_combat_stats.py
+++ b/default/python/AI/CombatRatingsAI/_ship_combat_stats.py
@@ -1,5 +1,5 @@
 import freeOrionAIInterface as fo
-from logging import warning
+from logging import debug, error, warning
 
 from AIDependencies import CombatTarget
 from aistate_interface import get_aistate
@@ -79,54 +79,130 @@ class ShipCombatStats:
 
         my_hit_points = self._structure
         if enemy_stats:
-            my_hit_points *= self._calculate_shield_factor(enemy_stats.attacks, self.shields)
+            # calculate extension of survival by using shields or flak
+            shield_factor, unshielded_bout_damage = self._calculate_shield_factor(enemy_stats.attacks, self.shields)
+            flak_factor, unflak_bout_damage = self._calculate_flak_factor(enemy_stats, self._flak_shots)
+            if shield_factor > 1.0 and flak_factor > 1.0:
+                # apply bonus of whatever kills us first; probably a partial/linear approach like below is more correct
+                my_hit_points *= min(shield_factor, flak_factor)
+            else:
+                if flak_factor > 1.0 and unshielded_bout_damage > 0.0:
+                    # basic idea: only a part of the factor should be applied if fighter damage is only a part of the damage
+                    # XXX probably this can be extended to accomodate all cases at once
+                    total_bout_damage = unshielded_bout_damage + (unflak_bout_damage / flak_factor)
+                    unflak_damage_portion = unflak_bout_damage / total_bout_damage
+                    if unflak_damage_portion > 1.0 or unflak_damage_portion <= 0:
+                        error(
+                            f"bad calculation, unflak_damage_portion ({unflak_damage_portion}) can never be > 1.0 or <= 0.0"
+                        )
+                    adjusted_flak_factor = 1.0 + ((flak_factor - 1.0) * min(1.0, unflak_damage_portion))
+                    if adjusted_flak_factor < 1.0:
+                        error(
+                            f"bad calculation, adjusted_flak_factor ({adjusted_flak_factor}) must be >= 1.0  (flak_factor {flak_factor}  unflak_damage_portion {unflak_damage_portion})"
+                        )
+                    my_hit_points *= max(1.0, adjusted_flak_factor)
+                else:
+                    my_hit_points *= max(shield_factor, flak_factor)
             my_total_attack = sum(n * max(dmg - enemy_stats.shields, 0.001) for dmg, n in self.attacks.items())
         else:
+            # assumes no shields
             my_total_attack = sum(n * dmg for dmg, n in self.attacks.items())
-            my_hit_points += self.shields
+            # assuming we get hit 3 times before dying
+            my_hit_points += self.shields * 3
+            # assuming point defens prevents being hit once by fighter
+            # XXX check if AI uses damage scaling / use AI Dependency here
+            my_hit_points += self._flak_shots * 4
 
         my_total_attack += self._estimate_fighter_damage()
         # TODO: Consider enemy fighters
         return my_total_attack * my_hit_points
 
-    def _calculate_shield_factor(self, e_attacks: dict[AttackDamage, AttackCount], my_shields: float) -> float:
+    def _calculate_flak_factor(self, enemy_stats: "ShipCombatStats", my_flak_shots: float) -> (float, float):
+        """
+        Calculates flak factor based on enemy fighter attacks and our flak_shots.
+        I.e. if the flak shots negate half the damage, the flak factor is 2.0
+        Mimimum flak factor is 1.0
+        Maximum flak factor is less the number of combat bouts the enemy fighter are afloat. I.e. 3.0 for 4 combat bouts
+        A typical flak factor is 2.67 for 3 flak shots vs a striker hangar for 4 combat bouts.
+        Flak factor is 1.0 against interceptors
+        """
+        capacity = enemy_stats._fighter_capacity
+        launch_rate = enemy_stats._fighter_launch_rate
+        damage = enemy_stats._fighter_damage
+        if damage <= 0 or capacity < 1 or launch_rate < 1:
+            debug(f"flak factor 1.0 because enemy is not a carrier ({launch_rate}/{capacity} * {damage}d)")
+            return (1.0, 0.0)
+        if enemy_stats._has_interceptors:
+            debug("flak factor 1.0 because enemy is an interceptor carrier / unable to hurt us")
+            return (1.0, 0.0)
+        enemy_fighter_dmg = self._estimate_fighter_damage_vs_flak(capacity, launch_rate, damage, 0.0)
+        if my_flak_shots <= 0.0:
+            return (1.0, enemy_fighter_dmg)
+        enemy_fighter_dmg_vs_flak = self._estimate_fighter_damage_vs_flak(capacity, launch_rate, damage, my_flak_shots)
+        if enemy_fighter_dmg < enemy_fighter_dmg_vs_flak:
+            error(
+                f"Bad calculation of flak_factor {enemy_fighter_dmg} should be greater than {enemy_fighter_dmg_vs_flak}"
+            )
+        flak_factor = enemy_fighter_dmg / enemy_fighter_dmg_vs_flak
+        if flak_factor > fo.getGameRules().getInt("RULE_NUM_COMBAT_ROUNDS") - 1:
+            error(
+                f"Bad calculation of flak_factor ({flak_factor}). Should never be higher than number of combat bouts that fighters do damage"
+            )
+        # usefulness of enemy point defense depends on us using fighters
+        return (max(1.0, flak_factor), enemy_fighter_dmg)
+
+    def _calculate_shield_factor(self, e_attacks: dict[AttackDamage, AttackCount], my_shields: float) -> (float, float):
         """
         Calculates shield factor based on enemy attacks and our shields.
+        I.e. if the shields negate half the damage, the shield factor is 2.0.
+        Mimimum shield factor is 1.0
+        Maximum shield factor is capped at 10.0 ; in theory it is unlimited if all damage gets negated.
         It is possible to have e_attacks with number attacks == 0,
         in that case we consider that there is an issue with the enemy stats and we jut set value to 1.0.
         """
         if not e_attacks:
-            return 1.0
+            return (1.0, 0.0)
         e_total_attack = sum(n * dmg for dmg, n in e_attacks.items())
         if e_total_attack:
             e_net_attack = sum(n * max(dmg - my_shields, 0.001) for dmg, n in e_attacks.items())
             e_net_attack = max(e_net_attack, 0.1 * e_total_attack)
             shield_factor = e_total_attack / e_net_attack
-            return max(1.0, shield_factor)
+            return (max(1.0, shield_factor), e_total_attack)
         else:
-            return 1.0
+            return (1.0, e_total_attack)
 
-    def _estimate_fighter_damage(self):
-        if self._fighter_launch_rate == 0:
+    def _estimate_fighter_damage_vs_flak(self, capacity, launch_rate, damage, opposing_flak):
+        """Estimates how much structural damage the given fighters do in an average bout"""
+        if launch_rate <= 0:
             return 0
-        full_launch_bouts = self._fighter_capacity // self._fighter_launch_rate
-        survival_rate = 0.2  # TODO estimate chance of a fighter not to be shot down in a bout
+        full_launch_bouts = capacity // launch_rate
+        generic_survival_rate = 0.6  # TODO estimate chance of a fighter not to be shot down in a bout
+        generic_flak_efficiency_rate = 0.6  # heuristic flak overkill efficiency
         flying_fighters = 0
         total_fighter_damage = 0
         # Cut that values down to a single turn (four bouts means max three launch bouts)
         num_bouts = fo.getGameRules().getInt("RULE_NUM_COMBAT_ROUNDS")
         for firing_bout in range(num_bouts - 1):
             if firing_bout < full_launch_bouts:
-                flying_fighters = (flying_fighters * survival_rate) + self._fighter_launch_rate
+                flying_fighters = flying_fighters + launch_rate
             elif firing_bout == full_launch_bouts:
                 # now handle a bout with lower capacity launch
-                flying_fighters = (flying_fighters * survival_rate) + (
-                    self._fighter_capacity % self._fighter_launch_rate
-                )
+                flying_fighters = flying_fighters + (capacity % launch_rate)
+            total_fighter_damage += damage * flying_fighters
+            if opposing_flak == -1:
+                flying_fighters = flying_fighters * generic_survival_rate
             else:
-                flying_fighters = flying_fighters * survival_rate
-            total_fighter_damage += self._fighter_damage * flying_fighters
+                # TODO check if there really is overkilling of fighters or not
+                flying_fighters = max(0, flying_fighters - (generic_flak_efficiency_rate * opposing_flak))
         return total_fighter_damage / num_bouts
+
+    def _estimate_fighter_damage(self):
+        """Estimates how much structural damage the fighters of this carrier in an average bout"""
+        capacity = self._fighter_capacity
+        launch_rate = self._fighter_launch_rate
+        damage = self._fighter_damage
+        enemy_flak_shots = -1
+        return self._estimate_fighter_damage_vs_flak(capacity, launch_rate, damage, enemy_flak_shots)
 
     def get_rating_vs_planets(self) -> float:
         """Heuristic to estimate combat strength against planets"""

--- a/default/python/AI/CombatRatingsAI/_targets.py
+++ b/default/python/AI/CombatRatingsAI/_targets.py
@@ -17,3 +17,53 @@ def get_allowed_targets(partname: str) -> int:
             )
             _issued_errors.add(partname)
         return CombatTarget.ANY
+
+
+def get_distractability_factor(allowed_targets: int, target_class: int) -> float:
+    """
+    Return a factor for the likeliness to be distracted by other targets.
+    The expected number of targets is usually fighters > ships > planets, so
+     e.g. planets are expected to not distract much from other targets
+    """
+    if target_class == CombatTarget.FIGHTER:
+        if allowed_targets & CombatTarget.SHIP:
+            return 0.95
+    elif target_class == CombatTarget.PLANET:
+        if allowed_targets & CombatTarget.SHIP:
+            return 0.9
+        if allowed_targets & CombatTarget.FIGHTER:
+            return 0.7
+    elif target_class == CombatTarget.SHIP:
+        if allowed_targets & CombatTarget.FIGHTER:
+            return 0.8
+    return 1.0
+
+
+def get_multi_target_split_damage_factor(allowed_targets: int, target_class: int) -> float:
+    """
+    Return a heuristic factor how much expected damage needs to be scaled down
+    for a certain each class of targets in case there multiple valid target classes.
+    If the military AI puts the ship to the correct use, the expected damage will be higher
+    than a simple division by the number of classes.
+    """
+    if not (allowed_targets & target_class):
+        error(f"bad call, not possible to target intended target ({(allowed_targets, target_class)}")
+        return 0.0
+    target_classes_cnt = 0
+    target_classes_cnt += int(allowed_targets & CombatTarget.FIGHTER != 0)
+    # target_classes_cnt += int (allowed_targets & CombatTarget.PLANET != 0) # damage is not considered in design value
+    target_classes_cnt += int(allowed_targets & CombatTarget.SHIP != 0)
+    if target_classes_cnt in [0, 1]:
+        # no relevant distractions, single resulting damage type
+        return 1.0
+    elif target_classes_cnt == 2:
+        # one type of distraction, two types of resulting damage
+        factor = 0.7
+    elif target_classes_cnt == 3:
+        # two types of distraction, three types of resulting damage
+        factor = 0.5
+    else:
+        error("bad target class count %i" % target_classes_cnt)
+        return 0.0
+
+    return factor * get_distractability_factor(allowed_targets, target_class)


### PR DESCRIPTION
* AI design add multi target class heuristics depending on target type ** it considers flexibility of multi--target-class weapons as a good thing ** but tries to estimate the effect of being distracted for multi--target-class weapon types

* AI war design considers using weapons contributing to _flak_shots ** add flak factor combination (this extends the usage of structure in case of armed enemy fighters) ** combine flak and shield factor calculations
* tweak standard enemy for design; do expect the fighter inquisition
* AI uses flak_shots to increase structural integrity value in case of an enemy with fighters

* Refactor: apply fighter survival_rate at the end of the bout (easier to grok)
* default ship can damage planets

TODOs
* check heavy bombers (aka has_bombers)
* check carrier designer