### PR TITLE
Remove Boost System dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -289,6 +289,13 @@ find_package(Boost ${MINIMUM_BOOST_VERSION}
         thread
     REQUIRED)
 
+if(APPLE)
+find_package(Boost ${MINIMUM_BOOST_VERSION}
+    COMPONENTS
+        system
+    REQUIRED)
+endif()
+
 message(STATUS "Boost version detected ${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION}")
 
 find_package(Boost OPTIONAL_COMPONENTS python${Boost_PYTHON_SUFFIX})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,7 +286,6 @@ find_package(Boost ${MINIMUM_BOOST_VERSION}
         log_setup
         random
         serialization
-        system
         thread
     REQUIRED)
 

--- a/GG/CMakeLists.txt
+++ b/GG/CMakeLists.txt
@@ -66,7 +66,7 @@ endif()
 
 set(MINIMUM_BOOST_VERSION 1.69.0)
 
-find_package(Boost ${MINIMUM_BOOST_VERSION} COMPONENTS filesystem regex system REQUIRED)
+find_package(Boost ${MINIMUM_BOOST_VERSION} COMPONENTS filesystem regex REQUIRED)
 
 find_package(OpenGL REQUIRED)
 find_package(GLEW REQUIRED)

--- a/GG/test/unit/CMakeLists.txt
+++ b/GG/test/unit/CMakeLists.txt
@@ -16,7 +16,6 @@ add_executable(gg_unittest
 target_link_libraries(gg_unittest
     GiGi
     Boost::boost
-    Boost::system
     Boost::unit_test_framework
 )
 

--- a/UI/About.cpp
+++ b/UI/About.cpp
@@ -39,22 +39,22 @@ About::About():
 void About::CompleteConstruction() {
     CUIWnd::CompleteConstruction();
 
-    if (m_done = Wnd::Create<CUIButton>(UserString("DONE"))) {
+    if ((m_done = Wnd::Create<CUIButton>(UserString("DONE")))) {
         AttachChild(m_done);
         m_done->LeftClickedSignal.connect([this]() { EndRun(); });
     }
 
-    if (m_license = Wnd::Create<CUIButton>(UserString("LICENSE"))) {
+    if ((m_license = Wnd::Create<CUIButton>(UserString("LICENSE")))) {
         AttachChild(m_license);
         m_license->LeftClickedSignal.connect([this]() { ShowLicense(); });
     }
 
-    if (m_vision = Wnd::Create<CUIButton>(UserString("VISION"))) {
+    if ((m_vision = Wnd::Create<CUIButton>(UserString("VISION")))) {
         AttachChild(m_vision);
         m_vision->LeftClickedSignal.connect([this]() { ShowVision(); });
     }
 
-    if (m_info = GG::Wnd::Create<CUIMultiEdit>(UserString("FREEORION_VISION"), GG::MULTI_WORDBREAK | GG::MULTI_READ_ONLY))
+    if ((m_info = GG::Wnd::Create<CUIMultiEdit>(UserString("FREEORION_VISION"), GG::MULTI_WORDBREAK | GG::MULTI_READ_ONLY)))
         AttachChild(m_info);
 
     DoLayout();

--- a/test/UI/CMakeLists.txt
+++ b/test/UI/CMakeLists.txt
@@ -23,7 +23,6 @@ add_library(fo_acceptance_runner STATIC
 
 target_link_libraries(fo_acceptance_runner
     PUBLIC
-        Boost::system
         GiGi::GiGi
         GLEW::GLEW
         ${SDL_LIBRARIES}


### PR DESCRIPTION
Seems to be broken with Boost 1.89 and Ubuntu 24.04.3 LTS.

Some discussion of similar issues here: https://www.linuxquestions.org/questions/slackware-14/sbo-scripts-not-building-on-current-read-1st-post-pls-4175561999/page470.html#post6588988
and: https://github.com/boostorg/system/issues/123