### PR TITLE
[focs] Linear fleet unstealthiness (no AI)

### DIFF
--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -61,11 +61,16 @@ Tech(
             effects=SetStealth(
                 value=Value
                 - NamedRealLookup(name="FLEET_UNSTEALTH_SHIPS_SCALING")
-                * StatisticCount(float, condition=
-                                 Ship
-                                 & ~InSystem()
-                                 & ((LocalCandidate.NextSystemID == Target.SystemID) |  (LocalCandidate.NextSystemID == Target.SystemID))
-                                 & OwnedBy(empire=Source.Owner))
+                * StatisticCount(
+                    float,
+                    condition=Ship
+                    & ~InSystem()
+                    & (
+                        (LocalCandidate.NextSystemID == Target.SystemID)
+                        | (LocalCandidate.NextSystemID == Target.SystemID)
+                    )
+                    & OwnedBy(empire=Source.Owner),
+                )
             ),
         ),
     ],

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -1,9 +1,7 @@
 from focs._effects import (
     BlackHole,
     EffectsGroup,
-    Floor,
     InSystem,
-    MaxOf,
     NamedReal,
     Neutron,
     NoStar,
@@ -53,23 +51,22 @@ Tech(
             accountinglabel="FLEET_UNSTEALTHINESS",
             effects=SetStealth(
                 value=Value
-                - NamedReal(name="FLEET_UNSTEALTH_SHIPS_SCALING", value=5.0)
-                * Floor(
-                    float,
-                    MaxOf(
-                        float,
-                        0,
-                        (
-                            StatisticCount(
-                                float, condition=Ship & InSystem(id=Target.SystemID) & OwnedBy(empire=Source.Owner)
-                            )
-                        )
-                        - NamedReal(name="FLEET_UNSTEALTHY_SHIPS_THRESHOLD", value=10),
-                    )
-                    ** 0.5,
-                )
+                - NamedReal(name="FLEET_UNSTEALTH_SHIPS_SCALING", value=1.0)
+                * StatisticCount(float, condition=Ship & InSystem(id=Target.SystemID) & OwnedBy(empire=Source.Owner))
             ),
-            # large fleets only start affecting stealth when there are more than the threshold of ships in a single system
+        ),
+        EffectsGroup(
+            scope=Ship & ~InSystem() & OwnedBy(empire=Source.Owner),
+            accountinglabel="FLEET_UNSTEALTHINESS",
+            effects=SetStealth(
+                value=Value
+                - NamedRealLookup(name="FLEET_UNSTEALTH_SHIPS_SCALING")
+                * StatisticCount(float, condition=
+                                 Ship
+                                 & ~InSystem()
+                                 & ((LocalCandidate.NextSystemID == Target.SystemID) |  (LocalCandidate.NextSystemID == Target.SystemID))
+                                 & OwnedBy(empire=Source.Owner))
+            ),
         ),
     ],
 )

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6740,7 +6740,7 @@ Stealth
 METER_STEALTH_VALUE_DESC
 '''The term Stealth represents the ability of an object to dodge all kinds of sensors. Only empires with a [[encyclopedia DETECTION_TITLE]] higher than or equal to the Stealth value can see the object.
 
-If an empire owns more than [[value FLEET_UNSTEALTHY_SHIPS_THRESHOLD]] in a system, that empire will suffer a stealth penalty of [[value FLEET_UNSTEALTH_SHIPS_SCALING]] multiplied by the square root of the number of excess ships.
+Larger fleets are easier to detect. Empire's ships will suffer a stealth penalty of [[value FLEET_UNSTEALTH_SHIPS_SCALING]] multiplied the number of ships in the system or on a starlane.
 
 Space ships, buildings, specials, systems and planets have a Stealth meter.
 


### PR DESCRIPTION
Make fleet unstealthiness linear in order to have a bigger impact

[forum discussion](https://freeorion.org/forum/viewtopic.php?t=13419)

this was playtested in systems and starlanes

note it seems there is no AI support yet for fleet unstealthiness at all

also as result of that discussion i would like to implement a scheme which allows to hide part of a fleet where a few ships have higher stealth (see discussion) , but in a different issue/PR
