### PR TITLE
some explicit utf8 path encoding to deal with out-of-codepage paths on Windows

### DIFF
--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -431,7 +431,7 @@ namespace {
             {
                 std::string file_name = GetOptionsDB().Get<std::string>("resource.stringtable.path");
                 std::string stringtable_str;
-                boost::filesystem::ifstream ifs(file_name);
+                boost::filesystem::ifstream ifs(FilenameToPath(file_name));
                 while (ifs) {
                     std::string line;
                     std::getline(ifs, line);
@@ -447,7 +447,7 @@ namespace {
                 DebugLogger() << "Non-default stringtable!";
                 std::string file_name = GetOptionsDB().GetDefault<std::string>("resource.stringtable.path");
                 std::string stringtable_str;
-                boost::filesystem::ifstream ifs(file_name);
+                boost::filesystem::ifstream ifs(FilenameToPath(file_name));
                 while (ifs) {
                     std::string line;
                     std::getline(ifs, line);

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -90,7 +90,7 @@ AIClientApp::AIClientApp(const std::vector<std::string>& args) {
     // Force the log file if requested.
     if (GetOptionsDB().Get<std::string>("log-file").empty()) {
         std::string ai_log_dir = GetOptionsDB().Get<std::string>("ai-log-dir");
-        const std::string AICLIENT_LOG_FILENAME(((ai_log_dir.empty() ? GetUserDataDir() : FilenameToPath(ai_log_dir)) / (m_player_name + ".log")).string());
+        std::string AICLIENT_LOG_FILENAME(PathToString((ai_log_dir.empty() ? GetUserDataDir() : FilenameToPath(ai_log_dir)) / (m_player_name + ".log")));
         GetOptionsDB().Set("log-file", AICLIENT_LOG_FILENAME);
     }
     // Force the log threshold if requested.

--- a/client/AI/AIFramework.cpp
+++ b/client/AI/AIFramework.cpp
@@ -112,8 +112,8 @@ auto PythonAI::InitModules() -> bool
 
     // Confirm existence of the directory containing the AI Python scripts
     // and add it to Pythons sys.path to make sure Python will find our scripts
-    std::string ai_path = boost::filesystem::canonical(GetResourceDir() / GetOptionsDB().Get<std::string>("ai-path")).string();
-    DebugLogger() << "AI Python script path: " << ai_path;
+    fs::path ai_path = fs::weakly_canonical(GetResourceDir() / FilenameToPath(GetOptionsDB().Get<std::string>("ai-path")));
+    DebugLogger() << "AI Python script path: " << PathToString(ai_path);
     if (!fs::exists(ai_path)) {
         ErrorLogger() << "Can't find folder containing AI scripts";
         return false;

--- a/client/AI/AIWrapper.cpp
+++ b/client/AI/AIWrapper.cpp
@@ -744,7 +744,7 @@ namespace FreeOrionPython {
         py::def("currentTurn",              CurrentTurn,       "Returns the current game turn (int).");
 
         py::def("getAIDir",
-                +[]() -> std::string { return (GetResourceDir() / GetOptionsDB().Get<std::string>("ai-path")).string(); },
+                +[]() -> std::string { return PathToString(GetResourceDir() / FilenameToPath(GetOptionsDB().Get<std::string>("ai-path"))); },
                 py::return_value_policy<py::return_by_value>());
 
         py::def("initMeterEstimatesDiscrepancies",

--- a/client/human/GGHumanClientApp.cpp
+++ b/client/human/GGHumanClientApp.cpp
@@ -232,7 +232,7 @@ GGHumanClientApp::GGHumanClientApp(int width, int height, bool calculate_fps, st
 
     // Force the log file if requested.
     if (GetOptionsDB().Get<std::string>("log-file").empty()) {
-        const std::string HUMAN_CLIENT_LOG_FILENAME((GetUserDataDir() / "freeorion.log").string());
+        const std::string HUMAN_CLIENT_LOG_FILENAME(PathToString(GetUserDataDir() / "freeorion.log"));
         GetOptionsDB().Set("log-file", HUMAN_CLIENT_LOG_FILENAME);
     }
     // Force the log threshold if requested.

--- a/python/PythonBase.cpp
+++ b/python/PythonBase.cpp
@@ -100,25 +100,29 @@ void PythonBase::Finalize() {
     }
 }
 
-void PythonBase::SetCurrentDir(const std::string dir) {
+void PythonBase::SetCurrentDir(const fs::path& dir) {
     if (!fs::exists(dir)) {
-        ErrorLogger() << "Tried setting current dir to non-existing dir: " << dir;
+        ErrorLogger() << "Tried setting current dir to non-existing dir: " << PathToString(dir);
         return;
     }
-    std::string script = "import os\n"
-    "os.chdir(r'" + dir + "')\n"
-    "print ('Python current directory set to', os.getcwd())";
-    exec(script.c_str(), *m_namespace, *m_namespace);
+    py::str script = "import os\n"
+        "os.chdir(r'";
+    script += dir.native();
+    script += "')\n"
+        "print ('Python current directory set to', os.getcwd())";
+    exec(script, *m_namespace, *m_namespace);
 }
 
-void PythonBase::AddToSysPath(const std::string dir) {
+void PythonBase::AddToSysPath(const fs::path& dir) {
     if (!fs::exists(dir)) {
-        ErrorLogger() << "Tried adding non-existing dir to sys.path: " << dir;
+        ErrorLogger() << "Tried adding non-existing dir to sys.path: " << PathToString(dir);
         return;
     }
-    std::string script = "import sys\n"
-        "sys.path.append(r'" + dir + "')";
-    exec(script.c_str(), *m_namespace, *m_namespace);
+    py::str script = "import sys\n"
+        "sys.path.append(r'";
+    script += dir.native();
+    script += "')";
+    exec(script, *m_namespace, *m_namespace);
 }
 
 void PythonBase::SetErrorModule(py::object& module)
@@ -149,8 +153,8 @@ std::vector<std::string> PythonBase::ErrorReport() {
     return err_list;
 }
 
-const std::string GetPythonDir()
-{ return GetResourceDir().string() + "/python"; }
+fs::path GetPythonDir()
+{ return GetResourceDir() / "python"; }
 
-const std::string GetPythonCommonDir()
+fs::path GetPythonCommonDir()
 { return GetPythonDir(); }

--- a/python/PythonBase.h
+++ b/python/PythonBase.h
@@ -11,6 +11,8 @@
 
 #include "../util/PythonCommon.h"
 
+namespace boost::filesystem { class path; }
+
 class PythonBase : public PythonCommon {
 public:
     PythonBase() = default;
@@ -20,9 +22,9 @@ public:
     virtual bool InitCommonImports() override;         // initializes Python imports, must be implemented by derived classes
     virtual bool InitImports() = 0;                    // initializes Python imports, must be implemented by derived classes
     virtual bool InitModules() = 0;                    // initializes Python modules, must be implemented by derived classes
-    void         SetCurrentDir(const std::string dir); // sets Python current work directory or throws error_already_set
-    void         AddToSysPath(const std::string dir);  // adds directory to Python sys.path or throws error_already_set
-    void         SetErrorModule(boost::python::object& module); // sets Python module that contains error report function defined on the Python side
+    void         SetCurrentDir(const boost::filesystem::path& dir); // sets Python current work directory or throws error_already_set
+    void         AddToSysPath(const boost::filesystem::path& dir);  // adds directory to Python sys.path or throws error_already_set
+    void         SetErrorModule(boost::python::object& module);     // sets Python module that contains error report function defined on the Python side
 
     std::vector<std::string> ErrorReport();            // wraps call to error report function defined on the Python side
 
@@ -34,10 +36,10 @@ private:
 };
 
 // returns root folder containing all the Python scripts
-const std::string GetPythonDir();
+boost::filesystem::path GetPythonDir();
 
 // returns folder containing common Python modules used by all Python scripts
-const std::string GetPythonCommonDir();
+boost::filesystem::path GetPythonCommonDir();
 
 
 #endif /* defined(__FreeOrion__Python__PythonBase__) */

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -93,7 +93,7 @@ ServerApp::ServerApp() :
 {
     // Force the log file if requested.
     if (GetOptionsDB().Get<std::string>("log-file").empty()) {
-        const std::string SERVER_LOG_FILENAME((GetUserDataDir() / "freeoriond.log").string());
+        const std::string SERVER_LOG_FILENAME(PathToString(GetUserDataDir() / "freeoriond.log"));
         GetOptionsDB().Set("log-file", SERVER_LOG_FILENAME);
     }
     // Force the log threshold if requested.
@@ -182,7 +182,7 @@ namespace {
 #else
             "freeorionca";
 #endif
-        return (GetBinDir() / ai_client_exe_filename).string();
+        return PathToString(GetBinDir() / ai_client_exe_filename);
     }
 }
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -192,7 +192,7 @@ namespace {
 
         std::string save_filename = boost::io::str(boost::format("FreeOrion_%04d_%s%s") % current_turn % datetime_str % extension);
         boost::filesystem::path save_path(autosave_dir_path / save_filename);
-        return save_path.string();
+        return PathToString(save_path);
     }
 
     bool IsMultiplayerSaveFile(const boost::filesystem::path& path)
@@ -1836,7 +1836,7 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
 
             if (!m_lobby_data->new_game) {
                 // Load game ...
-                std::string save_filename = (GetServerSaveDir() / m_lobby_data->save_game).string();
+                std::string save_filename = PathToString((GetServerSaveDir() / m_lobby_data->save_game));
 
                 try {
                     LoadGame(save_filename,             *m_server_save_game_data,

--- a/server/ServerFramework.cpp
+++ b/server/ServerFramework.cpp
@@ -5,6 +5,7 @@
 #include "../python/CommonWrappers.h"
 
 #include "../util/Logger.h"
+#include "../util/Directories.h"
 #include "../universe/Condition.h"
 #include "../universe/Universe.h"
 
@@ -62,31 +63,34 @@ auto PythonServer::InitModules() -> bool
     // Confirm existence of the directory containing the universe generation
     // Python scripts and add it to Pythons sys.path to make sure Python will
     // find our scripts
-    if (!fs::exists(GetPythonUniverseGeneratorDir())) {
-        ErrorLogger() << "Can't find folder containing universe generation scripts";
+    auto python_universe_generator_dir = GetPythonUniverseGeneratorDir();
+    if (!fs::exists(python_universe_generator_dir)) {
+        ErrorLogger() << "Can't find folder containing universe generation scripts: " << PathToString(python_universe_generator_dir);
         return false;
     }
-    AddToSysPath(GetPythonUniverseGeneratorDir());
+    AddToSysPath(python_universe_generator_dir);
 
     // Confirm existence of the directory containing the turn event Python
     // scripts and add it to Pythons sys.path to make sure Python will find
     // our scripts
-    if (!fs::exists(GetPythonTurnEventsDir())) {
-        ErrorLogger() << "Can't find folder containing turn events scripts";
+    auto python_turn_events_dir = GetPythonTurnEventsDir();
+    if (!fs::exists(python_turn_events_dir)) {
+        ErrorLogger() << "Can't find folder containing turn events scripts:" << PathToString(python_turn_events_dir);
         return false;
     }
-    AddToSysPath(GetPythonTurnEventsDir());
+    AddToSysPath(python_turn_events_dir);
 
     // import universe generator script file
     m_python_module_turn_events = py::import("turn_events");
 
     // Confirm existence of the directory containing the auth Python scripts
     // and add it to Pythons sys.path to make sure Python will find our scripts
-    if (!fs::exists(GetPythonAuthDir())) {
-        ErrorLogger() << "Can't find folder containing auth scripts";
+    auto python_auth_dir = GetPythonAuthDir();
+    if (!fs::exists(python_auth_dir)) {
+        ErrorLogger() << "Can't find folder containing auth scripts:" << PathToString(python_auth_dir);
         return false;
     }
-    AddToSysPath(GetPythonAuthDir());
+    AddToSysPath(python_auth_dir);
 
     // import auth script file
     m_python_module_auth = py::import("auth");
@@ -282,11 +286,12 @@ auto PythonServer::CreateUniverse(std::map<int, PlayerSetupData>& player_setup_d
     // Confirm existence of the directory containing the universe generation
     // Python scripts and add it to Pythons sys.path to make sure Python will
     // find our scripts
-    if (!fs::exists(GetPythonUniverseGeneratorDir())) {
-        ErrorLogger() << "Can't find folder containing universe generation scripts";
+    auto python_universe_generator_dir = GetPythonUniverseGeneratorDir();
+    if (!fs::exists(python_universe_generator_dir)) {
+        ErrorLogger() << "Can't find folder containing universe generation scripts: " << PathToString(python_universe_generator_dir);
         return false;
     }
-    AddToSysPath(GetPythonUniverseGeneratorDir());
+    AddToSysPath(python_universe_generator_dir);
 
     // import universe generator script file
     m_python_module_universe_generator = py::import("universe_generator");
@@ -338,14 +343,14 @@ auto PythonServer::AsyncIOTick() -> bool
     return true;
 }
 
-auto GetPythonUniverseGeneratorDir() -> const std::string
-{ return GetPythonDir() + "/universe_generation"; }
+auto GetPythonUniverseGeneratorDir() -> fs::path
+{ return GetPythonDir() / "universe_generation"; }
 
-auto GetPythonTurnEventsDir() -> const std::string
-{ return GetPythonDir() + "/turn_events"; }
+auto GetPythonTurnEventsDir() -> fs::path
+{ return GetPythonDir() / "turn_events"; }
 
-auto GetPythonAuthDir() -> const std::string
-{ return GetPythonDir() + "/auth"; }
+auto GetPythonAuthDir() -> fs::path
+{ return GetPythonDir() / "auth"; }
 
-auto GetPythonChatDir() -> const std::string
-{ return GetPythonDir() + "/chat"; }
+auto GetPythonChatDir() -> fs::path
+{ return GetPythonDir() / "chat"; }

--- a/server/ServerFramework.h
+++ b/server/ServerFramework.h
@@ -44,16 +44,16 @@ private:
 };
 
 // Returns folder containing the Python universe generator scripts
-const std::string GetPythonUniverseGeneratorDir();
+boost::filesystem::path GetPythonUniverseGeneratorDir();
 
 // Returns folder containing the Python turn events scripts
-const std::string GetPythonTurnEventsDir();
+boost::filesystem::path GetPythonTurnEventsDir();
 
 // Returns folder containing the Python auth scripts
-const std::string GetPythonAuthDir();
+boost::filesystem::path GetPythonAuthDir();
 
 // Returns folder containing the Python chat scripts
-const std::string GetPythonChatDir();
+boost::filesystem::path GetPythonChatDir();
 
 
 #endif

--- a/util/Logger.cpp
+++ b/util/Logger.cpp
@@ -23,6 +23,8 @@
 #include <boost/optional.hpp>
 #include <boost/unordered_map.hpp>
 
+#include "Directories.h"
+
 #ifdef _MSC_VER
 #  include <ctime>
 #else
@@ -275,7 +277,7 @@ void InitLoggingSystem(const std::string& log_file, std::string_view _unnamed_lo
     // Create a sink backend that logs to a file
     auto& file_sink_backend = FileSinkBackend();
     file_sink_backend = boost::make_shared<LoggerTextFileSinkFrontend::sink_backend_type>(
-        keywords::file_name = log_file.c_str(),
+        keywords::file_name = FilenameToPath(log_file),
         keywords::auto_flush = true
     );
 

--- a/util/StringTable.cpp
+++ b/util/StringTable.cpp
@@ -146,7 +146,7 @@ void StringTable::Load(std::shared_ptr<const StringTable> fallback) {
     bool read_success = ReadFile(path, file_contents);
     if (!read_success) {
         [[unlikely]]
-        ErrorLogger() << "StringTable::Load failed to read file at path: " << path.string();
+        ErrorLogger() << "StringTable::Load failed to read file at path: " << m_filename;
         //m_initialized intentionally left false
         return;
     }

--- a/util/i18n.cpp
+++ b/util/i18n.cpp
@@ -131,22 +131,21 @@ namespace {
         // set option default value based on system locale
         auto default_stringtable_path = GetDefaultStringTableFileName();
         auto default_stringtable_path_string = PathToString(default_stringtable_path);
-        GetOptionsDB().SetDefault("resource.stringtable.path", PathToString(default_stringtable_path));
+        GetOptionsDB().SetDefault("resource.stringtable.path", default_stringtable_path_string);
 
         // get option-configured stringtable path. may be the default empty
         // string (set by call to:   db.Add<std::string>("resource.stringtable.path" ...
         // or this may have been overridden from one of the config XML files or from
         // a command line argument.
         std::string option_path = GetOptionsDB().Get<std::string>("resource.stringtable.path");
-        boost::filesystem::path stringtable_path{option_path};
+        boost::filesystem::path stringtable_path = FilenameToPath(option_path);
 
         // verify that option-derived stringtable file exists, with fallbacks
         DebugLogger() << "Stringtable option path: " << option_path;
 
         if (option_path.empty()) {
             DebugLogger() << "Stringtable option path not specified yet, using default: " << default_stringtable_path_string;
-            stringtable_path = std::move(default_stringtable_path_string);
-            GetOptionsDB().Set("resource.stringtable.path", PathToString(stringtable_path));
+            GetOptionsDB().Set("resource.stringtable.path", default_stringtable_path_string);
             stringtable_filename_init = true;
             return;
         }
@@ -156,12 +155,12 @@ namespace {
         if (!IsExistingFile(stringtable_path)) {
             set_option = true;
             // try interpreting path as a filename located in the stringtables directory
-            stringtable_path = GetResourceDir() / "stringtables" / option_path;
+            stringtable_path = GetResourceDir() / "stringtables" / FilenameToPath(option_path);
         }
         if (!IsExistingFile(stringtable_path)) {
             set_option = true;
             // try interpreting path as directory and filename in resources directory
-            stringtable_path = GetResourceDir() / option_path;
+            stringtable_path = GetResourceDir() / FilenameToPath(option_path);
         }
         if (!IsExistingFile(stringtable_path)) {
             set_option = true;


### PR DESCRIPTION
allows FreeOrionD.exe and FreeOrionCA.exe to start off such path

Fixes https://github.com/freeorion/freeorion/issues/4991

Though one would require https://github.com/freeorion/freeorion/pull/4987 to make main app FreeOrion.exe start, too

And https://github.com/freeorion/freeorion/issues/4988 to have sounds and graphics