### PR TITLE
Require Sufficient IP to Annex

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -528,7 +528,8 @@ bool Empire::PolicyAffordable(std::string_view name, const ScriptingContext& con
         return false;
     }
 
-    // TODO: include annexation costs in test?
+    // excluding annexation costs from costs since policy adoption happens before annexation
+
     const double other_this_turn_adopted_policies_cost = ThisTurnAdoptedPoliciesCost(context);
     TraceLogger() << "Empire::PolicyAffordable : Combined already-adopted policies this turn cost "
                   << other_this_turn_adopted_policies_cost;

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -396,11 +396,11 @@ public:
 
     /** Resets production of resources and calculates allocated resources (on
       * each item in queues and overall) for each resource by calling
-      * UpdateResearchQueue, UpdateProductionQueue, UpdateInfluenceSpending.  Does
-      * not actually "spend" resources, but just determines how much and on what
-      * to spend.  Actual consumption of resources, removal of items from queue,
-      * processing of finished items and population growth happens in various
-      * Check(Whatever)Progress functions. */
+      * UpdateResearchQueue, UpdateProductionQueue, UpdateInfluenceSpending.
+      * Does not actually "spend" resources, but just determines how much and
+      * on what to spend.  Actual consumption of resources, removal of items
+      * from queue, processing of finished items and population growth happens
+      * in various Check(Whatever)Progress functions. */
     void UpdateResourcePools(const ScriptingContext& context,
                              const std::vector<std::tuple<std::string_view, double, int>>& research_costs,
                              const std::vector<std::pair<int, double>>& annex_costs,

--- a/Empire/ResourcePool.cpp
+++ b/Empire/ResourcePool.cpp
@@ -157,6 +157,7 @@ void ResourcePool::Update(const ObjectMap& objects) {
         // resource when, for instance, distributing pp
         if (object_system_group.empty()) {
             // store object id in set, even though it is not likely actually a system
+            object_system_group.reserve(1); // quiet GCC warning https://gcc.gnu.org/bugzilla/show_bug.cgi?id=100366
             object_system_group.insert(object_id);
 
             const auto* mmt = obj->GetMeter(meter_type);

--- a/Empire/ResourcePool.h
+++ b/Empire/ResourcePool.h
@@ -14,7 +14,7 @@
 
 class ObjectMap;
 
-//! Types of resources that Empire%s can produce
+//! Types of resources that Empires can produce
 FO_ENUM(
     (ResourceType),
     ((INVALID_RESOURCE_TYPE, -1))

--- a/GG/GG/PtRect.h
+++ b/GG/GG/PtRect.h
@@ -56,14 +56,15 @@ struct GG_API Pt
     Y y = Y0;
 
     static constexpr std::size_t hash(std::size_t x) {
+        uint64_t h = static_cast<uint64_t>(x);
         // from Boost hash_mix_impl
-        const std::size_t m = (std::size_t(0xe9846afu) << 32u) + std::size_t(0x9b1a615du);
-        x ^= x >> 32u;
-        x *= m;
-        x ^= x >> 32u;
-        x *= m;
-        x ^= x >> 28u;
-        return x;
+        const uint64_t m = (uint64_t(0xe9846afu) << 32u) + uint64_t(0x9b1a615du);
+        h ^= h >> 32u;
+        h *= m;
+        h ^= h >> 32u;
+        h *= m;
+        h ^= h >> 28u;
+        return static_cast<std::size_t>(h);
     }
 
     static constexpr std::size_t hash(std::size_t x, std::size_t y)

--- a/GG/src/DrawUtil.cpp
+++ b/GG/src/DrawUtil.cpp
@@ -16,8 +16,33 @@
 
 
 #if !defined(__cpp_lib_integer_comparison_functions)
-constexpr bool cmp_less_equal(std::size_t l, int r) noexcept { return l <= r; }
-constexpr bool cmp_greater(std::size_t l, int r) noexcept { return l > r; }
+constexpr bool cmp_less_equal(std::size_t l, int r) noexcept
+{ return (r < 0) ? false : (l <= static_cast<std::size_t>(r)); }
+static_assert(cmp_less_equal(0u, 0));
+static_assert(cmp_less_equal(0u, 1));
+static_assert(cmp_less_equal(1u, 1));
+static_assert(!cmp_less_equal(1u, 0));
+static_assert(cmp_less_equal(1u, 2));
+static_assert(cmp_less_equal(0u, INT_MAX));
+static_assert(cmp_less_equal(static_cast<std::size_t>(INT_MAX), INT_MAX));
+static_assert(!cmp_less_equal(static_cast<std::size_t>(INT_MAX), 0));
+static_assert(!cmp_less_equal(0u, -1));
+static_assert(!cmp_less_equal(0u, INT_MIN));
+static_assert(!cmp_less_equal(static_cast<std::size_t>(INT_MAX), INT_MIN));
+
+constexpr bool cmp_greater(std::size_t l, int r) noexcept
+{ return (r < 0) ? true : (l > static_cast<std::size_t>(r)); }
+static_assert(!cmp_greater(0u, 0));
+static_assert(!cmp_greater(0u, 1));
+static_assert(!cmp_greater(1u, 1));
+static_assert(cmp_greater(1u, 0));
+static_assert(!cmp_greater(1u, 2));
+static_assert(!cmp_greater(0u, INT_MAX));
+static_assert(!cmp_greater(static_cast<std::size_t>(INT_MAX), INT_MAX));
+static_assert(cmp_greater(static_cast<std::size_t>(INT_MAX), 0));
+static_assert(cmp_greater(0u, -1));
+static_assert(cmp_greater(0u, INT_MIN));
+static_assert(cmp_greater(static_cast<std::size_t>(INT_MAX), INT_MIN));
 #else
 using std::cmp_less_equal;
 using std::cmp_greater;

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -2145,20 +2145,6 @@ Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddOpenTag(Clr c
 
 
 ///////////////////////////////////////
-// class GG::Font::RenderState
-///////////////////////////////////////
-namespace {
-    std::array<GLubyte, 4> GetCurrentByteColor() {
-        std::array<GLfloat, 4> current_float{};
-        glGetFloatv(GL_CURRENT_COLOR, current_float.data());
-        return std::array<GLubyte, 4>{static_cast<GLubyte>(current_float[0]*255),
-                                      static_cast<GLubyte>(current_float[1]*255),
-                                      static_cast<GLubyte>(current_float[2]*255),
-                                      static_cast<GLubyte>(current_float[3]*255)};
-    }
-}
-
-///////////////////////////////////////
 // struct GG::Font::Glyph
 ///////////////////////////////////////
 Font::Glyph::Glyph(std::shared_ptr<Texture> texture, Pt ul, Pt lr, int8_t y_ofs, int8_t lb, int8_t adv) :

--- a/GG/src/PtRect.cpp
+++ b/GG/src/PtRect.cpp
@@ -109,18 +109,18 @@ namespace StaticTests {
     static_assert([](){ Y y(Y1); y--; return y; }() == Y0);
     static_assert([](){ Y y(Y0); y--; return y; }() != Y0);
 
-    inline constexpr Y szy{22};
-    inline constexpr int margin = 3;
-    inline constexpr int tw = Value(szy - 4 * margin);
+    constexpr Y szy{22};
+    constexpr int margin = 3;
+    constexpr int tw = Value(szy - 4 * margin);
     static_assert(tw == 10);
-    inline constexpr int ow = tw + 3 * margin;
+    constexpr int ow = tw + 3 * margin;
     static_assert(ow == 19);
-    inline constexpr X szx{5};
-    inline constexpr X tl = szx - tw - margin * 5 / 2;
+    constexpr X szx{5};
+    constexpr X tl = szx - tw - margin * 5 / 2;
     static_assert(Value(tl) == -12);
-    inline constexpr auto btnl = szx - ow - margin;
+    constexpr auto btnl = szx - ow - margin;
     static_assert(btnl == GG::X(-17));
-    inline constexpr auto btnr = szx - margin;
+    constexpr auto btnr = szx - margin;
     static_assert(Value(btnr) == 2);
     static_assert(margin - szx == -Value(btnr));
 }

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -136,7 +136,6 @@ std::string_view TextControl::Text(CPSize from, CPSize to) const
     const auto out_length = std::max(low_string_idx, high_string_idx) - std::min(low_string_idx, high_string_idx);
 
     const auto low_it = m_text.begin() + low_string_idx;
-    const auto high_it = m_text.begin() + high_string_idx;
 
     try {
         return {&*low_it, out_length};

--- a/GG/src/dialogs/FileDlg.cpp
+++ b/GG/src/dialogs/FileDlg.cpp
@@ -493,7 +493,7 @@ void FileDlg::SetWorkingDirectory(const fs::path& p)
 {
     m_files_edit->Clear();
     FilesEditChanged(m_files_edit->Text());
-    s_working_dir = p;
+    s_working_dir = fs::canonical(p);
     UpdateDirectoryText();
     UpdateList();
 }

--- a/GG/src/dialogs/FileDlg.cpp
+++ b/GG/src/dialogs/FileDlg.cpp
@@ -711,9 +711,8 @@ void FileDlg::OpenDirectory()
         // remain in current directory
         UpdateList();
         return;
-    }
 
-    else if (directory_sv == "..") {
+    } else if (directory_sv == "..") {
         // move to parent directory of current directory
         if (s_working_dir.string() != s_working_dir.root_path().string() &&
             !s_working_dir.parent_path().string().empty())
@@ -731,10 +730,9 @@ void FileDlg::OpenDirectory()
             UpdateList();
         }
         return;
-    }
 
-    else {
-        std::string const directory{directory_sv.substr(1, directory.size() - 2)}; // strip off '[' and ']'
+    } else {
+        std::string const directory{directory_sv.substr(1, directory_sv.size() - 2)}; // strip off '[' and ']'
 
         // move to contained directory, which may be a drive selection...
         if (!m_in_win32_drive_selection) {

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -2121,7 +2121,7 @@ void MultiTurnProgressBar::Render() {
     // segment lines
     GG::GL2DVertexBuffer segment_verts;
     GG::GLRGBAColorBuffer segment_colors;
-    if (m_num_segments > 1u && m_num_segments < Value(Width())) {
+    if (m_num_segments > 1u && std::cmp_less(m_num_segments, Value(Width()))) {
         try {
             segment_verts.reserve(std::size_t{2u} * m_num_segments);
             segment_colors.reserve(std::size_t{2u} * m_num_segments);

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -1678,7 +1678,7 @@ public:
         m_panel->Resize(Size() - border);
     }
 
-    [[nodiscard]] GG::ListBox::Row::SortKeyType SortKey(std::size_t column) const noexcept
+    [[nodiscard]] GG::ListBox::Row::SortKeyType SortKey(std::size_t column) const override
     { return m_panel ? m_panel->SortKey(column) : EMPTY_STRING; }
 
     [[nodiscard]] int ObjectID() const noexcept

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -1284,8 +1284,8 @@ void OptionsWnd::FontOption(GG::ListBox* page, int indentation_level, std::strin
                             std::string text)
 {
     FileOption(page, indentation_level, std::move(option_name), std::move(text),
-               GetRootDataDir() / "default", {std::string(option_name), "*" + FONT_FILE_SUFFIX},
-               ValidFontFile);
+               GetRootDataDir() / "default",
+               {UserString("OPTIONS_FONT_FILE"), "*" + FONT_FILE_SUFFIX}, ValidFontFile);
 }
 
 void OptionsWnd::ResolutionOption(GG::ListBox* page, int indentation_level) {

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -408,11 +408,11 @@ namespace {
         double turn_spending, double total_cost, int turns, int number, double completed_progress) :
         GG::Control(x, y, w, DefaultHeight(), GG::NO_WND_FLAGS),
         elem(build),
-        m_in_progress(build.allocated_pp || build.turns_left_to_next_item == 1),
-        m_total_turns(turns),
         m_turn_spending(turn_spending),
         m_total_cost(total_cost),
-        m_completed_progress(completed_progress)
+        m_completed_progress(completed_progress),
+        m_total_turns(turns),
+        m_in_progress(build.allocated_pp || build.turns_left_to_next_item == 1)
     {
         if (m_total_turns < 1 || m_total_cost < 0)
             WarnLogger() << "Low turns or total cost";

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -896,7 +896,7 @@ namespace {
 
         [[nodiscard]] int SystemID() const noexcept { return m_system_id; }
 
-        [[nodiscard]] SortKeyType SortKey(std::size_t) const noexcept { return EMPTY_STRING; }
+        [[nodiscard]] SortKeyType SortKey(std::size_t) const noexcept override { return EMPTY_STRING; }
 
     private:
         int m_system_id;

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -1668,12 +1668,12 @@ namespace {
             ships_fighters_to_add_back[launched_from_id]++;
         }
         DebugLogger() << "Fighters left at end of combat:";
-        for (const auto [ship_id, fighter_count] : ships_fighters_to_add_back)
+        for (const auto& [ship_id, fighter_count] : ships_fighters_to_add_back)
             DebugLogger() << " ... from ship id " << ship_id << " : " << fighter_count;
 
 
         DebugLogger() << "Returning fighters to ships:";
-        for (const auto [ship_id, fighter_count] : ships_fighters_to_add_back) {
+        for (const auto& [ship_id, fighter_count] : ships_fighters_to_add_back) {
             auto ship = combat_info.objects.getRaw<Ship>(ship_id);
             if (!ship) {
                 ErrorLogger(combat) << "Couldn't get ship with id " << ship_id << " for fighter to return to...";

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3574,6 +3574,9 @@ Music files
 OPTIONS_SOUND_FILE
 Sound files
 
+OPTIONS_FONT_FILE
+Font files
+
 OPTIONS_DUMP_EFFECTS_GROUPS_DESC
 Auto-generated effect descriptions
 

--- a/parse/ConditionParser3.cpp
+++ b/parse/ConditionParser3.cpp
@@ -213,7 +213,7 @@ namespace parse::detail {
         unique_of1
             = ( omit_[tok.Unique_]
             >>  label(tok.sortkey_)  >> double_rules.expr
-            >   label(tok.condition_) > condition_parser)
+            >  (label(tok.condition_) > condition_parser))
             [ _val = construct_movable_(new_<Condition::SortedNumberOf>(
                 deconstruct_movable_(construct_movable_(new_<ValueRef::Constant<int>>(std::numeric_limits<int>::max())), _pass),
                 deconstruct_movable_(_1, _pass),
@@ -224,7 +224,7 @@ namespace parse::detail {
         unique_of2
             = ( omit_[tok.Unique_]
             >>  label(tok.sortkey_) >> string_grammar
-            >   label(tok.condition_) > condition_parser)
+            >  (label(tok.condition_) > condition_parser))
             [ _val = construct_movable_(new_<Condition::SortedNumberOf>(
                 deconstruct_movable_(construct_movable_(new_<ValueRef::Constant<int>>(std::numeric_limits<int>::max())), _pass),
                 deconstruct_movable_(_1, _pass),

--- a/parse/ConditionParser3.cpp
+++ b/parse/ConditionParser3.cpp
@@ -211,9 +211,9 @@ namespace parse::detail {
             ;
 
         unique_of1
-            = ( omit_[tok.Unique_]
-            >>  label(tok.sortkey_)  >> double_rules.expr
-            >  (label(tok.condition_) > condition_parser))
+            = ((omit_[tok.Unique_]
+            >>  label(tok.sortkey_)  >> double_rules.expr)
+            >   label(tok.condition_) > condition_parser)
             [ _val = construct_movable_(new_<Condition::SortedNumberOf>(
                 deconstruct_movable_(construct_movable_(new_<ValueRef::Constant<int>>(std::numeric_limits<int>::max())), _pass),
                 deconstruct_movable_(_1, _pass),
@@ -222,9 +222,9 @@ namespace parse::detail {
             ;
 
         unique_of2
-            = ( omit_[tok.Unique_]
-            >>  label(tok.sortkey_) >> string_grammar
-            >  (label(tok.condition_) > condition_parser))
+            = ((omit_[tok.Unique_]
+            >> label(tok.sortkey_) >> string_grammar)
+            >  label(tok.condition_) > condition_parser)
             [ _val = construct_movable_(new_<Condition::SortedNumberOf>(
                 deconstruct_movable_(construct_movable_(new_<ValueRef::Constant<int>>(std::numeric_limits<int>::max())), _pass),
                 deconstruct_movable_(_1, _pass),

--- a/util/Random.cpp
+++ b/util/Random.cpp
@@ -25,7 +25,9 @@ namespace StaticTests {
     using namespace RandomImpl;
 
     constexpr auto test_num_hash0 = hash(uint8_t{0});
+    static_assert(test_num_hash0 == 220086046u);
     constexpr auto test_num_hash1 = hash(uint8_t{1});
+    static_assert(test_num_hash1 == 555565661u);
 
     constexpr std::array<char, 9> zt{"00:00:00"};
     constexpr std::array test_nums{CxPRNG(0, zt), CxPRNG(1, zt) % 20, CxPRNG(2, zt) % 20, CxPRNG(3, zt) % 20,


### PR DESCRIPTION
Prevents annexation without sufficient IP. Accounts for policy adoption and other annexations on the same turn.