### PR TITLE
Allow to see and dismiss stale ghost buildings [v0.5.1*]

### DIFF
--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -107,7 +107,7 @@ void BuildingsPanel::Update() {
         // skip known destroyed and stale info objects
         if (this_client_known_destroyed_objects.contains(object_id))
             continue;
-        if (this_client_stale_object_info.contains(object_id))
+        if (this_client_stale_object_info.contains(object_id) && !GetOptionsDB().Get<bool>("ui.map.sidepanel.stale-buildings.shown"))
             continue;
 
         auto building = Objects().get<Building>(object_id);
@@ -413,6 +413,17 @@ void BuildingIndicator::RClick(GG::Pt pt, GG::Flags<GG::ModKey> mod_keys) {
             popup->AddMenuItem(GG::MenuItem(UserString("ORDER_CANCEL_BUIDLING_SCRAP"), false, false,
                                             un_scrap_building_action));
         }
+    }
+
+    // find sensor ghost
+    if (empire_id != ALL_EMPIRES &&
+        !building->OwnedBy(empire_id) &&
+        context.ContextVis(m_building_id, empire_id) < Visibility::VIS_BASIC_VISIBILITY)
+    {
+        auto forget_building_action = [this, map_wnd]() { map_wnd->ForgetObject(m_building_id); };
+
+        popup->AddMenuItem(GG::MenuItem(UserString("FW_ORDER_DISMISS_SENSOR_GHOST"), false, false,
+                                        forget_building_action));
     }
 
     const std::string& building_type = building->BuildingTypeName();

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -547,6 +547,7 @@ void OptionsWnd::CompleteConstruction() {
     BoolOption(current_page, 0, "ui.map.sidepanel.planet.shown", UserString("OPTIONS_SHOW_SIDEPANEL_PLANETS"));
     BoolOption(current_page, 0, "ui.reposition.auto.enabled", UserString("OPTIONS_AUTO_REPOSITION_WINDOWS"));
     BoolOption(current_page, 0, "ui.map.messages.timestamp.shown", UserString("OPTIONS_DISPLAY_TIMESTAMP"));
+    BoolOption(current_page, 0, "ui.map.sidepanel.stale-buildings.shown", UserString("OPTIONS_SHOW_SIDEPANEL_STALE_BUILDING"));
 
     // manual reposition windows button
     auto window_reset_button = Wnd::Create<CUIButton>(UserString("OPTIONS_WINDOW_RESET"));

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -468,6 +468,7 @@ namespace {
                GG::Clr(0, 0, 0, 128),       Validator<GG::Clr>());
         db.Add("UI.sidepanel-planet-status-icon-size",       UserStringNop("OPTIONS_DB_UI_PLANET_STATUS_ICON_SIZE"),
                32,                          RangedValidator<int>(8, 128));
+        db.Add("ui.map.sidepanel.stale-buildings.shown",     UserStringNop("OPTIONS_DB_UI_SHOW_SIDEPANEL_STALE_BUILDING"), false,         Validator<bool>());
     }
     bool temp_bool = RegisterOptions(&AddOptions);
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -2013,6 +2013,9 @@ Sets the color of the scan-line shading over planet graphics on the sidepanel.
 OPTIONS_DB_UI_PLANET_STATUS_ICON_SIZE
 Sets the size of the planet status icon.
 
+OPTIONS_DB_UI_SHOW_SIDEPANEL_STALE_BUILDING
+Enables display of stale visibility buildings on sidepanel. Stale visibility means previously detected and should be currently visible based on last known state and location and a player's current detection levels, but nevertheless not currently detected anywhere.
+
 OPTIONS_DB_UI_PLANET_STATUS_ICON_TITLE
 Planet status notification
 
@@ -3111,6 +3114,9 @@ Automatically reposition windows
 
 OPTIONS_DISPLAY_TIMESTAMP
 Show chat timestamp
+
+OPTIONS_SHOW_SIDEPANEL_STALE_BUILDING
+Show stale visibility buildings on sidepanel
 
 OPTIONS_MISC_UI
 Miscellaneous UI Settings


### PR DESCRIPTION
Fixes [#5230](https://github.com/freeorion/freeorion/issues/5230)

It doesn't fix why buildings became stale but allows players to fix outcome.