### PR TITLE
Fixing Chat Formatting

### DIFF
--- a/GG/GG/DrawUtil.h
+++ b/GG/GG/DrawUtil.h
@@ -67,6 +67,10 @@ GG_API void EndStencilClipping();
     color and thickness. */
 GG_API void Line(Pt pt1, Pt pt2, Clr color, float thick = 1.0f);
 
+/** Renders a line between the specified coordinates, with the specified
+    color and thickness. */
+GG_API void Line(X x1, Y y1, X x2, Y y2, Clr color, float thick = 1.0f);
+
 /** Renders line between specified coordinates. */
 GG_API void Line(X x1, Y y1, X x2, Y y2);
 

--- a/GG/GG/Edit.h
+++ b/GG/GG/Edit.h
@@ -128,9 +128,13 @@ protected:
         the focus was gained. */
     bool RecentlyEdited() const noexcept { return m_recently_edited; }
 
-    /** Returns the index of the code point \a x pixels from left edge of
+    /** Returns the index of the glyph \a x pixels from left edge of
         visible portion of string. */
-    CPSize GlyphIndexOf(X x) const;
+    CPSize GlyphIndexAt(X x) const;
+
+    /** Returns the code point index of the start of the glyph \a x pixels from left edge of
+        visible portion of string. */
+    CPSize CPIndexOfGlyphAt(X x) const;
 
     /** Returns the distance from the beginning of the string to just before
         the first visible character. */
@@ -174,14 +178,14 @@ protected:
         exists, the returned range will be empty (its .first and .second
         members will be equal).  This function should be called in
         LButtonDown() overrides. */
-    virtual std::pair<CPSize, CPSize> GetDoubleButtonDownWordIndices(CPSize char_index);
+    virtual std::pair<CPSize, CPSize> GetDoubleButtonDownWordIndices(CPSize cp_index);
 
     /** Returns the code point indices that delimit the word around index \a
         char_index.  If no such word exists, the returned range will be empty
         (its .first and .second members will be equal).  This function should
         be called in LDrag() overrides when InDoubleButtonDownMode() is
         true. */
-    virtual std::pair<CPSize, CPSize> GetDoubleButtonDownDragWordIndices(CPSize char_index);
+    virtual std::pair<CPSize, CPSize> GetDoubleButtonDownDragWordCPIndices(CPSize cp_index);
 
     /** Sets the value of InDoubleButtonDownMode() to false.  This should be
         called in LClick() and LButtonUp() overrides. */

--- a/GG/GG/Edit.h
+++ b/GG/GG/Edit.h
@@ -69,7 +69,7 @@ public:
     auto CursorPosn() const noexcept { return m_cursor_pos; }
 
     /** Returns the text that is selected in this control. */
-    std::string_view SelectedText() const { return Text(m_cursor_pos.first, m_cursor_pos.second); }
+    std::string_view SelectedText() const;
 
     /** Returns the color used to render the iterior of the control. */
     Clr InteriorColor() const noexcept { return m_int_color; }
@@ -187,7 +187,8 @@ protected:
         called in LClick() and LButtonUp() overrides. */
     void ClearDoubleButtonDownMode();
 
-    /** If .first == .second, the caret is drawn before character at
+    /** Code point indices (not glyphs) of cursor.
+        If .first == .second, the caret is drawn before character at
         m_cursor_pos.first; otherwise, the range is selected (when range is
         selected, caret is considered at .second) */
     std::pair<CPSize, CPSize> m_cursor_pos = {CP0, CP0};

--- a/GG/GG/Edit.h
+++ b/GG/GG/Edit.h
@@ -130,7 +130,7 @@ protected:
 
     /** Returns the index of the code point \a x pixels from left edge of
         visible portion of string. */
-    CPSize CharIndexOf(X x) const;
+    CPSize GlyphIndexOf(X x) const;
 
     /** Returns the distance from the beginning of the string to just before
         the first visible character. */

--- a/GG/GG/Edit.h
+++ b/GG/GG/Edit.h
@@ -77,9 +77,6 @@ public:
     /** Returns the color used to render hiliting around selected text. */
     Clr HiliteColor() const noexcept { return m_hilite_color; }
 
-    /** Returns the color used to render selected text. */
-    Clr SelectedTextColor() const noexcept { return m_sel_text_color; }
-
     /** The edited signal object for this Edit. */
     mutable EditedSignalType EditedSignal;
 
@@ -95,9 +92,6 @@ public:
 
     /** Sets the color used to render hiliting around selected text. */
     void SetHiliteColor(Clr c);
-
-    /** Sets the color used to render selected text. */
-    void SetSelectedTextColor(Clr c);
 
     /** Selects all text in the given range.  When \a from == \a to, this
         function just places the caret at \a from.  Note that it is legal to
@@ -208,7 +202,6 @@ private:
     CPSize m_first_char_shown = CP0;    ///< Index of the first character on the left end of the control's viewable area
     Clr    m_int_color;                 ///< Color of background inside text box
     Clr    m_hilite_color = CLR_SHADOW; ///< Color behind selected range
-    Clr    m_sel_text_color = CLR_WHITE;///< Color of selected text
 
     bool   m_recently_edited = false; ///< The contents when the focus was last gained
 };

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -861,7 +861,7 @@ GG_API StrSize StringIndexOf(std::size_t line, CPSize index,
 GG_API std::pair<std::size_t, CPSize>
 LinePositionOf(CPSize index, const std::vector<Font::LineData>& line_data);
 
-GG_API std::pair<StrSize, StrSize> CodePointIndicesRangeToStringSizeIndices(
+GG_API std::pair<StrSize, StrSize> GlyphIndicesRangeToStringSizeIndices(
     CPSize start_idx, CPSize end_idx, const std::vector<Font::LineData>& line_data);
 
 /** \brief A singleton that loads and stores fonts for use by GG.

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -471,6 +471,8 @@ public:
         Alignment justification = ALIGN_CENTER;
     };
 
+
+
     /** \brief Holds the state of tags during rendering of text.
 
         By keeping track of this state across multiple calls to RenderText(),

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -215,9 +215,14 @@ public:
         [[nodiscard]] CONSTEXPR_FONT operator std::string_view() const noexcept(op_sv_nox) { return {data(), size()}; }
 
         /** Comparison with std::string. */
-        bool operator==(const std::string& rhs) const;
-        bool operator==(std::string_view rhs) const;
-        bool operator==(const Substring& rhs) const;
+        CONSTEXPR_FONT bool operator==(const std::string& rhs) const
+        { return size() == rhs.size() && std::string_view(*this) == rhs; }
+
+        CONSTEXPR_FONT bool operator==(std::string_view rhs) const
+        { return size() == rhs.size() && std::string_view(*this) == rhs; }
+
+        CONSTEXPR_FONT bool operator==(const Substring& rhs) const
+        { return size() == rhs.size() && std::string_view(*this) == std::string_view(rhs); }
 
         /** Concatenation with base.  \a rhs.first must be <= \a rhs.second.
           * .second must be equal to \a rhs.first (*this and \a rhs must be contiguous). */

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -700,7 +700,7 @@ public:
     static void RegisterKnownTags(std::vector<std::string_view> tags);
 
     /** Returns the input \a text, stripped of any formatting tags. */
-    static std::string StripTags(std::string_view text, bool strip_unpaired_tags = true);
+    static std::string StripTags(std::string_view text);
 
     /** The base class for Font exceptions. */
     GG_ABSTRACT_EXCEPTION(Exception);

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -840,6 +840,9 @@ private:
 /** Stream output operator for Font::Substring. */
 GG_API std::ostream& operator<<(std::ostream& os, Font::Substring substr);
 
+GG_API CPSize GlyphIndexOf(std::size_t line_index, CPSize glyph_index,
+                           const std::vector<Font::LineData>& line_data);
+
 /** Returns the code point index of the <i>index</i>-th glyph on line \a
     line within the text represented by \a line_data.  Returns the index of
     the code point one past the end of the text if \a line is out of bounds.

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -329,7 +329,18 @@ public:
         [[nodiscard]] CONSTEXPR_FONT bool IsNewline() const noexcept { return type == TextElementType::NEWLINE; }
 
         /** Returns the width of the element. */
-        [[nodiscard]] X Width() const;
+        [[nodiscard]] CONSTEXPR_FONT X Width() const
+        {
+            if (cached_width == -X1)
+                cached_width = [](const auto& widths) -> X {
+                    X rv = X0;
+                    for (const auto& w : widths)
+                        rv += w;
+                    return rv;
+                }(widths);
+            return cached_width;
+        }
+
 
         /* Returns the number of characters in the original string that the
            element represents. */

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -861,6 +861,8 @@ GG_API StrSize StringIndexOf(std::size_t line, CPSize index,
 GG_API std::pair<std::size_t, CPSize>
 LinePositionOf(CPSize index, const std::vector<Font::LineData>& line_data);
 
+GG_API std::pair<StrSize, StrSize> CodePointIndicesRangeToStringSizeIndices(
+    CPSize start_idx, CPSize end_idx, const std::vector<Font::LineData>& line_data);
 
 /** \brief A singleton that loads and stores fonts for use by GG.
 

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -840,16 +840,20 @@ private:
 /** Stream output operator for Font::Substring. */
 GG_API std::ostream& operator<<(std::ostream& os, Font::Substring substr);
 
-GG_API CPSize GlyphIndexOf(std::size_t line_index, CPSize glyph_index,
-                           const std::vector<Font::LineData>& line_data);
+GG_API CPSize GlyphIndexOfLineAndGlyph(std::size_t line_index, CPSize glyph_index,
+                                       const std::vector<Font::LineData>& line_data);
 
 /** Returns the code point index of the <i>index</i>-th glyph on line \a
     line within the text represented by \a line_data.  Returns the index of
     the code point one past the end of the text if \a line is out of bounds.
     Returns the index of the next previous code point from the end of line
     \a line if \a glyph_index is out of bounds on that line. */
-GG_API CPSize CodePointIndexOf(std::size_t line_index, CPSize glyph_index,
-                               const std::vector<Font::LineData>& line_data);
+GG_API CPSize CodePointIndexOfLineAndGlyph(std::size_t line_index, CPSize glyph_index,
+                                           const std::vector<Font::LineData>& line_data);
+
+GG_API CPSize CodePointIndexOfLineAndCodePoint(std::size_t line_index, CPSize cp_index,
+                                               const std::vector<Font::LineData>& line_data);
+
 
 /** Returns the code point index (CPI) after the previous glyph to the glyph at \a glyph_index.
   *
@@ -865,22 +869,32 @@ GG_API CPSize CodePointIndexOf(std::size_t line_index, CPSize glyph_index,
 GG_API CPSize CodePointIndexAfterPreviousGlyph(std::size_t line_index, CPSize glyph_index,
                                                const std::vector<Font::LineData>& line_data);
 
-/** Returns the string index of the <i>index</i>-th code point on line \a line
+/** Returns the string index of the <i>index</i>-th glyph on line \a line
     within the text represented by \a line_data.  Returns the index of the
     character one past the end of the text if \a line or \a index are out of
     bounds. */
-GG_API StrSize StringIndexOf(std::size_t line, CPSize index,
-                             const std::vector<Font::LineData>& line_data);
+GG_API StrSize StringIndexOfLineAndGlyph(std::size_t line, CPSize index,
+                                         const std::vector<Font::LineData>& line_data);
+
+/** Returns the string indiex of the <i>index</i>-th code point in \a line_data */
+GG_API StrSize StringIndexOfCodePoint(CPSize index, const std::vector<Font::LineData>& line_data);
 
 /** Returns the line L and the code point index within L of the
-    <i>index</i>-th code point within the text represented by \a line_data.
+    <i>index</i>-th glyph within the text represented by \a line_data.
     Returns (std::numeric_limits<std::size_t>::max(), INVALID_CP_SIZE) if \a
     index is out of bounds. */
 GG_API std::pair<std::size_t, CPSize>
-LinePositionOf(CPSize index, const std::vector<Font::LineData>& line_data);
+LinePositionOfGlyph(CPSize index, const std::vector<Font::LineData>& line_data);
+
+GG_API std::pair<std::size_t, CPSize>
+LinePositionOfCodePoint(CPSize index, const std::vector<Font::LineData>& line_data);
 
 GG_API std::pair<StrSize, StrSize> GlyphIndicesRangeToStringSizeIndices(
     CPSize start_idx, CPSize end_idx, const std::vector<Font::LineData>& line_data);
+
+GG_API std::pair<StrSize, StrSize> CodePointIndicesRangeToStringSizeIndices(
+    CPSize start_idx, CPSize end_idx, const std::vector<Font::LineData>& line_data);
+
 
 /** \brief A singleton that loads and stores fonts for use by GG.
 

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -660,20 +660,8 @@ public:
     /** Sets \a render_state as if all the text in \a char_data had just been rendered. */
     static void ProcessLineTags(const std::vector<LineData::CharData>& char_data, RenderState& render_state);
 
-
-    /** Return a vector of TextElements parsed from \p text, using the
-        FORMAT_IGNORETAGS bit in \p format to determine if all KnownTags()
-        are ignored.
-
-        This function is costly even on single character texts. Do not call
-        it from tight loops.  Do not call it from within Render().  Do not
-        call it repeatedly on a known text.
-    */
-    std::vector<Font::TextElement> ExpensiveParseFromTextToTextElements(
-        const std::string& text, const Flags<TextFormat> format) const;
-
     /** \brief This just holds the essential data necessary to render a glyph
-    from the OpenGL texture(s) created at GG::Font creation time. */
+        from the OpenGL texture(s) created at GG::Font creation time. */
     struct Glyph
     {
         Glyph() = default;
@@ -687,6 +675,20 @@ public:
     };
 
     using GlyphMap = boost::unordered_map<uint32_t, Glyph>;
+
+    /** Return a vector of TextElements parsed from \p text, using the
+        FORMAT_IGNORETAGS bit in \p format to determine if all KnownTags()
+        are ignored.
+
+        This function is costly even on single character texts. Do not call
+        it from tight loops.  Do not call it from within Render().  Do not
+        call it repeatedly on a known text. */
+    static std::vector<Font::TextElement> ExpensiveParseFromTextToTextElements(
+        const std::string& text, const Flags<TextFormat> format, const GlyphMap& glyphs, int8_t space_width);
+    std::vector<Font::TextElement> ExpensiveParseFromTextToTextElements(
+        const std::string& text, const Flags<TextFormat> format) const
+    { return ExpensiveParseFromTextToTextElements(text, format, m_glyphs, m_space_width); }
+
 
     /** Change \p text_elements and \p text to replace the text of the TextElement at
         \p targ_offset with \p new_text.

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -840,12 +840,27 @@ private:
 /** Stream output operator for Font::Substring. */
 GG_API std::ostream& operator<<(std::ostream& os, Font::Substring substr);
 
-/** Returns the code point index of the <i>index</i>-th code point on line \a
+/** Returns the code point index of the <i>index</i>-th glyph on line \a
     line within the text represented by \a line_data.  Returns the index of
-    the code point one past the end of the text if \a line or \a index are out
-    of bounds. */
-GG_API CPSize CodePointIndexOf(std::size_t line, CPSize index,
+    the code point one past the end of the text if \a line is out of bounds.
+    Returns the index of the next previous code point from the end of line
+    \a line if \a glyph_index is out of bounds on that line. */
+GG_API CPSize CodePointIndexOf(std::size_t line_index, CPSize glyph_index,
                                const std::vector<Font::LineData>& line_data);
+
+/** Returns the code point index (CPI) after the previous glyph to the glyph at \a glyph_index.
+  *
+  * Ranges of glyphs are specified [closed, open) eg. [1, 3) includes glyphs
+  * 1 and 2, but not the 3rd glyph. If finding the corresponding CPI range,
+  * for the end glyph, the result should not include any CPI after the end of
+  * the second to last glyph, even if there are non-glyph code points between them.
+  *
+  * For example, "ab<i>c" has glyphs at CPIs 0 (a), 1 (b), and 5 (c) and also has
+  * non-glyph (ie. tag) CPIs 2 (<), 3 (i), and 4 (>). If just getting the CPI for
+  * the starts of glyphs, the end glyph would start at code point 5 (c), but the
+  * CPI after the last glyph included in the range is actually 2 (<). */
+GG_API CPSize CodePointIndexAfterPreviousGlyph(std::size_t line_index, CPSize glyph_index,
+                                               const std::vector<Font::LineData>& line_data);
 
 /** Returns the string index of the <i>index</i>-th code point on line \a line
     within the text represented by \a line_data.  Returns the index of the

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -223,7 +223,7 @@ public:
             return *this;
         }
 
-        Substring() noexcept = default;
+        constexpr Substring() noexcept = default;
 
     private:
         static const std::string EMPTY_STRING;
@@ -708,7 +708,7 @@ public:
     static void ClearKnownTags();
 
     /** Returns the input \a text, stripped of any formatting tags. */
-    static std::string StripTags(std::string_view text, bool strip_unpaired_tags = true);
+    static std::string StripTags(std::string_view text);
 
     /** The base class for Font exceptions. */
     GG_ABSTRACT_EXCEPTION(Exception);

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -976,21 +976,6 @@ GG_API FontManager& GetFontManager();
 GG_EXCEPTION(FailedFTLibraryInit);
 
 namespace detail {
-    template <typename CharT, bool CharIsSigned = std::is_signed_v<CharT>>
-    struct ValidUTFChar;
-
-    template <typename CharT>
-    struct ValidUTFChar<CharT, true>
-    {
-        constexpr bool operator()(CharT c) noexcept { return 0x0 <= c; }
-    };
-
-    template <typename CharT>
-    struct ValidUTFChar<CharT, false>
-    {
-        constexpr bool operator()(CharT c) noexcept { return c <= 0x7f; }
-    };
-
     struct GG_API FTFaceWrapper
     {
         FTFaceWrapper() = default;

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -699,16 +699,8 @@ public:
         "<foo [arg1 [arg2 ...]]>", and "</foo>" as tags. */
     static void RegisterKnownTags(std::vector<std::string_view> tags);
 
-    /** Removes \a tag from the known tag list.  Does not remove the built in
-        tags: \<i>, \<u>, \<rgba r g b a>, and \<pre>. */
-    static void RemoveKnownTag(std::string_view tag);
-
-    /** Removes all tags from the known tag list.  Does not remove the built
-        in tags: \<i>, \<u>, \<rgba r g b a>, and \<pre>. */
-    static void ClearKnownTags();
-
     /** Returns the input \a text, stripped of any formatting tags. */
-    static std::string StripTags(std::string_view text);
+    static std::string StripTags(std::string_view text, bool strip_unpaired_tags = true);
 
     /** The base class for Font exceptions. */
     GG_ABSTRACT_EXCEPTION(Exception);

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -42,6 +42,11 @@ class GL2DVertexBuffer;
     channels r, b, g, a. */
 GG_API std::string RgbaTag(Clr c);
 
+#if defined(__cpp_lib_constexpr_vector) && defined(__cpp_lib_constexpr_string)
+#  define CONSTEXPR_FONT constexpr
+#else
+#  define CONSTEXPR_FONT
+#endif
 
 /** \brief A bitmapped font rendering class.
 
@@ -135,15 +140,15 @@ public:
     public:
         using IterPair = std::pair<std::string::const_iterator, std::string::const_iterator>;
 
-        explicit Substring(const std::string& str_) noexcept :
+        CONSTEXPR_FONT explicit Substring(const std::string& str_) noexcept :
             str(&str_)
         {}
-        constexpr explicit Substring(const std::string* str_) noexcept :
+        CONSTEXPR_FONT explicit Substring(const std::string* str_) noexcept :
             str(str_)
         {}
 
         /** Construction from two offsets. \a first_ must be <= \a second_. */
-        constexpr Substring(const std::string* str_, uint32_t first_, uint32_t second_) noexcept :
+        CONSTEXPR_FONT Substring(const std::string* str_, uint32_t first_, uint32_t second_) noexcept :
             str(str_),
             first(first_),
             second(second_)
@@ -153,24 +158,24 @@ public:
             assert(second_ <= str->size());
         }
         template <typename T, std::enable_if_t<std::is_unsigned_v<T>>* = nullptr>
-        Substring(const std::string& str_, T first_, T second_) noexcept :
+        CONSTEXPR_FONT Substring(const std::string& str_, T first_, T second_) noexcept :
             Substring(&str_, static_cast<uint32_t>(first_), static_cast<uint32_t>(second_))
         {}
 
-        Substring(const std::string& str_, std::ptrdiff_t first_, std::ptrdiff_t second_) noexcept :
+        CONSTEXPR_FONT Substring(const std::string& str_, std::ptrdiff_t first_, std::ptrdiff_t second_) noexcept :
             Substring(str_, static_cast<uint32_t>(first_), static_cast<uint32_t>(second_))
         {}
 
         /** Construction from two iterators. \a first_ must be <= \a second_.
           * Both must be valid iterators into \a str_. */
-        Substring(const std::string& str_,
-                  std::string::const_iterator first_,
-                  std::string::const_iterator second_) :
+        CONSTEXPR_FONT Substring(const std::string& str_,
+                                 std::string::const_iterator first_,
+                                 std::string::const_iterator second_) :
             Substring(str_,
                       static_cast<uint32_t>(std::distance(str_.begin(), first_)),
                       static_cast<uint32_t>(std::distance(str_.begin(), second_)))
         {}
-        Substring(const std::string& str_, const IterPair& pair) :
+        CONSTEXPR_FONT Substring(const std::string& str_, const IterPair& pair) :
             Substring(str_, pair.first, pair.second)
         {}
 
@@ -178,36 +183,36 @@ public:
         /** Attach this Substring to \p str_.
           * This changes any future-returned iterators from pointing into the previously-bound
           * string to pointing into \p str_. */
-        void Bind(const std::string& str_) noexcept
+        CONSTEXPR_FONT void Bind(const std::string& str_) noexcept
         {
             assert(std::distance(str_.begin(), str_.end()) >= second);
             str = &str_;
         }
 
-        [[nodiscard]] auto data() const noexcept -> const std::string::value_type*
+        [[nodiscard]] CONSTEXPR_FONT auto data() const noexcept -> const std::string::value_type*
         { return (str && (str->size() >= first)) ? (str->data() + first) : EMPTY_STRING.data(); }
 
         /** Returns an iterator to the beginning of the substring. */
-        [[nodiscard]] auto begin() const noexcept -> std::string::const_iterator
+        [[nodiscard]] CONSTEXPR_FONT auto begin() const noexcept -> std::string::const_iterator
         { return (str && str->size() >= first) ? (str->cbegin() + first) : EMPTY_STRING.cbegin(); }
 
         /** Returns an iterator to one-past-the-end of the substring. */
-        [[nodiscard]] auto end() const noexcept -> std::string::const_iterator
+        [[nodiscard]] CONSTEXPR_FONT auto end() const noexcept -> std::string::const_iterator
         { return (str && str->size() >= second) ? (str->cbegin() + second) : EMPTY_STRING.cend(); }
 
         /** True iff .first == .second. */
-        [[nodiscard]] bool empty() const noexcept { return first == second; }
+        [[nodiscard]] CONSTEXPR_FONT bool empty() const noexcept { return first == second; }
 
-        [[nodiscard]] bool IsDefaultEmpty() const noexcept { return str == &EMPTY_STRING; }
+        [[nodiscard]] CONSTEXPR_FONT bool IsDefaultEmpty() const noexcept { return str == &EMPTY_STRING; }
 
         /** Length, in original string chars, of the substring. */
-        [[nodiscard]] std::size_t size() const noexcept { return static_cast<std::size_t>(second - first); }
-        [[nodiscard]] auto offsets() const noexcept { return std::pair<uint32_t, uint32_t>{first, second}; }
+        [[nodiscard]] CONSTEXPR_FONT std::size_t size() const noexcept { return static_cast<std::size_t>(second - first); }
+        [[nodiscard]] CONSTEXPR_FONT auto offsets() const noexcept { return std::pair<uint32_t, uint32_t>{first, second}; }
 
         /** Implicit conversion to std::string. */
-        [[nodiscard]] operator std::string() const { return std::string(begin(), end()); }
+        [[nodiscard]] CONSTEXPR_FONT operator std::string() const { return std::string(begin(), end()); }
         static constexpr bool op_sv_nox = noexcept(std::string_view{(const char*)(nullptr), std::size_t{}});
-        [[nodiscard]] operator std::string_view() const noexcept(op_sv_nox) { return {data(), size()}; }
+        [[nodiscard]] CONSTEXPR_FONT operator std::string_view() const noexcept(op_sv_nox) { return {data(), size()}; }
 
         /** Comparison with std::string. */
         bool operator==(const std::string& rhs) const;
@@ -216,7 +221,7 @@ public:
 
         /** Concatenation with base.  \a rhs.first must be <= \a rhs.second.
           * .second must be equal to \a rhs.first (*this and \a rhs must be contiguous). */
-        Substring& operator+=(const IterPair& rhs)
+        CONSTEXPR_FONT Substring& operator+=(const IterPair& rhs)
         {
             assert(rhs.first <= rhs.second);
             assert(std::distance(str->begin(), rhs.first) == second);
@@ -224,11 +229,15 @@ public:
             return *this;
         }
 
-        constexpr Substring() noexcept = default;
+        CONSTEXPR_FONT Substring() noexcept = default;
+
+#if defined(__cpp_lib_constexpr_string) && defined(_MSC_VER) && (_MSC_VER >= 1934)
+        static constexpr std::string EMPTY_STRING;
+#else
+        static const std::string EMPTY_STRING;
+#endif
 
     private:
-        static const std::string EMPTY_STRING;
-
         const std::string* str = &EMPTY_STRING;
         uint32_t first = 0;
         uint32_t second = 0;
@@ -250,26 +259,26 @@ public:
             NEWLINE
         };
 
-        explicit TextElement(TextElementType type_) noexcept :
+        CONSTEXPR_FONT explicit TextElement(TextElementType type_) noexcept :
             type(type_)
         {}
-        explicit TextElement(Substring text_) noexcept(noexcept(Substring{std::declval<Substring>()})) :
+        CONSTEXPR_FONT explicit TextElement(Substring text_) noexcept(noexcept(Substring{std::declval<Substring>()})) :
             text(text_),
             type(TextElementType::TEXT)
         {}
 
-        TextElement(Substring text_, TextElementType type_)
+        CONSTEXPR_FONT TextElement(Substring text_, TextElementType type_)
             noexcept(noexcept(Substring{std::declval<Substring>()})) :
             text(text_),
             type(type_)
         {}
-        TextElement(Substring text_, Substring tag_name_,
+        CONSTEXPR_FONT TextElement(Substring text_, Substring tag_name_,
                     TextElementType type_) noexcept(noexcept(Substring{std::declval<Substring>()})) :
             text(text_),
             tag_name(tag_name_),
             type(type_)
         {}
-        TextElement(Substring text_, Substring tag_name_, std::vector<Substring> params_,
+        CONSTEXPR_FONT TextElement(Substring text_, Substring tag_name_, std::vector<Substring> params_,
                     TextElementType type_) noexcept(noexcept(Substring{std::declval<Substring>()})) :
             text(text_),
             tag_name(tag_name_),
@@ -298,7 +307,7 @@ public:
             entire vectors of TextElement with different std::strings
             without re-parsing the std::string.
          */
-        void Bind(const std::string& whole_text) noexcept
+        CONSTEXPR_FONT void Bind(const std::string& whole_text) noexcept
         {
             text.Bind(whole_text);
             tag_name.Bind(whole_text);
@@ -307,24 +316,24 @@ public:
         }
 
         /** Returns the TextElementType of the element. */
-        [[nodiscard]] TextElementType Type() const noexcept { return type; };
-        [[nodiscard]] bool IsCloseTag() const noexcept { return type == TextElementType::CLOSE_TAG; }
-        [[nodiscard]] bool IsOpenTag() const noexcept { return type == TextElementType::OPEN_TAG; }
-        [[nodiscard]] bool IsTag() const noexcept { return IsCloseTag() || IsOpenTag(); }
-        [[nodiscard]] bool IsWhiteSpace() const noexcept { return type == TextElementType::WHITESPACE; }
-        [[nodiscard]] bool IsNewline() const noexcept { return type == TextElementType::NEWLINE; }
+        [[nodiscard]] CONSTEXPR_FONT TextElementType Type() const noexcept { return type; };
+        [[nodiscard]] CONSTEXPR_FONT bool IsCloseTag() const noexcept { return type == TextElementType::CLOSE_TAG; }
+        [[nodiscard]] CONSTEXPR_FONT bool IsOpenTag() const noexcept { return type == TextElementType::OPEN_TAG; }
+        [[nodiscard]] CONSTEXPR_FONT bool IsTag() const noexcept { return IsCloseTag() || IsOpenTag(); }
+        [[nodiscard]] CONSTEXPR_FONT bool IsWhiteSpace() const noexcept { return type == TextElementType::WHITESPACE; }
+        [[nodiscard]] CONSTEXPR_FONT bool IsNewline() const noexcept { return type == TextElementType::NEWLINE; }
 
         /** Returns the width of the element. */
         [[nodiscard]] X Width() const;
 
         /* Returns the number of characters in the original string that the
            element represents. */
-        [[nodiscard]] StrSize StringSize() const noexcept
+        [[nodiscard]] CONSTEXPR_FONT StrSize StringSize() const noexcept
         { return StrSize(text.size()); }
 
         /** Returns the number of code points in the original string that the
             element represents. */
-        [[nodiscard]] CPSize CodePointSize() const noexcept
+        [[nodiscard]] CONSTEXPR_FONT CPSize CodePointSize() const noexcept
         { return CPSize(widths.size()); }
 
         bool operator==(const TextElement &rhs) const noexcept // ignores cached_width
@@ -352,7 +361,7 @@ public:
         TextElementType type = TextElementType::TEXT;
 
     protected:
-        TextElement() = default;
+        CONSTEXPR_FONT TextElement() = default;
 
     private:
         mutable X cached_width{-X1};
@@ -410,8 +419,8 @@ public:
         formatting tags present on that line as well. */
     struct GG_API LineData
     {
-        LineData() noexcept = default;
-        explicit LineData(Alignment justification_) noexcept :
+        CONSTEXPR_FONT LineData() noexcept = default;
+        CONSTEXPR_FONT explicit LineData(Alignment justification_) noexcept :
             justification(justification_)
         {}
 
@@ -420,10 +429,20 @@ public:
             rendering of a visible glyph. */
         struct GG_API CharData
         {
-            CharData() = default;
+            CONSTEXPR_FONT CharData() = default;
 
-            CharData(X extent_, StrSize str_index, StrSize str_size, CPSize cp_index,
-                     const std::vector<TextElement>& tags_);
+            CONSTEXPR_FONT CharData(X extent_, StrSize str_index, StrSize str_size, CPSize cp_index,
+                                    const std::vector<TextElement>& tags_) :
+                extent(extent_),
+                string_index(str_index),
+                string_size(str_size),
+                code_point_index(cp_index)
+            {
+                tags.reserve(tags_.size());
+                for (auto& tag : tags_)
+                    if (tag.IsTag())
+                        tags.push_back(tag);
+            }
 
             /** The furthest-right extent of this glyph as it appears on the line. */
             X extent = X0;
@@ -441,8 +460,8 @@ public:
             std::vector<TextElement> tags;
         };
 
-        X    Width() const noexcept { return char_data.empty() ? X0 : char_data.back().extent; }
-        bool Empty() const noexcept { return char_data.empty(); }
+        CONSTEXPR_FONT X    Width() const noexcept { return char_data.empty() ? X0 : char_data.back().extent; }
+        CONSTEXPR_FONT bool Empty() const noexcept { return char_data.empty(); }
 
         /** Data on each individual glyph. */
         std::vector<CharData> char_data;

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -143,12 +143,12 @@ public:
         CONSTEXPR_FONT explicit Substring(const std::string& str_) noexcept :
             str(&str_)
         {}
-        CONSTEXPR_FONT explicit Substring(const std::string* str_) noexcept :
+        constexpr explicit Substring(const std::string* str_) noexcept :
             str(str_)
         {}
 
         /** Construction from two offsets. \a first_ must be <= \a second_. */
-        CONSTEXPR_FONT Substring(const std::string* str_, uint32_t first_, uint32_t second_) noexcept :
+        constexpr Substring(const std::string* str_, uint32_t first_, uint32_t second_) noexcept :
             str(str_),
             first(first_),
             second(second_)
@@ -201,13 +201,13 @@ public:
         { return (str && str->size() >= second) ? (str->cbegin() + second) : EMPTY_STRING.cend(); }
 
         /** True iff .first == .second. */
-        [[nodiscard]] CONSTEXPR_FONT bool empty() const noexcept { return first == second; }
+        [[nodiscard]] constexpr bool empty() const noexcept { return first == second; }
 
         [[nodiscard]] CONSTEXPR_FONT bool IsDefaultEmpty() const noexcept { return str == &EMPTY_STRING; }
 
         /** Length, in original string chars, of the substring. */
-        [[nodiscard]] CONSTEXPR_FONT std::size_t size() const noexcept { return static_cast<std::size_t>(second - first); }
-        [[nodiscard]] CONSTEXPR_FONT auto offsets() const noexcept { return std::pair<uint32_t, uint32_t>{first, second}; }
+        [[nodiscard]] constexpr std::size_t size() const noexcept { return static_cast<std::size_t>(second - first); }
+        [[nodiscard]] constexpr auto offsets() const noexcept { return std::pair<uint32_t, uint32_t>{first, second}; }
 
         /** Implicit conversion to std::string. */
         [[nodiscard]] CONSTEXPR_FONT operator std::string() const { return std::string(begin(), end()); }

--- a/GG/GG/GUI.h
+++ b/GG/GG/GUI.h
@@ -172,9 +172,9 @@ public:
     bool                        MouseLRSwapped() const;             ///< returns true if the left and right mouse button press events are set to be swapped before event handling. This is to facilitate left-handed mouse users semi-automatically.
     virtual std::string         ClipboardText() const;              ///< returns text stored in a clipboard
 
-    /** Returns the (begin, end) indices of the code points or char indices
-      * of the word-tokens in the given string. */
+    /** Returns the (begin, end) code point indices of the of the word-tokens in the given string. */
     std::vector<std::pair<CPSize, CPSize>>   FindWords(std::string_view str) const;
+    /** Returns the (begin, end) string indices of the of the word-tokens in the given string. */
     std::vector<std::pair<StrSize, StrSize>> FindWordsStringIndices(std::string_view str) const;
     std::vector<std::string_view>            FindWordsStringViews(std::string_view str) const;
 

--- a/GG/GG/Menu.h
+++ b/GG/GG/Menu.h
@@ -83,7 +83,6 @@ public:
     Clr InteriorColor() const noexcept { return m_int_color; }          ///< returns the color used to render the interior of the control
     Clr TextColor() const noexcept { return m_text_color; }             ///< returns the color used to render menu item text
     Clr HiliteColor() const noexcept { return m_hilite_color; }         ///< returns the color used to indicate a hilited menu item
-    Clr SelectedTextColor() const noexcept { return m_sel_text_color; } ///< returns the color used to render a hilited menu item's text
 
     /** Add \p menu_item to the end of the popup menu and store its callback.*/
     void AddMenuItem(MenuItem&& menu_item);
@@ -104,7 +103,6 @@ public:
     void SetInteriorColor(Clr clr);     ///< sets the color used to render the interior of the control
     void SetTextColor(Clr clr);         ///< sets the color used to render menu item text
     void SetHiliteColor(Clr clr);       ///< sets the color used to indicate a hilited menu item
-    void SetSelectedTextColor(Clr clr); ///< sets the color used to render a hilited menu item's text
 
     static constexpr std::size_t INVALID_CARET = std::numeric_limits<std::size_t>::max();;
 
@@ -125,7 +123,6 @@ private:
     Clr               m_int_color;      ///< color painted into the client area of the control
     Clr               m_text_color;     ///< color used to paint text in control
     Clr               m_hilite_color;   ///< color behind selected items
-    Clr               m_sel_text_color; ///< color of selected text
 
     MenuItem          m_menu_data;      ///< this is not just a single menu item; the next_level element represents the entire menu
 

--- a/GG/GG/MultiEdit.h
+++ b/GG/GG/MultiEdit.h
@@ -117,13 +117,14 @@ protected:
     std::pair<std::size_t, CPSize> CharAt(CPSize idx) const;
 
     /** Returns the code point index of the start of the UTF-8 sequence for
-        the code point at \a <i>char_idx</i> in row \a row, using \a line_data
-        instead of the current line data, if it is supplied.  If \a row, \a
-        char_idx refers to a character preceeded by formatting tags, the index
-        of the first character of the first formatting tag is returned instead.
-        Not range-checked. */
-    CPSize CharIndexOf(std::size_t row, CPSize char_idx,
-                       const std::vector<Font::LineData>* line_data = nullptr) const;
+        the code point at \a char_idx in row \a row, using \a line_data
+        instead of the current line data, if it is supplied.
+        If \a row, \a char_idx refers to a character preceeded by formatting
+        tags, the index of the first character of the first formatting tag is
+        returned instead. Not range-checked. */
+    static CPSize CharIndexOf(std::size_t row, CPSize char_idx, const std::vector<Font::LineData>& line_data);
+    CPSize CharIndexOf(std::size_t row, CPSize char_idx) const
+    { return CharIndexOf(row, char_idx, GetLineData()); }
 
     /** Returns the x-coordinate of the beginning of row \a row, in
         cleint-space coordinates.  Not range-checked. */

--- a/GG/GG/MultiEdit.h
+++ b/GG/GG/MultiEdit.h
@@ -117,15 +117,9 @@ protected:
         a non-visible character. */
     std::pair<std::size_t, CPSize> GlyphAt(CPSize idx) const;
 
-    /** Returns the code point index of the start of the UTF-8 sequence for
-        the code point at \a char_idx in row \a row, using \a line_data
-        instead of the current line data, if it is supplied.
-        If \a row, \a char_idx refers to a character preceeded by formatting
-        tags, the index of the first character of the first formatting tag is
-        returned instead. Not range-checked. */
-    static CPSize GlyphIndexOf(std::size_t row, CPSize char_idx, const std::vector<Font::LineData>& line_data);
-    CPSize GlyphIndexOf(std::size_t row, CPSize char_idx) const
-    { return GlyphIndexOf(row, char_idx, GetLineData()); }
+    /** Returns the code point index of the glyph at position \a glyph_idx in row \a row_idx within \a line_data */
+    CPSize GlyphIndexOf(std::size_t row_idx, CPSize glyph_idx) const
+    { return GG::GlyphIndexOf(row_idx, glyph_idx, GetLineData()); }
 
     /** Returns the x-coordinate of the beginning of row \a row, in
         cleint-space coordinates.  Not range-checked. */

--- a/GG/GG/MultiEdit.h
+++ b/GG/GG/MultiEdit.h
@@ -117,10 +117,6 @@ protected:
         a non-visible character. */
     std::pair<std::size_t, CPSize> GlyphAt(CPSize idx) const;
 
-    /** Returns the code point index of the glyph at position \a glyph_idx in row \a row_idx within \a line_data */
-    CPSize GlyphIndexOf(std::size_t row_idx, CPSize glyph_idx) const
-    { return GG::GlyphIndexOf(row_idx, glyph_idx, GetLineData()); }
-
     /** Returns the x-coordinate of the beginning of row \a row, in
         cleint-space coordinates.  Not range-checked. */
     X RowStartX(std::size_t row) const;

--- a/GG/GG/MultiEdit.h
+++ b/GG/GG/MultiEdit.h
@@ -107,14 +107,15 @@ protected:
         none). */
     Y BottomMargin() const noexcept;
 
-    /** Returns row and character index of \a pt, or (0, 0) if \a pt falls
-        outside the text.  \a pt is in client-space coordinates. */
-    std::pair<std::size_t, CPSize> CharAt(Pt pt) const;
+    /** Returns row and rendered character (glyph) index of \a pt,
+        or (0, 0) if \a pt falls outside the text.
+        \a pt is in client-space coordinates. */
+    std::pair<std::size_t, CPSize> GlyphAt(Pt pt) const;
 
-    /** Returns row and character index of char at \a idx, or (0, 0) if \a idx
-        falls outside the text, or if \a idx refers to a non-visible
-        character. */
-    std::pair<std::size_t, CPSize> CharAt(CPSize idx) const;
+    /** Returns row and rendered character (glyph) index of char at \a idx,
+        or (0, 0) if \a idx falls outside the text, or if \a idx refers to
+        a non-visible character. */
+    std::pair<std::size_t, CPSize> GlyphAt(CPSize idx) const;
 
     /** Returns the code point index of the start of the UTF-8 sequence for
         the code point at \a char_idx in row \a row, using \a line_data
@@ -122,9 +123,9 @@ protected:
         If \a row, \a char_idx refers to a character preceeded by formatting
         tags, the index of the first character of the first formatting tag is
         returned instead. Not range-checked. */
-    static CPSize CharIndexOf(std::size_t row, CPSize char_idx, const std::vector<Font::LineData>& line_data);
-    CPSize CharIndexOf(std::size_t row, CPSize char_idx) const
-    { return CharIndexOf(row, char_idx, GetLineData()); }
+    static CPSize GlyphIndexOf(std::size_t row, CPSize char_idx, const std::vector<Font::LineData>& line_data);
+    CPSize GlyphIndexOf(std::size_t row, CPSize char_idx) const
+    { return GlyphIndexOf(row, char_idx, GetLineData()); }
 
     /** Returns the x-coordinate of the beginning of row \a row, in
         cleint-space coordinates.  Not range-checked. */
@@ -140,7 +141,7 @@ protected:
 
     /** Returns the index of the character in row \a row that falls under X
         coordinate \a x.  \a x must be in client-space coordinates. */
-    CPSize CharAt(std::size_t row, X x) const;
+    CPSize GlyphAt(std::size_t row, X x) const;
 
     /** Returns the index of the first visible row, or 0 if none. */
     std::size_t FirstVisibleRow() const;
@@ -198,8 +199,8 @@ private:
 
     Flags<MultiEditStyle> m_style;
 
-    std::pair<std::size_t, CPSize> m_cursor_begin; ///< The row and character index of the first character in the hilited selection
-    std::pair<std::size_t, CPSize> m_cursor_end;   ///< The row and character index + 1 of the last character in the hilited selection
+    std::pair<std::size_t, CPSize> m_cursor_begin; ///< The row and glyph index of the first character in the hilited selection
+    std::pair<std::size_t, CPSize> m_cursor_end;   ///< The row and glyph index + 1 of the last character in the hilited selection
     // if m_cursor_begin == m_cursor_end, the caret is draw at m_cursor_end
 
     Pt              m_contents_sz;          ///< The size of the entire text block in the control (not just the visible part)

--- a/GG/GG/Spin.h
+++ b/GG/GG/Spin.h
@@ -82,7 +82,6 @@ public:
     Clr     TextColor() const;          ///< returns the text color
     Clr     InteriorColor() const;      ///< returns the interior color of the control
     Clr     HiliteColor() const;        ///< returns the color used to render hiliting around selected text
-    Clr     SelectedTextColor() const;  ///< returns the color used to render selected text
 
     mutable ValueChangedSignalType ValueChangedSignal; ///< the value changed signal object for this Spin
 
@@ -104,7 +103,6 @@ public:
     void SetTextColor(Clr c);           ///< sets the text color
     void SetInteriorColor(Clr c);       ///< sets the interior color of the control
     void SetHiliteColor(Clr c);         ///< sets the color used to render hiliting around selected text
-    void SetSelectedTextColor(Clr c);   ///< sets the color used to render selected text   
 
 protected:
     typedef T ValueType;
@@ -228,10 +226,6 @@ Clr Spin<T>::HiliteColor() const
 { return m_edit->HiliteColor(); }
 
 template <typename T>
-Clr Spin<T>::SelectedTextColor() const
-{ return m_edit->SelectedTextColor(); }
-
-template <typename T>
 void Spin<T>::Render()
 {
     Clr color_to_use = Disabled() ? DisabledColor(Color()) : Color();
@@ -327,10 +321,6 @@ void Spin<T>::SetInteriorColor(Clr c)
 template <typename T>
 void Spin<T>::SetHiliteColor(Clr c)
 { m_edit->SetHiliteColor(c); }
-
-template <typename T>
-void Spin<T>::SetSelectedTextColor(Clr c)
-{ m_edit->SetSelectedTextColor(c); }
 
 template <typename T>
 Button* Spin<T>::UpButton() const

--- a/GG/GG/TextControl.h
+++ b/GG/GG/TextControl.h
@@ -109,7 +109,7 @@ public:
     const std::string& Text() const noexcept { return m_text; }
 
     /** Returns the text displayed in this control between the specified
-        position \a from through position \a to. */
+        position code point indices \a from through position \a to. */
     std::string_view Text(CPSize from, CPSize to) const;
 
     /** Returns the text format (vertical and horizontal justification, use of

--- a/GG/src/DrawUtil.cpp
+++ b/GG/src/DrawUtil.cpp
@@ -757,17 +757,14 @@ void GG::Triangle(X x1, Y y1, X x2, Y y2, X x3, Y y3, bool filled)
     glEnable(GL_TEXTURE_2D);
 }
 
-void GG::FlatRectangle(Pt ul, Pt lr, Clr color, Clr border_color,
-                       unsigned int border_thick)
+void GG::FlatRectangle(Pt ul, Pt lr, Clr color, Clr border_color, unsigned int border_thick)
 {
     Rectangle(ul, lr, color, border_color, border_color, border_thick,
               true, true, true, true);
 }
 
-void GG::BeveledRectangle(Pt ul, Pt lr, Clr color, Clr border_color, bool up,
-                          unsigned int bevel_thick, bool bevel_left,
-                          bool bevel_top, bool bevel_right,
-                          bool bevel_bottom)
+void GG::BeveledRectangle(Pt ul, Pt lr, Clr color, Clr border_color, bool up, unsigned int bevel_thick,
+                          bool bevel_left, bool bevel_top, bool bevel_right, bool bevel_bottom)
 {
     Rectangle(ul, lr, color,
               (up ? LightenClr(border_color) : DarkenClr(border_color)),
@@ -776,16 +773,14 @@ void GG::BeveledRectangle(Pt ul, Pt lr, Clr color, Clr border_color, bool up,
 }
 
 void GG::FlatRoundedRectangle(Pt ul, Pt lr, Clr color, Clr border_color,
-                              unsigned int corner_radius,
-                              unsigned int border_thick)
+                              unsigned int corner_radius, unsigned int border_thick)
 {
     RoundedRectangle(ul, lr, color, border_color, border_color,
                      corner_radius, border_thick);
 }
 
 void GG::BeveledRoundedRectangle(Pt ul, Pt lr, Clr color, Clr border_color, bool up,
-                                 unsigned int corner_radius,
-                                 unsigned int bevel_thick)
+                                 unsigned int corner_radius, unsigned int bevel_thick)
 {
     RoundedRectangle(ul, lr, color,
                      (up ? LightenClr(border_color) : DarkenClr(border_color)),

--- a/GG/src/DrawUtil.cpp
+++ b/GG/src/DrawUtil.cpp
@@ -679,6 +679,13 @@ void GG::Line(Pt pt1, Pt pt2, Clr color, float thick)
     Line(pt1.x, pt1.y, pt2.x, pt2.y);
 }
 
+void GG::Line(X x1, Y y1, X x2, Y y2, Clr color, float thick)
+{
+    glLineWidth(thick);
+    glColor(color);
+    Line(x1, y1, x2, y2);
+}
+
 void GG::Line(X x1, Y y1, X x2, Y y2)
 {
     const GLfloat vertices[4] = {GLfloat(Value(x1)), GLfloat(Value(y1)),

--- a/GG/src/Edit.cpp
+++ b/GG/src/Edit.cpp
@@ -365,7 +365,9 @@ void Edit::LDrag(Pt pt, Pt move, Flags<ModKey> mod_keys)
             AdjustView();
     }
 
-    //std::cout << "LDrag selected from: " << m_cursor_pos.first << "  to: " << m_cursor_pos.second << std::endl;
+    //std::cout << "LDrag at glyph: " << Value(GlyphIndexAt(xpos))
+    //          << " selected from cp idx: " << Value(m_cursor_pos.first)
+    //          << " to cp idx: " << Value(m_cursor_pos.second) << std::endl;
 }
 
 void Edit::LButtonUp(Pt pt, Flags<ModKey> mod_keys)

--- a/GG/src/Edit.cpp
+++ b/GG/src/Edit.cpp
@@ -55,7 +55,6 @@ void Edit::Render()
 {
     Clr color_to_use = Disabled() ? DisabledColor(Color()) : Color();
     Clr int_color_to_use = Disabled() ? DisabledColor(m_int_color) : m_int_color;
-    Clr sel_text_color_to_use = Disabled() ? DisabledColor(m_sel_text_color) : m_sel_text_color;
     Clr hilite_color_to_use = Disabled() ? DisabledColor(m_hilite_color) : m_hilite_color;
     Clr text_color_to_use = Disabled() ? DisabledColor(TextColor()) : TextColor();
 
@@ -83,35 +82,17 @@ void Edit::Render()
         CPSize low_cursor_pos  = std::min(CPSize(char_data.size()), std::max(CP0, std::min(m_cursor_pos.first, m_cursor_pos.second)));
         CPSize high_cursor_pos = std::min(CPSize(char_data.size()), std::max(CP0, std::max(m_cursor_pos.first, m_cursor_pos.second)));
 
-        // draw hiliting
+        // draw hilighting background box
         Pt hilite_ul(client_ul.x + (low_cursor_pos < CP1 ? X0 : char_data[Value(low_cursor_pos - CP1)].extent) - first_char_offset, client_ul.y);
         Pt hilite_lr(client_ul.x + (high_cursor_pos < CP1 ? X0 : char_data[Value(high_cursor_pos - CP1)].extent) - first_char_offset, client_lr.y);
         FlatRectangle(hilite_ul, hilite_lr, hilite_color_to_use, CLR_ZERO, 0);
 
-        // INDEX_0 to INDEX_1 is unhilited, INDEX_1 to
-        // INDEX_2 is hilited, and INDEX_2 to INDEX_3 is
-        // unhilited; each range may be empty
-        const StrSize INDEX_1 = StringIndexOf(0, std::max(low_cursor_pos, m_first_char_shown), GetLineData());
-        const StrSize INDEX_2 = StringIndexOf(0, std::min(high_cursor_pos, last_visible_char), GetLineData());
-
         // draw text
-        X text_x_pos = client_ul.x;
-        text_x_pos +=
-            font->RenderText(Pt(text_x_pos, text_y_pos),
-                             Text().substr(Value(INDEX_0), Value(INDEX_1 - INDEX_0)), rs);
-
-        rs.PushColor(sel_text_color_to_use);
-        text_x_pos +=
-            font->RenderText(Pt(text_x_pos, text_y_pos),
-                             Text().substr(Value(INDEX_1), Value(INDEX_2 - INDEX_1)), rs);
-        rs.PopColor();
-        text_x_pos +=
-            font->RenderText(Pt(text_x_pos, text_y_pos),
-                             Text().substr(Value(INDEX_2), Value(INDEX_END - INDEX_2)), rs);
+        font->RenderText(Pt(client_ul.x, text_y_pos), Text().substr(Value(INDEX_0), Value(INDEX_END - INDEX_0)), rs);
 
     } else { // no selected text
-        font->RenderText(Pt(client_ul.x, text_y_pos),
-                         Text().substr(Value(INDEX_0), Value(INDEX_END - INDEX_0)), rs);
+        font->RenderText(Pt(client_ul.x, text_y_pos), Text().substr(Value(INDEX_0), Value(INDEX_END - INDEX_0)), rs);
+
         if (GUI::GetGUI()->FocusWnd().get() == this) {
             // if we have focus, draw the caret as a simple vertical line
             X caret_x = ScreenPosOfChar(m_cursor_pos.second);
@@ -130,9 +111,6 @@ void Edit::SetInteriorColor(Clr c)
 
 void Edit::SetHiliteColor(Clr c)
 { m_hilite_color = c; }
-
-void Edit::SetSelectedTextColor(Clr c)
-{ m_sel_text_color = c; }
 
 void Edit::SelectAll()
 {

--- a/GG/src/Edit.cpp
+++ b/GG/src/Edit.cpp
@@ -115,7 +115,7 @@ void Edit::Render()
         if (GUI::GetGUI()->FocusWnd().get() == this) {
             // if we have focus, draw the caret as a simple vertical line
             X caret_x = ScreenPosOfChar(m_cursor_pos.second);
-            Line(caret_x, client_ul.y, caret_x, client_lr.y);
+            Line(caret_x, client_ul.y, caret_x, client_lr.y, text_color_to_use);
         }
     }
 

--- a/GG/src/Edit.cpp
+++ b/GG/src/Edit.cpp
@@ -179,7 +179,7 @@ void Edit::AcceptPastedText(const std::string& text)
 
     if (modified_text) {
         // moves cursor to end of pasted text
-        const CPSize text_span{static_cast<std::size_t>(utf8::distance(text.begin(), text.end()))};
+        const CPSize text_span{static_cast<std::size_t>(utf8::distance(text.begin(), text.end()))}; // TODO: this looks wrong... CPSize should be code points or glyphs, not char (byte) index in string
         m_cursor_pos.second = std::max(CP0, std::min(Length(), m_cursor_pos.second + text_span));
 
         // ensure nothing is selected after pasting
@@ -190,7 +190,7 @@ void Edit::AcceptPastedText(const std::string& text)
     }
 }
 
-CPSize Edit::CharIndexOf(X x) const
+CPSize Edit::GlyphIndexOf(X x) const
 {
     CPSize retval;
     const X first_char_offset = FirstCharOffset();
@@ -278,7 +278,7 @@ void Edit::LButtonDown(Pt pt, Flags<ModKey> mod_keys)
         return;
     //std::cout << "Edit::LButtonDown start" << std::endl;
     const X click_xpos = ScreenToClient(pt).x; // x coord of click within text space
-    const CPSize idx = CharIndexOf(click_xpos);
+    const CPSize idx = GlyphIndexOf(click_xpos);
     //std::cout << "Edit::LButtonDown got idx: " << idx << std::endl;
 
     const auto word_indices = GetDoubleButtonDownWordIndices(idx);
@@ -294,8 +294,8 @@ void Edit::LDrag(Pt pt, Pt move, Flags<ModKey> mod_keys)
         return;
 
     const X xpos = ScreenToClient(pt).x; // x coord for mouse position within text space
-    const CPSize idx = CharIndexOf(xpos);
-    //std::cout << "CharIndexOf mouse x-pos: " << xpos << std::endl;
+    const CPSize idx = GlyphIndexOf(xpos);
+    //std::cout << "GlyphIndexOf mouse x-pos: " << xpos << std::endl;
 
     if (m_in_double_click_mode) {
         const auto word_indices = GetDoubleButtonDownDragWordIndices(idx);

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -884,6 +884,13 @@ namespace {
     };
     static_assert(check_eq(long_chars_arr, long_chars_as_uint8_expected));
 
+    constexpr std::array<cdp, 6> long_chars_as_uint32_t_and_length_expected{{
+        {0x3B1, 2}, {'b', 1}, {0xE5, 2}, {0x30AA, 3}, {0x1F81E, 4}, {0x648, 2}}};
+    constexpr std::array<cdp, 6> long_chars_as_uint32_t_and_length_extracted{{
+        dummy_next_fn(long_chars_sv), dummy_next_fn(long_chars_sv.substr(2)), dummy_next_fn(long_chars_sv.substr(3)),
+        dummy_next_fn(long_chars_sv.substr(5)), dummy_next_fn(long_chars_sv.substr(8)), dummy_next_fn(long_chars_sv.substr(12))}};
+    static_assert(check_eq(long_chars_as_uint32_t_and_length_expected, long_chars_as_uint32_t_and_length_extracted));
+
 
     constexpr struct DummyGlyphMap {
         struct DummyGlyph { int8_t advance = 4; };

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -843,7 +843,6 @@ namespace {
 
 #if defined(__cpp_lib_constexpr_string) && ((!defined(__GNUC__) || (__GNUC__ > 12) || (__GNUC__ == 12 && __GNUC_MINOR__ >= 2))) && ((!defined(_MSC_VER) || (_MSC_VER >= 1934))) && ((!defined(__clang_major__) || (__clang_major__ >= 17)))
     constexpr struct DummyNextFn {
-
         static constexpr uint32_t cont_byte(uint8_t c) noexcept
         { return c & 0b00111111; };
 
@@ -975,14 +974,15 @@ namespace {
     }();
 #  endif
 
-    constexpr std::vector<Font::TextElement> ElementsForLongCharsText(const std::string& text)
+#  if defined(__cpp_lib_constexpr_vector)
+    CONSTEXPR_FONT std::vector<Font::TextElement> ElementsForLongCharsText(const std::string& text)
     {
         std::vector<Font::TextElement> elems;
         elems.emplace_back(Font::Substring(text, 0u, 14u));
         SetTextElementWidths(text, elems, dummy_glyph_map, 4, dummy_next_fn);
         return elems;
     }
-
+#  endif
 
     constexpr std::array<uint8_t, 14> long_chars_as_uint8_expected{
         0xCE, 0xB1,   'b',   0xC3, 0xA5,   0xE3, 0x82, 0xAA,   0xF0, 0x9F, 0xA0, 0x9E,   0xD9, 0x88};
@@ -1004,7 +1004,7 @@ namespace {
         dummy_next_fn(long_chars_sv.substr(5)), dummy_next_fn(long_chars_sv.substr(8)), dummy_next_fn(long_chars_sv.substr(12))}};
     static_assert(check_eq(long_chars_as_uint32_t_and_length_expected, long_chars_as_uint32_t_and_length_extracted));
 
-
+#  if defined(__cpp_lib_constexpr_vector)
     // tests getting line and code point index in line from overall code point index text with multi-byte chars
     constexpr auto test_multibyte_cpidx_to_line_and_cp = []() {
         const std::string text(long_chars_sv);
@@ -1030,10 +1030,11 @@ namespace {
     }};
 
     static_assert(test_multibyte_cpidx_to_line_and_cp == test_multibyte_line_and_cp_expected);
-
+#  endif
 
     constexpr std::string_view multi_line_text = "ab\ncd\n\nef";
-    constexpr std::vector<Font::TextElement> ElementsForMultiLineText(const std::string& text)
+#  if defined(__cpp_lib_constexpr_vector)
+    CONSTEXPR_FONT std::vector<Font::TextElement> ElementsForMultiLineText(const std::string& text)
     {
         std::vector<Font::TextElement> elems;
         elems.reserve(6);
@@ -1048,8 +1049,9 @@ namespace {
 
         return elems;
     }
+#  endif
 
-
+#  if defined(__cpp_lib_constexpr_vector)
     // tests line data for multi-line text
     constexpr auto test_multline_line_data = []() {
         const std::string text(multi_line_text);
@@ -1164,10 +1166,11 @@ namespace {
     static_assert(gltg41 == 6u);
     static_assert(gltg50 == 6u);
     static_assert(gltg51 == 6u);
-
+#  endif
 
     constexpr std::string_view tagged_test_text = "ab<i>cd</i>ef";
-    constexpr std::vector<Font::TextElement> ElementsForTaggedText(const std::string& text)
+#  if defined(__cpp_lib_constexpr_vector)
+    CONSTEXPR_FONT std::vector<Font::TextElement> ElementsForTaggedText(const std::string& text)
     {
         std::vector<Font::TextElement> elems;
         elems.reserve(5);
@@ -1181,8 +1184,9 @@ namespace {
 
         return elems;
     }
+#  endif
 
-
+#  if defined(__cpp_lib_constexpr_vector)
     // tests getting line and code point index in line from overall code point index text with tags
     constexpr auto test_tagged_cpidx_to_line_and_cp = []() {
         const std::string text(tagged_test_text);
@@ -1261,7 +1265,7 @@ namespace {
     static_assert(test_tagged_line_glyph_to_after_prev_glyph_cpi(4) == 7); // <
     static_assert(test_tagged_line_glyph_to_after_prev_glyph_cpi(5) == 12); // f
     static_assert(test_tagged_line_glyph_to_after_prev_glyph_cpi(6) == 13); // null
-
+#  endif
 #endif
 }
 
@@ -1416,6 +1420,7 @@ namespace {
 
 #if defined(__cpp_lib_constexpr_string) && ((!defined(__GNUC__) || (__GNUC__ > 12) || (__GNUC__ == 12 && __GNUC_MINOR__ >= 2))) && ((!defined(_MSC_VER) || (_MSC_VER >= 1934))) && ((!defined(__clang_major__) || (__clang_major__ >= 17)))
 
+#  if defined(__cpp_lib_constexpr_vector)
     // tests getting string index from glyph index in text with newlines
     constexpr auto test_line_glyph_to_str_idx = []() {
         const std::string text(multi_line_text);
@@ -1561,6 +1566,7 @@ namespace {
     static_assert(Value(test_multiline_line_glyph_to_cp(4u, CP1)) == 6u);
     static_assert(Value(test_multiline_line_glyph_to_cp(5u, CPSize{2})) == 6u);
     static_assert(Value(test_multiline_line_glyph_to_cp(6u, CPSize{3})) == 6u);
+#  endif
 #endif
 }
 
@@ -1602,7 +1608,7 @@ namespace {
     }
 
 #if defined(__cpp_lib_constexpr_string) && ((!defined(__GNUC__) || (__GNUC__ > 12) || (__GNUC__ == 12 && __GNUC_MINOR__ >= 2))) && ((!defined(_MSC_VER) || (_MSC_VER >= 1934))) && ((!defined(__clang_major__) || (__clang_major__ >= 17)))
-
+#  if defined(__cpp_lib_constexpr_vector)
     // tests getting a range pair of string indices from a range pair of glyph indices into text with tags,
     // where the second value should be just after the previous character in the text, which is not the same as
     // before the second character, since there could be non-rendered tag-text code points between them
@@ -1638,7 +1644,7 @@ namespace {
     static_assert(to_sv(test_tagged_glyph_to_str_idx_range(1u, 5u)) == "b<i>cd</i>e");
     static_assert(to_sv(test_tagged_glyph_to_str_idx_range(2u, 4u)) == "cd");
     static_assert(to_sv(test_tagged_glyph_to_str_idx_range(2u, 5u)) == "cd</i>e");
-
+#  endif
 #endif
 }
 
@@ -1837,6 +1843,7 @@ namespace {
 namespace {
     constexpr std::string_view TEST_TEXT_WITH_TAGS = "default<i>ital<u>_ul_it_</i>   _just_ul_</u>\nsecond line<i><sup>is";
 
+#  if defined(__cpp_lib_constexpr_vector)
     constexpr auto TestTextElems(const std::string& text)
     {
         std::vector<Font::TextElement> text_elems;
@@ -1925,6 +1932,7 @@ namespace {
         static_assert(element_widths[14] == element_widths_expected[14]);
         static_assert(element_widths[15] == element_widths_expected[15]);
     }
+#  endif
 }
 #endif
 
@@ -2801,6 +2809,7 @@ void Font::ChangeTemplatedText(std::string& text, std::vector<TextElement>& text
 
 #if defined(__cpp_lib_constexpr_string) && ((!defined(__GNUC__) || (__GNUC__ > 12) || (__GNUC__ == 12 && __GNUC_MINOR__ >= 2))) && ((!defined(_MSC_VER) || (_MSC_VER >= 1934))) && ((!defined(__clang_major__) || (__clang_major__ >= 17)))
 namespace {
+#  if defined(__cpp_lib_constexpr_vector)
     constexpr auto lines_and_lengths = []() {
         const std::string test_text(TEST_TEXT_WITH_TAGS);
         const auto text_elems = TestTextElems(test_text);
@@ -2910,6 +2919,7 @@ namespace {
         return rv;
     }();
     static_assert(static_cast<decltype(test_text_str_idxs)>(idxs_expected) == test_text_str_idxs);
+#  endif
 }
 #endif
 

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1094,9 +1094,9 @@ namespace {
     static_assert(Value(test_multibyte_cp_to_str_idx_len(6u)) == std::pair{14, 0});
 
 
-    // tests getting the nth code point on a single line of text with multi-byte characters.
-    // should output same index as input index, up to the limit of characters in string, and
-    // one past end otherwise
+    // tests getting the code point from line and glyph index in text with a
+    // single line with multi-byte characters. should output same index as input
+    // index, up to the limit of characters in string, and one past end otherwise
     constexpr auto test_multibyte_line_idx_to_cp = [](std::size_t line_idx, CPSize index) {
         const std::string text(long_chars_sv);
         const auto elems = ElementsForLongCharsText(text);
@@ -1138,6 +1138,33 @@ namespace {
     static_assert(Value(test_tagged_line_idx_to_cp(2u, CP1)) == 13u);
 
 
+    // tests getting the code point from line and glyph index in text with newlines
+    constexpr auto test_multiline_line_idx_to_cp = [](std::size_t line_idx, CPSize index) {
+        const std::string text(multi_line_text);
+        const auto elems = ElementsForMultiLineText(text);
+        const auto fmt = FORMAT_LEFT | FORMAT_TOP;
+        const auto line_data = AssembleLineData(fmt, GG::X(99999), elems, 4u, dummy_next_fn);
+
+        return CodePointIndexInLines(line_idx, index, line_data);
+    };
+
+    static_assert(Value(test_multiline_line_idx_to_cp(0u, CP0)) == 0u);
+    static_assert(Value(test_multiline_line_idx_to_cp(0u, CP1)) == 1u);
+    static_assert(Value(test_multiline_line_idx_to_cp(0u, CPSize{2})) == 2u);
+    static_assert(Value(test_multiline_line_idx_to_cp(0u, CPSize{3})) == 2u);
+    static_assert(Value(test_multiline_line_idx_to_cp(1u, CP0)) == 2u);
+    static_assert(Value(test_multiline_line_idx_to_cp(1u, CP1)) == 3u);
+    static_assert(Value(test_multiline_line_idx_to_cp(1u, CPSize{2})) == 4u);
+    static_assert(Value(test_multiline_line_idx_to_cp(1u, CPSize{3})) == 4u);
+    static_assert(Value(test_multiline_line_idx_to_cp(2u, CP0)) == 4u);
+    static_assert(Value(test_multiline_line_idx_to_cp(2u, CP1)) == 4u);
+    static_assert(Value(test_multiline_line_idx_to_cp(3u, CP0)) == 4u);
+    static_assert(Value(test_multiline_line_idx_to_cp(3u, CP1)) == 5u);
+    static_assert(Value(test_multiline_line_idx_to_cp(3u, CPSize{2})) == 6u);
+    static_assert(Value(test_multiline_line_idx_to_cp(4u, CP1)) == 6u);
+    static_assert(Value(test_multiline_line_idx_to_cp(4u, CP1)) == 6u);
+    static_assert(Value(test_multiline_line_idx_to_cp(5u, CPSize{2})) == 6u);
+    static_assert(Value(test_multiline_line_idx_to_cp(6u, CPSize{3})) == 6u);
 #endif
 }
 

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1,4 +1,4 @@
-﻿//! GiGi - A GUI for OpenGL
+//! GiGi - A GUI for OpenGL
 //!
 //!  Copyright (C) 2003-2008 T. Zachary Laine <whatwasthataddress@gmail.com>
 //!  Copyright (C) 2013-2021 The FreeOrion Project
@@ -340,16 +340,6 @@ namespace {
 ///////////////////////////////////////
 // class GG::Font::Substring
 ///////////////////////////////////////
-
-bool Font::Substring::operator==(const std::string& rhs) const
-{ return size() == rhs.size() && !std::memcmp(str->data() + first, rhs.data(), size()); }
-
-bool Font::Substring::operator==(std::string_view rhs) const
-{ return size() == rhs.size() && !std::memcmp(str->data() + first, rhs.data(), size()); }
-
-bool Font::Substring::operator==(const Substring& rhs) const
-{ return size() == rhs.size() && !std::memcmp(str->data() + first, rhs.data() + rhs.first, size()); }
-
 #if !(defined(__cpp_lib_constexpr_string) && defined(_MSC_VER) && (_MSC_VER >= 1934))
 const std::string Font::Substring::EMPTY_STRING{};
 #else
@@ -1591,8 +1581,8 @@ namespace {
         return format;
     }
 
-    void SetJustification(bool& last_line_of_curr_just, Font::LineData& line_data,
-                          Alignment orig_just, Alignment prev_just) noexcept
+    CONSTEXPR_FONT void SetJustification(bool& last_line_of_curr_just, Font::LineData& line_data,
+                                         Alignment orig_just, Alignment prev_just) noexcept
     {
         if (last_line_of_curr_just) {
             line_data.justification = orig_just;
@@ -1602,8 +1592,8 @@ namespace {
         }
     }
 
-    void AddNewline(X& x, bool& last_line_of_curr_just, std::vector<Font::LineData>& line_data,
-                    const Alignment orig_just)
+    CONSTEXPR_FONT void AddNewline(X& x, bool& last_line_of_curr_just, std::vector<Font::LineData>& line_data,
+                                   const Alignment orig_just)
     {
         line_data.emplace_back();
         SetJustification(last_line_of_curr_just,
@@ -1613,11 +1603,11 @@ namespace {
         x = X0;
     }
 
-    void AddWhitespace(X& x, const Font::Substring elem_text, const int8_t space_width, const X box_width,
-                       const bool expand_tabs, const X tab_pixel_width, const Flags<TextFormat> format,
-                       std::vector<Font::LineData>& line_data, bool& last_line_of_curr_just,
-                       const Alignment orig_just, const StrSize original_string_offset,
-                       CPSize& code_point_offset, std::vector<Font::TextElement>& pending_formatting_tags)
+    CONSTEXPR_FONT void AddWhitespace(X& x, const Font::Substring elem_text, const int8_t space_width, const X box_width,
+                                      const bool expand_tabs, const X tab_pixel_width, const Flags<TextFormat> format,
+                                      std::vector<Font::LineData>& line_data, bool& last_line_of_curr_just,
+                                      const Alignment orig_just, const StrSize original_string_offset,
+                                      CPSize& code_point_offset, std::vector<Font::TextElement>& pending_formatting_tags)
     {
         auto it = elem_text.begin();
         const auto end_it = elem_text.end();
@@ -1674,12 +1664,12 @@ namespace {
             ++code_point_offset;
         }
     }
-
-    void AddTextWordbreak(X& x, const Font::TextElement& elem, const Flags<TextFormat> format,
-                          const X box_width, std::vector<Font::LineData>& line_data,
-                          bool& last_line_of_curr_just, const Alignment orig_just,
-                          const StrSize original_string_offset, CPSize& code_point_offset,
-                          std::vector<Font::TextElement>& pending_formatting_tags)
+ 
+    CONSTEXPR_FONT void AddTextWordbreak(X& x, const Font::TextElement& elem, const Flags<TextFormat> format,
+                                         const X box_width, std::vector<Font::LineData>& line_data,
+                                         bool& last_line_of_curr_just, const Alignment orig_just,
+                                         const StrSize original_string_offset, CPSize& code_point_offset,
+                                         std::vector<Font::TextElement>& pending_formatting_tags)
     {
         // if the text "word" overruns this line, and isn't alone on
         // this line, move it down to the next line
@@ -1711,11 +1701,11 @@ namespace {
         }
     }
 
-    void AddTextNoWordbreak(X& x, const Font::TextElement& elem, const Flags<TextFormat> format,
-                            const X box_width, std::vector<Font::LineData>& line_data,
-                            bool& last_line_of_curr_just, const Alignment orig_just,
-                            const StrSize original_string_offset, CPSize& code_point_offset,
-                            std::vector<Font::TextElement>& pending_formatting_tags)
+    CONSTEXPR_FONT void AddTextNoWordbreak(X& x, const Font::TextElement& elem, const Flags<TextFormat> format,
+                                           const X box_width, std::vector<Font::LineData>& line_data,
+                                           bool& last_line_of_curr_just, const Alignment orig_just,
+                                           const StrSize original_string_offset, CPSize& code_point_offset,
+                                           std::vector<Font::TextElement>& pending_formatting_tags)
     {
         auto it = elem.text.begin();
         const auto end_it = elem.text.end();
@@ -1756,11 +1746,11 @@ namespace {
         }
     }
 
-    void AddText(X& x, const Font::TextElement& elem, const Flags<TextFormat> format,
-                 const X box_width, std::vector<Font::LineData>& line_data,
-                 bool& last_line_of_curr_just, const Alignment orig_just,
-                 const StrSize original_string_offset, CPSize& code_point_offset,
-                 std::vector<Font::TextElement>& pending_formatting_tags)
+    CONSTEXPR_FONT void AddText(X& x, const Font::TextElement& elem, const Flags<TextFormat> format,
+                                const X box_width, std::vector<Font::LineData>& line_data,
+                                bool& last_line_of_curr_just, const Alignment orig_just,
+                                const StrSize original_string_offset, CPSize& code_point_offset,
+                                std::vector<Font::TextElement>& pending_formatting_tags)
     {
         if (format & FORMAT_WORDBREAK) {
             AddTextWordbreak(x, elem, format, box_width, line_data, last_line_of_curr_just,
@@ -1773,9 +1763,9 @@ namespace {
         }
     }
 
-    void AddOpenTag(const Font::TextElement& elem, Alignment& justification,
-                    bool& last_line_of_curr_just, CPSize& code_point_offset,
-                    std::vector<Font::TextElement>& pending_formatting_tags)
+    CONSTEXPR_FONT void AddOpenTag(const Font::TextElement& elem, Alignment& justification,
+                                   bool& last_line_of_curr_just, CPSize& code_point_offset,
+                                   std::vector<Font::TextElement>& pending_formatting_tags)
     {
         if (elem.tag_name == Font::ALIGN_LEFT_TAG)
             justification = ALIGN_LEFT;
@@ -1789,9 +1779,9 @@ namespace {
         code_point_offset += elem.CodePointSize();
     }
 
-    void AddCloseTag(const Font::TextElement& elem, const Alignment justification,
-                     bool& last_line_of_curr_just, CPSize& code_point_offset,
-                     std::vector<Font::TextElement>& pending_formatting_tags)
+    CONSTEXPR_FONT void AddCloseTag(const Font::TextElement& elem, const Alignment justification,
+                                    bool& last_line_of_curr_just, CPSize& code_point_offset,
+                                    std::vector<Font::TextElement>& pending_formatting_tags)
     {
         if ((elem.tag_name == Font::ALIGN_LEFT_TAG && justification == ALIGN_LEFT) ||
             (elem.tag_name == Font::ALIGN_CENTER_TAG && justification == ALIGN_CENTER) ||
@@ -1802,6 +1792,64 @@ namespace {
             pending_formatting_tags.push_back(elem);
         }
         code_point_offset += elem.CodePointSize();
+    }
+
+    CONSTEXPR_FONT auto AssembleLineData(Flags<TextFormat> format, X box_width,
+                                         const std::vector<Font::TextElement>& text_elements, int8_t space_width)
+    {
+        format = ValidateFormat(format); // may modify format
+
+        using TextElement = Font::TextElement;
+
+        constexpr int tab_width = 8; // default tab width
+        const X tab_pixel_width = X{tab_width * space_width}; // get the length of a tab stop
+        const bool expand_tabs = format & FORMAT_LEFT; // tab expansion only takes place when the lines are left-justified (otherwise, tabs are just spaces)
+        const Alignment orig_just =
+            (format & FORMAT_LEFT) ? ALIGN_LEFT :
+            (format & FORMAT_CENTER) ? ALIGN_CENTER :
+            (format & FORMAT_RIGHT) ? ALIGN_RIGHT : ALIGN_NONE;
+        bool last_line_of_curr_just = false; // is this the last line of the current justification? (for instance when a </right> tag is encountered)
+
+        std::vector<Font::LineData> line_data;
+        if (!text_elements.empty())
+            line_data.emplace_back(orig_just);
+
+        X x = X0;
+        // the position within the original string of the current TextElement
+        StrSize original_string_offset(S0);
+        // the index of the first code point of the current TextElement
+        CPSize code_point_offset(CP0);
+        std::vector<TextElement> pending_formatting_tags;
+
+        for (const auto& elem : text_elements) {
+            switch (elem.Type()) {
+            case TextElement::TextElementType::NEWLINE:
+                AddNewline(x, last_line_of_curr_just, line_data, orig_just);
+                break;
+            case TextElement::TextElementType::WHITESPACE:
+                AddWhitespace(x, elem.text, space_width, box_width, expand_tabs, tab_pixel_width, format,
+                              line_data, last_line_of_curr_just, orig_just, original_string_offset,
+                              code_point_offset, pending_formatting_tags);
+                break;
+            case TextElement::TextElementType::TEXT:
+                AddText(x, elem, format, box_width, line_data, last_line_of_curr_just, orig_just,
+                        original_string_offset, code_point_offset, pending_formatting_tags);
+                break;
+            case TextElement::TextElementType::OPEN_TAG:
+                AddOpenTag(elem, line_data.back().justification, last_line_of_curr_just,
+                           code_point_offset, pending_formatting_tags);
+                break;
+            case TextElement::TextElementType::CLOSE_TAG:
+                AddCloseTag(elem, line_data.back().justification, last_line_of_curr_just,
+                            code_point_offset, pending_formatting_tags);
+                break;
+            }
+            original_string_offset += elem.StringSize();
+        }
+        // disregard the final pending formatting tag, if any, since this is the
+        // end of the text, and so it cannot have any effect
+
+        return line_data;
     }
 }
 
@@ -1816,61 +1864,13 @@ std::vector<Font::LineData> Font::DetermineLines(
         return std::vector<Font::LineData>{};
     }
 
-    format = ValidateFormat(format); // may modify format
-
-    static constexpr int tab_width = 8; // default tab width
-    const X tab_pixel_width = X{tab_width * m_space_width}; // get the length of a tab stop
-    const bool expand_tabs = format & FORMAT_LEFT; // tab expansion only takes place when the lines are left-justified (otherwise, tabs are just spaces)
-    const Alignment orig_just =
-        (format & FORMAT_LEFT) ? ALIGN_LEFT :
-        (format & FORMAT_CENTER) ? ALIGN_CENTER :
-        (format & FORMAT_RIGHT) ? ALIGN_RIGHT : ALIGN_NONE;
-    bool last_line_of_curr_just = false; // is this the last line of the current justification? (for instance when a </right> tag is encountered)
-
-    std::vector<Font::LineData> line_data;
-    if (!text_elements.empty())
-        line_data.emplace_back(orig_just);
-
-    X x = X0;
-    // the position within the original string of the current TextElement
-    StrSize original_string_offset(S0);
-    // the index of the first code point of the current TextElement
-    CPSize code_point_offset(CP0);
-    std::vector<TextElement> pending_formatting_tags;
-
-    for (const auto& elem : text_elements) {
-        switch (elem.Type()) {
-        case TextElement::TextElementType::NEWLINE:
-            AddNewline(x, last_line_of_curr_just, line_data, orig_just);
-            break;
-        case TextElement::TextElementType::WHITESPACE:
-            AddWhitespace(x, elem.text, m_space_width, box_width, expand_tabs, tab_pixel_width, format,
-                          line_data, last_line_of_curr_just, orig_just, original_string_offset,
-                          code_point_offset, pending_formatting_tags);
-            break;
-        case TextElement::TextElementType::TEXT:
-            AddText(x, elem, format, box_width, line_data, last_line_of_curr_just, orig_just,
-                    original_string_offset, code_point_offset, pending_formatting_tags);
-            break;
-        case TextElement::TextElementType::OPEN_TAG:
-            AddOpenTag(elem, line_data.back().justification, last_line_of_curr_just,
-                       code_point_offset, pending_formatting_tags);
-            break;
-        case TextElement::TextElementType::CLOSE_TAG:
-            AddCloseTag(elem, line_data.back().justification, last_line_of_curr_just,
-                        code_point_offset, pending_formatting_tags);
-            break;
-        }
-        original_string_offset += elem.StringSize();
-    }
-    // disregard the final pending formatting tag, if any, since this is the
-    // end of the text, and so it cannot have any effect
-
-#if DEBUG_DETERMINELINES
+ #if DEBUG_DETERMINELINES
+    auto line_data = AssembleLineData(format, box_width, text_elements, m_space_width);
     DebugOutput::PrintLineBreakdown(text, format, box_width, line_data);
-#endif
-
     return line_data;
+#else
+    return AssembleLineData(format, box_width, text_elements, m_space_width);
+#endif
 }
 
 FT_Error Font::GetFace(FT_Face& face)

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1,4 +1,4 @@
-//! GiGi - A GUI for OpenGL
+﻿//! GiGi - A GUI for OpenGL
 //!
 //!  Copyright (C) 2003-2008 T. Zachary Laine <whatwasthataddress@gmail.com>
 //!  Copyright (C) 2013-2021 The FreeOrion Project
@@ -340,7 +340,6 @@ namespace {
 ///////////////////////////////////////
 // class GG::Font::Substring
 ///////////////////////////////////////
-const std::string Font::Substring::EMPTY_STRING{};
 
 bool Font::Substring::operator==(const std::string& rhs) const
 { return size() == rhs.size() && !std::memcmp(str->data() + first, rhs.data(), size()); }
@@ -350,6 +349,13 @@ bool Font::Substring::operator==(std::string_view rhs) const
 
 bool Font::Substring::operator==(const Substring& rhs) const
 { return size() == rhs.size() && !std::memcmp(str->data() + first, rhs.data() + rhs.first, size()); }
+
+#if !(defined(__cpp_lib_constexpr_string) && defined(_MSC_VER) && (_MSC_VER >= 1934))
+const std::string Font::Substring::EMPTY_STRING{};
+#else
+static_assert(Font::Substring(Font::Substring::EMPTY_STRING).empty());
+static_assert(Font::Substring(Font::Substring::EMPTY_STRING).data() == Font::Substring::EMPTY_STRING.data());
+#endif
 
 ///////////////////////////////////////
 // Free Functions
@@ -858,24 +864,6 @@ namespace {
                                       static_cast<GLubyte>(current_float[3]*255)};
     }
 }
-
-
-///////////////////////////////////////
-// class GG::Font::LineData::CharData
-///////////////////////////////////////
-Font::LineData::CharData::CharData(X extent_, StrSize str_index, StrSize str_size, CPSize cp_index,
-                                   const std::vector<TextElement>& tags_) :
-    extent(extent_),
-    string_index(str_index),
-    string_size(str_size),
-    code_point_index(cp_index)
-{
-    tags.reserve(tags_.size());
-    for (auto& tag : tags_)
-        if (tag.IsTag())
-            tags.push_back(tag);
-}
-
 
 ///////////////////////////////////////
 // struct GG::Font::Glyph

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -852,7 +852,7 @@ namespace {
 
 
     // text with multi-byte chars
-#if defined(__cpp_lib_char8_t)
+#  if defined(__cpp_lib_char8_t)
     constexpr std::u8string_view long_chars = u8"αbåオ🠞و";
     constexpr auto long_chars_arr = []() {
         std::array<std::string_view::value_type, long_chars.size()> retval{};
@@ -861,9 +861,15 @@ namespace {
         return retval;
     }();
     constexpr std::string_view long_chars_sv(long_chars_arr.data(), long_chars_arr.size());
-#else
+#  else
     constexpr std::string_view long_chars_sv = u8"αbåオ🠞و";
-#endif
+    constexpr auto long_chars_arr = []() {
+        std::array<std::string_view::value_type, long_chars_sv.size()> retval{};
+        for (std::size_t idx = 0; idx < retval.size(); ++idx)
+            retval[idx] = long_chars_sv[idx];
+        return retval;
+    }();
+#  endif
 
     constexpr std::array<uint8_t, 14> long_chars_as_uint8_expected{
         0xCE, 0xB1,   'b',   0xC3, 0xA5,   0xE3, 0x82, 0xAA,   0xF0, 0x9F, 0xA0, 0x9E,   0xD9, 0x88};

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1043,7 +1043,7 @@ namespace {
 
 
     // tests getting string index and code point string length from code point index in text with tags
-    constexpr auto test_cp_idx_to_str_idx = [](std::size_t idx) {
+    constexpr auto test_tagged_cp_idx_to_str_idx = [](std::size_t idx) {
         const std::string text(tagged_test_text);
         const auto elems = ElementsForTaggedText(text);
         const auto fmt = FORMAT_LEFT | FORMAT_TOP;
@@ -1056,14 +1056,14 @@ namespace {
     constexpr std::pair<std::size_t, std::size_t> Value(std::pair<StrSize, StrSize> szs)
     { return {Value(szs.first), Value(szs.second)}; };
 
-    static_assert(Value(test_cp_idx_to_str_idx(0u)) == std::pair{0, 1});
-    static_assert(Value(test_cp_idx_to_str_idx(1u)) == std::pair{1, 1});
-    static_assert(Value(test_cp_idx_to_str_idx(2u)) == std::pair{5, 1});
-    static_assert(Value(test_cp_idx_to_str_idx(3u)) == std::pair{6, 1});
-    static_assert(Value(test_cp_idx_to_str_idx(4u)) == std::pair{11, 1});
-    static_assert(Value(test_cp_idx_to_str_idx(5u)) == std::pair{12, 1});
-    static_assert(Value(test_cp_idx_to_str_idx(6u)) == std::pair{13, 0});
-    static_assert(Value(test_cp_idx_to_str_idx(999u)) == std::pair{13, 0});
+    static_assert(Value(test_tagged_cp_idx_to_str_idx(0u)) == std::pair{0, 1});
+    static_assert(Value(test_tagged_cp_idx_to_str_idx(1u)) == std::pair{1, 1});
+    static_assert(Value(test_tagged_cp_idx_to_str_idx(2u)) == std::pair{5, 1});
+    static_assert(Value(test_tagged_cp_idx_to_str_idx(3u)) == std::pair{6, 1});
+    static_assert(Value(test_tagged_cp_idx_to_str_idx(4u)) == std::pair{11, 1});
+    static_assert(Value(test_tagged_cp_idx_to_str_idx(5u)) == std::pair{12, 1});
+    static_assert(Value(test_tagged_cp_idx_to_str_idx(6u)) == std::pair{13, 0});
+    static_assert(Value(test_tagged_cp_idx_to_str_idx(999u)) == std::pair{13, 0});
 
 
     constexpr std::vector<Font::TextElement> ElementsForLongCharsText(const std::string& text)
@@ -1078,7 +1078,6 @@ namespace {
     constexpr auto test_multibyte_cp_to_str_idx_len = [](std::size_t idx) {
         const std::string text(long_chars_sv);
         const auto elems = ElementsForLongCharsText(text);
-
         const auto fmt = FORMAT_LEFT | FORMAT_TOP;
         const auto line_data = AssembleLineData(fmt, GG::X(99999), elems, 4u, dummy_next_fn);
 
@@ -1101,7 +1100,6 @@ namespace {
     constexpr auto test_multibyte_line_idx_to_cp = [](std::size_t line_idx, CPSize index) {
         const std::string text(long_chars_sv);
         const auto elems = ElementsForLongCharsText(text);
-
         const auto fmt = FORMAT_LEFT | FORMAT_TOP;
         const auto line_data = AssembleLineData(fmt, GG::X(99999), elems, 4u, dummy_next_fn);
 
@@ -1116,6 +1114,29 @@ namespace {
     static_assert(Value(test_multibyte_line_idx_to_cp(0u, CPSize{7})) == 6u);
     static_assert(Value(test_multibyte_line_idx_to_cp(1u, CP0)) == 6u);
     static_assert(Value(test_multibyte_line_idx_to_cp(1u, CP1)) == 6u);
+
+
+    // tests getting the code point from line and glyph index in text with tags
+    constexpr auto test_tagged_line_idx_to_cp = [](std::size_t line_idx, CPSize index) {
+        const std::string text(tagged_test_text);
+        const auto elems = ElementsForTaggedText(text);
+        const auto fmt = FORMAT_LEFT | FORMAT_TOP;
+        const auto line_data = AssembleLineData(fmt, GG::X(99999), elems, 4u, dummy_next_fn);
+
+        return CodePointIndexInLines(line_idx, index, line_data);
+    };
+
+    static_assert(Value(test_tagged_line_idx_to_cp(0u, CP0)) == 0u);
+    static_assert(Value(test_tagged_line_idx_to_cp(0u, CP1)) == 1u);
+    static_assert(Value(test_tagged_line_idx_to_cp(0u, CPSize{2})) == 5u);
+    static_assert(Value(test_tagged_line_idx_to_cp(0u, CPSize{3})) == 6u);
+    static_assert(Value(test_tagged_line_idx_to_cp(0u, CPSize{4})) == 11u);
+    static_assert(Value(test_tagged_line_idx_to_cp(0u, CPSize{5})) == 12u);
+    static_assert(Value(test_tagged_line_idx_to_cp(0u, CPSize{6})) == 13u);
+    static_assert(Value(test_tagged_line_idx_to_cp(0u, CPSize{7})) == 13u);
+    static_assert(Value(test_tagged_line_idx_to_cp(1u, CP0)) == 13u);
+    static_assert(Value(test_tagged_line_idx_to_cp(2u, CP1)) == 13u);
+
 
 #endif
 }

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -706,20 +706,16 @@ public:
 
     auto Extract()
     {
-        if (!m_are_widths_calculated)
-            SetTextElementWidths(m_text, m_text_elements, m_text_elements.begin(),
-                                 m_font.GetGlyphs(), Value(m_font.SpaceWidth()));
+        SetTextElementWidths(m_text, m_text_elements, m_text_elements.begin(),
+                             m_font.GetGlyphs(), Value(m_font.SpaceWidth()));
         return std::pair(std::move(m_text), std::move(m_text_elements));
     }
 
     /** Return the constructed TextElements.*/
     const auto& Elements()
     {
-        if (!m_are_widths_calculated) {
-            SetTextElementWidths(m_text, m_text_elements, m_text_elements.begin(),
-                                 m_font.GetGlyphs(), Value(m_font.SpaceWidth()));
-            m_are_widths_calculated = true;
-        }
+        SetTextElementWidths(m_text, m_text_elements, m_text_elements.begin(),
+                             m_font.GetGlyphs(), Value(m_font.SpaceWidth()));
         return m_text_elements;
     }
 
@@ -728,8 +724,6 @@ public:
     {
         if (!tag_handler.IsKnown(tag))
             return;
-
-        m_are_widths_calculated = false;
 
         // Create open tag like "<tag>" with no parameters
         const auto tag_begin = m_text.size();
@@ -747,8 +741,6 @@ public:
     {
         if (!tag_handler.IsKnown(tag))
             return;
-
-        m_are_widths_calculated = false;
 
         const auto tag_begin = m_text.size();
 
@@ -780,8 +772,6 @@ public:
         if (!tag_handler.IsKnown(tag))
             return;
 
-        m_are_widths_calculated = false;
-
         // Create a close tag that looks like "</tag>"
         const auto tag_begin = m_text.size();
         const auto tag_name_begin = m_text.append("</").size();
@@ -797,8 +787,6 @@ public:
     template <typename S>
     void AddText(S&& text)
     {
-        m_are_widths_calculated = false;
-
         const auto begin = m_text.size();
         const auto end = m_text.append(text).size();
         m_text_elements.emplace_back(Substring{m_text, begin, end});
@@ -807,21 +795,15 @@ public:
     /** Add a white space element.*/
     void AddWhitespace(std::string_view whitespace)
     {
-        m_are_widths_calculated = false;
-
         auto begin = m_text.size();
         auto end = m_text.append(whitespace).size();
-
         m_text_elements.emplace_back(Substring(m_text, begin, end),
                                      Font::TextElement::TextElementType::WHITESPACE);
     }
 
     /** Add a newline element.*/
     void AddNewline()
-    {
-        m_are_widths_calculated = false;
-        m_text_elements.emplace_back(Font::TextElement::TextElementType::NEWLINE);
-    }
+    { m_text_elements.emplace_back(Font::TextElement::TextElementType::NEWLINE); }
 
     /** Add open color tag.*/
     void AddOpenTag(Clr color)
@@ -838,7 +820,6 @@ private:
     const Font& m_font;
     std::string m_text;
     std::vector<TextElement> m_text_elements;
-    bool m_are_widths_calculated = false;
 };
 
 

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -855,13 +855,17 @@ namespace {
 
 
     // for constexpr test purposes
+    struct DummyPair {
+        uint32_t first = 0;
+        struct { int8_t advance = 4; } second;
+    };
     constexpr struct DummyGlyphMap {
-        struct DummyGlyph { int8_t advance = 4; };
-        static constexpr std::pair<uint32_t, DummyGlyph> value{};
-
+        static constexpr DummyPair value{};
         constexpr auto* find(uint32_t) const noexcept { return &value; }
         constexpr decltype(value)* end() const noexcept { return nullptr; }
     } dummy_glyph_map;
+
+    static_assert(dummy_glyph_map.find(0)->second.advance == 4);
 
 
     // text with multi-byte chars

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -567,9 +567,9 @@ namespace {
 
     private:
         // set of tags known to the handler
-        static constexpr std::array<std::string_view, 10> m_default_tags{
+        static constexpr std::array<std::string_view, 11> m_default_tags{
             {Font::ITALIC_TAG, Font::SHADOW_TAG, Font::UNDERLINE_TAG, Font::SUPERSCRIPT_TAG, Font::SUBSCRIPT_TAG,
-            Font::RGBA_TAG, Font::ALIGN_LEFT_TAG, Font::ALIGN_CENTER_TAG, Font::ALIGN_RIGHT_TAG, Font::PRE_TAG}};
+             Font::RGBA_TAG, Font::ALIGN_LEFT_TAG, Font::ALIGN_CENTER_TAG, Font::ALIGN_RIGHT_TAG, Font::PRE_TAG, Font::RESET_TAG}};
 
         std::vector<std::string_view> m_custom_tags;
 
@@ -859,12 +859,6 @@ namespace {
     }
 }
 
-void Font::RenderState::PopColor()
-{
-    // Never remove the initial color from the stack
-    if (color_stack.size() > 1)
-        color_stack.pop();
-}
 
 ///////////////////////////////////////
 // class GG::Font::LineData::CharData
@@ -1116,6 +1110,8 @@ namespace {
                     std::cerr << std::endl;
                 }*/
             }
+        } else if (tag.tag_name == Font::RESET_TAG) {
+            render_state.Reset();
         }
     }
 }

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -963,8 +963,8 @@ namespace {
     // no code points on the requested line
     //
     // if searching back and no previous lines have a code point on them, return string index S0
-    CONSTEXPR_FONT std::pair<StrSize, StrSize> StringIndexInLines(std::size_t line_idx, CPSize index,
-                                                                  const std::vector<Font::LineData>& line_data)
+    CONSTEXPR_FONT std::pair<StrSize, StrSize> StringIndexInLines(
+        std::size_t line_idx, CPSize index, const std::vector<Font::LineData>& line_data)
     {
         if (line_idx < line_data.size() && Value(index) < line_data[line_idx].char_data.size()) {
             // line is valid, and requested code point index is within the line
@@ -1169,7 +1169,7 @@ namespace {
 }
 
 namespace {
-    CONSTEXPR_FONT std::pair<StrSize, StrSize> CodePointIndicesRangeToStringSizeIndicesInLines(
+    CONSTEXPR_FONT std::pair<StrSize, StrSize> GlyphIndicesRangeToStringSizeIndicesInLines(
         CPSize start_idx, CPSize end_idx, const std::vector<Font::LineData>& line_data)
     {
         if (start_idx == INVALID_CP_SIZE || end_idx == INVALID_CP_SIZE)
@@ -1210,7 +1210,7 @@ namespace {
         const auto fmt = FORMAT_LEFT | FORMAT_TOP;
         const auto line_data = AssembleLineData(fmt, GG::X(99999), elems, 4u, dummy_next_fn);
 
-        return CodePointIndicesRangeToStringSizeIndicesInLines(CPSize{low_idx}, CPSize{high_idx}, line_data);
+        return GlyphIndicesRangeToStringSizeIndicesInLines(CPSize{low_idx}, CPSize{high_idx}, line_data);
     };
 
 
@@ -1241,9 +1241,9 @@ namespace {
 }
 
 
-std::pair<StrSize, StrSize> GG::CodePointIndicesRangeToStringSizeIndices(CPSize start_idx, CPSize end_idx,
-                                                                         const std::vector<Font::LineData>& line_data)
-{ return CodePointIndicesRangeToStringSizeIndicesInLines(start_idx, end_idx, line_data); }
+std::pair<StrSize, StrSize> GG::GlyphIndicesRangeToStringSizeIndices(
+    CPSize start_idx, CPSize end_idx, const std::vector<Font::LineData>& line_data)
+{ return GlyphIndicesRangeToStringSizeIndicesInLines(start_idx, end_idx, line_data); }
 
 
 namespace {

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -390,8 +390,7 @@ CPSize GG::CodePointIndexOf(std::size_t line, CPSize index,
     return retval;
 }
 
-StrSize GG::StringIndexOf(std::size_t line, CPSize index,
-                          const std::vector<Font::LineData>& line_data)
+StrSize GG::StringIndexOf(std::size_t line, CPSize index, const std::vector<Font::LineData>& line_data)
 {
     StrSize retval(S0);
     if (line_data.size() <= line) {
@@ -420,11 +419,9 @@ StrSize GG::StringIndexOf(std::size_t line, CPSize index,
     return retval;
 }
 
-std::pair<std::size_t, CPSize> GG::LinePositionOf(
-    CPSize index, const std::vector<Font::LineData>& line_data)
+std::pair<std::size_t, CPSize> GG::LinePositionOf(CPSize index, const std::vector<Font::LineData>& line_data)
 {
-    std::pair<std::size_t, CPSize> retval(std::numeric_limits<std::size_t>::max(),
-                                          INVALID_CP_SIZE);
+    std::pair<std::size_t, CPSize> retval(std::numeric_limits<std::size_t>::max(), INVALID_CP_SIZE);
     for (std::size_t i = 0; i < line_data.size(); ++i) {
         const auto& char_data = line_data[i].char_data;
         if (!char_data.empty() &&
@@ -531,7 +528,7 @@ namespace {
         }
 
     private:
-        bool MatchesKnownTag(const boost::xpressive::ssub_match& sub)
+        bool MatchesKnownTag(const boost::xpressive::ssub_match& sub) const
         { return !m_ignore_tags && m_tag_handler.IsKnown(sub.str()); }
 
         bool MatchesTopOfStack(const boost::xpressive::ssub_match& sub) noexcept {
@@ -571,18 +568,6 @@ namespace {
             std::copy_if(tags.begin(), tags.end(), std::back_inserter(m_custom_tags),
                          [this](const auto tag) { return !IsKnown(tag); });
         }
-
-        /** Remove a tag from the set of known tags.*/
-        void Erase(std::string_view tag)
-        {
-            const auto it = std::find(m_custom_tags.begin(), m_custom_tags.end(), tag);
-            if (it != m_custom_tags.end())
-                m_custom_tags.erase(it);
-        }
-
-        /** Remove all tags from the set of known tags.*/
-        void Clear() noexcept
-        { m_custom_tags.clear(); }
 
         bool IsKnown(std::string_view tag) const
         {
@@ -898,16 +883,6 @@ namespace {
                                       static_cast<GLubyte>(current_float[3]*255)};
     }
 }
-
-Font::RenderState::RenderState()
-{
-    // Initialize the color stack with the current color
-    auto clr = GetCurrentByteColor();
-    PushColor(clr[0], clr[1], clr[2], clr[3]);
-}
-
-Font::RenderState::RenderState(Clr color)
-{ PushColor(color); }
 
 void Font::RenderState::PopColor()
 {
@@ -1343,12 +1318,6 @@ Pt Font::TextExtent(const std::vector<LineData>& line_data) const noexcept
 
 void Font::RegisterKnownTags(std::vector<std::string_view> tags)
 { tag_handler.Insert(std::move(tags)); }
-
-void Font::RemoveKnownTag(std::string_view tag)
-{ tag_handler.Erase(tag); }
-
-void Font::ClearKnownTags()
-{ tag_handler.Clear(); }
 
 void Font::ThrowBadGlyph(const std::string& format_str, uint32_t c)
 {

--- a/GG/src/Menu.cpp
+++ b/GG/src/Menu.cpp
@@ -38,7 +38,6 @@ PopupMenu::PopupMenu(X x, Y y, std::shared_ptr<Font> font, Clr text_color,
     m_int_color(interior_color),
     m_text_color(text_color),
     m_hilite_color(hilite_color),
-    m_sel_text_color(text_color),
     m_caret(1, INVALID_CARET),
     m_origin(x, y)
 { m_open_levels.resize(1); }
@@ -128,13 +127,7 @@ void PopupMenu::Render()
         Font::RenderState rs{m_text_color};
 
         for (std::size_t j = 0; j < menu.next_level.size(); ++j) {
-            const Clr clr = (m_caret[i] == j)
-                ? (menu.next_level[j].disabled
-                   ? DisabledColor(m_sel_text_color)
-                   : m_sel_text_color)
-                : (menu.next_level[j].disabled
-                   ? DisabledColor(m_text_color)
-                   : m_text_color);
+            const Clr clr = (menu.next_level[j].disabled) ? DisabledColor(m_text_color) : m_text_color;
 
             if (!menu.next_level[j].separator) {
                 // TODO cache line data v expensive calculation
@@ -262,9 +255,6 @@ void PopupMenu::SetTextColor(Clr clr)
 
 void PopupMenu::SetHiliteColor(Clr clr)
 { m_hilite_color = clr; }
-
-void PopupMenu::SetSelectedTextColor(Clr clr)
-{ m_sel_text_color = clr; }
 
 const std::shared_ptr<Font>& PopupMenu::GetFont() const
 { return m_font; }

--- a/GG/src/Menu.cpp
+++ b/GG/src/Menu.cpp
@@ -190,28 +190,30 @@ void PopupMenu::LClick(Pt pt, Flags<ModKey> mod_keys)
 void PopupMenu::LDrag(Pt pt, Pt move, Flags<ModKey> mod_keys)
 {
     bool cursor_is_in_menu = false;
-    for (int i = static_cast<int>(m_open_levels.size()) - 1; i >= 0; --i) {
-        // get the correct submenu
-        MenuItem* menu_ptr = &m_menu_data;
-        for (int j = 0; j < i; ++j)
-            menu_ptr = &menu_ptr->next_level[m_caret[j]];
-        MenuItem& menu = *menu_ptr;
+    if (!m_open_levels.empty()) {
+        for (auto i = m_open_levels.size() - 1u; i >= 0; --i) {
+            // get the correct submenu
+            MenuItem* menu_ptr = &m_menu_data;
+            for (std::size_t j = 0u; j < i; ++j)
+                menu_ptr = &menu_ptr->next_level[m_caret[j]];
+            MenuItem& menu = *menu_ptr;
 
-        if (pt.x >= m_open_levels[i].ul.x && pt.x <= m_open_levels[i].lr.x &&
-            pt.y >= m_open_levels[i].ul.y && pt.y <= m_open_levels[i].lr.y)
-        {
-            const std::size_t row_selected = (pt.y - m_open_levels[i].ul.y) / m_font->Lineskip();
-            if (row_selected == m_caret[i]) {
-                cursor_is_in_menu = true;
-            } else if (row_selected < menu.next_level.size()) {
-                m_caret[i] = row_selected;
-                m_open_levels.resize(i + 1);
-                m_caret.resize(i + 1);
-                if (!menu.next_level[row_selected].disabled && menu.next_level[row_selected].next_level.size()) {
-                    m_caret.emplace_back(INVALID_CARET);
-                    m_open_levels.emplace_back();
+            if (pt.x >= m_open_levels[i].ul.x && pt.x <= m_open_levels[i].lr.x &&
+                pt.y >= m_open_levels[i].ul.y && pt.y <= m_open_levels[i].lr.y)
+            {
+                const std::size_t row_selected = (pt.y - m_open_levels[i].ul.y) / m_font->Lineskip();
+                if (row_selected == m_caret[i]) {
+                    cursor_is_in_menu = true;
+                } else if (row_selected < menu.next_level.size()) {
+                    m_caret[i] = row_selected;
+                    m_open_levels.resize(i + 1u);
+                    m_caret.resize(i + 1u);
+                    if (!menu.next_level[row_selected].disabled && menu.next_level[row_selected].next_level.size()) {
+                        m_caret.emplace_back(INVALID_CARET);
+                        m_open_levels.emplace_back();
+                    }
+                    cursor_is_in_menu = true;
                 }
-                cursor_is_in_menu = true;
             }
         }
     }

--- a/GG/src/MultiEdit.cpp
+++ b/GG/src/MultiEdit.cpp
@@ -738,11 +738,17 @@ void MultiEdit::LDrag(Pt pt, Pt move, Flags<ModKey> mod_keys)
     // need to convert from rendered character (glyph) index to code point index in the underlying text
     // any tags that are not rendered will not be included in character counting but will affect the
     // code point index
-    const auto begin_cursor_cp_idx = CodePointIndexOfLineAndGlyph(m_cursor_begin.first, m_cursor_begin.second, line_data);
-    const auto end_cursor_cp_idx = CodePointIndexAfterPreviousGlyph(m_cursor_end.first, m_cursor_end.second, line_data);
+    const auto [begin_cursor_cp_idx, end_cursor_cp_idx] = (m_cursor_end >= m_cursor_begin) ?
+        std::pair{CodePointIndexOfLineAndGlyph(m_cursor_begin.first, m_cursor_begin.second, line_data),
+                  CodePointIndexAfterPreviousGlyph(m_cursor_end.first, m_cursor_end.second, line_data)} :
+        std::pair{CodePointIndexAfterPreviousGlyph(m_cursor_begin.first, m_cursor_begin.second, line_data),
+                  CodePointIndexOfLineAndGlyph(m_cursor_end.first, m_cursor_end.second, line_data)};
 
     m_cursor_pos = {begin_cursor_cp_idx, end_cursor_cp_idx};
 
+    //std::cout << "cursor begin: " << Value(m_cursor_begin.second) << " end: " << Value(m_cursor_end.second)
+    //          << " cp idx begin: " << Value(begin_cursor_cp_idx) << " end: " << Value(end_cursor_cp_idx)
+    //          << std::endl;
 
     // if dragging past the currently visible text, adjust
     // the view so more text can be selected

--- a/GG/src/MultiEdit.cpp
+++ b/GG/src/MultiEdit.cpp
@@ -707,7 +707,7 @@ void MultiEdit::LDrag(Pt pt, Pt move, Flags<ModKey> mod_keys)
         std::pair<CPSize, CPSize> initial_indices = DoubleButtonDownCursorPos();
 
         CPSize idx = GlyphIndexOfLineAndGlyph(m_cursor_end.first, m_cursor_end.second, GetLineData());
-        std::pair<CPSize, CPSize> word_indices = GetDoubleButtonDownDragWordIndices(idx);
+        std::pair<CPSize, CPSize> word_indices = GetDoubleButtonDownDragWordCPIndices(idx);
 
         std::pair<CPSize, CPSize> final_indices;
         if (word_indices.first == word_indices.second) {
@@ -1068,9 +1068,9 @@ void MultiEdit::ClearSelected()
     m_cursor_end = m_cursor_begin = low_pos;
     //std::cout << "low of cursor begin/end:  line: " << m_cursor_begin.first << " char: " << m_cursor_begin.second << std::endl;
 
-    CPSize cursor_pos = CodePointIndexOfLineAndGlyph(m_cursor_end.first, m_cursor_end.second, GetLineData());
+    CPSize cursor_pos_cp_idx = CodePointIndexOfLineAndGlyph(m_cursor_end.first, m_cursor_end.second, GetLineData());
     //std::cout << "got cursor pos: " << cursor_pos << std::endl;
-    this->m_cursor_pos = {cursor_pos, cursor_pos};
+    this->m_cursor_pos = {cursor_pos_cp_idx, cursor_pos_cp_idx};
 }
 
 void MultiEdit::AdjustView()

--- a/GG/src/MultiEdit.cpp
+++ b/GG/src/MultiEdit.cpp
@@ -706,16 +706,16 @@ void MultiEdit::LDrag(Pt pt, Pt move, Flags<ModKey> mod_keys)
         // if drag-selecting after a double click, select full words
         std::pair<CPSize, CPSize> initial_indices = DoubleButtonDownCursorPos();
 
-        CPSize idx = GlyphIndexOfLineAndGlyph(m_cursor_end.first, m_cursor_end.second, GetLineData());
-        std::pair<CPSize, CPSize> word_indices = GetDoubleButtonDownDragWordCPIndices(idx);
+        CPSize cp_idx = CodePointIndexOfLineAndGlyph(m_cursor_end.first, m_cursor_end.second, GetLineData());
+        std::pair<CPSize, CPSize> word_indices = GetDoubleButtonDownDragWordCPIndices(cp_idx);
 
         std::pair<CPSize, CPSize> final_indices;
         if (word_indices.first == word_indices.second) {
-            if (idx < initial_indices.first) {
-                final_indices.second = idx;
+            if (cp_idx < initial_indices.first) {
+                final_indices.second = cp_idx;
                 final_indices.first = initial_indices.second;
-            } else if (initial_indices.second < idx) {
-                final_indices.second = idx;
+            } else if (initial_indices.second < cp_idx) {
+                final_indices.second = cp_idx;
                 final_indices.first = initial_indices.first;
             } else {
                 final_indices = initial_indices;

--- a/GG/src/MultiEdit.cpp
+++ b/GG/src/MultiEdit.cpp
@@ -14,7 +14,6 @@
 #include <GG/StyleFactory.h>
 #include <GG/utf8/checked.h>
 #include <GG/WndEvent.h>
-#include <boost/nowide/iostream.hpp>
 
 using namespace GG;
 
@@ -448,7 +447,7 @@ std::pair<std::size_t, CPSize> MultiEdit::GlyphAt(Pt pt) const
 
     const auto char_idx = (row > constrained_row) ? line_sz : std::min(GlyphAt(row, pt.x), line_sz);
 
-    std::cout << "glyph at " << pt << ": line: " << constrained_row << "  glyph idx: " << Value(char_idx) << std::endl;
+    //std::cout << "glyph at " << pt << ": line: " << constrained_row << "  glyph idx: " << Value(char_idx) << std::endl;
 
     return {constrained_row, char_idx};
 }
@@ -701,7 +700,7 @@ void MultiEdit::LDrag(Pt pt, Pt move, Flags<ModKey> mod_keys)
     Pt click_pos = ScreenToClient(pt);
     m_cursor_end = GlyphAt(click_pos);
 
-    std::cout << "\n\nMultiEdit::LDrag at row: " << m_cursor_end.first << ", glyph: " << Value(m_cursor_end.second) << std::endl;
+    //std::cout << "\n\nMultiEdit::LDrag at row: " << m_cursor_end.first << ", glyph: " << Value(m_cursor_end.second) << std::endl;
 
     if (m_in_double_click_mode) {
         // if drag-selecting after a double click, select full words
@@ -736,30 +735,13 @@ void MultiEdit::LDrag(Pt pt, Pt move, Flags<ModKey> mod_keys)
 
     const auto& line_data = GetLineData();
 
-    CPSize begin_cursor_glyph_idx = GlyphIndexOfLineAndGlyph(m_cursor_begin.first, m_cursor_begin.second, line_data);
-    CPSize end_cursor_pos = GlyphIndexOfLineAndGlyph(m_cursor_end.first, m_cursor_end.second, line_data);
-    std::cout << "MultiEdit::LDrag cursor covers glyph indices: " << Value(begin_cursor_glyph_idx) << " to " << Value(end_cursor_pos) << std::endl;
-
     // need to convert from rendered character (glyph) index to code point index in the underlying text
     // any tags that are not rendered will not be included in character counting but will affect the
     // code point index
     const auto begin_cursor_cp_idx = CodePointIndexOfLineAndGlyph(m_cursor_begin.first, m_cursor_begin.second, line_data);
     const auto end_cursor_cp_idx = CodePointIndexAfterPreviousGlyph(m_cursor_end.first, m_cursor_end.second, line_data);
-    std::cout << "MultiEdit::LDrag cursor covers code points: " << Value(begin_cursor_cp_idx)
-              << " to " << Value(end_cursor_cp_idx) << std::endl;
 
-
-    // NOT TEST
     m_cursor_pos = {begin_cursor_cp_idx, end_cursor_cp_idx};
-    // END NOT TEXT
-
-
-    const std::pair<StrSize, StrSize> str_idxs =
-        GlyphIndicesRangeToStringSizeIndices(begin_cursor_glyph_idx, end_cursor_pos, line_data);
-    const auto txt_u8 = Text().substr(Value(str_idxs.first), Value(str_idxs.second - str_idxs.first));
-    boost::nowide::cout << "MultiEdit::LDrag cursor covers substring: " << txt_u8 << std::endl;
-
-    boost::nowide::cout << "this->SelectedText():" << this->SelectedText() << std::endl;
 
 
     // if dragging past the currently visible text, adjust

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -141,13 +141,9 @@ std::string_view TextControl::Text(CPSize from, CPSize to) const
     auto high_it = m_text.begin() + Value(high_string_idx);
 
     try {
-        //std::cout << "dist begin to low: " << std::distance(m_text.begin(), low_it) << std::endl;
-        //std::cout << "dist low to high: " << std::distance(low_it, high_it) << std::endl;
-        //std::cout << "dist high to end: " << std::distance(high_it, m_text.end()) << std::endl;
-
         return {&*low_it, static_cast<std::size_t>(std::distance(low_it, high_it))};
     } catch (...) {
-        return "";
+        return {};
     }
 }
 

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -127,6 +127,7 @@ std::string_view TextControl::Text(CPSize from, CPSize to) const
     if (from == INVALID_CP_SIZE || to == INVALID_CP_SIZE)
         return "";
 
+    std::tie(from, to) = [from, to]() { return std::pair{std::min(from, to), std::max(from, to)}; }();
 
     const auto txt_sz = m_text.size();
     auto [low_string_idx_strsz, high_string_idx_strsz] = CodePointIndicesRangeToStringSizeIndices(from, to, m_line_data);

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -328,9 +328,18 @@ void TextControl::SetResetMinSize(bool b)
 void TextControl::operator+=(const std::string& s)
 { SetText(m_text + s); }
 
+namespace {
+    constexpr bool IsValidUTFChar(char c) noexcept {
+        if constexpr (std::is_signed_v<char>)
+            return c >= 0;
+        else
+            return c <= 0x7f;
+    }
+}
+
 void TextControl::operator+=(char c)
 {
-    if (!detail::ValidUTFChar<char>()(c))
+    if (!IsValidUTFChar(c))
         throw utf8::invalid_utf8(c);
     SetText(m_text + c);
 }
@@ -361,7 +370,7 @@ void TextControl::Erase(CPSize pos, CPSize num)
 
 void TextControl::Insert(std::size_t line, CPSize pos, char c)
 {
-    if (!detail::ValidUTFChar<char>()(c))
+    if (!IsValidUTFChar(c))
         return;
     m_text.insert(Value(StringIndexOf(line, pos, m_line_data)), 1, c);
     SetText(std::move(m_text));

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -139,7 +139,7 @@ std::string_view TextControl::Text(CPSize from, CPSize to) const
 
 
     const auto txt_sz = m_text.size();
-    auto [low_string_idx_strsz, high_string_idx_strsz] = CodePointIndicesRangeToStringSizeIndices(from, to, m_line_data);
+    auto [low_string_idx_strsz, high_string_idx_strsz] = GlyphIndicesRangeToStringSizeIndices(from, to, m_line_data);
     const auto low_string_idx = std::min(Value(low_string_idx_strsz), txt_sz);
     const auto high_string_idx = std::min(Value(high_string_idx_strsz), txt_sz);
     const auto out_length = std::max(low_string_idx, high_string_idx) - std::min(low_string_idx, high_string_idx);

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -127,15 +127,15 @@ std::string_view TextControl::Text(CPSize from, CPSize to) const
     if (from == INVALID_CP_SIZE || to == INVALID_CP_SIZE)
         return "";
 
-    std::cout << "full text(" << m_text.size() << "): " << m_text << std::endl;
+    //std::cout << "full text(" << m_text.size() << "): " << m_text << std::endl;
 
     auto [from_line_idx, from_cp_in_line_dx] = LinePositionOf(from, m_line_data);
     auto from_stridx = StringIndexOf(from_line_idx, from_cp_in_line_dx, m_line_data);
-    std::cout << "from CPSize: " << Value(from) << " : " << m_text[Value(from_stridx)] << std::endl;
+    //std::cout << "from CPSize: " << Value(from) << " : " << m_text[Value(from_stridx)] << std::endl;
 
     auto [to_line_idx, to_cp_in_line_dx] = LinePositionOf(to, m_line_data);
     auto to_stridx = StringIndexOf(to_line_idx, to_cp_in_line_dx, m_line_data);
-    std::cout << "to CPSize: " << Value(to) << " : " << m_text[Value(to_stridx)] << std::endl;
+    //std::cout << "to CPSize: " << Value(to) << " : " << m_text[Value(to_stridx)] << std::endl;
 
 
     const auto txt_sz = m_text.size();

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1041,12 +1041,10 @@ void CensoredCUIEdit::AcceptPastedText(const std::string& text) {
     }
 
     if (!text.empty()) {
-        GG::CPSize pos;
-        std::size_t line;
-        std::tie(line, pos) = LinePositionOf(m_cursor_pos.first, GetLineData());
+        const auto [line, pos] = LinePositionOfGlyph(m_cursor_pos.first, GetLineData()); // TODO: should look up code point, not glyph index
 
         std::string new_raw_text = m_raw_text;
-        new_raw_text.insert(Value(StringIndexOf(line, pos, GetLineData())), text);
+        new_raw_text.insert(Value(StringIndexOfLineAndGlyph(line, pos, GetLineData())), text);
 
         SetText(std::move(new_raw_text));
 

--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -377,14 +377,17 @@ void MessageWnd::HandlePlayerChatMessage(const std::string& text,
             wrapped_text.append(formatted_timestamp);
     }
     if (player_name.empty()) {
-        wrapped_text.append(filtered_message).append("</rgba>");
+        wrapped_text.append(filtered_message);
     } else {
         wrapped_text.append(player_name);
 
         if (pm)
             wrapped_text.append(UserString("MESSAGES_WHISPER"));
-        wrapped_text.append(": ").append(filtered_message).append("</rgba>");
+        wrapped_text.append(": ").append(filtered_message);
     }
+    wrapped_text.append("<reset>");
+    static_assert(GG::Font::RESET_TAG == "reset");
+
     TraceLogger() << "HandlePlayerChatMessage sender: " << player_name
                   << "  sender colour rgba tag: " << RgbaTag(text_color)
                   << "  filtered message: " << filtered_message

--- a/UI/ChatWnd.h
+++ b/UI/ChatWnd.h
@@ -24,7 +24,7 @@ public:
     void PreRender() override;
 
     void HandlePlayerChatMessage(const std::string& text, const std::string& player_name,
-                                 GG::Clr text_color, const boost::posix_time::ptime& timestamp,
+                                 GG::Clr player_name_color, const boost::posix_time::ptime& timestamp,
                                  int recipient_player_id, bool pm);
     void HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id, bool prefixed = false);
     void HandleGameStatusUpdate(const std::string& text);

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -3161,9 +3161,7 @@ namespace {
         return retval;
     }
 
-    std::unordered_map<std::string_view, std::string> SpeciesSuitabilityColumn1(
-        const std::vector<std::string_view>& species_names)
-    {
+    auto SpeciesSuitabilityColumn1(const std::vector<std::string_view>& species_names) {
         std::unordered_map<std::string_view, std::string> retval;
         auto font = ClientUI::GetFont();
 

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -1721,14 +1721,17 @@ void SidePanel::PlanetPanel::Refresh(ScriptingContext& context_in) {
     wrapped_planet_name = planet->Name();
     if (is_homeworld)
         wrapped_planet_name = "<i>" + wrapped_planet_name + "</i>";
+    static_assert(GG::Font::ITALIC_TAG == "i");
     if (has_shipyard)
         wrapped_planet_name = "<u>" + wrapped_planet_name + "</u>";
+    static_assert(GG::Font::UNDERLINE_TAG == "u");
     if (GetOptionsDB().Get<bool>("ui.name.id.shown"))
         wrapped_planet_name = wrapped_planet_name + " (" + std::to_string(m_planet_id) + ")";
 
 
     // set name
     m_planet_name->SetText("<s>" + wrapped_planet_name + "</s>");
+    static_assert(GG::Font::SHADOW_TAG == "s");
     m_planet_name->MoveTo(GG::Pt(GG::X(MaxPlanetDiameter() + EDGE_PAD), GG::Y0));
     m_planet_name->Resize(m_planet_name->MinUsableSize());
 

--- a/msvc2022/Common/Common.vcxproj
+++ b/msvc2022/Common/Common.vcxproj
@@ -147,10 +147,11 @@
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
       <DisableAnalyzeExternal>true</DisableAnalyzeExternal>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/msvc2022/FreeOrion/FreeOrion.vcxproj
+++ b/msvc2022/FreeOrion/FreeOrion.vcxproj
@@ -158,10 +158,11 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
       <DisableAnalyzeExternal>true</DisableAnalyzeExternal>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/msvc2022/FreeOrionCA/FreeOrionCA.vcxproj
+++ b/msvc2022/FreeOrionCA/FreeOrionCA.vcxproj
@@ -150,10 +150,11 @@
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
       <DisableAnalyzeExternal>true</DisableAnalyzeExternal>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/msvc2022/FreeOrionD/FreeOrionD.vcxproj
+++ b/msvc2022/FreeOrionD/FreeOrionD.vcxproj
@@ -152,10 +152,11 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
       <ShowIncludes>false</ShowIncludes>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
       <DisableAnalyzeExternal>true</DisableAnalyzeExternal>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/msvc2022/GiGi/GiGi.vcxproj
+++ b/msvc2022/GiGi/GiGi.vcxproj
@@ -286,10 +286,11 @@
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
       <DisableAnalyzeExternal>true</DisableAnalyzeExternal>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/msvc2022/Parsers/Parsers.vcxproj
+++ b/msvc2022/Parsers/Parsers.vcxproj
@@ -156,9 +156,10 @@
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
       <DisableAnalyzeExternal>true</DisableAnalyzeExternal>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/msvc2022/Test/Test.vcxproj
+++ b/msvc2022/Test/Test.vcxproj
@@ -162,10 +162,11 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
-      <LanguageStandard>stdcpp20</LanguageStandard>
+      <LanguageStandard>stdcpplatest</LanguageStandard>
       <AdditionalOptions>/utf-8 %(AdditionalOptions)</AdditionalOptions>
       <TreatAngleIncludeAsExternal>true</TreatAngleIncludeAsExternal>
       <DisableAnalyzeExternal>true</DisableAnalyzeExternal>
+      <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
-reworks text tag processing to not have a stack
-adds a `<reset>` text tag that cancels any open tags
-renames and separates concepts of glyphs and code points (and individual chars) in renderable text and functions that convert between these indices in text that has been parsed into line structs for rendering
-makes various parsed text handlers constexpr and adds static_assert tests, when suitable vector and string constexpr support is available
-still an issue if selecting text that has tab character
-fixes rendering of text input cursor
-just colours player names, not whole line of text, in chat window