### PR TITLE
change priorities of nest eradication and nest spawning

### DIFF
--- a/default/scripting/buildings/NEST_ERADICATOR.focs.txt
+++ b/default/scripting/buildings/NEST_ERADICATOR.focs.txt
@@ -33,7 +33,8 @@ EG_NEST_REMOVAL
                 Planet
                 HasSpecial name = "@1@_NEST_SPECIAL"
             ]
-            stackinggroup = "@1@_NEST_STACK"  // groups with @1@_NEST_SPECIAL
+            stackinggroup = "@1@_NEST_STACK"             // groups with @1@_NEST_SPECIAL
+            priority = [[BEFORE_ANYTHING_ELSE_PRIORITY]] // so eradication happens first and any monster spawn is prevented
             effects = [
                 RemoveSpecial name = "@1@_NEST_SPECIAL"
                 GenerateSitRepMessage
@@ -46,4 +47,4 @@ EG_NEST_REMOVAL
 '''
 
 #include "/scripting/macros/base_prod.macros"
-
+#include "/scripting/macros/priorities.macros"

--- a/default/scripting/specials/planet/monster_nest/monster_nest.macros
+++ b/default/scripting/specials/planet/monster_nest/monster_nest.macros
@@ -15,6 +15,7 @@ MONSTER_NEST
                 Random probability = @3@ * (GameRule name = "RULE_DOMESTIC_NEST_MONSTER_SPAWN_FACTOR")
             ]
             stackinggroup = "@1@_NEST_STACK"  // groups with BLD_NEST_ERADICATOR
+            priority = [[DEFAULT_PRIORITY]]   // eradication is going to happen earlier to prevent monster spawn
             effects = [
                 CreateShip designname = "SM_@1@_1" empire = Source.Owner
                 GenerateSitRepMessage
@@ -38,6 +39,9 @@ MONSTER_NEST
                 ]
                 Random probability = 0.12 * (GameRule name = "RULE_WILD_NEST_MONSTER_SPAWN_FACTOR") * GalaxyMonsterFrequency / 2.0
             ]
-            stackinggroup = "@1@_NEST_STACK"
+            stackinggroup = "@1@_NEST_STACK"  // groups with BLD_NEST_ERADICATOR
+            priority = [[DEFAULT_PRIORITY]]   // eradication is going to happen earlier to prevent monster spawn
             effects = CreateShip designname = "SM_@1@_1"
 '''
+
+#include "/scripting/macros/priorities.macros"


### PR DESCRIPTION
fixes https://github.com/freeorion/freeorion/issues/4952

maybe the effect stacking was to prevent monster spawning when nest is eradicated, but in practice I see nest eradication prevented when monster spawns.

Removing stacking group was easiest fix for me though it may mean that monster spawns as nest is being eradicated, by I suppose that's better than nest not being eradicated and losing production on the building

I am open to suggestions what other stacking group it could be so that eradication triggers first and monster spawning doesn't trigger later, if that's possible. Ultimately I don't mind though if monster spawns but nest gets removed