### PR TITLE
Remove Win32 MSVC project file config

### DIFF
--- a/.github/workflows/_build-windows-msvs.yml
+++ b/.github/workflows/_build-windows-msvs.yml
@@ -17,7 +17,7 @@ jobs:
         id: download-sdk
         uses: suisei-cn/actions-download-file@v1.4.0
         with:
-          url: https://github.com/freeorion/freeorion-sdk/releases/download/v15/FreeOrionSDK_15_MSVC-v143-Win32.zip
+          url: https://github.com/freeorion/freeorion-sdk/releases/download/v15/FreeOrionSDK_15_MSVC-v143-x64.zip
           target: ../
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1.3.1

--- a/msvc2022/FreeOrion.sln
+++ b/msvc2022/FreeOrion.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30907.101
+# Visual Studio Version 17
+VisualStudioVersion = 17.12.35527.113 d17.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "GiGi", "GiGi\GiGi.vcxproj", "{2CEC3AB3-36A0-4037-AEC2-DA0435A4DADB}"
 EndProject
@@ -38,36 +38,21 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "UnitTests", "Test\Test.vcxp
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Release|Win32 = Release|Win32
 		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{2CEC3AB3-36A0-4037-AEC2-DA0435A4DADB}.Release|Win32.ActiveCfg = Release|Win32
-		{2CEC3AB3-36A0-4037-AEC2-DA0435A4DADB}.Release|Win32.Build.0 = Release|Win32
 		{2CEC3AB3-36A0-4037-AEC2-DA0435A4DADB}.Release|x64.ActiveCfg = Release|x64
 		{2CEC3AB3-36A0-4037-AEC2-DA0435A4DADB}.Release|x64.Build.0 = Release|x64
-		{311D02C0-427D-4A03-AAEB-B819A9ACF5AB}.Release|Win32.ActiveCfg = Release|Win32
-		{311D02C0-427D-4A03-AAEB-B819A9ACF5AB}.Release|Win32.Build.0 = Release|Win32
 		{311D02C0-427D-4A03-AAEB-B819A9ACF5AB}.Release|x64.ActiveCfg = Release|x64
 		{311D02C0-427D-4A03-AAEB-B819A9ACF5AB}.Release|x64.Build.0 = Release|x64
-		{B9808A04-CE5E-4660-99CB-B8C8C4E64402}.Release|Win32.ActiveCfg = Release|Win32
-		{B9808A04-CE5E-4660-99CB-B8C8C4E64402}.Release|Win32.Build.0 = Release|Win32
 		{B9808A04-CE5E-4660-99CB-B8C8C4E64402}.Release|x64.ActiveCfg = Release|x64
 		{B9808A04-CE5E-4660-99CB-B8C8C4E64402}.Release|x64.Build.0 = Release|x64
-		{77E8E74E-F581-4850-A4C6-A088564DF9A7}.Release|Win32.ActiveCfg = Release|Win32
-		{77E8E74E-F581-4850-A4C6-A088564DF9A7}.Release|Win32.Build.0 = Release|Win32
 		{77E8E74E-F581-4850-A4C6-A088564DF9A7}.Release|x64.ActiveCfg = Release|x64
 		{77E8E74E-F581-4850-A4C6-A088564DF9A7}.Release|x64.Build.0 = Release|x64
-		{9925F25C-A72E-42AE-B2E3-6657255BF293}.Release|Win32.ActiveCfg = Release|Win32
-		{9925F25C-A72E-42AE-B2E3-6657255BF293}.Release|Win32.Build.0 = Release|Win32
 		{9925F25C-A72E-42AE-B2E3-6657255BF293}.Release|x64.ActiveCfg = Release|x64
 		{9925F25C-A72E-42AE-B2E3-6657255BF293}.Release|x64.Build.0 = Release|x64
-		{BEDF460A-EAE9-4E20-AFB2-2C8434051150}.Release|Win32.ActiveCfg = Release|Win32
-		{BEDF460A-EAE9-4E20-AFB2-2C8434051150}.Release|Win32.Build.0 = Release|Win32
 		{BEDF460A-EAE9-4E20-AFB2-2C8434051150}.Release|x64.ActiveCfg = Release|x64
 		{BEDF460A-EAE9-4E20-AFB2-2C8434051150}.Release|x64.Build.0 = Release|x64
-		{650719CA-7F2F-4C39-84F4-3F4684788117}.Release|Win32.ActiveCfg = Release|Win32
-		{650719CA-7F2F-4C39-84F4-3F4684788117}.Release|Win32.Build.0 = Release|Win32
 		{650719CA-7F2F-4C39-84F4-3F4684788117}.Release|x64.ActiveCfg = Release|x64
 		{650719CA-7F2F-4C39-84F4-3F4684788117}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection


### PR DESCRIPTION
This was the default, which cause some confusing linker errors when building the default settings with x64 SDK.