### PR TITLE
Update Docker CI Fedora to 35

### DIFF
--- a/.github/docker/fedora-35/Dockerfile
+++ b/.github/docker/fedora-35/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/fedora:33
+FROM docker.io/fedora:35
 
 RUN dnf update -y
 RUN dnf install -y cmake \

--- a/.github/workflows/_build-docker.yml
+++ b/.github/workflows/_build-docker.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         image:
           - ubuntu-24.10
-          - fedora-33
+          - fedora-35
           - debian-oldstable
           - debian-stable
           - debian-sid


### PR DESCRIPTION
Updates Fedora CI to mininal version with Python 3.10