### PR TITLE
better command line options for multiplayer

### DIFF
--- a/UI/ServerConnectWnd.cpp
+++ b/UI/ServerConnectWnd.cpp
@@ -32,6 +32,7 @@ namespace {
 
     void AddOptions(OptionsDB& db) {
         db.Add("setup.multiplayer.player.name",     UserStringNop("OPTIONS_DB_MP_PLAYER_NAME"),     std::string(""),            Validator<std::string>());
+        db.Add("setup.multiplayer.player.role",     UserStringNop("OPTIONS_DB_MP_PLAYER_ROLE"),     'p',                        Validator<std::string>());
         db.Add("setup.multiplayer.host.address",    UserStringNop("OPTIONS_DB_MP_HOST_ADDRESS"),    std::string("localhost"),   Validator<std::string>());
     }
     bool temp_bool = RegisterOptions(&AddOptions);
@@ -150,7 +151,22 @@ void ServerConnectWnd::CompleteConstruction() {
     m_client_type_list->Insert(GG::Wnd::Create<ClientTypeRow>(Networking::ClientType::CLIENT_TYPE_HUMAN_MODERATOR));
     m_client_type_list->Insert(GG::Wnd::Create<ClientTypeRow>(Networking::ClientType::CLIENT_TYPE_HUMAN_OBSERVER));
 
-    m_client_type_list->Select(0);
+    using namespace std::string_literals;
+
+    auto role = GetOptionsDB().Get<std::string>("setup.multiplayer.player.role");
+    if (role.empty()) {
+      ErrorLogger() << "Got empty setup.multiplayer.player.role '" << role << "' using 'p' for Player instead";
+      m_client_type_list->Select(0);
+    } else if ("moderator"s.starts_with(role)) {
+      m_client_type_list->Select(1);
+    } else if ("observer"s.starts_with(role)) {
+      m_client_type_list->Select(2);
+    } else if ("player"s.starts_with(role)) {
+      m_client_type_list->Select(0);
+    } else {
+      ErrorLogger() << "Got weird setup.multiplayer.player.role '" << role << "' using 'p' for Player instead";
+      m_client_type_list->Select(0);
+    }
     m_result.type = Networking::ClientType::CLIENT_TYPE_HUMAN_PLAYER;
 
     m_host_or_join_radio_group->SetCheck(0);

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1741,7 +1741,10 @@ OPTIONS_DB_MP_HOST_ADDRESS
 Address to connect to when joining a multiplayer game.
 
 OPTIONS_DB_MP_PLAYER_NAME
-Player name to use when hosting or joining a multiplayer game.
+Player name to use when hosting or joining a multiplayer game. This sets the default value in the multiplayer connection window.
+
+OPTIONS_DB_MP_PLAYER_ROLE
+Player role to use when hosting or joining a multiplayer game. Use p for Player, m for Moderator, or o for Observer. This sets the default value in the multiplayer connection window.
 
 OPTIONS_DB_MP_AI_MIN
 Set the minimum number of ai players required to start a multiplayer game.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1613,7 +1613,7 @@ OPTIONS_DB_SINGLEPLAYER
 Start server in single player host mode. This only allows clients on localhost to connect.
 
 OPTIONS_DB_HOSTLESS
-Start server in hostless mode. Server accepts players in the multiplayer lobby, and returns to the lobby after the game session ends.
+Start server in hostless mode. Server accepts players in the multiplayer lobby, and returns to the lobby after the game session ends. If restarting a server in hostless mode, the running game can be specified by giving the current save file name or the containing directory using the --load option. Or one can use --load-or-quickstart 1 and --setup.game.uid GAME-UID. The game UID can be specified on first start using --setup.game.uid MY-CHOSEN-GAME-UID. Note that the auth.txt file must be configured correctly in order for players to connect to the server.
 
 OPTIONS_DB_SKIP_CHECKSUM
 Skip comparing the resource directory checksums.  This allows faster startup when client and server are on the same machine, using the same resource directory.
@@ -2368,7 +2368,7 @@ OPTIONS_DB_UI_SITREP_ICONSIZE
 Sets the sitrep icon width and height; default 16 (min 12, max 64).
 
 OPTIONS_DB_LOAD
-Loads and starts the specified single-player or multi-player save game. In multi-player, it requires hostless mode and no restriction on the minimum number of connected players, because the server will start with no connected players.
+Loads and starts the specified single-player or multi-player save game. If a directory is specified, the newest game (by lexicographical order) in that folder gets loaded. In multi-player, it requires hostless mode and no restriction on the minimum number of connected players, because the server will start with no connected players.
 
 OPTIONS_DB_EFFECTS_THREADS_UI_DESC
 Specifies number of threads to use for effects processing in the user interface. More than one thread may lead to unpredictable crashes.

--- a/util/OptionValidators.h
+++ b/util/OptionValidators.h
@@ -52,8 +52,15 @@ struct Validator : public ValidatorBase
             return boost::any(StringToList(str));
         else if constexpr (std::is_same_v<T, std::string>)
             return boost::any(std::string{str});
-        else
+        else {
+            if constexpr (std::is_same_v<T, char>) {
+                try {
+                    return boost::any(boost::lexical_cast<int>(str));
+                } catch (const std::exception& e) {
+                }
+            }
             return boost::any(boost::lexical_cast<T>(str));
+        }
     }
 
     [[nodiscard]] std::string String(const boost::any& value) const override {


### PR DESCRIPTION
this provides some tooling for use with hostless server.

* using a directory in `--load` will load the newest game in the given directory. (this is a way to provide a full path, the existing option looks up for a directory named by the game uid in the save directory). Newest game means the save game with the last file in lexicographical order.
* one can preset the multiplayer dialog role to Moderator, Observer, or Player (`--role m`, `--role o`, or `--role p`); defaulting to Player  

Note: first use of a OptionValidator<char>