### PR TITLE
don't forward args twice when checking then issuing order in AI wrapper

### DIFF
--- a/client/AI/AIWrapper.cpp
+++ b/client/AI/AIWrapper.cpp
@@ -241,7 +241,7 @@ namespace {
         auto app = ClientApp::GetApp();
         ScriptingContext context;
 
-        if (!OrderType::Check(app->EmpireID(), std::forward<Args>(args)..., context))
+        if (!OrderType::Check(app->EmpireID(), args..., context))
             return 0;
 
         app->Orders().IssueOrder(


### PR DESCRIPTION
Wrapper for issuing orders in AI Wrapper was forwarding arguments twice, which could lead to eg. a name string being passed the second time empty instead of what was passed in if it was an rvalue. Probably wasn't actually an issue, but would be better to fix.