### PR TITLE
Postpone Automatic History Analyzer and make it more expensive

### DIFF
--- a/default/scripting/techs/learning/ALGO_ELEGANCE.focs.py
+++ b/default/scripting/techs/learning/ALGO_ELEGANCE.focs.py
@@ -9,6 +9,6 @@ Tech(
     researchcost=18 * TECH_COST_MULTIPLIER,
     researchturns=3,
     tags=["PEDIA_LEARNING_CATEGORY"],
-    unlock=Item(type=UnlockPolicy, name="PLC_ALGORITHMIC_RESEARCH"),
+    unlock=[Item(type=UnlockPolicy, name="PLC_LIBERTY"), Item(type=UnlockPolicy, name="PLC_ALGORITHMIC_RESEARCH")],
     graphic="icons/tech/algorithmic_elegance.png",
 )

--- a/default/scripting/techs/learning/PHYSICAL_BRAIN.focs.py
+++ b/default/scripting/techs/learning/PHYSICAL_BRAIN.focs.py
@@ -6,9 +6,10 @@ Tech(
     description="LRN_PHYS_BRAIN_DESC",
     short_description="BUILDING_UNLOCK_SHORT_DESC",
     category="LEARNING_CATEGORY",
-    researchcost=10 * TECH_COST_MULTIPLIER,
+    researchcost=20 * TECH_COST_MULTIPLIER,
     researchturns=2,
     tags=["PEDIA_LEARNING_CATEGORY"],
-    unlock=[Item(type=UnlockPolicy, name="PLC_LIBERTY"), Item(type=UnlockBuilding, name="BLD_AUTO_HISTORY_ANALYSER")],
+    prerequisites=["LRN_ALGO_ELEGANCE"],
+    unlock=Item(type=UnlockBuilding, name="BLD_AUTO_HISTORY_ANALYSER"),
     graphic="icons/tech/the_physical_brain.png",
 )


### PR DESCRIPTION
https://freeorion.org/forum/viewtopic.php?p=121862&

Behold the brainlessness of building the AHA!
The automatic history analyzer is very powerful we want to delay it hoping some empires will choose to invest into something else before

- Adding LRN_ALGO_ELEGANCE (18RP) as prerequisite to LRN_PHYS_BRAIN.
- Increase RP cost of LRN_PHYS_BRAIN (maybe 20 RP, +10PP, +100%).

LRN_PHYS_BRAIN also unlocks translinguistics and liberty in order not to delay liberty so much:
- move LIBERTY policy to LRN_ALGO_ELEGANCE

AI: research and policy choices should be looked at
en: the liberty and algorithmic elegance fluff might need enhancement

Will need playtesting