### PR TITLE
Fix stringtables build constraint for Species InterDesign Academy (six -> seven)

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -15308,7 +15308,7 @@ The research bonus requires a stability of [[value BLD_INTERSPECIES_ACADEMY_MIN_
 
 Learning to design devices for use by different species is crucial for developing universally usable tools.
 
-Each empire may contain an academy on up to six planets with different species. To build an academy, a planet must have a stability of [[value BLD_INTERSPECIES_ACADEMY_MIN_STABILITY_BUILD]], and must be more than three starlane jumps away from the nearest existing academy.'''
+Each empire may contain an academy on up to seven planets with different species. To build an academy, a planet must have a stability of [[value BLD_INTERSPECIES_ACADEMY_MIN_STABILITY_BUILD]], and must be more than three starlane jumps away from the nearest existing academy.'''
 
 BLD_STOCKPILING_CENTER
 Imperial Entanglement Center


### PR DESCRIPTION
Fixes #5120

Species InterDesign Academy building is limited to maximum 7 copies on 7 planets with unique species. Not on only 6 planets