### PR TITLE
close some rgba tags

### DIFF
--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -106,7 +106,7 @@ CreditsWnd::CreditsWnd(GG::X x, GG::Y y, GG::X w, GG::Y h, int cx, int cy, int c
     auto task_format = boost::format(" - <rgba 204 204 204 255>%1%</rgba>");
     auto resource_format = boost::format("%1% - <rgba 153 153 153 255>%2%</rgba>\n%3% %4%%5%\n");
     auto source_format = boost::format(" - <rgba 153 153 153 255>%1%</rgba>");
-    auto note_format = boost::format("<rgba 204 204 204 255>(%1%)\n");
+    auto note_format = boost::format("<rgba 204 204 204 255>(%1%)</rgba>\n");
 
     for (const XMLElement& group : credits_node.Children()) {
         if (0 == group.Tag().compare("GROUP")) {

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -150,7 +150,7 @@ namespace {
                 if (empire->Eliminated()) continue;
                 if (empires.GetDiplomaticStatus(empire_id, m_empire_id) == m_diplo_status) {
                     m_empire_ids.insert(empire_id);
-                    empires_names_text.append(GG::RgbaTag(empire->Color())).append(empire->Name()).append("\n");
+                    empires_names_text.append(GG::RgbaTag(empire->Color())).append(empire->Name()).append("</rgba>\n");
                 }
             }
 


### PR DESCRIPTION
- in Empires window popup about diplomatic status with other empires
- in Credits window when an item has notes section


I was exploring issue https://github.com/freeorion/freeorion/issues/4946 and supposed maybe it's something about not closed rgba tags, and went searching, and I actually found some, while it doesn't seem to fix that issue I think it's still preferable to actually close those tags