### PR TITLE
Avoid warning about __TIME__ in non-test builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ if(BUILD_TESTING)
     message( STATUS "Building Tests")
     enable_testing()
     enable_coverage()
+    add_compile_options(-DSTATIC_RANDOM_TESTS)
 
     if(NOT TARGET unittest)
         add_custom_target(unittest

--- a/util/Random.h
+++ b/util/Random.h
@@ -71,7 +71,11 @@ inline consteval int32_t RandIntCx(const int32_t min, const int32_t max,
     return min + static_cast<int32_t>(val_in_range);
 }
 inline consteval int32_t RandIntCx(const int32_t min, const int32_t max, const int16_t n,
-                                   const std::array<char, 9> seed = std::array<char, 9>{__TIME__}) noexcept
+#ifdef STATIC_RANDOM_TESTS
+        const std::array<char, 9> seed = std::array<char, 9>{__TIME__}) noexcept
+#else
+        const std::array<char, 9> seed = std::array<char, 9>{"12:34:45"}) noexcept
+#endif
 {
     if (min >= max)
         return min;

--- a/util/Random.h
+++ b/util/Random.h
@@ -45,7 +45,11 @@ namespace RandomImpl {
     }
     // generate a compile-time PRNG int that is seeded differently for each second of the day.
     // \a n indicates which value for the current seed to return.
+#ifdef STATIC_RANDOM_TESTS
     inline consteval uint32_t CxPRNG(int16_t n = counter_val, std::array<char, 9> seed = std::array<char, 9>{__TIME__}) {
+#else
+    inline consteval uint32_t CxPRNG(int16_t n = counter_val, std::array<char, 9> seed = std::array<char, 9>{"12:34:56"}) {
+#endif
         uint32_t retval{TimeToInt(seed)};
         for (; n > 0; --n)
             retval = hash(retval);


### PR DESCRIPTION
This could be a way to fix #4811