### PR TITLE
arc syphon part

### DIFF
--- a/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
@@ -39,18 +39,19 @@ Part
                 [[THE_BOOKKEEPING_ARC_SYPHON_SHIP_IN_SOURCE_FLEET]]
             ]
             stackinggroup = "SR_ARC_SYPHON_CHARGE_STACK"
+            priority = [[TARGET_LAST_BEFORE_OVERRIDE_PRIORITY]]
             effects = [
                AddSpecial name = "SR_ARC_SYPHON_CHARGE_SPECIAL"
                SetSpecialCapacity
                 name = "SR_ARC_SYPHON_CHARGE_SPECIAL"
-                capacity = Statistic Sum value = ((ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = SecondaryStat object = LocalCandidate.ID) * (PartsInShipDesign name = "SR_ARC_DISRUPTOR" design = LocalCandidate.DesignID))
+                capacity = Statistic Sum value = (Value(ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = SecondaryStat object = LocalCandidate.ID) * (PartsInShipDesign name = "SR_ARC_DISRUPTOR" design = LocalCandidate.DesignID))
                            condition = [[ALL_ARC_DISRUPTOR_SHIPS_IN_SOURCE_FLEET]]
                GenerateSitRepMessage
                     message = "SITREP_SR_ARC_SYPHON_DEBUG"
                     label = "SITREP_SR_ARC_SYPHON_DEBUG_LABEL"
                     icon = "icons/ship_parts/pulse-laser.png"
                     parameters = [
-                        tag = "syphoned" data = Statistic Sum value = ((ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = SecondaryStat object = LocalCandidate.ID) * (PartsInShipDesign name = "SR_ARC_DISRUPTOR" design = LocalCandidate.DesignID)) condition = [[ALL_ARC_DISRUPTOR_SHIPS_IN_SOURCE_FLEET]]
+                        tag = "syphoned" data = Statistic Sum value = (Value(ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = SecondaryStat object = LocalCandidate.ID) * (PartsInShipDesign name = "SR_ARC_DISRUPTOR" design = LocalCandidate.DesignID)) condition = [[ALL_ARC_DISRUPTOR_SHIPS_IN_SOURCE_FLEET]]
                         tag = "specialcapacity" data = 0
                         tag = "shipdesign" data = Source.DesignID
                         tag = "ship" data = Source.ID
@@ -69,6 +70,7 @@ Part
                 Source
                 [[THE_BOOKKEEPING_ARC_SYPHON_SHIP_IN_SOURCE_FLEET]]
             ]
+            priority = [[TARGET_LAST_BEFORE_OVERRIDE_PRIORITY]]
             effects = [
                 SetMaxSecondaryStat partname = "SR_ARC_SYPHON" value = ((SpecialCapacity name = "SR_ARC_SYPHON_CHARGE_SPECIAL" object = Source.ID) /
                     (Statistic Count condition = [[ALL_ARC_SYPHON_SHIPS_IN_SOURCE_FLEET]] ))
@@ -104,6 +106,7 @@ Part
                 ]
             ]
             stackinggroup = "SR_ARC_SYPHON_NULLIFY_DISRUPTOR_STACK"
+            priority = [[TARGET_LAST_BEFORE_OVERRIDE_PRIORITY]]
             effects = [
                 SetSecondaryStat partname = "SR_ARC_DISRUPTOR" value = 0
                 SetMaxSecondaryStat partname = "SR_ARC_DISRUPTOR" value = 0
@@ -112,8 +115,8 @@ Part
                     label = "SITREP_SR_ARC_SYPHON_NULLIFY_LABEL"
                     icon = "icons/ship_parts/pulse-laser.png"
                     parameters = [
-                        tag = "shipdesign" data = Source.DesignID
-                        tag = "ship" data = Source.ID
+                        tag = "shipdesign" data = Target.DesignID
+                        tag = "ship" data = Target.ID
                         tag = "fleet" data = Source.FleetID
                     ]
                     empire = Source.Owner
@@ -157,3 +160,4 @@ ALL_ARC_DISRUPTOR_SHIPS_IN_SOURCE_FLEET
 
 #include "/scripting/macros/upkeep.macros"
 #include "/scripting/ship_parts/targeting.macros"
+#include "/scripting/macros/priorities.macros"

--- a/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
@@ -22,10 +22,24 @@ Part
                 [[THE_BOOKKEEPING_ARC_SYPHON_SHIP_IN_SOURCE_FLEET]]
             ]
             stackinggroup = "SR_ARC_SYPHON_CHARGE_STACK"
-            effects = SetSpecialCapacity
+            effects = [
+               SetSpecialCapacity
                 name = "SR_ARC_SYPHON_CHARGE"
                 capacity = Statistic Sum value = ((ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = SecondaryStat object = LocalCandidate.ID) * (PartsInShipDesign name = "SR_ARC_DISRUPTOR" design = LocalCandidate.DesignID))
-                           condition = [[ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET]]
+                           condition = [[ALL_ARC_DISRUPTOR_SHIPS_IN_SOURCE_FLEET]]
+               GenerateSitRepMessage
+                    message = "SITREP_SR_ARC_SYPHON_DEBUG"
+                    label = "SITREP_SR_ARC_SYPHON_DEBUG_LABEL"
+                    icon = "icons/ship_parts/pulse-laser.png"
+                    parameters = [
+                        tag = "syphoned" data = Statistic Sum value = ((ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = SecondaryStat object = LocalCandidate.ID) * (PartsInShipDesign name = "SR_ARC_DISRUPTOR" design = LocalCandidate.DesignID)) condition = [[ALL_ARC_DISRUPTOR_SHIPS_IN_SOURCE_FLEET]]
+                        tag = "shipdesign" data = Source.DesignID
+                        tag = "ship" data = Source.ID
+                        tag = "fleet" data = Source.FleetID
+                    ]
+                    empire = Source.Owner
+            ]
+
 
         // TODO distribute to syphons in this fleet, at a later priority
         // TODO test
@@ -42,10 +56,7 @@ Part
         // TODO timing; e.g. with the policies
         // then nullify all capacity of arc disruptors
         EffectsGroup
-            scope = And [
-                Ship
-                ContainedBy condition = Object id = Source.FleetID
-            ]
+            scope = [[ALL_ARC_DISRUPTOR_SHIPS_IN_SOURCE_FLEET]]
             activation = And [
                 Object id = Source.FleetID
                 Fleet
@@ -55,7 +66,19 @@ Part
                 ]
             ]
             stackinggroup = "SR_ARC_SYPHON_STACK"
-            effects = SetSecondaryStat partname = "SR_ARC_DISRUPTOR" value = 0
+            effects = [
+                SetSecondaryStat partname = "SR_ARC_DISRUPTOR" value = 0
+                GenerateSitRepMessage
+                    message = "SITREP_SR_ARC_SYPHON_NULLIFY"
+                    label = "SITREP_SR_ARC_SYPHON_NULLIFY_LABEL"
+                    icon = "icons/ship_parts/pulse-laser.png"
+                    parameters = [
+                        tag = "shipdesign" data = Source.DesignID
+                        tag = "ship" data = Source.ID
+                        tag = "fleet" data = Source.FleetID
+                    ]
+                    empire = Source.Owner
+            ]
     ]
     icon = "icons/ship_parts/pulse-laser.png"
 
@@ -72,11 +95,22 @@ THE_BOOKKEEPING_ARC_SYPHON_SHIP_IN_SOURCE_FLEET
 ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET
 '''
             And [
-                // ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET
+                // ALL_ARC_SYPHON_SHIPS_IN_SOURCE_FLEET
                 Ship
                 ContainedBy condition = Object id = Source.FleetID
                 DesignHasPart low = 1 high = 999 name = "SR_ARC_SYPHON"
                 // end ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET
+            ]
+'''
+
+ALL_ARC_DISRUPTOR_SHIPS_IN_SOURCE_FLEET
+'''
+            And [
+                // ALL_ARC_DISRUPTOR_SHIPS_IN_SOURCE_FLEET
+                Ship
+                ContainedBy condition = Object id = Source.FleetID
+                DesignHasPart low = 1 high = 999 name = "SR_ARC_DISRUPTOR"
+                // end ALL_ARC_DISRUPTOR_SHIPS_IN_SOURCE_FLEET
             ]
 '''
 

--- a/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
@@ -110,16 +110,36 @@ Part
             stackinggroup = "SR_ARC_SYPHON_NULLIFY_DISRUPTOR_STACK"
             priority = [[TARGET_LAST_BEFORE_OVERRIDE_PRIORITY]]
             effects = [
-                SetSecondaryStat partname = "SR_ARC_DISRUPTOR" value = 0
+                GenerateSitRepMessage
+                    message = "SITREP_SR_ARC_SYPHON_NULLIFY"
+                    label = "SITREP_SR_ARC_SYPHON_NULLIFY_LABEL"
+                    icon = "icons/ship_parts/pulse-laser.png"
+                    parameters = [
+                        tag = "pre" data = "before setting stat(s): "
+                        tag = "shipdesign" data = Target.DesignID
+                        tag = "ship" data = Target.ID
+                        tag = "fleet" data = Source.FleetID
+                        tag = "currentSecondaryStat" data = Value(ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = SecondaryStat object = Target.ID)
+                        tag = "initialSecondaryStat" data = ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = SecondaryStat object = Target.ID
+                        tag = "currentMaxSecondaryStat" data = Value(ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = MaxSecondaryStat object = Target.ID)
+                        tag = "initialMaxSecondaryStat" data = ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = MaxSecondaryStat object = Target.ID
+                    ]
+                    empire = Source.Owner
+                SetSecondaryStat partname = "SR_ARC_DISRUPTOR" value = 1
                 SetMaxSecondaryStat partname = "SR_ARC_DISRUPTOR" value = 0
                 GenerateSitRepMessage
                     message = "SITREP_SR_ARC_SYPHON_NULLIFY"
                     label = "SITREP_SR_ARC_SYPHON_NULLIFY_LABEL"
                     icon = "icons/ship_parts/pulse-laser.png"
                     parameters = [
+                        tag = "pre" data = "after setting stat(s): "
                         tag = "shipdesign" data = Target.DesignID
                         tag = "ship" data = Target.ID
                         tag = "fleet" data = Source.FleetID
+                        tag = "currentSecondaryStat" data = Value(ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = SecondaryStat object = Target.ID)
+                        tag = "initialSecondaryStat" data = ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = SecondaryStat object = Target.ID
+                        tag = "currentMaxSecondaryStat" data = Value(ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = MaxSecondaryStat object = Target.ID)
+                        tag = "initialMaxSecondaryStat" data = ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = MaxSecondaryStat object = Target.ID
                     ]
                     empire = Source.Owner
             ]

--- a/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
@@ -97,6 +97,8 @@ Part
         EffectsGroup
             scope = [[ALL_ARC_DISRUPTOR_SHIPS_IN_SOURCE_FLEET]]
             activation = And [
+                [[THE_BOOKKEEPING_ARC_SYPHON_SHIP_IN_SOURCE_FLEET]]
+                ((SpecialCapacity name = "SR_ARC_SYPHON_CHARGE_SPECIAL" object = Source.ID) > 0)
                 ContainedBy condition = And [
                     Object id = Source.FleetID
                     Contains condition = And [

--- a/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
@@ -1,0 +1,63 @@
+Part
+    name = "SR_ARC_SYPHON"
+    description = "SR_ARC_SYPHON_DESC"
+    class = ShortRange
+    damage = 4
+    shots = 0
+    mountableSlotTypes = Core
+    buildcost = 40 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildtime = 1
+    tags = [ "PEDIA_PC_DIRECT_WEAPON" ]
+    location = And [
+        Planet
+        OwnedBy empire = Source.Owner
+    ]
+    effectsgroups = [
+        // syphon all arcs in the same fleet
+        // once: first collect arc disruptor shot count as a special on the lowest syphon ship id
+        EffectsGroup
+            scope = Source
+            activation = And [
+                Source
+                Object id = Statistic Min value = LocalCandidate.ID condition = And [
+                    Ship
+                    ContainedBy condition = Object id = Source.FleetID
+                    DesignHasPart low = 1 high = 999 name = "SR_ARC_SYPHON"
+                ]
+            ]
+            stackinggroup = "SR_ARC_SYPHON_CHARGE_STACK"
+            effects = SetSpecialCapacity
+                name = "SR_ARC_SYPHON_CHARGE"
+                capacity = Statistic Sum value = ((ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = SecondaryStat object = LocalCandidate.ID) * (PartsInShipDesign name = "SR_ARC_DISRUPTOR" design = LocalCandidate.DesignID))
+                           condition = And [
+                               Ship
+                               ContainedBy condition = Object id = Source.FleetID
+                               DesignHasPart low = 1 high = 999 name = "SR_ARC_DISRUPTOR"
+                ]
+
+        // TODO distribute to syphons, at a later priority
+
+        // TODO timing; e.g. with the policies
+        // then nullify all capacity of arc disruptors
+        EffectsGroup
+            scope = And [
+                Ship
+                ContainedBy condition = Object id = Source.FleetID
+            ]
+            activation = And [
+                Object id = Source.FleetID
+                Fleet
+                Contains condition = And [
+                    Ship
+                    DesignHasPart low = 1 high = 999 name = "SR_ARC_DISRUPTOR"
+                ]
+            ]
+            stackinggroup = "SR_ARC_SYPHON_STACK"
+            effects = SetSecondaryStat partname = "SR_ARC_DISRUPTOR" value = 0
+    ]
+    icon = "icons/ship_parts/pulse-laser.png"
+
+#include "shortrange.macros"
+
+#include "/scripting/macros/upkeep.macros"
+#include "/scripting/ship_parts/targeting.macros"

--- a/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
@@ -19,23 +19,25 @@ Part
             scope = Source
             activation = And [
                 Source
-                Object id = Statistic Min value = LocalCandidate.ID condition = And [
-                    Ship
-                    ContainedBy condition = Object id = Source.FleetID
-                    DesignHasPart low = 1 high = 999 name = "SR_ARC_SYPHON"
-                ]
+                [[THE_BOOKKEEPING_ARC_SYPHON_SHIP_IN_SOURCE_FLEET]]
             ]
             stackinggroup = "SR_ARC_SYPHON_CHARGE_STACK"
             effects = SetSpecialCapacity
                 name = "SR_ARC_SYPHON_CHARGE"
                 capacity = Statistic Sum value = ((ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = SecondaryStat object = LocalCandidate.ID) * (PartsInShipDesign name = "SR_ARC_DISRUPTOR" design = LocalCandidate.DesignID))
-                           condition = And [
-                               Ship
-                               ContainedBy condition = Object id = Source.FleetID
-                               DesignHasPart low = 1 high = 999 name = "SR_ARC_DISRUPTOR"
-                ]
+                           condition = [[ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET]]                ]
 
-        // TODO distribute to syphons, at a later priority
+        // TODO distribute to syphons in this fleet, at a later priority
+        // TODO test
+        // TODO need to handle fractions better
+        EffectsGroup
+            scope = [[ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET]]
+            activation = And [
+                Source
+		[[THE_BOOKKEEPING_ARC_SYPHON_SHIP_IN_SOURCE_FLEET]]
+            ]
+            effects = SetSecondaryStat partname = "SR_ARC_DISRUPTOR" value = ((SpecialCapacity name = "SR_ARC_SYPHON_CHARGE" object = Source.ID) /
+            (Statistic Count condition = [[ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET]] ))
 
         // TODO timing; e.g. with the policies
         // then nullify all capacity of arc disruptors
@@ -56,6 +58,24 @@ Part
             effects = SetSecondaryStat partname = "SR_ARC_DISRUPTOR" value = 0
     ]
     icon = "icons/ship_parts/pulse-laser.png"
+
+THE_BOOKKEEPING_ARC_SYPHON_SHIP_IN_SOURCE_FLEET
+'''
+                Object id = Statistic Min value = LocalCandidate.ID condition = And [
+                    Ship
+                    ContainedBy condition = Object id = Source.FleetID
+                    DesignHasPart low = 1 high = 999 name = "SR_ARC_SYPHON"
+                ]
+'''
+
+ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET
+'''
+            And [
+                Ship
+                ContainedBy condition = Object id = Source.FleetID
+                DesignHasPart low = 1 high = 999 name = "SR_ARC_SYPHON"
+            ]
+'''
 
 #include "shortrange.macros"
 

--- a/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
@@ -39,19 +39,19 @@ Part
                 [[THE_BOOKKEEPING_ARC_SYPHON_SHIP_IN_SOURCE_FLEET]]
             ]
             stackinggroup = "SR_ARC_SYPHON_CHARGE_STACK"
-            priority = [[TARGET_LAST_BEFORE_OVERRIDE_PRIORITY]]
+            priority = [[LATE_AFTER_ALL_TARGET_MAX_METERS_PRIORITY]]
             effects = [
                AddSpecial name = "SR_ARC_SYPHON_CHARGE_SPECIAL"
                SetSpecialCapacity
                 name = "SR_ARC_SYPHON_CHARGE_SPECIAL"
-                capacity = Statistic Sum value = (Value(ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = SecondaryStat object = LocalCandidate.ID) * (PartsInShipDesign name = "SR_ARC_DISRUPTOR" design = LocalCandidate.DesignID))
+                capacity = Statistic Sum value = (Value(ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = MaxSecondaryStat object = LocalCandidate.ID) * (PartsInShipDesign name = "SR_ARC_DISRUPTOR" design = LocalCandidate.DesignID))
                            condition = [[ALL_ARC_DISRUPTOR_SHIPS_IN_SOURCE_FLEET]]
                GenerateSitRepMessage
                     message = "SITREP_SR_ARC_SYPHON_DEBUG"
                     label = "SITREP_SR_ARC_SYPHON_DEBUG_LABEL"
                     icon = "icons/ship_parts/pulse-laser.png"
                     parameters = [
-                        tag = "syphoned" data = Statistic Sum value = (Value(ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = SecondaryStat object = LocalCandidate.ID) * (PartsInShipDesign name = "SR_ARC_DISRUPTOR" design = LocalCandidate.DesignID)) condition = [[ALL_ARC_DISRUPTOR_SHIPS_IN_SOURCE_FLEET]]
+                        tag = "syphoned" data = Statistic Sum value = (Value(ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = MaxSecondaryStat object = LocalCandidate.ID) * (PartsInShipDesign name = "SR_ARC_DISRUPTOR" design = LocalCandidate.DesignID)) condition = [[ALL_ARC_DISRUPTOR_SHIPS_IN_SOURCE_FLEET]]
                         tag = "specialcapacity" data = 0
                         tag = "shipdesign" data = Source.DesignID
                         tag = "ship" data = Source.ID
@@ -70,7 +70,7 @@ Part
                 Source
                 [[THE_BOOKKEEPING_ARC_SYPHON_SHIP_IN_SOURCE_FLEET]]
             ]
-            priority = [[TARGET_LAST_BEFORE_OVERRIDE_PRIORITY]]
+            priority = [[LATE_AFTER_ALL_TARGET_MAX_METERS_PRIORITY]]
             effects = [
                 SetMaxSecondaryStat partname = "SR_ARC_SYPHON" value = ((SpecialCapacity name = "SR_ARC_SYPHON_CHARGE_SPECIAL" object = Source.ID) /
                     (Statistic Count condition = [[ALL_ARC_SYPHON_SHIPS_IN_SOURCE_FLEET]] ))
@@ -108,7 +108,7 @@ Part
                 ]
             ]
             stackinggroup = "SR_ARC_SYPHON_NULLIFY_DISRUPTOR_STACK"
-            priority = [[TARGET_LAST_BEFORE_OVERRIDE_PRIORITY]]
+            priority = [[LATE_AFTER_ALL_TARGET_MAX_METERS_PRIORITY]]
             effects = [
                 GenerateSitRepMessage
                     message = "SITREP_SR_ARC_SYPHON_NULLIFY"

--- a/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
@@ -4,6 +4,22 @@ Part
     class = ShortRange
     damage = 4
     shots = 0
+    destroyFightersPerBattleMax =
+        ShipPartMeter part = "SR_ARC_SYPHON" meter = SecondaryStat object = Source.ID
+        * NamedRealLookup name = "NUM_REAL_COMBAT_ROUNDS_IN_CLOSE_TARGETING_RANGE"
+    damageStructurePerBattleMax =
+        max(0,ShipPartMeter part = "SR_ARC_SYPHON" meter = Capacity object = Source.ID - Value(Target.Shield))
+        * ShipPartMeter part = "SR_ARC_SYPHON" meter = SecondaryStat object = Source.ID
+        * NamedRealLookup name = "NUM_REAL_COMBAT_ROUNDS_IN_CLOSE_TARGETING_RANGE"
+    combatTargets = And [
+        (CombatBout >= NamedIntegerLookup name = "FIRST_COMBAT_ROUND_IN_CLOSE_TARGETING_RANGE")
+        [[COMBAT_TARGETS_VISIBLE_ENEMY]]
+        Or [
+           Fighter
+           [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
+           [[COMBAT_TARGETS_PLANET_WITH_DEFENSE]]
+        ]
+    ]
     mountableSlotTypes = Core
     buildcost = 40 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1
@@ -15,6 +31,7 @@ Part
     effectsgroups = [
         // syphon all arcs in the same fleet
         // once: first collect arc disruptor shot count as a special on the lowest syphon ship id
+        //       TODO: note we could rather put this special on the fleet, trigger the effect from the part and use a stackinggroup to prevent it from happening more than once
         EffectsGroup
             scope = Source
             activation = And [
@@ -23,8 +40,9 @@ Part
             ]
             stackinggroup = "SR_ARC_SYPHON_CHARGE_STACK"
             effects = [
+               AddSpecial name = "SR_ARC_SYPHON_CHARGE_SPECIAL"
                SetSpecialCapacity
-                name = "SR_ARC_SYPHON_CHARGE"
+                name = "SR_ARC_SYPHON_CHARGE_SPECIAL"
                 capacity = Statistic Sum value = ((ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = SecondaryStat object = LocalCandidate.ID) * (PartsInShipDesign name = "SR_ARC_DISRUPTOR" design = LocalCandidate.DesignID))
                            condition = [[ALL_ARC_DISRUPTOR_SHIPS_IN_SOURCE_FLEET]]
                GenerateSitRepMessage
@@ -33,6 +51,7 @@ Part
                     icon = "icons/ship_parts/pulse-laser.png"
                     parameters = [
                         tag = "syphoned" data = Statistic Sum value = ((ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = SecondaryStat object = LocalCandidate.ID) * (PartsInShipDesign name = "SR_ARC_DISRUPTOR" design = LocalCandidate.DesignID)) condition = [[ALL_ARC_DISRUPTOR_SHIPS_IN_SOURCE_FLEET]]
+                        tag = "specialcapacity" data = 0
                         tag = "shipdesign" data = Source.DesignID
                         tag = "ship" data = Source.ID
                         tag = "fleet" data = Source.FleetID
@@ -45,29 +64,49 @@ Part
         // TODO test
         // TODO need to handle fractions better
         EffectsGroup
-            scope = [[ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET]]
+            scope = [[ALL_ARC_SYPHON_SHIPS_IN_SOURCE_FLEET]]
             activation = And [
                 Source
                 [[THE_BOOKKEEPING_ARC_SYPHON_SHIP_IN_SOURCE_FLEET]]
             ]
-            effects = SetSecondaryStat partname = "SR_ARC_DISRUPTOR" value = ((SpecialCapacity name = "SR_ARC_SYPHON_CHARGE" object = Source.ID) /
-            (Statistic Count condition = [[ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET]] ))
+            effects = [
+                SetMaxSecondaryStat partname = "SR_ARC_SYPHON" value = ((SpecialCapacity name = "SR_ARC_SYPHON_CHARGE_SPECIAL" object = Source.ID) /
+                    (Statistic Count condition = [[ALL_ARC_SYPHON_SHIPS_IN_SOURCE_FLEET]] ))
+                SetSecondaryStat partname = "SR_ARC_SYPHON" value = ((SpecialCapacity name = "SR_ARC_SYPHON_CHARGE_SPECIAL" object = Source.ID) /
+                    (Statistic Count condition = [[ALL_ARC_SYPHON_SHIPS_IN_SOURCE_FLEET]] ))
+                GenerateSitRepMessage
+                    message = "SITREP_SR_ARC_SYPHON_BOOST"
+                    label = "SITREP_SR_ARC_SYPHON_BOOST_LABEL"
+                    icon = "icons/ship_parts/pulse-laser.png"
+                    parameters = [
+                        tag = "shipdesign" data = Target.DesignID
+                        tag = "ship" data = Target.ID
+                        tag = "fleet" data = Source.FleetID
+                        tag = "charge" data = SpecialCapacity name = "SR_ARC_SYPHON_CHARGE_SPECIAL" object = Source.ID
+                        tag = "count" data = Statistic Count condition = [[ALL_ARC_SYPHON_SHIPS_IN_SOURCE_FLEET]]
+                        tag = "upgrade" data = ((SpecialCapacity name = "SR_ARC_SYPHON_CHARGE_SPECIAL" object = Source.ID) /
+                    (Statistic Count condition = [[ALL_ARC_SYPHON_SHIPS_IN_SOURCE_FLEET]] ))
+                    ]
+                    empire = Source.Owner
+            ]
 
         // TODO timing; e.g. with the policies
         // then nullify all capacity of arc disruptors
         EffectsGroup
             scope = [[ALL_ARC_DISRUPTOR_SHIPS_IN_SOURCE_FLEET]]
             activation = And [
-                Object id = Source.FleetID
-                Fleet
-                Contains condition = And [
-                    Ship
-                    DesignHasPart low = 1 high = 999 name = "SR_ARC_DISRUPTOR"
+                ContainedBy condition = And [
+                    Object id = Source.FleetID
+                    Contains condition = And [
+                        Ship
+                        DesignHasPart low = 1 high = 999 name = "SR_ARC_DISRUPTOR"
+                    ]
                 ]
             ]
-            stackinggroup = "SR_ARC_SYPHON_STACK"
+            stackinggroup = "SR_ARC_SYPHON_NULLIFY_DISRUPTOR_STACK"
             effects = [
                 SetSecondaryStat partname = "SR_ARC_DISRUPTOR" value = 0
+                SetMaxSecondaryStat partname = "SR_ARC_DISRUPTOR" value = 0
                 GenerateSitRepMessage
                     message = "SITREP_SR_ARC_SYPHON_NULLIFY"
                     label = "SITREP_SR_ARC_SYPHON_NULLIFY_LABEL"
@@ -92,14 +131,14 @@ THE_BOOKKEEPING_ARC_SYPHON_SHIP_IN_SOURCE_FLEET
                 ]
 '''
 
-ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET
+ALL_ARC_SYPHON_SHIPS_IN_SOURCE_FLEET
 '''
             And [
                 // ALL_ARC_SYPHON_SHIPS_IN_SOURCE_FLEET
                 Ship
                 ContainedBy condition = Object id = Source.FleetID
                 DesignHasPart low = 1 high = 999 name = "SR_ARC_SYPHON"
-                // end ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET
+                // end ALL_ARC_SYPHON_SHIPS_IN_SOURCE_FLEET
             ]
 '''
 

--- a/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_ARC_SYPHON.focs.txt
@@ -25,7 +25,7 @@ Part
             effects = SetSpecialCapacity
                 name = "SR_ARC_SYPHON_CHARGE"
                 capacity = Statistic Sum value = ((ShipPartMeter part = "SR_ARC_DISRUPTOR" meter = SecondaryStat object = LocalCandidate.ID) * (PartsInShipDesign name = "SR_ARC_DISRUPTOR" design = LocalCandidate.DesignID))
-                           condition = [[ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET]]                ]
+                           condition = [[ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET]]
 
         // TODO distribute to syphons in this fleet, at a later priority
         // TODO test
@@ -34,7 +34,7 @@ Part
             scope = [[ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET]]
             activation = And [
                 Source
-		[[THE_BOOKKEEPING_ARC_SYPHON_SHIP_IN_SOURCE_FLEET]]
+                [[THE_BOOKKEEPING_ARC_SYPHON_SHIP_IN_SOURCE_FLEET]]
             ]
             effects = SetSecondaryStat partname = "SR_ARC_DISRUPTOR" value = ((SpecialCapacity name = "SR_ARC_SYPHON_CHARGE" object = Source.ID) /
             (Statistic Count condition = [[ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET]] ))
@@ -61,6 +61,7 @@ Part
 
 THE_BOOKKEEPING_ARC_SYPHON_SHIP_IN_SOURCE_FLEET
 '''
+                //THE_BOOKKEEPING_ARC_SYPHON_SHIP_IN_SOURCE_FLEET
                 Object id = Statistic Min value = LocalCandidate.ID condition = And [
                     Ship
                     ContainedBy condition = Object id = Source.FleetID
@@ -71,9 +72,11 @@ THE_BOOKKEEPING_ARC_SYPHON_SHIP_IN_SOURCE_FLEET
 ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET
 '''
             And [
+                // ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET
                 Ship
                 ContainedBy condition = Object id = Source.FleetID
                 DesignHasPart low = 1 high = 999 name = "SR_ARC_SYPHON"
+                // end ALL_ARC_SIPHON_SHIPS_IN_SOURCE_FLEET
             ]
 '''
 

--- a/default/scripting/specials/SR_ARC_SYPHON_CHARGE.focs.txt
+++ b/default/scripting/specials/SR_ARC_SYPHON_CHARGE.focs.txt
@@ -1,0 +1,8 @@
+Special
+    name = "SR_ARC_SYPHON_CHARGE_SPECIAL"
+    description = "SR_ARC_SYPHON_CHARGE_SPECIAL_DESC"
+    spawnrate = 0.0
+    // NB: the associated effectsgroups are in the SR_ARC_SYPHON part
+    graphic = "icons/ship_parts/pulse-laser.png"
+
+#include "/scripting/macros/priorities.macros"

--- a/default/scripting/techs/ship_weapons/ship_weapons.py
+++ b/default/scripting/techs/ship_weapons/ship_weapons.py
@@ -59,8 +59,10 @@ def WEAPON_BASE_EFFECTS(part_name: str):
 # @3@ unscaled_upgrade gets added to max capacity after scaling it with SHIP_WEAPON_DAMAGE_FACTOR
 # @4@ upgraded_damage_override if given overrides the total sum over the researched techs shown in the upgrade info sitrep
 def WEAPON_UPGRADE_CAPACITY_EFFECTS(
-    tech_name: str, part_name: str, unscaled_upgrade: int, upgraded_damage_override: int = -1
+    tech_name: str, part_name: str, unscaled_upgrade: int, upgraded_damage_override: int = -1, stringtable_prefix = None
 ):
+    if stringtable_prefix is None:
+        stringtable_prefix = tech_name
     # the following recursive lookup works, but is not acceptable because of delays. as long as the parser is sequential, the parallel waiting feature is kind of a bug
     # previous_upgrade_effect = PartCapacity(name=part_name) if (tech_name[-1] == "2") else NamedRealLookup(name = tech_name[0:-1] + "2_UPGRADED_DAMAGE")  # + str(int(tech_name[-1]) - 1))
     upgraded_damage = (
@@ -86,10 +88,10 @@ def WEAPON_UPGRADE_CAPACITY_EFFECTS(
                     "tech": CurrentContent,
                     # str(CurrentContent) -> <ValueRefString object at 0x...>
                     "dam": NamedReal(
-                        name=tech_name + "_UPGRADE_DAMAGE", value=unscaled_upgrade * SHIP_WEAPON_DAMAGE_FACTOR
+                        name=stringtable_prefix +  "_UPGRADE_DAMAGE", value=unscaled_upgrade * SHIP_WEAPON_DAMAGE_FACTOR
                     ),
                     "sum": NamedReal(
-                        name=tech_name + "_UPGRADED_DAMAGE",
+                        name=stringtable_prefix + "_UPGRADED_DAMAGE",
                         value=PartCapacity(name=part_name) + (SHIP_WEAPON_DAMAGE_FACTOR * upgraded_damage),
                     ),
                 },

--- a/default/scripting/techs/ship_weapons/short_range/SHP_ARC_DISRUPTOR.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_ARC_DISRUPTOR.focs.py
@@ -2,12 +2,13 @@ from focs._tech import *
 from macros.base_prod import TECH_COST_MULTIPLIER
 from techs.ship_weapons.ship_weapons import (
     WEAPON_BASE_EFFECTS,
-    WEAPON_UPGRADE_CAPACITY_EFFECTS as w_upgrade_c_e,
+    WEAPON_UPGRADE_CAPACITY_EFFECTS,
 )
 
 AD_2_upgrade = 2
 AD_3_upgrade = 3
 AD_2_plus_3_upgrade = AD_2_upgrade + AD_3_upgrade
+w_upgrade_c_e = WEAPON_UPGRADE_CAPACITY_EFFECTS
 
 # In absense of shields this weapon can get almost as good as Plasma. Against shields its pretty useless
 Tech(
@@ -21,8 +22,8 @@ Tech(
     prerequisites=["SHP_ROOT_AGGRESSION"],
     unlock=[Item(type=UnlockShipPart, name="SR_ARC_DISRUPTOR"), Item(type=UnlockShipPart, name="SR_ARC_SYPHON")],
     effectsgroups=[
-        WEAPON_BASE_EFFECTS("SR_ARC_DISRUPTOR"),
-        WEAPON_BASE_EFFECTS("SR_ARC_SYPHON"),
+        *WEAPON_BASE_EFFECTS("SR_ARC_DISRUPTOR"),
+        *WEAPON_BASE_EFFECTS("SR_ARC_SYPHON"),
     ],
     graphic="icons/ship_parts/pulse-laser-1.png",
 )
@@ -37,8 +38,8 @@ Tech(
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_ARC_DISRUPTOR_1"],
     effectsgroups=[
-        w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_2", "SR_ARC_DISRUPTOR", AD_2_upgrade),
-        w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_2", "SR_ARC_SYPHON", 2*AD_2_upgrade),
+        *w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_2", "SR_ARC_DISRUPTOR", AD_2_upgrade),
+        *w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_2", "SR_ARC_SYPHON", 2*AD_2_upgrade),
     ],
     graphic="icons/ship_parts/pulse-laser-2.png",
 )
@@ -54,8 +55,8 @@ Tech(
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_ARC_DISRUPTOR_2"],
     effectsgroups=[
-        w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_3", "SR_ARC_DISRUPTOR", AD_3_upgrade, upgraded_damage_override=AD_2_plus_3_upgrade),
-        w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_3", "SR_ARC_SYPHON", 2*AD_3_upgrade, upgraded_damage_override=2*AD_2_plus_3_upgrade),
+        *w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_3", "SR_ARC_DISRUPTOR", AD_3_upgrade, upgraded_damage_override=AD_2_plus_3_upgrade),
+        *w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_3", "SR_ARC_SYPHON", 2*AD_3_upgrade, upgraded_damage_override=2*AD_2_plus_3_upgrade),
     ],
     graphic="icons/ship_parts/pulse-laser-3.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_ARC_DISRUPTOR.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_ARC_DISRUPTOR.focs.py
@@ -39,7 +39,7 @@ Tech(
     prerequisites=["SHP_WEAPON_ARC_DISRUPTOR_1"],
     effectsgroups=[
         *w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_2", "SR_ARC_DISRUPTOR", AD_2_upgrade),
-        *w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_2", "SR_ARC_SYPHON", 2*AD_2_upgrade),
+        *w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_2", "SR_ARC_SYPHON", 2*AD_2_upgrade, stringtable_prefix = "SHP_WEAPON_ARC_DISRUPTOR_2_SYPHON"),
     ],
     graphic="icons/ship_parts/pulse-laser-2.png",
 )
@@ -56,7 +56,7 @@ Tech(
     prerequisites=["SHP_WEAPON_ARC_DISRUPTOR_2"],
     effectsgroups=[
         *w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_3", "SR_ARC_DISRUPTOR", AD_3_upgrade, upgraded_damage_override=AD_2_plus_3_upgrade),
-        *w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_3", "SR_ARC_SYPHON", 2*AD_3_upgrade, upgraded_damage_override=2*AD_2_plus_3_upgrade),
+        *w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_3", "SR_ARC_SYPHON", 2*AD_3_upgrade, upgraded_damage_override=2*AD_2_plus_3_upgrade, stringtable_prefix = "SHP_WEAPON_ARC_DISRUPTOR_3_SYPHON"),
     ],
     graphic="icons/ship_parts/pulse-laser-3.png",
 )

--- a/default/scripting/techs/ship_weapons/short_range/SHP_ARC_DISRUPTOR.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_ARC_DISRUPTOR.focs.py
@@ -2,7 +2,7 @@ from focs._tech import *
 from macros.base_prod import TECH_COST_MULTIPLIER
 from techs.ship_weapons.ship_weapons import (
     WEAPON_BASE_EFFECTS,
-    WEAPON_UPGRADE_CAPACITY_EFFECTS,
+    WEAPON_UPGRADE_CAPACITY_EFFECTS as w_upgrade_c_e,
 )
 
 AD_2_upgrade = 2
@@ -19,8 +19,11 @@ Tech(
     researchturns=4,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_ROOT_AGGRESSION"],
-    unlock=Item(type=UnlockShipPart, name="SR_ARC_DISRUPTOR"),
-    effectsgroups=WEAPON_BASE_EFFECTS("SR_ARC_DISRUPTOR"),
+    unlock=[Item(type=UnlockShipPart, name="SR_ARC_DISRUPTOR"), Item(type=UnlockShipPart, name="SR_ARC_SYPHON")],
+    effectsgroups=[
+        WEAPON_BASE_EFFECTS("SR_ARC_DISRUPTOR"),
+        WEAPON_BASE_EFFECTS("SR_ARC_SYPHON"),
+    ],
     graphic="icons/ship_parts/pulse-laser-1.png",
 )
 
@@ -33,7 +36,10 @@ Tech(
     researchturns=8,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_ARC_DISRUPTOR_1"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_ARC_DISRUPTOR_2", "SR_ARC_DISRUPTOR", AD_2_upgrade),
+    effectsgroups=[
+        w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_2", "SR_ARC_DISRUPTOR", AD_2_upgrade),
+        w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_2", "SR_ARC_SYPHON", 2*AD_2_upgrade),
+    ],
     graphic="icons/ship_parts/pulse-laser-2.png",
 )
 
@@ -47,8 +53,9 @@ Tech(
     researchturns=12,
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_ARC_DISRUPTOR_2"],
-    effectsgroups=WEAPON_UPGRADE_CAPACITY_EFFECTS(
-        "SHP_WEAPON_ARC_DISRUPTOR_3", "SR_ARC_DISRUPTOR", AD_3_upgrade, upgraded_damage_override=AD_2_plus_3_upgrade
-    ),
+    effectsgroups=[
+        w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_3", "SR_ARC_DISRUPTOR", AD_3_upgrade, upgraded_damage_override=AD_2_plus_3_upgrade),
+        w_upgrade_c_e("SHP_WEAPON_ARC_DISRUPTOR_3", "SR_ARC_SYPHON", 2*AD_3_upgrade, upgraded_damage_override=2*AD_2_plus_3_upgrade),
+    ],
     graphic="icons/ship_parts/pulse-laser-3.png",
 )

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -17,6 +17,18 @@ English
 # یای مجهو
 
 
+SITREP_SR_ARC_SYPHON_DEBUG
+Bookkeep Syphoner: %shipdesign% %ship% (%rawtext:ship%)  Syphoned: %rawtext:syphoned% Fleet: %fleet%
+
+SITREP_SR_ARC_SYPHON_DEBUG_LABEL
+Debug Info Arc Syphon Step
+
+SITREP_SR_ARC_SYPHON_NULLIFY
+Arc Disruptor got syphoned on %shipdesign% %ship% Fleet: %fleet%
+
+SITREP_SR_ARC_SYPHON_NULLIFY_LABEL
+Arc Syphon nullifies Arc Disruptor
+
 ##
 ## Common phrases
 ##

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -31,7 +31,7 @@ SITREP_SR_ARC_SYPHON_BOOST_LABEL
 Syphoners Get Extra Shots from Last Turn Charge
 
 SITREP_SR_ARC_SYPHON_NULLIFY
-Arc Disruptor got syphoned on %shipdesign% %ship% Fleet: %fleet%
+%rawtext:pre%Arc Disruptor got syphoned on %shipdesign% %ship% Fleet: %fleet%  cur2nd: %rawtext:currentSecondaryStat% curMax2nd: %rawtext:currentMaxSecondaryStat%  ini2nd: %rawtext:initialSecondaryStat%  iniMax2nd: %rawtext:initialMaxSecondaryStat%
 
 SITREP_SR_ARC_SYPHON_NULLIFY_LABEL
 Arc Syphon nullifies Arc Disruptor

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -19,9 +19,16 @@ English
 
 SITREP_SR_ARC_SYPHON_DEBUG
 Bookkeep Syphoner: %shipdesign% %ship% (%rawtext:ship%)  Syphoned: %rawtext:syphoned% Fleet: %fleet%
+#(current special capacity: %rawtext:specialcapacity%
 
 SITREP_SR_ARC_SYPHON_DEBUG_LABEL
 Debug Info Arc Syphon Step
+
+SITREP_SR_ARC_SYPHON_BOOST
+Extra Shots: %rawtext:upgrade%  Syphoner:  %shipdesign% %ship% Charge: %rawtext:charge%  Fleet: %fleet% has %rawtext:count% syphoners
+
+SITREP_SR_ARC_SYPHON_BOOST_LABEL
+Syphoners Get Extra Shots from Last Turn Charge
 
 SITREP_SR_ARC_SYPHON_NULLIFY
 Arc Disruptor got syphoned on %shipdesign% %ship% Fleet: %fleet%
@@ -16060,6 +16067,18 @@ Charged polaron capacitors generate a molecular disruption flux wave that arcs t
 Upgrading the weapon technology will increase the shot damage.
 
 The weapon's [[encyclopedia DAMAGE_TITLE]] is a combination of the shot damage and any active modifiers. Piloting trait does not affect damage. The Arc Disruptor has [[value SR_ARC_DISRUPTOR_PART_CAPACITY]] basic shot damage. Upgrade tech [[tech SHP_WEAPON_ARC_DISRUPTOR_2]] increases this by [[value SHP_WEAPON_ARC_DISRUPTOR_2_UPGRADE_DAMAGE]].'''
+
+SR_ARC_SYPHON
+Arc Syphon
+
+SR_ARC_SYPHON_DESC
+'''The Arc Syphon, a close combat range multi-shot ship weapon which transforms [[shippart SR_ARC_DISRUPTOR]] shots to be more effective against shielded targets.
+
+The syphon collects and concentrates the molecular disruption flux waves of [[shippart SR_ARC_DISRUPTOR]]s. Doubling the shot damage of arc disruptors shots, the concentrated disruption flux is prone to being deflected around ship shields.
+
+Upgrading the arc disruptor weapon technology will strongly increase the shot damage.
+
+The weapon's [[encyclopedia DAMAGE_TITLE]] is a combination of the shot damage and any active modifiers. Piloting trait does not affect damage. The Arc Syphon has [[value SR_ARC_SYPHON_PART_CAPACITY]] basic shot damage. Upgrade tech [[tech SHP_WEAPON_ARC_DISRUPTOR_2]] increases this by [[value SHP_WEAPON_ARC_DISRUPTOR_2_SYPHON_UPGRADE_DAMAGE]].'''
 
 SR_SPINAL_ANTIMATTER
 Spinal Antimatter Cannon


### PR DESCRIPTION
arc syphon drains arc disruptor shots and concentrates those by shooting double damage only in short range distance (so same total damage, but more concentration/shield piercing and different timing). 

implementation for the design as in the
[forum discussion](https://freeorion.org/forum/viewtopic.php?p=119532#p119532)

currently the shots oscillate between arc disruptors and arc siphons.

do not think i can do a good AI implementation; but the AI wont build it because the base part does no damage at all