### PR TITLE
Initialize error handler within sub-interpreter context

### DIFF
--- a/parse/GameRulesParser.cpp
+++ b/parse/GameRulesParser.cpp
@@ -101,7 +101,7 @@ object insert_rule_(const grammar& g, GameRulesTypeMap& game_rules, const tuple&
 namespace parse {
     GameRulesTypeMap game_rules(const PythonParser& parser, const boost::filesystem::path& path, bool& success) {
         GameRulesTypeMap game_rules;
-        py_parse::detail::parse_file<grammar, GameRulesTypeMap>(parser, path, grammar(parser), game_rules);
+        success = py_parse::detail::parse_file<grammar, GameRulesTypeMap>(parser, path, grammar(parser), game_rules);
         return game_rules;
     }
 }

--- a/parse/PythonParser.cpp
+++ b/parse/PythonParser.cpp
@@ -73,6 +73,11 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
         throw std::runtime_error("Python sub-interpreter isn't initialized");
     }
 
+    if (!m_python.InitErrorHandler()) {
+        ErrorLogger() << "Python error handler isn't initialized!";
+        throw std::runtime_error("Python error handler isn't initialized!");
+    }
+
     try {
         type_int = py::import("builtins").attr("int");
         type_float = py::import("builtins").attr("float");
@@ -310,10 +315,11 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
         py::implicitly_convertible<value_ref_wrapper<int>, condition_wrapper>();
 
         m_meta_path = py::extract<py::list>(py::import("sys").attr("meta_path"))();
+#if PY_VERSION_HEX < 0x030c0000
         const auto meta_path_len = py::len(*m_meta_path);
         for (std::decay_t<decltype(meta_path_len)> i = 0; i < meta_path_len; ++i)
             m_meta_path->pop();
-
+#endif
         m_meta_path->append(boost::cref(*this));
         m_meta_path_len = static_cast<int>(py::len(*m_meta_path));
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,6 +60,7 @@ max-complexity = 10
 "default/scripting/focs/*" = ["F405"]
 "default/scripting/game_rules.focs.py"=["F821"]
 "test-scripting/game_rules.focs.py"=["F821"]
+"test-scripting/game_rules_failed.focs.py"=["F821"]
 "test-scripting/*"=["F405", "F403"]
 
 [tool.ruff.lint.isort]

--- a/python/PythonBase.cpp
+++ b/python/PythonBase.cpp
@@ -35,6 +35,11 @@ bool PythonBase::Initialize() {
         return false;
     }
 
+    if (!InitErrorHandler()) {
+        ErrorLogger() << "Python error handler isn't initialized!";
+        return false;
+    }
+
     DebugLogger() << "Initializing C++ interfaces for Python";
 
     try {

--- a/test-scripting/game_rules_failed.focs.py
+++ b/test-scripting/game_rules_failed.focs.py
@@ -1,0 +1,10 @@
+GameRuleFailed(
+    name="RULE_SHIP_HULL_COST_FACTOR",
+    description="RULE_SHIP_HULL_COST_FACTOR_DESC",
+    category="BALANCE",
+    type=float,
+    default=1.0,
+    min=0.1,
+    max=10.0,
+    rank=20,
+)

--- a/test/parse/TestDefaultPythonParser.cpp
+++ b/test/parse/TestDefaultPythonParser.cpp
@@ -119,7 +119,11 @@ BOOST_AUTO_TEST_CASE(parse_buildings_full) {
     auto named_values = Pending::ParseSynchronously(parse::named_value_refs, m_default_scripting_dir / "macros");
 
     auto buildings_p = Pending::ParseSynchronously(parse::buildings, parser, m_default_scripting_dir / "buildings");
-    const auto buildings = *Pending::WaitForPendingUnlocked(std::move(buildings_p));
+    auto buildings_opt = Pending::WaitForPendingUnlocked(std::move(buildings_p));
+
+    BOOST_REQUIRE(buildings_opt);
+
+    const auto buildings = *std::move(buildings_opt);
 
     BOOST_CHECK(!buildings.empty());
 

--- a/test/parse/TestPythonParser.cpp
+++ b/test/parse/TestPythonParser.cpp
@@ -50,10 +50,24 @@ BOOST_AUTO_TEST_CASE(parse_game_rules) {
     PythonParser parser(m_python, m_test_scripting_dir);
 
     auto game_rules_p = Pending::ParseSynchronously(parse::game_rules, parser,  m_test_scripting_dir / "game_rules.focs.py");
-    auto game_rules = *Pending::WaitForPendingUnlocked(std::move(game_rules_p));
+    auto game_rules_opt = Pending::WaitForPendingUnlocked(std::move(game_rules_p));
+
+    BOOST_REQUIRE(game_rules_opt);
+
+    const auto game_rules = *std::move(game_rules_opt);
+
     BOOST_REQUIRE(!game_rules.empty());
     BOOST_REQUIRE(game_rules.contains("RULE_HABITABLE_SIZE_MEDIUM"));
     BOOST_REQUIRE(GameRule::Type::TOGGLE == game_rules.at("RULE_ENABLE_ALLIED_REPAIR").type);
+}
+
+BOOST_AUTO_TEST_CASE(parse_game_rules_failed) {
+    PythonParser parser(m_python, m_test_scripting_dir);
+
+    auto game_rules_p = Pending::ParseSynchronously(parse::game_rules, parser,  m_test_scripting_dir / "game_rules_failed.focs.py");
+    auto game_rules_opt = Pending::WaitForPendingUnlocked(std::move(game_rules_p));
+
+    BOOST_REQUIRE(!game_rules_opt);
 }
 
 BOOST_AUTO_TEST_CASE(parse_techs) {

--- a/util/PythonCommon.cpp
+++ b/util/PythonCommon.cpp
@@ -90,6 +90,10 @@ bool PythonCommon::Initialize() {
         return false;
     }
 
+    return true;
+}
+
+bool PythonCommon::InitErrorHandler() {
     try {
         m_system_exit = py::import("builtins").attr("SystemExit");
         m_traceback_format_exception = py::import("traceback").attr("format_exception");
@@ -122,7 +126,6 @@ void PythonCommon::HandleErrorAlreadySet() {
         return;
     }
 
-#if PY_VERSION_HEX < 0x030c0000
     PyObject *extype, *value, *traceback;
     PyErr_Fetch(&extype, &value, &traceback);
     PyErr_NormalizeException(&extype, &value, &traceback);
@@ -141,9 +144,6 @@ void PythonCommon::HandleErrorAlreadySet() {
         boost::algorithm::trim_right(line);
         ErrorLogger() << line;
     }
-#else
-    PyErr_Print();
-#endif
     return;
 }
 
@@ -167,6 +167,8 @@ void PythonCommon::Finalize() {
         } catch (const std::exception& e) {
             ErrorLogger() << "Caught exception when cleaning up FreeOrion Python interface: " << e.what();
             return;
+        } catch (...) {
+            ErrorLogger() << "Caught unknown exception when cleaning up FreeOrion Python interface";
         }
     }
 }

--- a/util/PythonCommon.h
+++ b/util/PythonCommon.h
@@ -29,6 +29,8 @@ public:
 
     bool Initialize();        // initializes and runs the Python interpreter, prepares the Python environment
 
+    bool InitErrorHandler();  // initializes error handler
+
     virtual bool InitCommonImports(); // initializes Python imports
 
     void Finalize();          // stops Python interpreter and releases its resources


### PR DESCRIPTION
Fixes printing Python exceptions to logs on Python 3.12 and above.