### PR TITLE
Warning fixes

### DIFF
--- a/Empire/ResearchQueue.cpp
+++ b/Empire/ResearchQueue.cpp
@@ -287,7 +287,7 @@ void ResearchQueue::Update(float RPs, const std::map<std::string, float>& resear
             cur_turn_rp_available -= RPs_to_spend;
 
             auto next_res_tech_it = cur_tech_it;
-            int next_res_tech_idx = 0;
+            std::size_t next_res_tech_idx = 0;
             if (++next_res_tech_it == dp_researchable_techs.end())
                 next_res_tech_idx = m_queue.size() + 1;
             else

--- a/GG/src/MultiEdit.cpp
+++ b/GG/src/MultiEdit.cpp
@@ -866,7 +866,7 @@ void MultiEdit::KeyPress(Key key, uint32_t key_code_point, Flags<ModKey> mod_key
                 //std::cout << "put cursor end at " << m_cursor_end.first
                 //          << " : " << Value(m_cursor_end.second) << std::endl;
                 
-                if (auto res = LineEndsWithEndlineCharacter(line, Text())) {
+                if (LineEndsWithEndlineCharacter(line, Text())) {
                     --m_cursor_end.second;
                     //std::cout << "last char is newline so moved to " << m_cursor_end.first
                     //          << " : " << Value(m_cursor_end.second) << std::endl;

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -417,7 +417,7 @@ void BuildingIndicator::RClick(GG::Pt pt, GG::Flags<GG::ModKey> mod_keys) {
     }
 
     const std::string& building_type = building->BuildingTypeName();
-    if (const BuildingType* bt = GetBuildingType(building_type)) {
+    if (GetBuildingType(building_type)) {
         auto pedia_lookup_building_type_action = [building_type]()
         { ClientUI::GetClientUI()->ZoomToBuildingType(building_type); };
         std::string popup_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) % UserString(building_type));

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -3482,7 +3482,7 @@ void OnPlanet::Eval(const ScriptingContext& parent_context,
 
 std::string OnPlanet::Description(bool negated) const {
     std::string planet_str;
-    int planet_id = m_planet_id && m_planet_id->ConstantExpr() ? planet_id = m_planet_id->Eval() : INVALID_OBJECT_ID;
+    int planet_id = (m_planet_id && m_planet_id->ConstantExpr()) ? m_planet_id->Eval() : INVALID_OBJECT_ID;
     if (auto planet = IApp::GetApp()->GetContext().ContextObjects().getRaw<Planet>(planet_id))
         planet_str = planet->Name();
     else if (m_planet_id)

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -1520,7 +1520,7 @@ void Pathfinder::PathfinderImpl::UpdateCommonFilteredSystemGraphs(
         return;
     }
 
-    const auto [eit, success] = m_graph_impl.empire_system_graph_views.emplace(
+    m_graph_impl.empire_system_graph_views.emplace(
         std::piecewise_construct,
         std::forward_as_tuple(ALL_EMPIRES),
         std::forward_as_tuple(*m_graph_impl.system_graph, 

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1903,7 +1903,7 @@ void Universe::ExecuteEffects(std::map<int, Effect::SourcesEffectsTargetsAndCaus
 
     for (auto obj_id : context.ContextUniverse().m_marked_destroyed | range_keys) {
         // do actual recursive destruction.
-        if (const auto* obj = m_objects.getRaw(obj_id))
+        if (m_objects.getRaw(obj_id))
             RecursiveDestroy(obj_id, empire_ids);
     }
 }


### PR DESCRIPTION
Those are the low hanging fruits for a quick warning hunt.

Done on:
* void linux x86_64
* gcc-13.2.0
* musl libc

Compiled then play-tested for a bit, nothing strange happened.

There are other kinds of warnings that have a lot of instances, I fixed the lonely ones.

with the following added to CMakeLists.txt:
```
+    $<$<CXX_COMPILER_ID:GNU>:-Wno-reorder>
+    $<$<CXX_COMPILER_ID:GNU>:-Wno-comma-subscript>
+    $<$<CXX_COMPILER_ID:GNU>:-Wno-unused-function>
+    $<$<CXX_COMPILER_ID:GNU>:-Wno-overloaded-virtual>
+    $<$<CXX_COMPILER_ID:GNU>:-Wno-maybe-uninitialized>
```

We're mostly warning-clean, there's another one that I'll do in another PR, since it may not be as obvious as those. 