### PR TITLE
CI: Add automatic weekly test build Snap publication

### DIFF
--- a/.github/workflows/_build-macos.yml
+++ b/.github/workflows/_build-macos.yml
@@ -82,7 +82,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ inputs.weekly-deploy }}
         with:
-          name: weekly-artifacts-macos-${{ github.run_number }}
+          name: weekly-artifacts-sf-macos-${{ github.run_number }}
           path: build/FreeOrion_*_Test_MacOSX_*.dmg
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/_build-windows-msvs.yml
+++ b/.github/workflows/_build-windows-msvs.yml
@@ -62,7 +62,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ inputs.weekly-deploy }}
         with:
-          name: weekly-artifacts-windows-msvs-${{ github.run_number }}
+          name: weekly-artifacts-sf-windows-msvs-${{ github.run_number }}
           path: FreeOrion_*_Test_Win32_Setup.exe
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/_build-windows.yml
+++ b/.github/workflows/_build-windows.yml
@@ -74,7 +74,7 @@ jobs:
         uses: actions/upload-artifact@v4
         if: ${{ inputs.weekly-deploy }}
         with:
-          name: weekly-artifacts-windows-${{ github.run_number }}
+          name: weekly-artifacts-sf-windows-${{ github.run_number }}
           path: build/FreeOrion_*.zip
           if-no-files-found: error
           retention-days: 1

--- a/.github/workflows/_build_snapcraft.yml
+++ b/.github/workflows/_build_snapcraft.yml
@@ -2,6 +2,10 @@ name: "Snapcraft"
 
 on:
   workflow_call:
+    inputs:
+      weekly-deploy:
+        type: boolean
+        default: false
 
 jobs:
   snapcraft:
@@ -24,4 +28,12 @@ jobs:
       uses: coactions/setup-xvfb@v1
       with:
         run: /bin/bash .github/snap-xvfb-launch.sh
+    - name: Upload binaries artifacts
+      uses: actions/upload-artifact@v4
+      if: ${{ inputs.weekly-deploy }}
+      with:
+        name: weekly-artifacts-snap-${{ github.run_number }}
+        path: ${{ steps.snapcraft.outputs.snap }}
+        if-no-files-found: error
+        retention-days: 1
 

--- a/.github/workflows/build_weekly_scheduled.yml
+++ b/.github/workflows/build_weekly_scheduled.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Download artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: weekly-artifacts-*
+          pattern: weekly-artifacts-sf-*
           merge-multiple: true
       - name: Check artifacts
         run: ls -l .

--- a/.github/workflows/build_weekly_scheduled.yml
+++ b/.github/workflows/build_weekly_scheduled.yml
@@ -56,10 +56,15 @@ jobs:
     uses: ./.github/workflows/_build-windows-msvs.yml
     with:
       weekly-deploy: true
+  linux-snap:
+    needs: check-run
+    uses: ./.github/workflows/_build_snapcraft.yml
+    with:
+      weekly-deploy: true
   merge-binaries-to-sf:
-    name: Merge binaries
+    name: Merge binaries and publish to SourceForge
     runs-on: ubuntu-latest
-    needs: [macos, windows, windows-msvs]
+    needs: [macos, windows, windows-msvs, linux-snap]
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -80,6 +85,28 @@ jobs:
         run: ls -l .
       - name: Upload artifacts
         run: scp -vv -o ServerAliveCountMax=2 -o ServerAliveInterval=300 -o ConnectTimeout=120 -o ConnectionAttempts=5 FreeOrion_*_Test_MacOSX_*.dmg FreeOrion_*_Test_Win32_Setup.exe FreeOrion_*.zip o01eg@frs.sourceforge.net:/home/frs/project/freeorion/FreeOrion/Test/
+  to-snap:
+    name: Publish snap
+    needs: [macos, windows, windows-msvs, linux-snap] 
+    steps:
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: weekly-artifacts-snap-*
+      - name: Check artifacts
+        run: ls -l .
+      - name: Upload artifacts
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: "*.snap"
+          release: edge
+  publish-post:
+    name: Publish post about weekly test build
+    runs-on: ubuntu-latest
+    needs: [merge-binaries-to-sf, to-snap]
+    steps:
       - name: Get version
         id: get-version
         run: TZ=UTC0 git show ${{ github.sha }} --format="short-version=%cd.%h" --quiet --date='format-local:%Y-%m-%d' --abbrev=7 >> "$GITHUB_OUTPUT"
@@ -88,7 +115,7 @@ jobs:
           curl -X POST
           -H "Authorization: Bearer ${{ secrets.MASTODON_ACCESS_TOKEN }}"
           -H "Idempotency-Key: ${{ steps.get-version.outputs.short-version }}"
-          --data-raw 'status=New test builds available for Windows and macOS (build ${{ steps.get-version.outputs.short-version }}):%0Ahttps://sourceforge.net/projects/freeorion/files/FreeOrion/Test/'
+          --data-raw 'status=New test builds available (build ${{ steps.get-version.outputs.short-version }}):%0AFor Windows and macOS: https://sourceforge.net/projects/freeorion/files/FreeOrion/Test/%0AFor Snap: https://snapcraft.io/freeorion'
           -d 'visibility=public'
           -d 'language=en'
           https://fosstodon.org/api/v1/statuses


### PR DESCRIPTION
Introduces secret `SNAPCRAFT_STORE_CREDENTIALS`. Also changes text of status from what we had in Twitter 

```
New test builds available for Windows and macOS (build ${{ short-version }}):
https://sourceforge.net/projects/freeorion/files/FreeOrion/Test/
```

to 

```
New test builds available (build ${{ short-version }}):
For Windows and macOS: https://sourceforge.net/projects/freeorion/files/FreeOrion/Test/
For Snap: <new some link maybe>
```
