### PR TITLE
Add option to enable/disable cppcheck

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ option(BUILD_CLIENT_GODOT "Build Godot client (experimental)" OFF)
 option(BUILD_SERVER "Build server" ON)
 option(BUILD_AI "Build AI" ON)
 option(BUILD_PARSERS "Build parsers" ON)
+option(ENABLE_CPPCHECK "Enable cppcheck check"  OFF)
 
 set(GODOT_CPP_ROOT "" CACHE PATH "Path to Godot CPP libraries (empty to build internally)")
 

--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -1,17 +1,18 @@
-find_package(CPPCheck)
+if(ENABLE_CPPCHECK)
+    find_package(CPPCheck REQUIRED)
 
-if(TARGET Cppcheck::cppcheck)
-    add_custom_target(check-cpp
-        COMMAND
-            "$<TARGET_FILE:Cppcheck::cppcheck>"
-            --quiet
-            --template=gcc
-            --std=c++14
-            ${PROJECT_SOURCE_DIR}
-        COMMENT "Check C++ for problematic code"
-    )
+    if(TARGET Cppcheck::cppcheck)
+        add_custom_target(check-cpp
+            COMMAND
+                "$<TARGET_FILE:Cppcheck::cppcheck>"
+                --quiet
+                --template=gcc
+                --std=c++14
+                ${PROJECT_SOURCE_DIR}
+            COMMENT "Check C++ for problematic code"
+        )
+    endif()
 endif()
-
 
 if(NOT TARGET check)
     add_custom_target(check
@@ -19,7 +20,7 @@ if(NOT TARGET check)
     )
 endif()
 
-if(TARGET check-cpp)
+if(ENABLE_CPPCHECK AND TARGET check-cpp)
     add_dependencies(check check-cpp)
 endif()
 


### PR DESCRIPTION
Debian mentioned it as an issue:

> Marked for autoremoval on 22 April due to [cppcheck](https://tracker.debian.org/pkg/cppcheck): [#1099986](https://bugs.debian.org/1099986) high
Version 0.5.0.1-1 of freeorion is marked for autoremoval from testing on Tue 22 Apr 2025. It depends (transitively) on [cppcheck](https://tracker.debian.org/pkg/cppcheck), affected by [#1099986](https://bugs.debian.org/1099986). You should try to prevent the removal by fixing these RC bugs.