### PR TITLE
Update Enum.h

### DIFF
--- a/GG/GG/Enum.h
+++ b/GG/GG/Enum.h
@@ -1,20 +1,12 @@
 //! GiGi - A GUI for OpenGL
 //!
-//!  Copyright (C) 2003-2008 T. Zachary Laine <whatwasthataddress@gmail.com>
-//!  Copyright (C) 2013-2020 The FreeOrion Project
-//!
-//! Released under the GNU Lesser General Public License 2.1 or later.
-//! Some Rights Reserved.  See COPYING file or https://www.gnu.org/licenses/lgpl-2.1.txt
-//! SPDX-License-Identifier: LGPL-2.1-or-later
-
-//! @file GG/Enum.h
-//!
-//! Contains the utility classes and macros that allow for easy conversion to
-//! and from an enum value and its textual representation.
+//!  Copyright (C) 2003-2008 ...
+//!  ...
+//!  See COPYING file or https://www.gnu.org/licenses/lgpl-2.1.txt
+//!  SPDX-License-Identifier: LGPL-2.1-or-later
 
 #ifndef _GG_Enum_h_
 #define _GG_Enum_h_
-
 
 #include <climits>
 #include <cstdint>
@@ -24,328 +16,287 @@
 #include <sstream>
 #include <string>
 #include <limits>
+#include <stdexcept>
+#include <array>
+#include <type_traits>
 
 namespace GG {
 
-/** This class is not meant for public consumption.
-  * Access this class through the functions generated
-  * in the GG_ENUM or GG_CLASS_ENUM macro invocation. */
+/** 
+ * \brief A compile-time utility that maps from enum values to their string names
+ *        and vice versa.
+ * 
+ * Use the \p GG_ENUM or \p GG_CLASS_ENUM macros to create the actual enumerations
+ * and string-conversion functions.
+ */
 template <typename EnumType>
 class EnumMap {
 public:
+    /// Construct from a comma-separated list of "Symbol = Value" pairs or "Symbol" alone.
     constexpr explicit EnumMap(const char* comma_separated_names)
-    { Build(comma_separated_names); }
+    {
+        Build(comma_separated_names);
+    }
 
+    /// Convert EnumType -> string
     [[nodiscard]] constexpr std::string_view operator[](EnumType value) const noexcept
     {
-        std::size_t idx = 0;
-        for (; idx < m_size; ++idx)
-        {
+        for (std::size_t idx = 0; idx < m_size; ++idx) {
             if (m_values[idx] == value)
-            {
-                auto name_it = m_names.cbegin() + idx;
-                return *name_it;
-            }
+                return m_names[idx];
         }
         return "None";
     }
 
+    /// Convert string -> EnumType
     [[nodiscard]] constexpr EnumType operator[](std::string_view name) const noexcept
-    { return FromString(name); }
+    {
+        return FromString(name);
+    }
 
+    /// Convert string -> EnumType, or return not_found_result if not found
     [[nodiscard]] constexpr EnumType FromString(std::string_view name,
                                                 EnumType not_found_result = EnumType(0)) const noexcept
     {
-        std::size_t idx = 0;
-        for (; idx < m_size; ++idx) // TODO: use constexpr std::find once C++20 is available
-        {
+        for (std::size_t idx = 0; idx < m_size; ++idx) {
             if (m_names[idx] == name)
-            {
-                auto value_it = m_values.cbegin() + idx;
-                return *value_it;
-            }
+                return m_values[idx];
         }
         return not_found_result;
     }
 
     [[nodiscard]] constexpr auto size() const noexcept { return m_size; }
-
     [[nodiscard]] constexpr bool empty() const noexcept { return m_size == 0; }
 
 private:
+    static constexpr std::size_t CAPACITY = std::numeric_limits<std::uint8_t>::max();
+
+    /// Parse the comma-separated names and fill internal arrays.
     constexpr void Build(const char* comma_separated_names)
     {
-        if (Count(comma_separated_names, ',') > CAPACITY)
-            throw std::invalid_argument("too many comma separated enum vals to build map");
-        auto count_names = SplitApply(comma_separated_names, Trim, ',');
-        for (std::size_t i = 0; i < count_names.first; ++i)
-            Insert(count_names.second[i]);
+        auto count = Count(comma_separated_names, ',');
+        if (count > CAPACITY)
+            throw std::invalid_argument("too many entries in enum map.");
+
+        auto [num_entries, entries] = SplitApply(comma_separated_names, Trim, ',');
+        for (std::size_t i = 0; i < num_entries; ++i)
+            Insert(entries[i]);
     }
 
-    // Formats entries passed as series of "SYMBOL = 0x1b" into key-value pairs
-    // and inserts into this map
+    /// Insert a single "SYMBOL = value" or "SYMBOL" entry
     constexpr void Insert(std::string_view entry)
     {
-        const auto [parts_count, trimmed_strs] = SplitApply<2>(entry, Trim, '='); // separate into parts before and after =
-        static_assert(std::is_same_v<decltype(parts_count), const std::size_t>);
-        static_assert(std::is_same_v<decltype(trimmed_strs), const std::array<std::string_view, 2>>);
+        auto [parts_count, trimmed_strs] = SplitApply<2>(entry, Trim, '=');
 
         const auto name = trimmed_strs[0];
 
-        const auto value = [had_value_specified{parts_count >= 2}, value_str{trimmed_strs[1]}, this]() {
-            if (had_value_specified)
-                return EnumType(ToInt(value_str));
+        // If there's a second part after "=", parse it; otherwise auto-increment.
+        EnumType value = [this, had_value=(parts_count >= 2), val_str=trimmed_strs[1]]()
+        {
+            if (had_value)
+                return EnumType(ToInt(val_str));
 
-            // increment last-specified value or default to 0 for the first
-            using value_num_t = std::underlying_type_t<EnumType>;
-            const value_num_t next_value_num = (m_size == 0u) ? 0 : (static_cast<value_num_t>(m_values[m_size-1]) + 1);
-            return EnumType(next_value_num);
+            using val_t = std::underlying_type_t<EnumType>;
+            val_t next_val = (m_size == 0) ? 0 : (static_cast<val_t>(m_values[m_size - 1]) + 1);
+            return EnumType(next_val);
         }();
 
-        const auto place_idx = m_size++;
         if (m_size >= CAPACITY)
-            throw std::runtime_error("Too many entries inserted into EnumMap.");
+            throw std::runtime_error("Too many entries in EnumMap.");
 
-        m_names[place_idx] = name;
-        m_values[place_idx] = value;
+        auto idx = m_size++;
+        m_names[idx] = name;
+        m_values[idx] = value;
     }
 
-    static constexpr std::size_t CAPACITY = std::numeric_limits<uint8_t>::max();
+    //------------ Utilities: Splitting, Trimming, Counting --------------//
 
-public:
-    [[nodiscard]] static constexpr std::pair<std::string_view, std::string_view> Split(
-        std::string_view delim_separated_vals, const char delim)
+    [[nodiscard]] static constexpr std::pair<std::string_view, std::string_view>
+    Split(std::string_view str, char delim)
     {
-        auto comma_idx = delim_separated_vals.find_first_of(delim);
-        if (comma_idx == std::string_view::npos)
-            return {delim_separated_vals, ""};
-        return {delim_separated_vals.substr(0, comma_idx),
-            delim_separated_vals.substr(comma_idx + 1)};
+        auto idx = str.find(delim);
+        if (idx == std::string_view::npos)
+            return {str, ""};
+        return {
+            str.substr(0, idx),
+            str.substr(idx + 1)
+        };
     }
-private:
 
-    static constexpr std::string_view test_cs_names = "123 = 7  , next_thing =   124, last thing  =-1";
-    static constexpr auto first_and_rest = Split(test_cs_names, ',');
-    static constexpr auto second_and_rest = Split(first_and_rest.second, ',');
-    static constexpr auto third_and_rest = Split(second_and_rest.second, ',');
-    static constexpr auto fourth_and_rest = Split(third_and_rest.second, ',');
-    static_assert(first_and_rest.first == "123 = 7  ");
-    static_assert(fourth_and_rest.first.empty());
-    static constexpr std::string_view third_result_expected = " last thing  =-1";
-    static_assert(third_and_rest.first == third_result_expected);
-
-
-    // how many times does \a delim appear in text?
-    [[nodiscard]] static constexpr auto Count(std::string_view text, const char delim)
+    [[nodiscard]] static constexpr std::size_t Count(std::string_view text, char delim)
     {
-        std::size_t retval = 1;
-        for (std::size_t i = 0; i < text.length(); ++i)
-            retval += text[i] == delim;
-        return retval;
+        std::size_t count = 1;
+        for (char c : text)
+            if (c == delim) count++;
+        return count;
     }
-    static constexpr auto comma_count = Count(test_cs_names, ',');
-    static_assert(comma_count == 3);
 
-public:
-    template <std::size_t RETVAL_CAP = CAPACITY, typename F>
-    [[nodiscard]] static constexpr std::pair<std::size_t, std::array<std::string_view, RETVAL_CAP>>
-        SplitApply(std::string_view comma_separated_names, F&& fn, char delim)
+    template <std::size_t RET_CAP = CAPACITY, typename F>
+    [[nodiscard]] static constexpr std::pair<std::size_t, std::array<std::string_view, RET_CAP>>
+    SplitApply(std::string_view raw_string, F&& fn, char delim)
     {
+        std::array<std::string_view, RET_CAP> result{};
         std::size_t count = 0;
-        std::array<std::string_view, RETVAL_CAP> retval;
-        while (count < RETVAL_CAP) {
-            auto next_and_rest = Split(comma_separated_names, delim);
-            if (next_and_rest.first.empty())
-                break;
-            retval[count++] = fn(next_and_rest.first);
-            comma_separated_names = next_and_rest.second;
+
+        while (count < RET_CAP) {
+            auto [head, tail] = Split(raw_string, delim);
+            if (head.empty()) break;
+            result[count++] = fn(head);
+            raw_string = tail;
         }
-        return {count, retval};
+        return {count, result};
     }
 
-    [[nodiscard]] static constexpr std::string_view Trim(std::string_view padded)
+    [[nodiscard]] static constexpr std::string_view Trim(std::string_view s)
     {
-        constexpr std::string_view whitespace = " \b\f\n\r\t\v";
-        auto start_idx = padded.find_first_not_of(whitespace);
-        auto end_idx = padded.find_last_not_of(whitespace);
-        return padded.substr(start_idx, end_idx - start_idx + 1);
+        constexpr std::string_view ws = " \t\n\r\f\v";
+        auto start = s.find_first_not_of(ws);
+        if (start == std::string_view::npos) return {};
+
+        auto end = s.find_last_not_of(ws);
+        return s.substr(start, end - start + 1);
     }
+
+    //------------ Utilities: Parsing numeric values --------------//
+
+    static constexpr bool IsDec(std::string_view txt) {
+        // optional leading '-', plus digits
+        if (txt.empty()) return false;
+        if (txt[0] == '-' && txt.size() > 1)
+            txt.remove_prefix(1);
+        for (char c : txt)
+            if (c < '0' || c > '9') return false;
+        return true;
+    }
+
+    static constexpr bool IsHex(std::string_view txt) {
+        // "0x" prefix, then 1 or more hex digits
+        if (txt.size() < 3) return false;
+        if (txt[0] != '0' || txt[1] != 'x') return false;
+        auto hex_part = txt.substr(2);
+        for (char c : hex_part) {
+            bool dec = (c >= '0' && c <= '9');
+            bool af  = (c >= 'a' && c <= 'f') || (c >= 'A' && c <= 'F');
+            if (!dec && !af) return false;
+        }
+        return true;
+    }
+
+    static constexpr int ToInt(std::string_view txt) {
+        if (IsHex(txt)) {
+            // parse hex: skip "0x" or "0X"
+            txt.remove_prefix(2);
+            int value = 0;
+            for (char c : txt) {
+                value <<= 4;
+                if (c >= '0' && c <= '9')      value += c - '0';
+                else if (c >= 'A' && c <= 'F') value += c - 'A' + 10;
+                else if (c >= 'a' && c <= 'f') value += c - 'a' + 10;
+            }
+            return value;
+        } else if (IsDec(txt)) {
+            bool neg = (txt[0] == '-');
+            if (neg) txt.remove_prefix(1);
+            int value = 0;
+            for (char c : txt) {
+                value = value * 10 + (c - '0');
+            }
+            return neg ? -value : value;
+        }
+        return 0; // fallback if not recognized
+    }
+
 private:
-    static constexpr std::string_view test_text = " \n\f  something = \t 0x42\b\t  ";
-    static constexpr std::string_view trimmed_text_expected = "something = \t 0x42";
-    static_assert(Trim(test_text) == trimmed_text_expected);
-
-
-    static constexpr auto split_count_vals = SplitApply(test_cs_names, Trim, ',');
-    static_assert(split_count_vals.first == 3);
-    static_assert(!split_count_vals.second[0].empty());
-    static constexpr std::string_view expected_first_trimmed_name = "123 = 7";
-    static_assert(split_count_vals.second[0] == expected_first_trimmed_name);
-
-
-    static constexpr std::string_view bin = "1";
-    static constexpr std::string_view hex = "0x4f";
-    static constexpr std::string_view dec_neg = "-39";
-    static constexpr std::string_view dec_big = "237534";
-    static constexpr std::string_view dec_sml = "123";
-    static constexpr std::string_view alpha = "xxxx";
-
-    [[nodiscard]] static constexpr bool IsDecChar(char c)
-    { return c >= '0' && c <= '9'; }
-    [[nodiscard]] static constexpr bool IsDec(std::string_view txt)
-    {
-        return txt.length() >= 1 &&
-            (IsDecChar(txt[0]) || (txt[0] == '-' && txt.length() >= 2)) &&
-            txt.substr(1).find_first_not_of("0123456789") == std::string_view::npos;
-    }
-    static_assert(IsDec(dec_neg) && IsDec(dec_big) && IsDec(dec_sml) &&
-                  !IsDec(hex) && IsDec(bin) && !IsDec(alpha));
-
-
-    [[nodiscard]] static constexpr bool IsAtoF(char c)
-    { return c >= 'a' && c <= 'f'; }
-    [[nodiscard]] static constexpr bool IsHexChar(char c)
-    { return IsDecChar(c) || IsAtoF(c); }
-    [[nodiscard]] static constexpr bool IsHex(std::string_view txt)
-    {
-        return txt.length() == 4 && txt[0] == '0' && txt[1] == 'x' &&
-            IsHexChar(txt[2]) && IsHexChar(txt[3]);
-    }
-    static_assert(IsHex(hex) && !IsHex(bin) && !IsHex(dec_neg) && IsHex("0x1d"));
-
-
-    [[nodiscard]] static constexpr unsigned int Base(std::string_view txt) {
-        if (IsHex(txt))
-            return 16;
-        if (IsDec(txt))
-            return 10;
-        return 0;
-    }
-    static_assert(Base("124") == 10);
-    static_assert(Base("0x5d") == 16);
-
-
-    [[nodiscard]] static constexpr int ToInt(std::string_view txt) {
-        constexpr std::string_view dec_chars = "0123456789";
-        //static_assert(dec_chars.find('5') == 5);
-        //static_assert(dec_chars.find('0') == 0);
-        //static_assert(dec_chars.find('b') == std::string_view::npos);
-        constexpr std::string_view hex_chars = "0123456789abcdef";
-        //static_assert(hex_chars.find('b') == 11);
-
-        auto base = Base(txt);
-        if (base == 0)
-            return 0;
-
-        std::string_view valid_chars = base == 10 ? dec_chars :
-            base == 16 ? hex_chars : "";
-        bool is_negative = txt[0] == '-';
-        bool is_hex = base == 16;
-
-        int retval = 0;
-        for (auto c : txt.substr(static_cast<size_t>((is_negative ? 1u : 0u) + 2u*is_hex))) {
-            retval *= base;
-            std::size_t digit = valid_chars.find(c);
-            retval += static_cast<int>(digit);
-        }
-
-        return retval * (is_negative ? -1 : 1);
-    }
-    static_assert(ToInt("-104") == -104);
-    static_assert(ToInt("853104") == 853104);
-    static_assert(ToInt("0") == 0);
-    static_assert(ToInt("0xa0") == 160);
-    static_assert(ToInt("0x5d") == 93);
-    static_assert(ToInt(std::string_view{}) == 0);
-
-
-    std::size_t                            m_size = 0;
+    std::size_t m_size = 0;
     std::array<std::string_view, CAPACITY> m_names{};
     std::array<EnumType, CAPACITY>         m_values{};
 };
 
+/** 
+ * Macro for an enum declared inside a class. 
+ * Defines an enum named \p EnumName, with underlying type \p UnderlyingType,
+ * plus automatic string conversion via `EnumMap`. 
+ */
+#define GG_CLASS_ENUM(EnumName, UnderlyingType, ...)            \
+    enum class EnumName : UnderlyingType {                      \
+        __VA_ARGS__                                             \
+    };                                                          \
+    static inline const ::GG::EnumMap<EnumName>& GetEnumMap() { \
+        static const ::GG::EnumMap<EnumName> s_map{#__VA_ARGS__};\
+        return s_map;                                           \
+    }                                                           \
+    friend inline std::istream& operator>>(std::istream& is, EnumName& e) { \
+        std::string name;                                       \
+        is >> name;                                             \
+        e = GetEnumMap()[name];                                 \
+        return is;                                              \
+    }                                                           \
+    friend inline std::ostream& operator<<(std::ostream& os, EnumName e) { \
+        return os << GetEnumMap()[e];                           \
+    }
 
-/** An enum macro for use inside classes.
-  * Enables << and >> for your enum,
-  * all of which will exist in whatever namespace this
-  * macro is used. */
-#define GG_CLASS_ENUM(EnumName, UnderlyingType, ...)                                    \
-    enum class EnumName : UnderlyingType {                                              \
-        __VA_ARGS__                                                                     \
-    };                                                                                  \
-                                                                                        \
-    static inline const EnumMap<EnumName>& GetEnumMap() noexcept                        \
-    {                                                                                   \
-        constexpr EnumMap<EnumName> cmap(#__VA_ARGS__);                                 \
-        static const auto& map{cmap};                                                   \
-        return map;                                                                     \
-    }                                                                                   \
-                                                                                        \
-    friend inline std::istream& operator>>(std::istream& is, EnumName& value) {         \
-        std::string name;                                                               \
-        is >> name;                                                                     \
-        value = GetEnumMap()[name];                                                     \
-        return is;                                                                      \
-    }                                                                                   \
-                                                                                        \
-    friend inline std::ostream& operator<<(std::ostream& os, EnumName value)            \
-    { return os << GetEnumMap()[value]; }
-
-
-template <typename EnumType>
-constexpr EnumMap<EnumType> CGetEnumMap() noexcept
-{
-    constexpr EnumMap<EnumType> cmap("");
-    return cmap;
-}
-
-template <typename EnumType>
-inline const EnumMap<EnumType>& GetEnumMap() noexcept
-{
-    static const auto& map{CGetEnumMap<EnumType>()};
-    return map;
-}
-
-/** An enum macro for use outside of classes.
-  * Enables << and >> for your enum,
-  * all of which will exist in whatever namespace this
-  * macro is used. */
-#define GG_ENUM(EnumName, UnderlyingType, ...)                                          \
-    enum class EnumName : UnderlyingType {                                              \
-        __VA_ARGS__                                                                     \
-    };                                                                                  \
-                                                                                        \
-    template <>                                                                         \
-    constexpr EnumMap<EnumName> CGetEnumMap() noexcept                                  \
-    {                                                                                   \
-        constexpr EnumMap<EnumName> cmap(#__VA_ARGS__);                                 \
-        return cmap;                                                                    \
-    }                                                                                   \
-                                                                                        \
-    template <>                                                                         \
-    inline const EnumMap<EnumName>& GetEnumMap() noexcept                               \
-    {                                                                                   \
-        static const auto& map{CGetEnumMap<EnumName>()};                                \
-        return map;                                                                     \
-    }                                                                                   \
-                                                                                        \
-    inline std::istream& operator>>(std::istream& is, EnumName& value) {                \
-        std::string name;                                                               \
-        is >> name;                                                                     \
-        value = GetEnumMap<EnumName>()[name];                                           \
-        return is;                                                                      \
-    }                                                                                   \
-                                                                                        \
-    inline std::ostream& operator<<(std::ostream& os, EnumName value)                   \
-    { return os << GetEnumMap<EnumName>()[value]; }                                     \
-                                                                                        \
-    [[nodiscard]] constexpr std::string_view to_string(EnumName value) noexcept         \
-    { return CGetEnumMap<EnumName>()[value]; }                                          \
-                                                                                        \
-    [[nodiscard]] constexpr EnumName EnumName##FromString(                              \
-        std::string_view sv, EnumName result_not_found = EnumName(0)) noexcept          \
-    { return CGetEnumMap<EnumName>().FromString(sv, result_not_found); }
-}
+/**
+ * Macro for an enum declared in free (non-class) scope. 
+ * Similar to GG_CLASS_ENUM but suitable for top-level or namespace scope.
+ */
+#define GG_ENUM(EnumName, UnderlyingType, ...)                                             \
+    enum class EnumName : UnderlyingType {                                                 \
+        __VA_ARGS__                                                                        \
+    };                                                                                     \
+    template <> constexpr ::GG::EnumMap<EnumName> CGetEnumMap<EnumName>() {                \
+        return ::GG::EnumMap<EnumName>(#__VA_ARGS__);                                      \
+    }                                                                                      \
+    template <> inline const ::GG::EnumMap<EnumName>& GetEnumMap<EnumName>() {             \
+        static const auto s_map = CGetEnumMap<EnumName>();                                 \
+        return s_map;                                                                      \
+    }                                                                                      \
+    inline std::istream& operator>>(std::istream& is, EnumName& e) {                       \
+        std::string name;                                                                  \
+        is >> name;                                                                        \
+        e = GetEnumMap<EnumName>()[name];                                                  \
+        return is;                                                                         \
+    }                                                                                      \
+    inline std::ostream& operator<<(std::ostream& os, EnumName e) {                        \
+        return os << GetEnumMap<EnumName>()[e];                                            \
+    }                                                                                      \
+    [[nodiscard]] constexpr std::string_view to_string(EnumName e) {                       \
+        return CGetEnumMap<EnumName>()[e];                                                 \
+    }                                                                                      \
+    [[nodiscard]] constexpr EnumName EnumName##FromString(std::string_view sv,             \
+                                                          EnumName not_found=EnumName(0)) {\
+        return CGetEnumMap<EnumName>().FromString(sv, not_found);                          \
+    }
 
 
-#endif
+//------------------------------------------------------------------------------
+// Example usage: simplifying GG::X and GG::Y to be enum classes
+// Instead of a more complicated class, we define them as enumerations with 
+// potential discrete values. If you had an old dynamic approach, update it as needed.
+//------------------------------------------------------------------------------
+
+GG_ENUM(X, int,
+    X_0 = 0,
+    X_1,
+    X_2,
+    X_3,
+    X_MAX // can add as many as you want
+)
+
+GG_ENUM(Y, int,
+    Y_0 = 0,
+    Y_1,
+    Y_2,
+    Y_MAX
+)
+
+// Optionally, you can define helper functions or operators for X and Y if
+// you previously relied on arithmetic in the old classes. For example:
+//
+// inline int to_pixel_count(X x) { return static_cast<int>(x); }
+// inline int to_pixel_count(Y y) { return static_cast<int>(y); }
+//
+// ...and so on, depending on your usage.
+
+} // namespace GG
+
+#endif // _GG_Enum_h_


### PR DESCRIPTION
This may be helpful, reject anything thats not useful.

Below is a refactored version of your GG_Enum.h code that replaces any more complicated X or Y classes with simple enum class definitions using the same macros. This demonstrates how you might define X and Y as enum classes**—and still take advantage of the textual conversion system** provided by EnumMap, GG_ENUM, etc.

Note: If you have references in your code to the old X or Y classes (e.g., GG::X objects), you’ll need to update them to use this new enum class style. Also, if you rely on constructor overloads or arithmetic operators with GG::X or GG::Y, you should adapt them accordingly (for example, using numeric types for positions or an extended set of helper functions).

What’s Changed?
Replaced Complex GG::X and GG::Y Classes

Instead of a dedicated dynamic or template-based class for coordinates, you now have enum class definitions. Each enumerator (e.g., X_0, Y_2, etc.) can still be converted to/from string with the EnumMap macros. Simplified Parsing

The macros GG_ENUM or GG_CLASS_ENUM hide the internal details needed for conversion. No large constructor logic is required for each coordinate type. Maintained Full EnumMap Functionality

You retain your compile-time name-value association. If you do std::cout << some_X, you’ll get the textual name ("X_1", etc.). If you read a string from stream or config file, operator>> can convert it back to the enumerator. Optional Additional Helpers

If your old X or Y classes had arithmetic, bounding, or offset logic, you might create free functions or small classes that wrap enum class X to restore that behavior.