### PR TITLE
Correct damage boost by techs Laser-3, Plasma-3, DeathRay-3

### DIFF
--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_3.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_2_3.focs.py
@@ -12,7 +12,7 @@ Tech(
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_2_2"],
     effectsgroups=[
-        *WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_2_3", "SR_WEAPON_1_1", 1),
+        *WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_2_3", "SR_WEAPON_2_1", 2),
         *WEAPON_UPGRADE_SECONDARY_STAT_EFFECTS("SHP_WEAPON_2_3", "SR_WEAPON_0_1", 1),
     ],
     graphic="icons/ship_parts/laser-3.png",

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_3.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_3_3.focs.py
@@ -12,7 +12,7 @@ Tech(
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_3_2"],
     effectsgroups=[
-        *WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_3_3", "SR_WEAPON_1_1", 1),
+        *WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_3_3", "SR_WEAPON_3_1", 3),
         *WEAPON_UPGRADE_SECONDARY_STAT_EFFECTS("SHP_WEAPON_3_3", "SR_WEAPON_0_1", 1),
     ],
     graphic="icons/ship_parts/plasma-3.png",

--- a/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_3.focs.py
+++ b/default/scripting/techs/ship_weapons/short_range/SHP_WEAPON_4_3.focs.py
@@ -12,7 +12,7 @@ Tech(
     tags=["PEDIA_SR_WEAPON_TECHS"],
     prerequisites=["SHP_WEAPON_4_2"],
     effectsgroups=[
-        *WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_4_3", "SR_WEAPON_1_1", 1),
+        *WEAPON_UPGRADE_CAPACITY_EFFECTS("SHP_WEAPON_4_3", "SR_WEAPON_4_1", 5),
         *WEAPON_UPGRADE_SECONDARY_STAT_EFFECTS("SHP_WEAPON_4_3", "SR_WEAPON_0_1", 1),
     ],
     graphic="icons/ship_parts/death-ray-3.png",


### PR DESCRIPTION
Laser-3, Plasma-3, DeathRay-3 applied a +1 damage boost to Mass Driver instead of the correct ones 2,3, and 5 to Laser, Plasma, and DeathRay parts.