### PR TITLE
Default disable pedia article text search

### DIFF
--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -59,7 +59,7 @@ namespace {
 
     void AddOptions(OptionsDB& db) {
         db.Add("resource.effects.description.shown", UserStringNop("OPTIONS_DB_DUMP_EFFECTS_GROUPS_DESC"), false);
-        db.Add("ui.pedia.search.articles.enabled", UserStringNop("OPTIONS_DB_UI_ENC_SEARCH_ARTICLE"), true);
+        db.Add("ui.pedia.search.articles.enabled", UserStringNop("OPTIONS_DB_UI_ENC_SEARCH_ARTICLE"), false);
     }
     bool temp_bool = RegisterOptions(&AddOptions);
 


### PR DESCRIPTION
Reportedly avoids crash reported here: https://freeorion.org/forum/viewtopic.php?p=120738#p120738 which I otherwise don't know how to fix.