### PR TITLE
move shared bld black hole pow gen min stability to named values (0.5.1.1)

### DIFF
--- a/default/scripting/buildings/BLACK_HOLE_POW_GEN.focs.txt
+++ b/default/scripting/buildings/BLACK_HOLE_POW_GEN.focs.txt
@@ -19,7 +19,7 @@ BuildingType
                 Planet
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
-                Happiness low = (NamedReal name = "BLD_BLACK_HOLE_POW_GEN_MIN_STABILITY" value = 20)
+                Happiness low = NamedRealLookup name = "BLD_BLACK_HOLE_POW_GEN_MIN_STABILITY"
                 ResourceSupplyConnected empire = Source.Owner condition = Source
             ]
             activation = Star type = BlackHole

--- a/default/scripting/macros/named_values.focs.txt
+++ b/default/scripting/macros/named_values.focs.txt
@@ -42,6 +42,9 @@ SPATIAL_FLUX_STEALTH_HULL_BASE
 SPATIAL_FLUX_STEALTH_NON_AGGRESSIVE_BONUS
 '''10'''
 
+// Black hole and hyper dam
+NamedReal name = "BLD_BLACK_HOLE_POW_GEN_MIN_STABILITY" value = 20
+
 NamedReal name = "PLC_LIBERTY_DISLIKE_FACTOR" value = 2.0
 
 NamedReal name = "PLC_CONFORMANCE_DISLIKE_FACTOR" value = 0.5


### PR DESCRIPTION
Move shared BLD_BLACK_HOLE_POW_GEN_MIN_STABILITY valueref definition to named_values.focs.txt ; currently this might delay parsing [forum discussion](https://freeorion.org/forum/viewtopic.php?p=121012)

@o01eg This should also be fixed in master, but as the buildings get migrated to python, it maybe makes sense to merge both the hyperspatial dam and the black hole generator into a single file and define the named valueref there. 