### PR TITLE
Fix address sanitizer error in pyhon FOCS parser

### DIFF
--- a/parse/PythonParser.cpp
+++ b/parse/PythonParser.cpp
@@ -40,6 +40,8 @@ namespace {
     void translate(import_error const& e) {
         PyErr_SetString(PyExc_ImportError, e.what());
     }
+
+    constexpr bool STATIC_FALSE = false;
 }
 
 struct module_spec {
@@ -97,8 +99,8 @@ PythonParser::PythonParser(PythonCommon& _python, const boost::filesystem::path&
             .def_readonly("_uninitialized_submodules", &module_spec::uninitialized_submodules)
             .add_static_property("loader", py::make_getter(*this, py::return_value_policy<py::reference_existing_object>()))
             .def_readonly("submodule_search_locations", &module_spec::path)
-            .def_readonly("has_location", false)
-            .def_readonly("cached", false)
+            .def_readonly("has_location", STATIC_FALSE)
+            .def_readonly("cached", STATIC_FALSE)
             .def_readonly("parent", &module_spec::parent);
 
         // Use wrappers to not collide with types in server and AI


### PR DESCRIPTION
`def_readonly` accepts reference to value but literals alive only in function they declared.