### PR TITLE
do docker builds when ubuntu builds are triggered on pull requests

### DIFF
--- a/.github/workflows/build_on_pull_request.yml
+++ b/.github/workflows/build_on_pull_request.yml
@@ -38,6 +38,10 @@ jobs:
     needs: detect_changed_files
     if: ${{ needs.detect_changed_files.outputs.build_ubuntu == 'true' }}
     uses: ./.github/workflows/_build-ubuntu.yml
+  docker:
+    needs: detect_changed_files
+    if: ${{ needs.detect_changed_files.outputs.build_ubuntu == 'true' }}
+    uses: ./.github/workflows/_build-docker.yml
   windows-msvc:
     needs: detect_changed_files
     if: ${{ needs.detect_changed_files.outputs.build_windows_with_msvs == 'true' }}


### PR DESCRIPTION
@o01eg seemed like a reasonable way to decide when to do them, but is there something better / that should be done instead?