### PR TITLE
Add exploration research from killed ships as well

### DIFF
--- a/default/scripting/policies/EXPLORATION.focs.txt
+++ b/default/scripting/policies/EXPLORATION.focs.txt
@@ -70,27 +70,50 @@ Policy
                     message = "SITREP_FIELD_RESEARCH"
                     label = "SITREP_FIELD_RESEARCH_LABEL"
                     icon = "icons/tech/environmental_encapsulation.png"
-                    parameters = tag = "system" data = Target.SystemID
+                    parameters = [
+                        tag = "system" data = Target.SystemID
+                        tag = "policy" data = "PLC_EXPLORATION"
+                    ]
                     empire = Source.Owner
 
         EffectsGroup
-            scope = Source
-            activation = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]]
+            scope = And [ Source (Statistic Count condition = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]] > 0) ]
+            activation = Source
             priority = [[END_CLEANUP_PRIORITY]]
             effects = [
                 SetResearch value = Value +
-                    Statistic Count condition = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]]
+                    (Statistic Count condition = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]] * NamedRealLookup name = "EXPLORATION_RESEARCH_BONUS_TOTAL")
                 SetSpecialCapacity name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL"
-                    capacity = Statistic Count condition =[[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]]
+                    capacity = (Statistic Count condition = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]] * NamedRealLookup name = "EXPLORATION_RESEARCH_BONUS_TOTAL")
                 SetTargetResearch value = Value +
-                    Statistic Count condition = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]]
+                    (Statistic Count condition = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]] * NamedRealLookup name = "EXPLORATION_RESEARCH_BONUS_TOTAL")
                 GenerateSitRepMessage
                     message = "SITREP_FIELD_RESEARCH_KILLED"
-                    label = "SITREP_FIELD_RESEARCH_LABEL"
+                    label = "SITREP_FIELD_RESEARCH_KILLED_LABEL"
                     icon = "icons/tech/environmental_encapsulation.png"
                     parameters = [
                         tag = "system" data = Target.SystemID
-                        tag = "rawtext" data = SpecialCapacity name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET" object = Source.ID
+//                        tag = "turn" data = CurrentTurn
+//                        tag = "rpbonusspecialisnotaccessible" data = SpecialCapacity name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET" object = Source.ID
+                        tag = "rpbonus" data = Statistic Count condition =[[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]]
+                    ]
+                    empire = Source.Owner
+           ]
+
+        EffectsGroup
+            scope = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]]
+            activation = Source
+            priority = [[END_CLEANUP_PRIORITY]]
+            effects = [
+                GenerateSitRepMessage
+                    message = "SITREP_FIELD_RESEARCH_KILLED_SYSTEM"
+                    label = "SITREP_FIELD_RESEARCH_KILLED_SYSTEM_LABEL"
+                    icon = "icons/tech/environmental_encapsulation.png"
+                    parameters = [
+                        tag = "system" data = Target.SystemID
+                        tag = "system" data = Target.SystemID
+                        tag = "rpbonus" data = NamedRealLookup name = "EXPLORATION_RESEARCH_BONUS_TOTAL"
+                        tag = "turn" data = CurrentTurn
                     ]
                     empire = Source.Owner
            ]
@@ -102,7 +125,7 @@ NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET
              And [
                 System
                 (CurrentTurn == TurnSystemExplored empire = Source.Owner id = LocalCandidate.ID)
-                Contains And [
+                Not Contains And [
                     Fleet
                     OwnedBy empire = Source.Owner
                 ]

--- a/default/scripting/policies/EXPLORATION.focs.txt
+++ b/default/scripting/policies/EXPLORATION.focs.txt
@@ -78,15 +78,11 @@ Policy
 
         EffectsGroup
             scope = And [ Source (Statistic Count condition = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]] > 0) ]
-            activation = Source
+            activation = ((CurrentTurn % 2) == 0)
             priority = [[END_CLEANUP_PRIORITY]]
             effects = [
-                SetResearch value = Value +
-                    (Statistic Count condition = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]] * NamedRealLookup name = "EXPLORATION_RESEARCH_BONUS_TOTAL")
                 SetSpecialCapacity name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL"
                     capacity = (Statistic Count condition = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]] * NamedRealLookup name = "EXPLORATION_RESEARCH_BONUS_TOTAL")
-                SetTargetResearch value = Value +
-                    (Statistic Count condition = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]] * NamedRealLookup name = "EXPLORATION_RESEARCH_BONUS_TOTAL")
                 GenerateSitRepMessage
                     message = "SITREP_FIELD_RESEARCH_KILLED"
                     label = "SITREP_FIELD_RESEARCH_KILLED_LABEL"
@@ -95,7 +91,29 @@ Policy
                         tag = "system" data = Target.SystemID
 //                        tag = "turn" data = CurrentTurn
 //                        tag = "rpbonusspecialisnotaccessible" data = SpecialCapacity name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET" object = Source.ID
-                        tag = "rpbonus" data = Statistic Count condition =[[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]]
+//                        tag = "rpbonus" data = Statistic Count condition =[ [NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET] ]
+                        tag = "rpbonus" data = 888
+                    ]
+                    empire = Source.Owner
+           ]
+
+        EffectsGroup
+            scope = And [ Source (Statistic Count condition = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]] > 0) ]
+//            activation = Source
+            activation = (CurrentTurn % 2 == 1)
+            priority = [[END_CLEANUP_PRIORITY]]
+            effects = [
+                SetSpecialCapacity name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_ODD"
+                    capacity = (Statistic Count condition = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]] * NamedRealLookup name = "EXPLORATION_RESEARCH_BONUS_TOTAL")
+                GenerateSitRepMessage
+                    message = "SITREP_FIELD_RESEARCH_KILLED"
+                    label = "SITREP_FIELD_RESEARCH_KILLED_LABEL"
+                    icon = "icons/tech/environmental_encapsulation.png"
+                    parameters = [
+                        tag = "system" data = Target.SystemID
+//                        tag = "turn" data = CurrentTurn
+//                        tag = "rpbonusspecialisnotaccessible" data = SpecialCapacity name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET" object = Source.ID
+                        tag = "rpbonus" data = 333
                     ]
                     empire = Source.Owner
            ]

--- a/default/scripting/policies/EXPLORATION.focs.txt
+++ b/default/scripting/policies/EXPLORATION.focs.txt
@@ -83,39 +83,15 @@ Policy
             effects = [
                 SetSpecialCapacity name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL"
                     capacity = (Statistic Count condition = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]] * NamedRealLookup name = "EXPLORATION_RESEARCH_BONUS_TOTAL")
-                GenerateSitRepMessage
-                    message = "SITREP_FIELD_RESEARCH_KILLED"
-                    label = "SITREP_FIELD_RESEARCH_KILLED_LABEL"
-                    icon = "icons/tech/environmental_encapsulation.png"
-                    parameters = [
-                        tag = "system" data = Target.SystemID
-//                        tag = "turn" data = CurrentTurn
-//                        tag = "rpbonusspecialisnotaccessible" data = SpecialCapacity name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET" object = Source.ID
-//                        tag = "rpbonus" data = Statistic Count condition =[ [NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET] ]
-                        tag = "rpbonus" data = 888
-                    ]
-                    empire = Source.Owner
            ]
 
         EffectsGroup
             scope = And [ Source (Statistic Count condition = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]] > 0) ]
-//            activation = Source
-            activation = (CurrentTurn % 2 == 1)
+            activation = ((CurrentTurn % 2) == 1)
             priority = [[END_CLEANUP_PRIORITY]]
             effects = [
                 SetSpecialCapacity name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_ODD"
                     capacity = (Statistic Count condition = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]] * NamedRealLookup name = "EXPLORATION_RESEARCH_BONUS_TOTAL")
-                GenerateSitRepMessage
-                    message = "SITREP_FIELD_RESEARCH_KILLED"
-                    label = "SITREP_FIELD_RESEARCH_KILLED_LABEL"
-                    icon = "icons/tech/environmental_encapsulation.png"
-                    parameters = [
-                        tag = "system" data = Target.SystemID
-//                        tag = "turn" data = CurrentTurn
-//                        tag = "rpbonusspecialisnotaccessible" data = SpecialCapacity name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET" object = Source.ID
-                        tag = "rpbonus" data = 333
-                    ]
-                    empire = Source.Owner
            ]
 
         EffectsGroup
@@ -129,7 +105,7 @@ Policy
                     icon = "icons/tech/environmental_encapsulation.png"
                     parameters = [
                         tag = "system" data = Target.SystemID
-                        tag = "system" data = Target.SystemID
+                        tag = "target" data = Source.SystemID
                         tag = "rpbonus" data = NamedRealLookup name = "EXPLORATION_RESEARCH_BONUS_TOTAL"
                         tag = "turn" data = CurrentTurn
                     ]

--- a/default/scripting/policies/EXPLORATION.focs.txt
+++ b/default/scripting/policies/EXPLORATION.focs.txt
@@ -47,7 +47,15 @@ Policy
                         Ship
                         OwnedBy empire = Source.Owner
                     ])
-        
+
+                // FIXME the research boost needs to be temporary/removed after resource creation/next turn
+                //       else it is like a super-charged research growth
+                //       or better add directly to the empire research without tinkering on meters
+                //       current workaround would be to add this after resource growth and
+                //       * add a special to remember how much this added and then
+                //       * remove that from research at the beginning of next turn
+                // FIXME parser does not want this as data for GenerateSitrepMessage:
+                //       data = (Statistic·Count·condition·=·[ [ NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET ] ] )
         EffectsGroup
             scope = And [
                 System
@@ -64,8 +72,42 @@ Policy
                     icon = "icons/tech/environmental_encapsulation.png"
                     parameters = tag = "system" data = Target.SystemID
                     empire = Source.Owner
+
+        EffectsGroup
+            scope = Source
+            activation = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]]
+            priority = [[END_CLEANUP_PRIORITY]]
+            effects = [
+                SetResearch value = Value +
+                    Statistic Count condition = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]]
+                SetSpecialCapacity name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL"
+                    capacity = Statistic Count condition =[[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]]
+                SetTargetResearch value = Value +
+                    Statistic Count condition = [[NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET]]
+                GenerateSitRepMessage
+                    message = "SITREP_FIELD_RESEARCH_KILLED"
+                    label = "SITREP_FIELD_RESEARCH_LABEL"
+                    icon = "icons/tech/environmental_encapsulation.png"
+                    parameters = [
+                        tag = "system" data = Target.SystemID
+                        tag = "rawtext" data = SpecialCapacity name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET" object = Source.ID
+                    ]
+                    empire = Source.Owner
+           ]
     ]
     graphic = "icons/policies/military_exploration.png"
+
+NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET
+'''
+             And [
+                System
+                (CurrentTurn == TurnSystemExplored empire = Source.Owner id = LocalCandidate.ID)
+                Contains And [
+                    Fleet
+                    OwnedBy empire = Source.Owner
+                ]
+            ]
+'''
 
 #include "/scripting/policies/policies.macros"
 #include "/scripting/macros/priorities.macros"

--- a/default/scripting/specials/planet/NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET.focs.txt
+++ b/default/scripting/specials/planet/NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET.focs.txt
@@ -1,0 +1,16 @@
+Special
+    name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL"
+    description = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_DESC"
+    spawnrate = 0.0
+    effectsgroups = EffectsGroup
+            scope = Source
+            priority = [[BEFORE_ANYTHING_ELSE_PRIORITY]]
+            effects = [
+                SetResearch value = Value - (SpecialCapacity name = ThisSpecial object = Source.ID)
+                RemoveSpecial name = ThisSpecial
+            ]
+
+    graphic = "icons/policies/military_exploration.png"
+
+#include "/scripting/macros/misc.macros"
+#include "/scripting/macros/priorities.macros"

--- a/default/scripting/specials/planet/NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET.focs.txt
+++ b/default/scripting/specials/planet/NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET.focs.txt
@@ -5,22 +5,57 @@ Special
     effectsgroups = [
         EffectsGroup
             scope = Source
-            activation = (CurrentTurn % 2 == 0)
+            activation = Turn low = (3 + SpecialAddedOnTurn name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL" object = Source.ID )
             stackinggroup = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_GROUP"
             priority = [[BEFORE_ANYTHING_ELSE_PRIORITY]]
             effects = [
+                GenerateSitRepMessage
+                    message = "PLANET_SPECIAL_INFO"
+                    label = "SITREP_FIELD_RESEARCH_KILLED_LABEL"
+                    icon = "icons/tech/environmental_encapsulation.png"
+                    parameters = [
+	         tag = "system" data = Source.SystemID
+                          tag = "planet" data = Source.PlanetID
+                          tag = "special" data = ThisSpecial
+                          tag = "turn" data = CurrentTurn
+                          tag = "specialcapacity" data = SpecialCapacity name = ThisSpecial object = Source.ID
+                          tag = "specialaddedonturn" data = SpecialAddedOnTurn name = ThisSpecial object = Source.ID
+                          tag = "remark" data = "{removing the special}"
+                          tag = "remark2" data = Source.Research
+                    ]
                 RemoveSpecial name = ThisSpecial
             ]
 
         EffectsGroup
             scope = Source
-            activation = Turn high = ( 1 + SpecialAddedOnTurn name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL" object = Source.ID )
+            activation = Turn low = (2 + SpecialAddedOnTurn name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL" object = Source.ID )
             stackinggroup = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_GROUP"
             priority = [[BEFORE_ANYTHING_ELSE_PRIORITY]]
+            effects = SetResearch value = Value - (SpecialCapacity name = ThisSpecial object = Source.ID)
+
+        EffectsGroup
+            scope = Source
+            activation = Turn low = (1 + SpecialAddedOnTurn name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL" object = Source.ID )
+            stackinggroup = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_GROUP"
+            priority = [[END_CLEANUP_PRIORITY]]
             effects = [
-                SetResearch value = Value + (SpecialCapacity name = ThisSpecial object = Source.ID)
-                SetTargetResearch value = Value + (SpecialCapacity name = ThisSpecial object = Source.ID)
-           ]
+               GenerateSitRepMessage
+                    message = "PLANET_SPECIAL_INFO"
+                    label = "SITREP_FIELD_RESEARCH_KILLED_LABEL"
+                    icon = "icons/tech/environmental_encapsulation.png"
+                    parameters = [
+	         tag = "system" data = Source.SystemID
+                          tag = "planet" data = Source.PlanetID
+                          tag = "special" data = ThisSpecial
+                          tag = "turn" data = CurrentTurn
+                          tag = "specialcapacity" data = SpecialCapacity name = ThisSpecial object = Source.ID
+                          tag = "specialaddedonturn" data = SpecialAddedOnTurn name = ThisSpecial object = Source.ID
+                          tag = "remark" data = "{main application add research}"
+                          tag = "remark2" data = Source.Research
+                    ]
+               SetResearch value = Value + (SpecialCapacity name = ThisSpecial object = Source.ID)
+               SetTargetResearch value = Value + (SpecialCapacity name = ThisSpecial object = Source.ID)
+            ]
     ]
 
     graphic = "icons/policies/military_exploration.png"

--- a/default/scripting/specials/planet/NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_ODD.focs.txt
+++ b/default/scripting/specials/planet/NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_ODD.focs.txt
@@ -1,12 +1,12 @@
 Special
-    name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL"
+    name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_ODD"
     description = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_DESC"
     spawnrate = 0.0
     effectsgroups = [
         EffectsGroup
             scope = Source
-            activation = (CurrentTurn % 2 == 0)
-            stackinggroup = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_GROUP"
+            activation = (CurrentTurn % 2 == 1)
+            stackinggroup = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_ODD_GROUP"
             priority = [[BEFORE_ANYTHING_ELSE_PRIORITY]]
             effects = [
                 RemoveSpecial name = ThisSpecial
@@ -14,8 +14,8 @@ Special
 
         EffectsGroup
             scope = Source
-            activation = Turn high = ( 1 + SpecialAddedOnTurn name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL" object = Source.ID )
-            stackinggroup = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_GROUP"
+            activation = Turn high = (1 + SpecialAddedOnTurn name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_ODD" object = Source.ID )
+            stackinggroup = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_ODD_GROUP"
             priority = [[BEFORE_ANYTHING_ELSE_PRIORITY]]
             effects = [
                 SetResearch value = Value + (SpecialCapacity name = ThisSpecial object = Source.ID)

--- a/default/scripting/specials/planet/NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_ODD.focs.txt
+++ b/default/scripting/specials/planet/NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_ODD.focs.txt
@@ -5,22 +5,57 @@ Special
     effectsgroups = [
         EffectsGroup
             scope = Source
-            activation = (CurrentTurn % 2 == 1)
+            activation = Turn low = (3 + SpecialAddedOnTurn name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_ODD" object = Source.ID )
             stackinggroup = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_ODD_GROUP"
             priority = [[BEFORE_ANYTHING_ELSE_PRIORITY]]
             effects = [
+                GenerateSitRepMessage
+                    message = "PLANET_SPECIAL_INFO"
+                    label = "SITREP_FIELD_RESEARCH_KILLED_LABEL"
+                    icon = "icons/tech/environmental_encapsulation.png"
+                    parameters = [
+	         tag = "system" data = Source.SystemID
+                          tag = "planet" data = Source.PlanetID
+                          tag = "special" data = ThisSpecial
+                          tag = "turn" data = CurrentTurn
+                          tag = "specialcapacity" data = SpecialCapacity name = ThisSpecial object = Source.ID
+                          tag = "specialaddedonturn" data = SpecialAddedOnTurn name = ThisSpecial object = Source.ID
+                          tag = "remark" data = "{removing the special}"
+                          tag = "remark2" data = Source.Research
+                    ]
                 RemoveSpecial name = ThisSpecial
             ]
 
         EffectsGroup
             scope = Source
-            activation = Turn high = (1 + SpecialAddedOnTurn name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_ODD" object = Source.ID )
+            activation = Turn low = (2 + SpecialAddedOnTurn name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_ODD" object = Source.ID )
             stackinggroup = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_ODD_GROUP"
             priority = [[BEFORE_ANYTHING_ELSE_PRIORITY]]
+            effects = SetResearch value = Value - (SpecialCapacity name = ThisSpecial object = Source.ID)
+
+        EffectsGroup
+            scope = Source
+            activation = Turn low = (1 + SpecialAddedOnTurn name = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_ODD" object = Source.ID )
+            stackinggroup = "NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_ODD_GROUP"
+            priority = [[END_CLEANUP_PRIORITY]]
             effects = [
-                SetResearch value = Value + (SpecialCapacity name = ThisSpecial object = Source.ID)
-                SetTargetResearch value = Value + (SpecialCapacity name = ThisSpecial object = Source.ID)
-           ]
+               GenerateSitRepMessage
+                    message = "PLANET_SPECIAL_INFO"
+                    label = "SITREP_FIELD_RESEARCH_KILLED_LABEL"
+                    icon = "icons/tech/environmental_encapsulation.png"
+                    parameters = [
+	         tag = "system" data = Source.SystemID
+                          tag = "planet" data = Source.PlanetID
+                          tag = "special" data = ThisSpecial
+                          tag = "turn" data = CurrentTurn
+                          tag = "specialcapacity" data = SpecialCapacity name = ThisSpecial object = Source.ID
+                          tag = "specialaddedonturn" data = SpecialAddedOnTurn name = ThisSpecial object = Source.ID
+                          tag = "remark" data = "{main application add research}"
+                          tag = "remark2" data = Source.Research
+                    ]
+               SetResearch value = Value + (SpecialCapacity name = ThisSpecial object = Source.ID)
+               SetTargetResearch value = Value + (SpecialCapacity name = ThisSpecial object = Source.ID)
+            ]
     ]
 
     graphic = "icons/policies/military_exploration.png"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -8464,13 +8464,13 @@ SITREP_FIELD_RESEARCH
 At %system%: %policy% generated research.
 
 SITREP_FIELD_RESEARCH_KILLED
-TURN %rawtext:turn%  %system% received research  (%rawtext:rpbon% RP).(%rawtext:rpbonus% RP) from newly explored systems before the exploring ships were all destroyed.
+TURN %rawtext:turn%  %system% received research (%rpbonus% RP) from newly explored systems before the exploring ships were all destroyed.
 
 SITREP_FIELD_RESEARCH_KILLED_LABEL
 Research from Killed Explorers
 
 SITREP_FIELD_RESEARCH_KILLED_SYSTEM
-All your ships in newly explored %system% were destroyed. Exploration research got send to %target% (%rawtext:rpbonus% RP).
+All your ships in newly explored %system% were destroyed. Exploration research got send to %system:target% (%rawtext:rpbonus% RP).
 
 SITREP_FIELD_RESEARCH_KILLED_SYSTEM_LABEL
 All Ships Destroyed
@@ -10160,6 +10160,9 @@ Salvaged Exploration
 
 NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_DESC
 Recorded [[policy Exploration]] research sent from destroyed ships. This special is a technical artifact: it decreases research meter and removes itself in order to counter temporary research meter growth.
+
+PLANET_SPECIAL_INFO
+In %system% planet %planet% had special %special% with capacity %rawtext:specialcapacity% added on turn %rawtext:specialaddedonturn% (Turn %rawtext:turn%) %rawtext:remark% %rawtext:remark2%
 
 ACCRETION_DISC_SPECIAL
 Accretion Disc

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -8461,7 +8461,19 @@ SITREP_FIELD_RESEARCH_LABEL
 Exploration Research
 
 SITREP_FIELD_RESEARCH
-At %system%: exploration generated research.
+At %system%: %policy% generated research.
+
+SITREP_FIELD_RESEARCH_KILLED
+TURN %rawtext:turn%  %system% received research  (%rawtext:rpbon% RP).(%rawtext:rpbonus% RP) from newly explored systems before the exploring ships were all destroyed.
+
+SITREP_FIELD_RESEARCH_KILLED_LABEL
+Research from Killed Explorers
+
+SITREP_FIELD_RESEARCH_KILLED_SYSTEM
+All your ships in newly explored %system% were destroyed. Exploration research got send to %target% (%rawtext:rpbonus% RP).
+
+SITREP_FIELD_RESEARCH_KILLED_SYSTEM_LABEL
+All Ships Destroyed
 
 CUSTOM_SITREP_INTRODUCTION
 Welcome to the initial Situation Report Briefing. Pursuant to the %tech% Directive, all the busy empire servants endeavor to collect important information and send it back to %system%, where it is compiled into Situation Reports, such as this, providing notice of important events and other reminders selected by the empire leadership.
@@ -10142,6 +10154,12 @@ Derelict Trooper
 
 DERELICT_SPECIAL_DESC
 An ancient derelict ship from an unknown species. Who knows what it could reveal...
+
+NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL
+Salvaged Exploration
+
+NEWLY_EXPLORED_SYSTEMS_WITH_NO_FLEET_SPECIAL_DESC
+Recorded [[policy Exploration]] research sent from destroyed ships. This special is a technical artifact: it decreases research meter and removes itself in order to counter temporary research meter growth.
 
 ACCRETION_DISC_SPECIAL
 Accretion Disc


### PR DESCRIPTION
implementation for reaping research from exploration policy in case all exploring ships in a system get killed on the turn of exploration

A fix for #4997 

Note that needs an ugly workaround we sidestepped by adding research to the ships and not the empire root in the first place. The workaround simulates a temporary change in a research meter. Without the workaround the research growth is completely off-balance.

not build yet, not cleaned yet, not tested yet, stringtable entries missing