### PR TITLE
Make outpost parts cheaper -20%/-10PP

### DIFF
--- a/default/scripting/ship_parts/Colony/CO_COLONY_POD.focs.txt
+++ b/default/scripting/ship_parts/Colony/CO_COLONY_POD.focs.txt
@@ -4,7 +4,7 @@ Part
     class = Colony
     capacity = 1
     mountableSlotTypes = Internal
-    buildcost = 120 * [[COLONY_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]] * [[COLONIZATION_POLICY_MULTIPLIER]]
+    buildcost = 130 * [[COLONY_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]] * [[COLONIZATION_POLICY_MULTIPLIER]]
     buildtime = 8
     tags = [ "PEDIA_PC_COLONY" ]
     location = And [

--- a/default/scripting/ship_parts/Colony/CO_COL_OUTPOST.focs.txt
+++ b/default/scripting/ship_parts/Colony/CO_COL_OUTPOST.focs.txt
@@ -4,7 +4,7 @@ Part
     class = Colony
     capacity = 0
     mountableSlotTypes = Internal
-    buildcost = 50 * [[COLONY_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]] * [[COLONIZATION_POLICY_MULTIPLIER]]
+    buildcost = 40 * [[COLONY_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]] * [[COLONIZATION_POLICY_MULTIPLIER]]
     buildtime = 3
     tags = [ "PEDIA_PC_COLONY" ]
     location = And [

--- a/default/scripting/ship_parts/Colony/CO_SUPEND_ANIM_POD.focs.txt
+++ b/default/scripting/ship_parts/Colony/CO_SUPEND_ANIM_POD.focs.txt
@@ -4,7 +4,7 @@ Part
     class = Colony
     capacity = [[MIN_RECOLONIZING_SIZE]]
     mountableSlotTypes = Internal
-    buildcost = 120 * [[COLONY_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]] * [[COLONIZATION_POLICY_MULTIPLIER]]
+    buildcost = 130 * [[COLONY_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]] * [[COLONIZATION_POLICY_MULTIPLIER]]
     buildtime = 10
     tags = [ "PEDIA_PC_COLONY" ]
     location = And [


### PR DESCRIPTION
https://freeorion.org/forum/viewtopic.php?p=121850

Make establishing outposts cheaper and keep the colonization costs the same.

minor objections/look out for:
* might become unbalanced if content gives resources from outposts
* increasing colonization cost also increases recolonization cost

AI - nothing to adapt
en - stringtable description still fits