### PR TITLE
add priorities.macros to MILITARY_STRENGTH.focs.txt

### DIFF
--- a/default/scripting/empire_statistics/MILITARY_STRENGTH.focs.txt
+++ b/default/scripting/empire_statistics/MILITARY_STRENGTH.focs.txt
@@ -21,4 +21,5 @@ Statistic name = "MILITARY_STRENGTH_STAT" value =
             OwnedBy empire = Source.Owner
         ]
 
+#include "/scripting/macros/priorities.macros"
 #include "/scripting/macros/misc.macros"


### PR DESCRIPTION
avoids parse error coming from not knowing priorites in misc.macros

fixes https://github.com/freeorion/freeorion/issues/4998

I wonder if it would be better for the error to be a warning but doesn't change much

also if misc.macros should include priorities.macros rather than all other files including priorities.macros before misc.macros... doesn't matter much I suppose