### PR TITLE
Complement org.freeorion.FreeOrion.metainfo.xml

### DIFF
--- a/packaging/org.freeorion.FreeOrion.metainfo.xml
+++ b/packaging/org.freeorion.FreeOrion.metainfo.xml
@@ -20,6 +20,7 @@
   <url type="faq">http://www.freeorion.org/index.php/FAQ</url>
   <url type="help">http://www.freeorion.org/forum/viewforum.php?f=25</url>
   <url type="homepage">http://www.freeorion.org</url>
+  <url type="vcs-browser">https://github.com/freeorion/freeorion</url>
   <screenshots>
     <screenshot type="default">
       <caption>Galaxy map with system statistics</caption>


### PR DESCRIPTION
Based on what is already available in the [LinuxPhoneApps listing](https://linuxphoneapps.org/games/org.freeorion.freeorion) I added some missing metainfo:
- Adds vcs-browser url