### PR TITLE
Fix out-of-codepage unicode path handling for sounds and fonts

### DIFF
--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -735,6 +735,7 @@ private:
     FT_Error          GetFace(const std::vector<uint8_t>& file_contents, FT_Face& face);
     void              CheckFace(FT_Face font, FT_Error error);
     void              Init(FT_Face& font);
+    void              Init();
 
     bool              GenerateGlyph(FT_Face font, uint32_t ch);
 
@@ -930,6 +931,10 @@ namespace detail {
         FTFaceWrapper() = default;
         ~FTFaceWrapper();
         FT_Face m_face = nullptr;
+#ifdef WIN32
+        // buffer in case we need to fall back to FT_New_Memory_Face, kept here so it is around until FT_Done_Face
+        std::vector<uint8_t> file_contents;
+#endif
     };
 }
 }
@@ -942,12 +947,7 @@ GG::Font::Font(std::string font_filename, unsigned int pts,
     m_pt_sz(pts),
     m_charsets(first, last)
 {
-    if (!m_font_filename.empty()) {
-        detail::FTFaceWrapper wrapper;
-        FT_Error error = GetFace(wrapper.m_face);
-        CheckFace(wrapper.m_face, error);
-        Init(wrapper.m_face);
-    }
+    Init();
 }
 
 template <typename CharSetIter>

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -15,6 +15,8 @@
 #include <iterator>
 #include <numeric>
 #include <sstream>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/fstream.hpp>
 #include <boost/format.hpp>
 #include <boost/xpressive/regex_actions.hpp>
 #include <boost/xpressive/xpressive.hpp>
@@ -932,16 +934,39 @@ namespace {
     Font::RenderCache shared_cache{};
 }
 
-Font::Font(std::string font_filename, unsigned int pts) :
-    m_font_filename(std::move(font_filename)),
-    m_pt_sz(pts)
+void Font::Init()
 {
     if (!m_font_filename.empty()) {
         detail::FTFaceWrapper wrapper;
         FT_Error error = GetFace(wrapper.m_face);
+#ifdef WIN32
+        if (error == FT_Err_Cannot_Open_Resource) {
+            // try loading file data ourselves to use FT_New_Memory_Face,
+            // speculating something might have gone wrong with utf8 path in FT_New_Face
+            if (wrapper.m_face) {
+                FT_Done_Face(wrapper.m_face);
+            }
+            std::wstring wide_path;
+            utf8::utf8to16(m_font_filename.cbegin(), m_font_filename.cend(), std::back_inserter(wide_path));
+            boost::filesystem::path path(std::move(wide_path));
+            boost::filesystem::ifstream file(path, std::ios::binary);
+            if (file.is_open()) {
+                wrapper.file_contents.resize(boost::filesystem::file_size(path));
+                file.read(reinterpret_cast<char*>(wrapper.file_contents.data()), wrapper.file_contents.size());
+                error = GetFace(wrapper.file_contents, wrapper.m_face);
+            }
+        }
+#endif
         CheckFace(wrapper.m_face, error);
         Init(wrapper.m_face);
     }
+}
+
+Font::Font(std::string font_filename, unsigned int pts) :
+    m_font_filename(std::move(font_filename)),
+    m_pt_sz(pts)
+{
+    Init();
 }
 
 Font::Font(std::string font_filename, unsigned int pts,

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -483,36 +483,36 @@ namespace {
         db.Add("video.fps.unfocused",                      UserStringNop("OPTIONS_DB_MAX_FPS_NO_FOCUS"),               15.0,                           RangedStepValidator<double>(0.125, 0.125, 30.0));
 
         // sound and music
-        db.Add("audio.music.path",                         UserStringNop("OPTIONS_DB_BG_MUSIC"),                       (GetRootDataDir() / "default" / "data" / "sound" / "artificial_intelligence_v3.ogg").string());
+        db.Add("audio.music.path",                         UserStringNop("OPTIONS_DB_BG_MUSIC"),                       PathToString(GetRootDataDir() / "default" / "data" / "sound" / "artificial_intelligence_v3.ogg"));
         db.Add("audio.music.volume",                       UserStringNop("OPTIONS_DB_MUSIC_VOLUME"),                   127,                            RangedValidator<int>(1, 255));
         db.Add("audio.effects.volume",                     UserStringNop("OPTIONS_DB_UI_SOUND_VOLUME"),                255,                            RangedValidator<int>(0, 255));
-        db.Add("ui.button.rollover.sound.path",            UserStringNop("OPTIONS_DB_UI_SOUND_BUTTON_ROLLOVER"),       (GetRootDataDir() / "default" / "data" / "sound" / "button_rollover.ogg").string());
-        db.Add("ui.button.press.sound.path",               UserStringNop("OPTIONS_DB_UI_SOUND_BUTTON_CLICK"),          (GetRootDataDir() / "default" / "data" / "sound" / "button_click.ogg").string());
-        db.Add("ui.button.turn.press.sound.path",          UserStringNop("OPTIONS_DB_UI_SOUND_TURN_BUTTON_CLICK"),     (GetRootDataDir() / "default" / "data" / "sound" / "turn_button_click.ogg").string());
-        db.Add("ui.listbox.select.sound.path",             UserStringNop("OPTIONS_DB_UI_SOUND_LIST_SELECT"),           (GetRootDataDir() / "default" / "data" / "sound" / "list_select.ogg").string());
-        db.Add("ui.listbox.drop.sound.path",               UserStringNop("OPTIONS_DB_UI_SOUND_ITEM_DROP"),             (GetRootDataDir() / "default" / "data" / "sound" / "list_select.ogg").string());//TODO: replace with dedicated 'item_drop' sound
-        db.Add("ui.dropdownlist.select.sound.path",        UserStringNop("OPTIONS_DB_UI_SOUND_LIST_PULLDOWN"),         (GetRootDataDir() / "default" / "data" / "sound" / "list_pulldown.ogg").string());
-        db.Add("ui.input.keyboard.sound.path",             UserStringNop("OPTIONS_DB_UI_SOUND_TEXT_TYPING"),           (GetRootDataDir() / "default" / "data" / "sound" / "text_typing.ogg").string());
-        db.Add("ui.window.minimize.sound.path",            UserStringNop("OPTIONS_DB_UI_SOUND_WINDOW_MAXIMIZE"),       (GetRootDataDir() / "default" / "data" / "sound" / "window_maximize.ogg").string());
-        db.Add("ui.window.maximize.sound.path",            UserStringNop("OPTIONS_DB_UI_SOUND_WINDOW_MINIMIZE"),       (GetRootDataDir() / "default" / "data" / "sound" / "window_minimize.ogg").string());
-        db.Add("ui.window.close.sound.path",               UserStringNop("OPTIONS_DB_UI_SOUND_WINDOW_CLOSE"),          (GetRootDataDir() / "default" / "data" / "sound" / "window_close.ogg").string());
-        db.Add("ui.alert.sound.path",                      UserStringNop("OPTIONS_DB_UI_SOUND_ALERT"),                 (GetRootDataDir() / "default" / "data" / "sound" / "alert.ogg").string());
-        db.Add("ui.map.fleet.button.rollover.sound.path",  UserStringNop("OPTIONS_DB_UI_SOUND_FLEET_BUTTON_ROLLOVER"), (GetRootDataDir() / "default" / "data" / "sound" / "fleet_button_rollover.ogg").string());
-        db.Add("ui.map.fleet.button.press.sound.path",     UserStringNop("OPTIONS_DB_UI_SOUND_FLEET_BUTTON_CLICK"),    (GetRootDataDir() / "default" / "data" / "sound" / "fleet_button_click.ogg").string());
-        db.Add("ui.map.system.icon.rollover.sound.path",   UserStringNop("OPTIONS_DB_UI_SOUND_SYSTEM_ICON_ROLLOVER"),  (GetRootDataDir() / "default" / "data" / "sound" / "fleet_button_rollover.ogg").string());
-        db.Add("ui.map.sidepanel.open.sound.path",         UserStringNop("OPTIONS_DB_UI_SOUND_SIDEPANEL_OPEN"),        (GetRootDataDir() / "default" / "data" / "sound" / "sidepanel_open.ogg").string());
+        db.Add("ui.button.rollover.sound.path",            UserStringNop("OPTIONS_DB_UI_SOUND_BUTTON_ROLLOVER"),       PathToString(GetRootDataDir() / "default" / "data" / "sound" / "button_rollover.ogg"));
+        db.Add("ui.button.press.sound.path",               UserStringNop("OPTIONS_DB_UI_SOUND_BUTTON_CLICK"),          PathToString(GetRootDataDir() / "default" / "data" / "sound" / "button_click.ogg"));
+        db.Add("ui.button.turn.press.sound.path",          UserStringNop("OPTIONS_DB_UI_SOUND_TURN_BUTTON_CLICK"),     PathToString(GetRootDataDir() / "default" / "data" / "sound" / "turn_button_click.ogg"));
+        db.Add("ui.listbox.select.sound.path",             UserStringNop("OPTIONS_DB_UI_SOUND_LIST_SELECT"),           PathToString(GetRootDataDir() / "default" / "data" / "sound" / "list_select.ogg"));
+        db.Add("ui.listbox.drop.sound.path",               UserStringNop("OPTIONS_DB_UI_SOUND_ITEM_DROP"),             PathToString(GetRootDataDir() / "default" / "data" / "sound" / "list_select.ogg"));//TODO: replace with dedicated 'item_drop' sound
+        db.Add("ui.dropdownlist.select.sound.path",        UserStringNop("OPTIONS_DB_UI_SOUND_LIST_PULLDOWN"),         PathToString(GetRootDataDir() / "default" / "data" / "sound" / "list_pulldown.ogg"));
+        db.Add("ui.input.keyboard.sound.path",             UserStringNop("OPTIONS_DB_UI_SOUND_TEXT_TYPING"),           PathToString(GetRootDataDir() / "default" / "data" / "sound" / "text_typing.ogg"));
+        db.Add("ui.window.minimize.sound.path",            UserStringNop("OPTIONS_DB_UI_SOUND_WINDOW_MAXIMIZE"),       PathToString(GetRootDataDir() / "default" / "data" / "sound" / "window_maximize.ogg"));
+        db.Add("ui.window.maximize.sound.path",            UserStringNop("OPTIONS_DB_UI_SOUND_WINDOW_MINIMIZE"),       PathToString(GetRootDataDir() / "default" / "data" / "sound" / "window_minimize.ogg"));
+        db.Add("ui.window.close.sound.path",               UserStringNop("OPTIONS_DB_UI_SOUND_WINDOW_CLOSE"),          PathToString(GetRootDataDir() / "default" / "data" / "sound" / "window_close.ogg"));
+        db.Add("ui.alert.sound.path",                      UserStringNop("OPTIONS_DB_UI_SOUND_ALERT"),                 PathToString(GetRootDataDir() / "default" / "data" / "sound" / "alert.ogg"));
+        db.Add("ui.map.fleet.button.rollover.sound.path",  UserStringNop("OPTIONS_DB_UI_SOUND_FLEET_BUTTON_ROLLOVER"), PathToString(GetRootDataDir() / "default" / "data" / "sound" / "fleet_button_rollover.ogg"));
+        db.Add("ui.map.fleet.button.press.sound.path",     UserStringNop("OPTIONS_DB_UI_SOUND_FLEET_BUTTON_CLICK"),    PathToString(GetRootDataDir() / "default" / "data" / "sound" / "fleet_button_click.ogg"));
+        db.Add("ui.map.system.icon.rollover.sound.path",   UserStringNop("OPTIONS_DB_UI_SOUND_SYSTEM_ICON_ROLLOVER"),  PathToString(GetRootDataDir() / "default" / "data" / "sound" / "fleet_button_rollover.ogg"));
+        db.Add("ui.map.sidepanel.open.sound.path",         UserStringNop("OPTIONS_DB_UI_SOUND_SIDEPANEL_OPEN"),        PathToString(GetRootDataDir() / "default" / "data" / "sound" / "sidepanel_open.ogg"));
         db.Add("ui.turn.start.sound.enabled",              UserStringNop("OPTIONS_DB_UI_SOUND_NEWTURN_TOGGLE"),        false);
-        db.Add("ui.turn.start.sound.path",                 UserStringNop("OPTIONS_DB_UI_SOUND_NEWTURN_FILE"),          (GetRootDataDir() / "default" / "data" / "sound" / "newturn.ogg").string());
+        db.Add("ui.turn.start.sound.path",                 UserStringNop("OPTIONS_DB_UI_SOUND_NEWTURN_FILE"),          PathToString(GetRootDataDir() / "default" / "data" / "sound" / "newturn.ogg"));
 
         // fonts
-        db.Add("ui.font.path",                             UserStringNop("OPTIONS_DB_UI_FONT"),                        (GetRootDataDir() / "default/data/fonts/Roboto-Regular.ttf").string());
-        db.Add("ui.font.bold.path",                        UserStringNop("OPTIONS_DB_UI_FONT_BOLD"),                   (GetRootDataDir() / "default" / "data" / "fonts" / "Roboto-Bold.ttf").string());
+        db.Add("ui.font.path",                             UserStringNop("OPTIONS_DB_UI_FONT"),                        PathToString(GetRootDataDir() / "default/data/fonts/Roboto-Regular.ttf"));
+        db.Add("ui.font.bold.path",                        UserStringNop("OPTIONS_DB_UI_FONT_BOLD"),                   PathToString(GetRootDataDir() / "default" / "data" / "fonts" / "Roboto-Bold.ttf"));
 #ifdef FREEORION_MACOSX
         db.Add("ui.font.size",                             UserStringNop("OPTIONS_DB_UI_FONT_SIZE"),                   15,                             RangedValidator<int>(4, 40));
 #else
         db.Add("ui.font.size",                             UserStringNop("OPTIONS_DB_UI_FONT_SIZE"),                   16,                             RangedValidator<int>(4, 40));
 #endif
-        db.Add("ui.font.title.path",                       UserStringNop("OPTIONS_DB_UI_TITLE_FONT"),                  (GetRootDataDir() / "default/data/fonts/Roboto-Regular.ttf").string());
+        db.Add("ui.font.title.path",                       UserStringNop("OPTIONS_DB_UI_TITLE_FONT"),                  PathToString(GetRootDataDir() / "default/data/fonts/Roboto-Regular.ttf"));
 #ifdef FREEORION_MACOSX
         db.Add("ui.font.title.size",                       UserStringNop("OPTIONS_DB_UI_TITLE_FONT_SIZE"),             16,                             RangedValidator<int>(4, 40));
 #else
@@ -626,7 +626,7 @@ ClientUI::ClientUI() :
     );
 
     // Set the root path for image tags in rich text.
-    GG::ImageBlock::SetDefaultImagePath(ArtDir().string());
+    GG::ImageBlock::SetDefaultImagePath(ArtDir());
 }
 
 ClientUI::~ClientUI()
@@ -1076,7 +1076,7 @@ std::shared_ptr<GG::Texture> ClientUI::GetTexture(const boost::filesystem::path&
     try {
         retval = GGHumanClientApp::GetApp()->GetTexture(path, mipmap);
     } catch (const std::exception& e) {
-        ErrorLogger() << "Unable to load texture \"" + path.generic_string() + "\"\n"
+        ErrorLogger() << "Unable to load texture \"" + PathToString(path) + "\"\n"
             "reason: " << e.what();
         try {
             retval = GGHumanClientApp::GetApp()->GetTexture(ClientUI::ArtDir() / "misc" / "missing.png", mipmap);
@@ -1084,7 +1084,7 @@ std::shared_ptr<GG::Texture> ClientUI::GetTexture(const boost::filesystem::path&
             return retval;
         }
     } catch (...) {
-        ErrorLogger() << "Unable to load texture \"" + path.generic_string() + "\"\n"
+        ErrorLogger() << "Unable to load texture \"" + PathToString(path) + "\"\n"
             "reason unknown...?";
         try {
             retval = GGHumanClientApp::GetApp()->GetTexture(ClientUI::ArtDir() / "misc" / "missing.png", mipmap);
@@ -1157,7 +1157,7 @@ const std::vector<std::shared_ptr<GG::Texture>>& ClientUI::GetPrefixedTextures(
         return EMPTY_VEC;
     }
 
-    std::string KEY{(dir / prefix.data()).string()};
+    std::string KEY{PathToString(dir / prefix.data())};
     auto prefixed_textures_it = m_prefixed_textures.find(KEY);
     if (prefixed_textures_it != m_prefixed_textures.end())
         return prefixed_textures_it->second;
@@ -1169,7 +1169,7 @@ const std::vector<std::shared_ptr<GG::Texture>>& ClientUI::GetPrefixedTextures(
         try {
             if (fs::exists(*it) &&
                 !fs::is_directory(*it) &&
-                boost::algorithm::starts_with(it->path().filename().string(), prefix))
+                boost::algorithm::starts_with(PathToString(it->path().filename()), prefix))
             { textures.push_back(ClientUI::GetTexture(*it, mipmap)); }
         } catch (const fs::filesystem_error& e) {
             // ignore files for which permission is denied, and rethrow other exceptions

--- a/UI/Sound.h
+++ b/UI/Sound.h
@@ -4,8 +4,6 @@
 #include <stdexcept>
 #include <memory>
 
-namespace boost::filesystem { class path; }
-
 class Sound {
 public:
     /** Temporarily disables UI sound effects, saving the old state (on or off), for later restoration upon object
@@ -28,7 +26,7 @@ public:
 
     /** Plays a music file.  The file will be played in an infinitve loop if \a loop is < 0, and it will be played \a
         loops + 1 times otherwise. */
-    void PlayMusic(const boost::filesystem::path& path, int loops = 0);
+    void PlayMusic(const std::string& path, int loops = 0);
 
     /** Pauses music play, to be continued from the same position */
     void PauseMusic();
@@ -40,10 +38,10 @@ public:
     void StopMusic();
 
     /** Plays a sound file. */
-    void PlaySound(const boost::filesystem::path& path, bool is_ui_sound = false);
+    void PlaySound(const std::string& path, bool is_ui_sound = false);
 
     /** Frees the cached sound data associated with the filename. */
-    void FreeSound(const boost::filesystem::path& path);
+    void FreeSound(const std::string& path);
 
     /** Frees all cached sound data. */
     void FreeAllSounds();


### PR DESCRIPTION
and some texture processing (tagged pedia images, prefixed images)

Fixes https://github.com/freeorion/freeorion/issues/4988

* OptionsDB in ClientUI would use path.string() to store some file paths -> use PathToString explicitly (because narrow conversions in boost::filesystem under windows may produce ??? for unrecognized chars in given codepage - and std::filesystem would even throw!)
* FreeOrion's Sound API would take boost::filesystem::path input but it was called with std::string, causing implicit conversion (failure point) -> make the API just take strings, and convert to wide string as needed for Windows, along using _fwopen instead of fopen (as a bonus on Linux etc there will be no back and forth conversions from std::string to boost::filesystem::path to std::string)
* FreeType's API FT_New_Face that takes narrow string path is also something that depends on locale and could cause failure to load -> fallback on reading file content ourselves and use FT_New_Memory_Face instead
* some texture operations were using troublesome string conversion, so fix those too in ClientUI -> GG::ImageBlock::SetDefaultImagePath takes filesystem::path, but was called with path.string(), causing unnecessary conversion path -> string -> path (and possible out-of-codepage conversion issues on Windows)