### PR TITLE
fix ai fighter damage dependencies

### DIFF
--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -502,9 +502,9 @@ PILOT_FIGHTERDAMAGE_UNSCALED_MODIFIER_DICT = {
     # Note: FT_HANGAR_1 fighters are not able to attack ships so pilot damage modifier does not apply
     "NO": {},
     "BAD": {"FT_HANGAR_1": 0, "FT_HANGAR_2": -1, "FT_HANGAR_3": -1, "FT_HANGAR_4": -1},
-    "GOOD": {"FT_HANGAR_1": 0, "FT_HANGAR_2": 1, "FT_HANGAR_3": 1, "FT_HANGAR_4": 1},
-    "GREAT": {"FT_HANGAR_1": 0, "FT_HANGAR_2": 2, "FT_HANGAR_3": 2, "FT_HANGAR_4": 2},
-    "ULTIMATE": {"FT_HANGAR_1": 0, "FT_HANGAR_2": 3, "FT_HANGAR_3": 3, "FT_HANGAR_4": 3},
+    "GOOD": {"FT_HANGAR_1": 0, "FT_HANGAR_2": 1.5, "FT_HANGAR_3": 1.5, "FT_HANGAR_4": 1.5},
+    "GREAT": {"FT_HANGAR_1": 0, "FT_HANGAR_2": 3, "FT_HANGAR_3": 3, "FT_HANGAR_4": 3},
+    "ULTIMATE": {"FT_HANGAR_1": 0, "FT_HANGAR_2": 4.5, "FT_HANGAR_3": 4.5, "FT_HANGAR_4": 4.5},
 }
 
 PILOT_FIGHTER_CAPACITY_MODIFIER_DICT = {


### PR DESCRIPTION
[forum post](https://freeorion.org/forum/viewtopic.php?p=120925)

for reference hangar values in species_macros/weapons.py:
    
    BAD_WEAPONS = _weapon(tag="BAD", tier_0=-1, tier_1=-1, tier_2=-2, tier_3=-3, tier_4=-5, hangar=-1.0)
    GOOD_WEAPONS = _weapon(tag="GOOD", tier_0=1, tier_1=1, tier_2=2, tier_3=3, tier_4=5, hangar=1.5)
    GREAT_WEAPONS = _weapon(tag="GREAT", tier_0=2, tier_1=2, tier_2=4, tier_3=6, tier_4=10, hangar=3.0)
    ULTIMATE_WEAPONS = _weapon(tag="ULTIMATE", tier_0=3, tier_1=3, tier_2=6, tier_3=9, tier_4=15, hangar=4.5)
