### PR TITLE
fix multiline color rendering issues by removing 255 stack limit on saved colors

### DIFF
--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -464,25 +464,23 @@ public:
         int8_t super_sub_shift = 0;
 
         /** The stack of text color indexes (as set by previous tags). */
-        std::stack<uint8_t> color_index_stack;
-
-        /** All colors that have been used. **/
-        std::vector<Clr> used_colors;
+        std::stack<Clr> color_stack;
 
         /// Add color to stack and remember it has been used
-        void PushColor(GLubyte r, GLubyte g, GLubyte b, GLubyte a);
-        void PushColor(Clr clr);
+        void PushColor(GLubyte r, GLubyte g, GLubyte b, GLubyte a) {
+            // The same color may end up being stored multiple times, but the cost of
+            // deduplication is greater than the cost of just letting it be so.
+            color_stack.emplace(r, g, b, a);
+        }
+        void PushColor(Clr clr) { color_stack.push(std::move(clr)); };
 
         /// Return to the previous used color, or remain as default
         void PopColor();
 
-        /// Return the index of the current color in used_colors
-        int CurrentIndex() const noexcept { return color_index_stack.top(); }
-
-        Clr CurrentColor() const;
+        Clr CurrentColor() const noexcept { return color_stack.top(); }
 
         /// Return true if there are no more colors to pop.
-        bool ColorsEmpty() const noexcept { return color_index_stack.size() <= 1; }
+        bool ColorsEmpty() const noexcept { return color_stack.size() <= 1; }
     };
 
     /** \brief Holds precomputed glyph position information for rendering. */

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -888,29 +888,14 @@ Font::RenderState::RenderState()
 }
 
 Font::RenderState::RenderState(Clr color)
-{ PushColor(color.r, color.g, color.b, color.a); }
-
-void Font::RenderState::PushColor(GLubyte r, GLubyte g, GLubyte b, GLubyte a)
-{
-    // The same color may end up being stored multiple times, but the cost of
-    // deduplication is greater than the cost of just letting it be so.
-    color_index_stack.push(static_cast<uint8_t>(used_colors.size()));
-    used_colors.emplace_back(r, g, b, a);
-}
-
-void Font::RenderState::PushColor(Clr clr)
-{ PushColor(clr.r, clr.g, clr.b, clr.a); }
+{ PushColor(color); }
 
 void Font::RenderState::PopColor()
 {
     // Never remove the initial color from the stack
-    if (color_index_stack.size() > 1)
-        color_index_stack.pop();
+    if (color_stack.size() > 1)
+        color_stack.pop();
 }
-
-Clr Font::RenderState::CurrentColor() const
-{ return used_colors[CurrentIndex()]; }
-
 
 ///////////////////////////////////////
 // class GG::Font::LineData::CharData


### PR DESCRIPTION
also get rid of indirection through index stack, just do color stack directly

Fixes https://github.com/freeorion/freeorion/issues/4946

I've seen that issues start popping after line 255, so that gave a lot away.

https://github.com/freeorion/freeorion/commit/d68bfe7f8e7f091c44c9e52b835495e18e5eafb6 has limited accounting for nested tags to 8 bits, which may be fair enough, but it also limited stack size of used colors, to 255, and that is not enough for things like chat window or even some pedia entries like about an Empire, which can have many more colored lines.

Looking at it I've also concluded the whole ordeal of going through index stack is not necessary if the colors aren't de-duplicated, anyway. Let's just go with color stack directly. 
