### PR TITLE
Fix PLC_ENGINEERING to have effect for RULE_SHIP_PART_BASED_UPKEEP

### DIFF
--- a/default/scripting/macros/upkeep.macros
+++ b/default/scripting/macros/upkeep.macros
@@ -5,7 +5,7 @@ FLEET_UPKEEP_MULTIPLICATOR
 '''(1 +
 
     // reduce by half if policy adopted
-    (1 - 0.5*Statistic If condition = And [Source EmpireHasAdoptedPolicy empire = Source.Owner name = "PLC_ENGINEERING"]) *
+    (1 - 0.5*Statistic If condition = And [Source EmpireHasAdoptedPolicy empire = Source.Owner name = "PLC_ENGINEERING"]) * (
     
     // increase cost dependent on number of ships or number of ship parts
     (1 - (GameRule name = "RULE_SHIP_PART_BASED_UPKEEP")) * (
@@ -17,7 +17,7 @@ FLEET_UPKEEP_MULTIPLICATOR
         (0.002 * ShipPartsOwned empire = Source.Owner class = Armour) +
         (0.002 * ShipPartsOwned empire = Source.Owner class = Troops) +
         (0.002 * ShipDesignsOwned empire = Source.Owner) +
-        (0.01 * ShipDesignsInProduction empire = Source.Owner)))'''
+        (0.01 * ShipDesignsInProduction empire = Source.Owner))))'''
 
 
 // used within a production cost calculation, in which the location at which the production happens


### PR DESCRIPTION
Lack of extra parentheses meant the engineering discount only applied to default per-ship upkeep, not the part-based upkeep.


This is present for quite a while, I've noticed that way back and was complaining a bit but only now double checked everything and have a fix ready, too