### PR TITLE
rule move before production effects to after production

### DIFF
--- a/default/scripting/buildings/CONC_CAMP.focs.txt
+++ b/default/scripting/buildings/CONC_CAMP.focs.txt
@@ -15,31 +15,24 @@ BuildingType
         [[SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS]]
     
         EffectsGroup
-            scope = And [
-                Object id = Source.PlanetID
-                Planet
+            scope = Source
+            activation = Or [
+                Not EmpireHasAdoptedPolicy empire = Source.Owner name = "PLC_RACIAL_PURITY"
+                Not ProducedByEmpire empire = Source.Owner
             ]
-            activation = ContainedBy And [
-                Object id = Source.PlanetID
-                Planet
-                OwnedBy empire = Source.Owner
-            ]
-            priority = [[TARGET_AFTER_SCALING_PRIORITY]]
-            effects = SetTargetIndustry value = Value + Target.Population
-                        * (NamedReal name = "BLD_CONC_CAMP_TARGET_INDUSTRY_PERPOP"
-                                     value = 3.75 * [[INDUSTRY_PER_POP]])
+            effects = Destroy
 
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
                 Planet
             ]
-            activation = Or [
-                Not EmpireHasAdoptedPolicy empire = Source.Owner name = "PLC_RACIAL_PURITY"
-                ContainedBy And [
-                    Object id = Source.PlanetID
-                    OwnedBy empire = Source.Owner
-                    Population low = 0.0001
+            activation = ContainedBy And [
+                Object id = Source.PlanetID
+		OwnedBy empire = Source.Owner
+		Population low = 0.0001
+                Or [
+                    Not EmpireHasAdoptedPolicy empire = Source.Owner name = "PLC_RACIAL_PURITY"
                     Not HasSpecial name = "CONC_CAMP_MASTER_SPECIAL"
                 ]
             ]
@@ -68,6 +61,21 @@ BuildingType
             ]
             activation = ContainedBy And [
                 Object id = Source.PlanetID
+                Planet
+                OwnedBy empire = Source.Owner
+            ]
+            priority = [[TARGET_AFTER_SCALING_PRIORITY]]
+            effects = SetTargetIndustry value = Value + Target.Population
+                        * (NamedReal name = "BLD_CONC_CAMP_TARGET_INDUSTRY_PERPOP"
+                                     value = 3.75 * [[INDUSTRY_PER_POP]])
+
+        EffectsGroup
+            scope = And [
+                Object id = Source.PlanetID
+                Planet
+            ]
+            activation = ContainedBy And [
+                Object id = Source.PlanetID
                 OwnedBy empire = Source.Owner
                 HasSpecial name = "CONC_CAMP_MASTER_SPECIAL"
             ]
@@ -81,14 +89,6 @@ BuildingType
                 SetPopulation value = min(Value, Target.Population + (NamedReal name = "BLD_CONC_CAMP_POPULATION_FLAT" value = -3))
                 SetIndustry value = Target.TargetIndustry
             ]
-
-        EffectsGroup
-            scope = Source
-            activation = Or [
-                Not EmpireHasAdoptedPolicy empire = Source.Owner name = "PLC_RACIAL_PURITY"
-                Not ProducedByEmpire empire = Source.Owner
-            ]
-            effects = Destroy
     ]
     icon = "icons/building/concentration-camp.png"
 

--- a/default/scripting/buildings/CONC_CAMP_REMNANT.focs.txt
+++ b/default/scripting/buildings/CONC_CAMP_REMNANT.focs.txt
@@ -8,6 +8,16 @@ BuildingType
         [[SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS]]
 
         EffectsGroup
+            scope = Source
+            activation =  ContainedBy And [
+                Object id = Source.PlanetID
+                Not HasSpecial name = "CONC_CAMP_MASTER_SPECIAL"
+                Not HasSpecial name = "CONC_CAMP_SLAVE_SPECIAL"
+                Industry high = Source.Planet.TargetIndustry + 2
+            ]
+            effects = Destroy
+
+        EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
                 Planet
@@ -19,16 +29,6 @@ BuildingType
             ]
             priority = [[CONCENTRATION_CAMP_PRIORITY]]
             effects = SetIndustry value = Target.TargetIndustry
-
-        EffectsGroup
-            scope = Source
-            activation =  ContainedBy And [
-                Object id = Source.PlanetID
-                Not HasSpecial name = "CONC_CAMP_MASTER_SPECIAL"
-                Not HasSpecial name = "CONC_CAMP_SLAVE_SPECIAL"
-                Industry high = Source.Planet.TargetIndustry + 2
-            ]
-            effects = Destroy
     ]
     icon = "icons/building/concentration-camp.png"
     

--- a/default/scripting/specials/system/DERELICT_3.focs.txt
+++ b/default/scripting/specials/system/DERELICT_3.focs.txt
@@ -23,7 +23,9 @@ Special
                 ]
             ]
             effects = [
-                AddSpecial name = "DERELICT_SPECIAL3"
+                If condition = (GameRule name = "RULE_APPLY_ALL_EFFECTS_AFTER_PRODUCTION" = 0 ) effects =
+                    AddSpecial name = "DERELICT_SPECIAL3"
+                    else = SetFuel value = Value + 100
                 GenerateSitRepMessage
                     message = "EFFECT_DERELICT_FUEL"
                     label = "EFFECT_DERELICT_FUEL_LABEL"
@@ -56,6 +58,8 @@ Special
                 Source
                 Ship
             ]
+            // NOTE: the whole special could be removed if the are no before-production effects
+            activation = (GameRule name = "RULE_APPLY_ALL_EFFECTS_AFTER_PRODUCTION" = 0 )
             effects = [
                 SetFuel value = Value + 100
                 RemoveSpecial name = "DERELICT_SPECIAL3"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1153,6 +1153,12 @@ Random Reseeding
 RULE_RESEED_PRNG_SERVER_DESC
 With reseeding, replaying the same save or using the same settings and seed is not expected to produce the same random results. This is possibly preferable if players want to be sure that none of them can predict future random results based on previous random results or if a player wants to 're-roll' the results of a battle or random effect when re-playing a turn, and not get the same results as a previous attempt.
 
+RULE_APPLY_ALL_EFFECTS_AFTER_PRODUCTION
+No Preproduction Effects (Experimental)
+
+RULE_APPLY_ALL_EFFECTS_AFTER_PRODUCTION
+Apply all effect evaluations after production of ships and buildings. Without this, all content effects are applied before production and the meter effects get reevaluated after production again in order to initialise newly build objects. This is an experimental feature and should either become the normal behavior or be removed before end of 2024.
+
 RULE_SHIP_SPEED_FACTOR
 Ship Speed Scaling
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -130,6 +130,9 @@ public:
      *  so that they can impose blockades */
     void UpdateMonsterTravelRestrictions();
 
+    /** TODO description */
+    void PostCombatProcessTurnsApplyUniverseChangingEffectsAndUpdateSupply(ScriptingContext& context);
+
     /** Determines resource and supply distribution pathes and connections,
       * updates research, production, influence spending,
       * does population growth, updates current turn number, checks for

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -73,6 +73,13 @@ namespace {
                         true, true,
                         GameRuleRanks::RULE_RESEED_PRNG_SERVER_RANK);
 
+	// XXX experimental feature should be removed before end of 2024
+        rules.Add<bool>(UserStringNop("RULE_APPLY_ALL_EFFECTS_AFTER_PRODUCTION"),
+                        UserStringNop("RULE_APPLY_ALL_EFFECTS_AFTER_PRODUCTION_DESC"),
+                        GameRuleCategories::GameRuleCategory::TEST,
+                        false, true,
+                        GameRuleRanks::RULE_APPLY_ALL_EFFECTS_AFTER_PRODUCTION_RANK);
+
         rules.Add<bool>(UserStringNop("RULE_STARLANES_EVERYWHERE"),
                         UserStringNop("RULE_STARLANES_EVERYWHERE_DESC"),
                         GameRuleCategories::GameRuleCategory::TEST,

--- a/util/GameRuleRanks.h
+++ b/util/GameRuleRanks.h
@@ -33,6 +33,8 @@ namespace GameRuleRanks {
         RULE_ALL_SYSTEMS_VISIBLE_RANK = 131,
         RULE_UNSEEN_STEALTHY_PLANETS_INVISIBLE_RANK = 132,
         RULE_STARLANES_EVERYWHERE_RANK = 135,
+	// EXPERIMENTAL FEATURES in "TEST" category
+        RULE_APPLY_ALL_EFFECTS_AFTER_PRODUCTION_RANK = 500,
 
         // "BALANCE_STABILITY" category (should there be a separate opinion and annexation group?)
         RULE_ANNEX_COST_OPINION_EXP_BASE_RANK = 5500,


### PR DESCRIPTION
Apply all kinds of effects after production iff RULE_APPLY_ALL_EFFECTS_AFTER_PRODUCTION and do not apply any effects directly before production. (This removes the "before-production phase")

Before: 
* apply all kinds of effects before production
* reset meters
* production
* apply meter effects after production
    
Before: 
* production
* apply all kinds of effects after production

Note that some content is aligned and (without changing) only works with the old timing. E.g. the derelict tanker special has a lot of workaround code which is not necessary with this PR.

The rule switch is there is there so we can mainline early and get test feedback before committing fully. If we are confident this is what we want we can remove it (and the old code).

Draft, because I need to go through the contents.
