### PR TITLE
GG: cmake: fix Config.h directory searching

### DIFF
--- a/GG/GG/CMakeLists.txt
+++ b/GG/GG/CMakeLists.txt
@@ -18,7 +18,7 @@ target_sources(GiGi
         ${CMAKE_CURRENT_LIST_DIR}/Button.h
         ${CMAKE_CURRENT_LIST_DIR}/ClrConstants.h
         ${CMAKE_CURRENT_LIST_DIR}/Clr.h
-        ${CMAKE_CURRENT_LIST_DIR}/Config.h
+        ${CMAKE_CURRENT_BINARY_DIR}/Config.h
         ${CMAKE_CURRENT_LIST_DIR}/Control.h
         ${CMAKE_CURRENT_LIST_DIR}/Cursor.h
         ${CMAKE_CURRENT_LIST_DIR}/DeferredLayout.h


### PR DESCRIPTION
EDIT: I'm not sure this is actually related to separate build directory from the source tree, but it looks possible.
Nor did I try the PR on master branch.

ORIGINAL:

While packaging FreeOrion 0.5.1.1 for void linux, I got the following build error:

```
CMake Error at CMakeLists.txt:686 (target_link_libraries):
  Cannot find source file:

    /builddir/freeorion-0.5.1.1/GG/GG/Config.h

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm
  .ccm .cxxm .c++m .h .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90
  .f95 .f03 .hip .ispc

CMake Error at GG/GG/CMakeLists.txt:13 (target_sources):
  Cannot find source file:

    /builddir/freeorion-0.5.1.1/GG/GG/Config.h

  Tried extensions .c .C .c++ .cc .cpp .cxx .cu .mpp .m .M .mm .ixx .cppm
  .ccm .cxxm .c++m .h .hh .h++ .hm .hpp .hxx .in .txx .f .F .for .f77 .f90
  .f95 .f03 .hip .ispc

CMake Error: CMake can not determine linker language for target: GiGi -- Generating done (0.1s)
CMake Generate step failed.  Build files cannot be regenerated correctly. => ERROR: freeorion-0.5.1.1_1: do_configure: 'CFLAGS="-DNDEBUG ${CFLAGS/ -pipe / }" CXXFLAGS="-DNDEBUG ${CXXFLAGS/ -pipe / }" cmake ${cmake_args} ${configure_args} -DCMAKE_POLICY_VERSION_MINIMUM=3.5 ${LIBS:+-DCMAKE_C_STANDARD_LIBRARIES="$LIBS"} ${LIBS:+-DCMAKE_CXX_STANDARD_LIBRARIES="$LIBS"} ${wrksrc}/${build_wrksrc}' exited with 1
=> ERROR:   in do_configure() at common/build-style/cmake.sh:77
```

This is the fix for it, the rationale being:

In [GG/CMakeLists.txt](https://github.com/freeorion/freeorion/blob/4bd782a81762dffeeb87c5d83887099094c5eb1f/GG/CMakeLists.txt#L96) the file is generated in:
`${CMAKE_CURRENT_BINARY_DIR}/GG/Config.h`
by the `configure_file` function.

But this file was referenced as:
`${CMAKE_CURRENT_LIST_DIR}/Config.h`
from within the [GG/GG/CMakeLists.txt](https://github.com/freeorion/freeorion/blob/4bd782a81762dffeeb87c5d83887099094c5eb1f/GG/GG/CMakeLists.txt#L21) file.

So it should be:
`${CMAKE_CURRENT_BINARY_DIR}/Config.h`
Where it is generated, removing the `GG` subfolder level, since we now are inside it.