### PR TITLE
Runtime improvement designwnd

### DIFF
--- a/UI/DesignWnd.h
+++ b/UI/DesignWnd.h
@@ -3,6 +3,14 @@
 
 #include <GG/Wnd.h>
 #include <boost/uuid/uuid.hpp>
+#include <optional>
+#include <vector>
+#include <string_view>
+#include <unordered_map>
+
+// Add type-safe enums for common boolean parameters
+enum class EmitSignal { No, Yes };
+enum class ChangeAllSimilar { No, Yes };
 
 class EncyclopediaDetailPanel;
 struct SaveGameUIData;


### PR DESCRIPTION
Runtime improvements. This is more of an experiment.

1. SlotControl::SetPart UI Component Reuse
Optimize the SlotControl::SetPart method to reuse existing PartControl objects when possible instead of recreating them for every part change.

2. Add PartControl::UpdatePart Method
Add a new method to allow updating a part in-place:
Location: In the PartControl class in DesignWnd.cpp, after the CompleteConstruction method
- Added declaration in the class definition

3. String Optimization in GetCleanDesignDump

4. Type-Safe Enums for Boolean Parameters
```
enum class EmitSignal { No, Yes };
enum class ChangeAllSimilar { No, Yes };
```

5. Replace std::list with std::vector in DisplayedShipDesignManager
Location: In DisplayedShipDesignManager class definition

6. Optimize MoveBefore Method for Vector
Location: DisplayedShipDesignManager::MoveBefore implementation

7. Optimize RefreshIncompleteDesign Method
(yet to be done)
