### PR TITLE
Force MapWnd Init Before Searching Pedia (on v0.5.1)

### DIFF
--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -4019,6 +4019,9 @@ void EncyclopediaDetailPanel::HandleSearchTextEntered() {
     SectionedScopedTimer timer("HandleSearchTextEntered");
     timer.EnterSection("Find words in search text");
 
+    // force MapWnd construction before possible parallel accesses below...
+    ClientUI::GetClientUI()->GetMapWnd();
+
     const unsigned int num_threads = static_cast<unsigned int>(std::max(1, EffectsProcessingThreads()));
     boost::asio::thread_pool thread_pool(num_threads);
 


### PR DESCRIPTION
hopefully addresses crash when searching from intro menu discussed here: https://freeorion.org/forum/viewtopic.php?p=120832#p120832
