### PR TITLE
Track Latest Turns Policies Adopted

### DIFF
--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -72,6 +72,7 @@ public:
     [[nodiscard]] int          TurnPolicyAdopted(std::string_view name) const;
     [[nodiscard]] int          CurrentTurnsPolicyHasBeenAdopted(std::string_view name) const;
     [[nodiscard]] int          CumulativeTurnsPolicyHasBeenAdopted(std::string_view name) const;
+    [[nodiscard]] int          LatestTurnPolicyWasAdopted(std::string_view name) const;
 
     [[nodiscard]] int                           SlotPolicyAdoptedIn(std::string_view name) const;
     [[nodiscard]] std::vector<std::string_view> AdoptedPolicies() const;
@@ -87,6 +88,7 @@ public:
     [[nodiscard]] std::map<std::string_view, int, std::less<>> TurnsPoliciesAdopted() const;
     [[nodiscard]] const auto& PolicyTotalAdoptedDurations() const noexcept { return m_policy_adoption_total_duration; }
     [[nodiscard]] const auto& PolicyCurrentAdoptedDurations() const noexcept { return m_policy_adoption_current_duration; }
+    [[nodiscard]] const auto& PolicyLatestTurnsAdopted() const noexcept { return m_policy_latest_turn_adopted; }
 
     /** Returns the set of policies / slots the empire has avaialble. */
     [[nodiscard]] const auto& AvailablePolicies() const noexcept { return m_available_policies; }
@@ -523,6 +525,7 @@ private:
     std::map<std::string, PolicyAdoptionInfo, std::less<>> m_initial_adopted_policies;         ///< adopted policies at start of turn
     std::map<std::string, int>                             m_policy_adoption_total_duration;   ///< how many turns each policy has been adopted over the course of the game by this empire
     std::map<std::string, int>                             m_policy_adoption_current_duration; ///< how many turns each currently-adopted policy has been adopted since it was last adopted. somewhat redundant with adoption_turn in AdoptionInfo, but seems necessary to avoid off-by-one issues between client and server
+    std::map<std::string, int>                             m_policy_latest_turn_adopted;       ///< on which turn was each policy most recently adopted
     std::set<std::string, std::less<>>                     m_available_policies;               ///< names of unlocked policies
 
 public:
@@ -534,12 +537,14 @@ private:
     std::map<int, decltype(m_initial_adopted_policies)>         m_initial_adopted_policies_to_serialize_for_empires;
     std::map<int, decltype(m_policy_adoption_total_duration)>   m_policy_adoption_total_duration_to_serialize_for_empires;
     std::map<int, decltype(m_policy_adoption_current_duration)> m_policy_adoption_current_duration_to_serialize_for_empires;
+    std::map<int, decltype(m_policy_latest_turn_adopted)>       m_policy_latest_turn_adopted_to_serialize_for_empires;
     std::map<int, decltype(m_available_policies)>               m_available_policies_to_serialize_for_empires;
 
     const decltype(m_adopted_policies)& GetAdoptedPoliciesToSerialize(int encoding_empire) const;
     const decltype(m_initial_adopted_policies)& GetInitialPoliciesToSerialize(int encoding_empire) const;
     const decltype(m_policy_adoption_total_duration)& GetAdoptionTotalDurationsToSerialize(int encoding_empire) const;
     const decltype(m_policy_adoption_current_duration)& GetAdoptionCurrentDurationsToSerialize(int encoding_empire) const;
+    const decltype(m_policy_latest_turn_adopted)& GetAdoptionLatestTurnsToSerialize(int encoding_empire) const;
     const decltype(m_available_policies)& GetAvailablePoliciesToSerialize(int encoding_empire) const;
 
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5732,6 +5732,25 @@ ADOPTED_POLICIES
 NO_POLICIES_ADOPTED
 No Policies Known Adopted
 
+# %1% name or link to policy
+# %2% turn start of current adoption, or "before first turn"
+# %3% total turns has been adopted
+POLICY_ADOPTED_ON_TURN_AND_TOTAL_TURNS
+%1%  since %2%  total turns: %3%
+
+FORMERLY_ADOPTED_POLICIES
+'''Formerly Adopted Policies: '''
+
+# %1% name or link to policy
+# %2% turn end of when policy was previously adopted
+# %3% total turns has been adopted
+POLICY_WAS_LAST_ADOPTED_ON_TURN_AND_TOTAL_TURNS
+%1%  last on %2%  total turns: %3%
+
+# %1% turn number
+POLICY_ADOPTED_TURN
+turn: %1%
+
 AVAILABLE_PARTS
 '''Available Parts: '''
 

--- a/parse/IntComplexValueRefParser.cpp
+++ b/parse/IntComplexValueRefParser.cpp
@@ -83,6 +83,7 @@ namespace parse {
                     |   tok.TurnPolicyAdopted_
                     |   tok.TurnsSincePolicyAdopted_
                     |   tok.CumulativeTurnsPolicyAdopted_
+                    |   tok.LatestTurnPolicyAdopted_
                     |   tok.NumPoliciesAdopted_
                     )
                 >  -(   label(tok.empire_) > int_rules.expr)

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -226,6 +226,7 @@
     (LastTurnColonized)                         \
     (LastTurnConquered)                         \
     (LastTurnMoveOrdered)                       \
+    (LatestTurnPolicyAdopted)                   \
     (LastTurnResupplied)                        \
     (LaunchedFrom)                              \
     (LeastHappySpecies)                         \

--- a/parse/ValueRefPythonParser.cpp
+++ b/parse/ValueRefPythonParser.cpp
@@ -1170,6 +1170,7 @@ void RegisterGlobalsValueRefs(boost::python::dict& globals, const PythonParser& 
                                  "TurnPolicyAdopted",
                                  "TurnsSincePolicyAdopted",
                                  "CumulativeTurnsPolicyAdopted",
+                                 "LatestTurnPolicyAdopted",
                                  "NumPoliciesAdopted"})
     {
         const auto f_insert_int_complex_variable = [variable](const boost::python::tuple& args, const boost::python::dict& kw) { return insert_int_complex_variable_(variable, args, kw); };

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -1716,6 +1716,8 @@ int ComplexVariable<int>::Eval(const ScriptingContext& context) const
         empire_property_string_key = &Empire::PolicyCurrentAdoptedDurations;
     else if (m_property_name == "CumulativeTurnsPolicyAdopted")
         empire_property_string_key = &Empire::PolicyTotalAdoptedDurations;
+    else if (m_property_name == "LatestTurnPolicyAdopted")
+        empire_property_string_key = &Empire::PolicyLatestTurnsAdopted;
 
     if (empire_property_string_key || empire_property_string_key2 || empire_property_string_key3) {
         std::shared_ptr<const Empire> empire;


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3730a3ef-3c25-46d5-af9b-ffb37b2de990)

Could be useful for #5245

@o01eg I don't recall what needs to be done for Python parser support for LatestTurnPolicyAdopted ComplexVariable<int>