### PR TITLE
Restrict meter updates for newly created objects to newly created ones

### DIFF
--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -4538,11 +4538,10 @@ void ServerApp::PostCombatProcessTurns() {
     // UniverseObjects will have effects applied to them this turn, allowing
     // (for example) ships to have max fuel meters greater than 0 on the turn
     // they are created.
-    std::vector<int> newly_created_ids;
-    for (auto& object : m_universe.Objects().all<UniverseObject>()) {
-        if (context.current_turn == object->CreationTurn())
-            newly_created_ids.push_back(object->ID());
-    }
+    const auto newly_created = [this, curturn{context.current_turn}](const UniverseObject& object) {
+        return curturn == object.CreationTurn();
+    };
+    std::vector<int> newly_created_ids = m_universe.Objects().findIDs<UniverseObject>(newly_created);
     if (!newly_created_ids.empty())
         m_universe.ApplyMeterEffectsAndUpdateMeters(newly_created_ids, context, false);
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -4541,7 +4541,7 @@ void ServerApp::PostCombatProcessTurns() {
     const auto newly_created = [this, curturn{context.current_turn}](const UniverseObject& object) {
         return curturn == object.CreationTurn();
     };
-    std::vector<int> newly_created_ids = m_universe.Objects().findIDs<UniverseObject>(newly_created);
+    auto newly_created_ids = m_universe.Objects().findIDs<UniverseObject>(newly_created);
     if (!newly_created_ids.empty())
         m_universe.ApplyMeterEffectsAndUpdateMeters(newly_created_ids, context, false);
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -4538,9 +4538,8 @@ void ServerApp::PostCombatProcessTurns() {
     // UniverseObjects will have effects applied to them this turn, allowing
     // (for example) ships to have max fuel meters greater than 0 on the turn
     // they are created.
-    const auto newly_created = [this, curturn{context.current_turn}](const UniverseObject& object) {
-        return curturn == object.CreationTurn();
-    };
+    const auto newly_created = [curturn{context.current_turn}](const UniverseObject& object) noexcept
+    { return curturn == object.CreationTurn(); };
     auto newly_created_ids = m_universe.Objects().findIDs<UniverseObject>(newly_created);
     if (!newly_created_ids.empty())
         m_universe.ApplyMeterEffectsAndUpdateMeters(newly_created_ids, context, false);

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -4538,9 +4538,15 @@ void ServerApp::PostCombatProcessTurns() {
     // UniverseObjects will have effects applied to them this turn, allowing
     // (for example) ships to have max fuel meters greater than 0 on the turn
     // they are created.
-    m_universe.ApplyMeterEffectsAndUpdateMeters(context, false);
+    std::vector<int> newly_created_ids;
+    for (auto& object : m_universe.Objects().all<UniverseObject>()) {
+        if (context.current_turn == object->CreationTurn())
+            newly_created_ids.push_back(object->ID());
+    }
+    if (!newly_created_ids.empty())
+        m_universe.ApplyMeterEffectsAndUpdateMeters(newly_created_ids, context, false);
 
-    TraceLogger(effects) << "!!!!!!! AFTER UPDATING METERS OF ALL OBJECTS";
+    TraceLogger(effects) << "!!!!!!! AFTER UPDATING METERS OF ALL NEWLY CREATED OBJECTS (CREATED BY EFFECTS OR PRODUCTION)";
     TraceLogger(effects) << m_universe.Objects().Dump();
 
     // Planet depopulation, some in-C++ meter modifications

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -579,13 +579,13 @@ void Universe::ApplyAllEffectsAndUpdateMeters(ScriptingContext& context, bool do
         object->ClampMeters();
 }
 
-void Universe::ApplyMeterEffectsAndUpdateMeters(const std::vector<int>& object_ids, ScriptingContext& context,
+void Universe::ApplyMeterEffectsAndUpdateMeters(const std::vector<int>& target_ids, ScriptingContext& context,
                                                 bool do_accounting)
 {
     CheckContextVsThisUniverse(*this, context);
-    if (object_ids.empty())
+    if (target_ids.empty())
         return;
-    ScopedTimer timer("Universe::ApplyMeterEffectsAndUpdateMeters on " + std::to_string(object_ids.size()) + " objects");
+    ScopedTimer timer("Universe::ApplyMeterEffectsAndUpdateMeters on " + std::to_string(target_ids.size()) + " objects");
     if (do_accounting) {
         // override if disabled
         do_accounting = GetOptionsDB().Get<bool>("effects.accounting.enabled");
@@ -593,16 +593,16 @@ void Universe::ApplyMeterEffectsAndUpdateMeters(const std::vector<int>& object_i
     // cache all activation and scoping condition results before applying Effects, since the application of
     // these Effects may affect the activation and scoping evaluations
     std::map<int, Effect::SourcesEffectsTargetsAndCausesVec> source_effects_targets_causes;
-    GetEffectsAndTargets(source_effects_targets_causes, object_ids, context, true);
+    GetEffectsAndTargets(source_effects_targets_causes, target_ids, context, true);
 
-    auto objects = context.ContextObjects().find(object_ids);
+    auto objects = context.ContextObjects().find(target_ids);
 
     // revert all current meter values (which are modified by effects) to
     // their initial state for this turn, so meter
     // value can be calculated (by accumulating all effects' modifications this
     // turn) and active meters have the proper baseline from which to
     // accumulate changes from effects
-    for (auto* object : context.ContextObjects().findRaw(object_ids)) {
+    for (auto* object : context.ContextObjects().findRaw(target_ids)) {
         object->ResetTargetMaxUnpairedMeters();
         object->ResetPairedActiveMeters();
     }


### PR DESCRIPTION
The meter updates after production also changed old objects. 
Besides being weird and unnecessary, this caused mismatches with the meter prediction in the UI. E.g. objects destroyed by effect did affect e.g. stability meters, but were not shown as such.

Change: objects which are were not created this turn do not get another round of meter effect application

Tested:
* ship newly created  by production was initialised to sensible values
* destruction of an object has no direct effect on meter changes, so the predicted meter changes happen. One could say the destruction happened after effect evaluation.
* does this enable #4967 to fully work as expected

Untested:
* ship newly created  by effect was initialised to sensible values
* does an existing object affect the newly created objects? e.g. a building which doubles weapon shots; or robotic shields etc based on ship count; ship newly created  by production/effect was initialised to correct values - I am unsure what the expected result should be; I think I'd prefer that the existing objects affect newly created ones.
* ship newly created  by production/effect was initialised to correct values
* effect of destruction on newly created object (i'd say this is undefined edge case; i expect it to have an effect if applicable)
* old/new behavior for effects which counted objects etc.  
* check what happens when setting meter basing on count of objects (check meter on old ship, meter on new ship, real count)
* see if focs can restrict conditions to old objects

Unclear: with this change, scrapping of objects works a bit more different from destruction via focs effects. This is okayish. It would be nice if there was more consistency. Maybe we should ponder to move scrapping after first round of effect application - it would also give the enemies a chance to prevent scrapping without having to add special coding everywhere.