### PR TITLE
[tools] Update buiding parser to filter unrelated log lines

### DIFF
--- a/check/focs_dump_parser/parser.py
+++ b/check/focs_dump_parser/parser.py
@@ -1,3 +1,4 @@
+import re
 from logging import error
 from typing import IO
 
@@ -7,6 +8,13 @@ def _get_name_from_line(line):
         return None
     body = line.rsplit(" : ", 2)[1]
     return body.removeprefix("BuildingType ")
+
+
+_log_like = re.compile(r"\d{2}:\d{2}:\d{2}\.\d{4}.*")
+
+
+def _is_regular_log(line):
+    return _log_like.match(line)
 
 
 def get_lines_with_dump(f: IO):
@@ -31,6 +39,8 @@ def parse_buildings(f: IO):
                 _result.append((_current[0], "".join(_current[1])))
             _current = [next_section, []]
         else:
+            if _is_regular_log(line):
+                continue
             if _current:
                 _current[1].append(line)
 

--- a/check/focs_dump_parser/test_parser.py
+++ b/check/focs_dump_parser/test_parser.py
@@ -15,7 +15,8 @@ BuildingType
 BuildingType
     name = "BLD_ART_BLACK_HOLE"
     description = "BLD_ART_BLACK_HOLE_DESC"
-00:00:34.029042 {0x00002980} [trace] parsing : BuildingsParser.cpp:261 : End parsing FOCS for BuildingTypes108
+00:35:48.229253 {0x000031f0} [debug] ai : i18n.cpp:100 : Detected locale language: en
+00:35:48.336232 {0x000031f0} [trace] parsing : BuildingsParser.cpp:263 : End parsing FOCS for BuildingTypes96
 """.strip()
 )
 


### PR DESCRIPTION
Logs about translation are injected into the building dump probably because parsing processes are run in parallel.  This change ignores all log startlines, that are special for the building parsing.