### PR TITLE
Fix fighter damage with scaling info in pedia

### DIFF
--- a/default/scripting/species/species_macros/weapons.py
+++ b/default/scripting/species/species_macros/weapons.py
@@ -33,7 +33,7 @@ def _weapon(*, tag: str, tier_0: int, tier_1: int, tier_2: int, tier_3: int, tie
             ),
             # TODO leave a comment why value multiplier are the same, but weaporns have different
             effects=[
-                SetMaxSecondaryStat(partname="FT_HANGAR_2", value=Value + FIGHTER_DAMAGE_FACTOR * hangar),
+                SetMaxSecondaryStat(partname="FT_HANGAR_2", value=Value + NamedReal(name=tag + "_PILOT_FIGHTER_DAMAGE_BONUS", value=FIGHTER_DAMAGE_FACTOR * hangar)),
                 SetMaxSecondaryStat(partname="FT_HANGAR_3", value=Value + FIGHTER_DAMAGE_FACTOR * hangar),
                 SetMaxSecondaryStat(partname="FT_HANGAR_4", value=Value + FIGHTER_DAMAGE_FACTOR * hangar),
             ],

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_2.focs.py
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_2.focs.py
@@ -4,7 +4,6 @@ from focs._effects import (
     OwnedBy,
     PartsInShipDesign,
     SetMaxCapacity,
-    SetMaxSecondaryStat,
     Ship,
     Source,
     Target,
@@ -12,7 +11,7 @@ from focs._effects import (
 )
 from focs._tech import *
 from macros.base_prod import TECH_COST_MULTIPLIER
-from macros.misc import FIGHTER_DAMAGE_FACTOR
+from techs.ship_weapons.ship_weapons import HANGAR_UPGRADE_SECONDARY_STAT_EFFECT
 
 Tech(
     name="SHP_FIGHTERS_2",
@@ -40,9 +39,9 @@ Tech(
                 SetMaxCapacity(
                     partname="FT_HANGAR_1", value=Value + PartsInShipDesign(name="FT_HANGAR_1", design=Target.DesignID)
                 ),
-                SetMaxSecondaryStat(partname="FT_HANGAR_2", value=Value + 2 * FIGHTER_DAMAGE_FACTOR),
-                SetMaxSecondaryStat(partname="FT_HANGAR_3", value=Value + 3 * FIGHTER_DAMAGE_FACTOR),
-                SetMaxSecondaryStat(partname="FT_HANGAR_4", value=Value + 6 * FIGHTER_DAMAGE_FACTOR),
+                HANGAR_UPGRADE_SECONDARY_STAT_EFFECT("SHP_FIGHTERS_2", "FT_HANGAR_2", 2),
+                HANGAR_UPGRADE_SECONDARY_STAT_EFFECT("SHP_FIGHTERS_2", "FT_HANGAR_3", 3),
+                HANGAR_UPGRADE_SECONDARY_STAT_EFFECT("SHP_FIGHTERS_2", "FT_HANGAR_4", 6),
             ],
         )
     ],

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_3.focs.py
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_3.focs.py
@@ -4,7 +4,6 @@ from focs._effects import (
     OwnedBy,
     PartsInShipDesign,
     SetMaxCapacity,
-    SetMaxSecondaryStat,
     Ship,
     Source,
     Target,
@@ -12,7 +11,7 @@ from focs._effects import (
 )
 from focs._tech import *
 from macros.base_prod import TECH_COST_MULTIPLIER
-from macros.misc import FIGHTER_DAMAGE_FACTOR
+from techs.ship_weapons.ship_weapons import HANGAR_UPGRADE_SECONDARY_STAT_EFFECT
 
 Tech(
     name="SHP_FIGHTERS_3",
@@ -38,9 +37,9 @@ Tech(
                 SetMaxCapacity(
                     partname="FT_HANGAR_1", value=Value + PartsInShipDesign(name="FT_HANGAR_1", design=Target.DesignID)
                 ),
-                SetMaxSecondaryStat(partname="FT_HANGAR_2", value=Value + 2 * FIGHTER_DAMAGE_FACTOR),
-                SetMaxSecondaryStat(partname="FT_HANGAR_3", value=Value + 3 * FIGHTER_DAMAGE_FACTOR),
-                SetMaxSecondaryStat(partname="FT_HANGAR_4", value=Value + 6 * FIGHTER_DAMAGE_FACTOR),
+                HANGAR_UPGRADE_SECONDARY_STAT_EFFECT("SHP_FIGHTERS_3", "FT_HANGAR_2", 2),
+                HANGAR_UPGRADE_SECONDARY_STAT_EFFECT("SHP_FIGHTERS_3", "FT_HANGAR_3", 3),
+                HANGAR_UPGRADE_SECONDARY_STAT_EFFECT("SHP_FIGHTERS_3", "FT_HANGAR_4", 6),
             ],
         )
     ],

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_4.focs.py
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_4.focs.py
@@ -4,7 +4,6 @@ from focs._effects import (
     OwnedBy,
     PartsInShipDesign,
     SetMaxCapacity,
-    SetMaxSecondaryStat,
     Ship,
     Source,
     Target,
@@ -12,7 +11,7 @@ from focs._effects import (
 )
 from focs._tech import *
 from macros.base_prod import TECH_COST_MULTIPLIER
-from macros.misc import FIGHTER_DAMAGE_FACTOR
+from techs.ship_weapons.ship_weapons import HANGAR_UPGRADE_SECONDARY_STAT_EFFECT
 
 Tech(
     name="SHP_FIGHTERS_4",
@@ -38,9 +37,9 @@ Tech(
                 SetMaxCapacity(
                     partname="FT_HANGAR_1", value=Value + PartsInShipDesign(name="FT_HANGAR_1", design=Target.DesignID)
                 ),
-                SetMaxSecondaryStat(partname="FT_HANGAR_2", value=Value + 2 * FIGHTER_DAMAGE_FACTOR),
-                SetMaxSecondaryStat(partname="FT_HANGAR_3", value=Value + 3 * FIGHTER_DAMAGE_FACTOR),
-                SetMaxSecondaryStat(partname="FT_HANGAR_4", value=Value + 6 * FIGHTER_DAMAGE_FACTOR),
+                HANGAR_UPGRADE_SECONDARY_STAT_EFFECT("SHP_FIGHTERS_4", "FT_HANGAR_2", 2),
+                HANGAR_UPGRADE_SECONDARY_STAT_EFFECT("SHP_FIGHTERS_4", "FT_HANGAR_3", 3),
+                HANGAR_UPGRADE_SECONDARY_STAT_EFFECT("SHP_FIGHTERS_4", "FT_HANGAR_4", 6),
             ],
         )
     ],

--- a/default/scripting/techs/ship_weapons/ship_weapons.py
+++ b/default/scripting/techs/ship_weapons/ship_weapons.py
@@ -23,7 +23,10 @@ from focs._effects import (
     TurnTechResearched,
     Value,
 )
-from macros.misc import SHIP_WEAPON_DAMAGE_FACTOR
+from macros.misc import (
+    FIGHTER_DAMAGE_FACTOR,
+    SHIP_WEAPON_DAMAGE_FACTOR,
+)
 from macros.priorities import AFTER_ALL_TARGET_MAX_METERS_PRIORITY
 from techs.techs import (
     ARBITRARY_BIG_NUMBER_FOR_METER_TOPUP,
@@ -157,3 +160,10 @@ def WEAPON_UPGRADE_SECONDARY_STAT_EFFECTS(tech_name: str, part_name: str, extra_
             ),
         ),
     ]
+
+# Tech Upgrade SetMaxSecondaryStat effect for hangar part damage
+# @1@ tech name
+# @2@ part name
+# @3@ base_damage_bonus scaled by figher damage gets added to max secondary stat
+def HANGAR_UPGRADE_SECONDARY_STAT_EFFECT(tech_name: str, part_name: str, base_damage_bonus: int):
+    return SetMaxSecondaryStat(partname=part_name, value=Value + NamedReal(name=tech_name + "_" + part_name + "_DAMAGE_BONUS", value=base_damage_bonus * FIGHTER_DAMAGE_FACTOR))

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -14446,7 +14446,7 @@ SHP_FIGHTERS_1_DESC
 
 A [[encyclopedia PC_FIGHTER_BAY]] can launch a number of fighters in each combat round. These fighters will then be both valid targets and able to attack ships and other fighters in subsequent combat rounds, but a single hit from any source will destroy a fighter. Unlike [[encyclopedia DAMAGE_TITLE]] inflicted by regular weapons, fighter damage ignores [[metertype METER_SHIELD]] on warships (they fire from within the shields).
 
-Piloting traits affect [[FT_HANGAR_2]], [[FT_HANGAR_3]], and [[FT_HANGAR_4]] fighters in the same way: bad piloting reduces damage by 6 per fighter; good piloting increases damage by 6, great piloting by 12, and ultimate piloting by 18 per fighter shot.
+Piloting traits affect [[FT_HANGAR_2]], [[FT_HANGAR_3]], and [[FT_HANGAR_4]] fighters in the same way: bad piloting reduces damage by [[value BAD_PILOT_FIGHTER_DAMAGE_BONUS]] per fighter; good piloting increases damage by [[value GOOD_PILOT_FIGHTER_DAMAGE_BONUS]], great piloting by [[value GREAT_PILOT_FIGHTER_DAMAGE_BONUS]], and ultimate piloting by [[value ULTIMATE_PILOT_FIGHTER_DAMAGE_BONUS]] per fighter shot.
 Piloting traits do not affect [[FT_HANGAR_1]] fighters.
 
 At the end of combat, carriers will collect any fighters that have survived. If a carrier is in [[metertype METER_SUPPLY]] immediately after movement is resolved, it will refill hangars to maximum.'''
@@ -14455,19 +14455,19 @@ SHP_FIGHTERS_2
 Fighters and Launch Bays 2
 
 SHP_FIGHTERS_2_DESC
-Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have laser weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 12, [[shippart FT_HANGAR_3]] by 18, and [[shippart FT_HANGAR_4]] by 36. For [[shippart FT_HANGAR_1]] fighters the capacity is increased by 1 and the launch rate for the [[shippart FT_BAY_1]] is increased by 1.
+Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have laser weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by [[value SHP_FIGHTERS_2_FT_HANGAR_2_DAMAGE_BONUS]], [[shippart FT_HANGAR_3]] by [[value SHP_FIGHTERS_2_FT_HANGAR_3_DAMAGE_BONUS]], and [[shippart FT_HANGAR_4]] by [[value SHP_FIGHTERS_2_FT_HANGAR_4_DAMAGE_BONUS]]. For [[shippart FT_HANGAR_1]] fighters the capacity is increased by 1 and the launch rate for the [[shippart FT_BAY_1]] is increased by 1.
 
 SHP_FIGHTERS_3
 Fighters and Launch Bays 3
 
 SHP_FIGHTERS_3_DESC
-Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have plasma weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 12, [[shippart FT_HANGAR_3]] by 18, and [[shippart FT_HANGAR_4]] by 36. For [[shippart FT_HANGAR_1]] fighters the capacity is increased by 1 and the launch rate for the [[shippart FT_BAY_1]] is increased by 1.
+Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have laser weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by [[value SHP_FIGHTERS_3_FT_HANGAR_2_DAMAGE_BONUS]], [[shippart FT_HANGAR_3]] by [[value SHP_FIGHTERS_3_FT_HANGAR_3_DAMAGE_BONUS]], and [[shippart FT_HANGAR_4]] by [[value SHP_FIGHTERS_3_FT_HANGAR_4_DAMAGE_BONUS]]. For [[shippart FT_HANGAR_1]] fighters the capacity is increased by 1 and the launch rate for the [[shippart FT_BAY_1]] is increased by 1.
 
 SHP_FIGHTERS_4
 Fighters and Launch Bays 4
 
 SHP_FIGHTERS_4_DESC
-Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have death ray weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 12, [[shippart FT_HANGAR_3]] by 18, and [[shippart FT_HANGAR_4]] by 36. For [[shippart FT_HANGAR_1]] fighters the capacity is increased by 1 and the launch rate for the [[shippart FT_BAY_1]] is increased by 1.
+Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have laser weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by [[value SHP_FIGHTERS_4_FT_HANGAR_2_DAMAGE_BONUS]], [[shippart FT_HANGAR_3]] by [[value SHP_FIGHTERS_4_FT_HANGAR_3_DAMAGE_BONUS]], and [[shippart FT_HANGAR_4]] by [[value SHP_FIGHTERS_4_FT_HANGAR_4_DAMAGE_BONUS]]. For [[shippart FT_HANGAR_1]] fighters the capacity is increased by 1 and the launch rate for the [[shippart FT_BAY_1]] is increased by 1.
 
 SHP_WEAPON_1_2
 Mass Driver 2


### PR DESCRIPTION
pedia had (partly wrong) constant damage values for fighter pilot traits and tech upgrades
[forum post](https://freeorion.org/forum/viewtopic.php?p=120925)

this is for 0.5.1 and master