### PR TITLE
Add new badges for README.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/release.md
+++ b/.github/ISSUE_TEMPLATE/release.md
@@ -60,6 +60,7 @@ git checkout -b release-vX.Y.Z master
 * [ ] *On release branch HEAD* - Update version number in `CMakeLists.txt` and
       `cmake/make_versioncpp.py` to `vX.Y.Z`, remove trailing `+` if needed.
 * [ ] *On release branch HEAD* - Disable `Super Testers` species by default.
+* [ ] *On release branch HEAD* - Change branch of CI badge in `README.md` to `release-vX.Y.Z`
 * [ ] *On master branch HEAD* - Update version number in `CMakeLists.txt` and
       `cmake/make_versioncpp.py` to `vX.Y.Z+`.
 * [ ] Push updated release and master branch to GitHub.
@@ -103,6 +104,7 @@ git tag --annotate --message="X.Y.Z Stable Release"  vX.Y.Z
 * [ ] Update `Main` page of FreeOrion Wiki.
 * [ ] Update `Download` page of FreeOrion Wiki.
 * [ ] Announce release on Twitter as @FreeOrion
+* [ ] Announce release on Mastodon as @freeorion@fosstodon.org
 * [ ] Announce release on YouTube.
 
 

--- a/README.md
+++ b/README.md
@@ -13,10 +13,14 @@
         <img src="https://img.shields.io/github/contributors/freeorion/freeorion" alt="Contributors" /></a>
     <a href="https://github.com/freeorion/freeorion/graphs/commit-activity">
         <img src="https://img.shields.io/github/commit-activity/m/freeorion/freeorion"  alt="Activity" /></a>
+    <a href="https://github.com/freeorion/freeorion/actions/workflows/build_on_master.yml?query=event%3Apush+branch=master">
+        <img src="https://github.com/freeorion/freeorion/actions/workflows/build_on_master.yml/badge.svg?event=push&amp;branch=master" alt="CI status" /></a>
 </p>
 <p align="center">
     <a href="https://twitter.com/intent/follow?screen_name=Freeorion">
         <img src="https://img.shields.io/twitter/follow/Freeorion?style=social&logo=twitter" alt="follow on Twitter"></a>
+    <a href="https://fosstodon.org/@freeorion">
+        <img src="https://img.shields.io/mastodon/follow/113905657321190683?domain=fosstodon.org&style=social" alt="Mastodon Follow"/></a>
 </p>
 
 FreeOrion


### PR DESCRIPTION
Fixes #611

We don't use Travis CI anymore so it's going to be Github Actions CI badge, also I updated social links.