### PR TITLE
Use GCC 14 with Debian sid in Docker CI

### DIFF
--- a/.github/docker/debian-sid/Dockerfile
+++ b/.github/docker/debian-sid/Dockerfile
@@ -24,16 +24,15 @@ APT::Install-Recommends \"false\";\n\
 APT::Install-Suggests \"false\";\n\
 " > /etc/apt/apt.conf.d/docker-no-suggests
 
-# add experimental repository to test issue https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1037667
+# add experimental repository to test issue https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1074967
 RUN echo "deb http://deb.debian.org/debian experimental main\n\
 " >> /etc/apt/sources.list
 
 RUN apt-get update --assume-yes
-# install experimental g++ to test issue https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1037667
-#RUN apt-get -t=experimental install --assume-yes g++ binutils # broken binutils dependency
+# install experimental g++ to test issue https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1074967
+RUN apt-get -t=experimental install --assume-yes g++ binutils # broken binutils dependency
 RUN apt-get install --assume-yes \
         git \
-        g++ \
         make \
         cmake \
         python3 \


### PR DESCRIPTION
Mostly to test https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1074967 but it looks was already fixed in master