### PR TITLE
fix un stealth pedia

### DIFF
--- a/default/scripting/encyclopedia/game_concepts/FLEET_UNSTEALTHINESS.focs.txt
+++ b/default/scripting/encyclopedia/game_concepts/FLEET_UNSTEALTHINESS.focs.txt
@@ -1,0 +1,6 @@
+Article
+    name = "FLEET_UNSTEALTHINESS_TITLE"
+    category = "CATEGORY_GAME_CONCEPTS"
+    short_description = "METER_ARTICLE_SHORT_DESC"
+    description = "FLEET_UNSTEALTHINESS_TEXT"
+    icon = "icons/meter/detection.png"

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -166,7 +166,7 @@ Tech(
         # apply the lowest resulting stealth of ships of higher/equal stealth
         EffectsGroup(
             scope=Ship & InSystem() & OwnedBy(empire=Source.Owner),
-            accountinglabel="FLEET_UNSTEALTHINESS_INSYSTEM",
+            accountinglabel="FLEET_UNSTEALTHINESS_INSYSTEM_LABEL",
             priority=LATE_AFTER_ALL_TARGET_MAX_METERS_PRIORITY,
             effects=[
                 SetStealth(
@@ -177,7 +177,7 @@ Tech(
         # Do test a) ships going via different starlanes to/from the same system
         EffectsGroup(
             scope=Ship & ~InSystem() & OwnedBy(empire=Source.Owner),
-            accountinglabel="FLEET_UNSTEALTHINESS",
+            accountinglabel="FLEET_UNSTEALTHINESS_ON_STARLANE_LABEL",
             priority=LATE_AFTER_ALL_TARGET_MAX_METERS_PRIORITY,
             effects=[
                 SetStealth(

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -15110,6 +15110,19 @@ Ships with lower stealth meter value can be detected more easily, see [[encyclop
 FLEET_UNSTEALTHY_SHIPS_THRESHOLD
 Number of ships in a system owned by the same empire, above which ships receive a stealth penalty
 
+# specials used for FLEET_UNSTEALTHINESS implementation
+LOWER_STEALTH_COUNT_SPECIAL
+Pre-Unstealthiness Lower Stealth Ship Count
+
+LOWER_STEALTH_COUNT_SPECIAL_DESC
+Count of own ships at the same location before applying fleet unstealthiness effect. Used in implementation of [[encyclopedia FLEET_UNSTEALTHINESS_TITLE]].
+
+BASE_STEALTH_SPECIAL
+Pre-Unstealthiness Stealth
+
+BASE_STEALTH_SPECIAL_DESC
+Stealth meter before applying fleet unstealthiness effect. Used in implementation of [[encyclopedia FLEET_UNSTEALTHINESS_TITLE]].
+
 
 ##
 ## Technology refinement

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -15056,23 +15056,23 @@ SPY_PLANET_STEALTH_MOD_DESC
 
 [[PLANET_STEALTH_MODIFIERS]]
 
-For other kinds of object receiving stealth, have a look at the [[metertype METER_STEALTH]] entry.'''
+Stealth received by other types of objects are listed in [[metertype METER_STEALTH]].'''
 
 PLANET_STEALTH_MODIFIERS
 '''• [[BASIC_PLANET_STEALTH]] gives [[value PLANET_BASIC_STEALTH]] [[metertype METER_STEALTH]] to all planets.
 • Colonies may have an extra malus or bonus to [[metertype METER_STEALTH]] based on the colony's species.
-• Planetary stealth specials decrease [[metertype METER_STEALTH]] of the planet. The main source for these specials is the research of planetary stealth technologies.'''
+• Planetary stealth specials increase [[metertype METER_STEALTH]] of the planet. The main source for these specials is the research of planetary stealth technologies.'''
 
 # Note: ship stealth decrease by stars is also shown in DETECTION_STAR_MODIFIERS
 SHIP_STEALTH_MODIFIERS
 '''
-• Larger fleets are easier to detect. Empire's ships will suffer a malus to [[metertype METER_STEALTH]] based on the number of ships in the system or on a starlane. See [[encyclopedia FLEET_UNSTEALTHINESS_TITLE]].
+• Larger fleets are easier to detect. Empire's ships will suffer a malus to [[metertype METER_STEALTH]] based on the number of ships in the same system or on the same starlane. See [[encyclopedia FLEET_UNSTEALTHINESS_TITLE]].
 • Stealth ship parts add a bonus to ship [[metertype METER_STEALTH]].
 • Ships in systems with [[STAR_NONE]] receive a [[value SPY_DECEPTION_EMPTY_SPACE_PENALTY]] penalty to [[metertype METER_STEALTH]] due to being [[SPY_DECEPTION_EMPTY_SPACE_PENALTY]].
 • Ships in systems with a [[STAR_RED]] star receive a [[value SPY_DECEPTION_DIM_STAR_PENALTY]] penalty to [[metertype METER_STEALTH]] due to being [[SPY_DECEPTION_DIM_STAR_PENALTY]].
 • Ships in systems with a [[STAR_NEUTRON]] star receive a [[value SPY_DECEPTION_NEUTRON_INTERFERENCE]] bonus to [[metertype METER_STEALTH]] due to [[SPY_DECEPTION_SUBSTELLAR_INTERFERENCE]].
 • Ships in systems with a [[STAR_BLACK]] star receive a [[value SPY_DECEPTION_BLACK_INTERFERENCE]] bonus to [[metertype METER_STEALTH]] due to [[SPY_DECEPTION_SUBSTELLAR_INTERFERENCE]].
-• Ships inside fields like [[fieldtype FLD_ION_STORM]] or [[fieldtype FLD_NEBULA_1]] can increase [[metertype METER_STEALTH]].
+• Ships inside fields like [[fieldtype FLD_ION_STORM]] or [[fieldtype FLD_NEBULA_1]] have increased [[metertype METER_STEALTH]].
 • There are also buildings and policies which reduce [[metertype METER_STEALTH]]'''
 
 BASIC_PLANET_STEALTH
@@ -15088,14 +15088,15 @@ FLEET_UNSTEALTHINESS_TITLE
 Fleet Unstealthiness (Game Concept)
 
 FLEET_UNSTEALTHINESS_TEXT
-'''Empire's ships will suffer a malus to [[metertype METER_STEALTH]] based on the number of those ships in the system or on a starlane. This effect is called fleet unstealthiness.
+'''Empire's ships will suffer a malus to [[metertype METER_STEALTH]] based on the number of those ships in the same system or on the same starlane. This effect is called fleet unstealthiness.
 
 
 Fleet unstealthiness decreases a ship's stealth meter by an amount equal to a count of ships:
 
-• Only ships of the ship's empire are counted. Other empires' ships are ignored, example given also allies' ships are ignored.
+• Only ships of the ship's empire are counted. Other empires' ships are ignored, including allied empires' ships, do not contribute.
 
 • This gets counted for each starlane and each system separately. For each system all own ships in all fleets in that system are considered. For each starlane all own fleets on that starlane are considered, ignoring the direction of travel.
+Fleet unstealthiness is applied and calculated separately for each starlane and each system. For each system, all ships with the same owner are counted. For each starlane, all ships with the same owner are counted, regardless of direction of travel or location on the starlane.
 
 • Only ships which have lower or equal stealth are counted for the malus. This is for gameplay reasons: without this restriction an observer would know the count of invisible ships. With this restriction one can hide higher stealth ships in a mixed fleet completely.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6737,14 +6737,17 @@ An abstract value for the size of an object, group of objects, or area.
 METER_STEALTH_VALUE_LABEL
 Stealth
 
+# This is the entry point to the stealth descriptions
 METER_STEALTH_VALUE_DESC
 '''The term Stealth represents the ability of an object to dodge all kinds of sensors. Only empires with a [[encyclopedia DETECTION_TITLE]] higher than or equal to the Stealth value can see the object.
 
-Larger fleets are easier to detect. Empire's ships will suffer a stealth penalty of [[value FLEET_UNSTEALTH_SHIPS_SCALING]] multiplied the number of ships in the system or on a starlane.
-
 Space ships, buildings, specials, systems and planets have a Stealth meter.
 
-[[DETECTION_STAR_MODIFIERS]]'''
+Modifiers of planetary Stealth meter:
+[[PLANET_STEALTH_MODIFIERS]]
+
+Modifiers of space ship Stealth meter:
+[[SHIP_STEALTH_MODIFIERS]]'''
 
 METER_DETECTION_VALUE_LABEL
 Detection Range
@@ -6758,12 +6761,13 @@ Some content may allow vision outside of this range. This includes the species a
 
 [[DETECTION_STAR_MODIFIERS]]'''
 
+# Note: stealth decrease is also shown in SHIP_STEALTH_MODIFIERS
 DETECTION_STAR_MODIFIERS
 '''Detection Range and Ship Stealth are modified by the systems star type:
-• No Star: +10 Detection Range. -10 Ship Stealth.
-• Neutron Star: -15 Detection Range. +5 Ship Stealth.
-• Black Hole: +5 Detection Range. +10 Ship Stealth.
-• Red Star: -5 Ship Stealth.
+• No Star: +10 Detection Range. [[value SPY_DECEPTION_EMPTY_SPACE_PENALTY]] Ship Stealth.
+• Neutron Star: -15 Detection Range. [[value SPY_DECEPTION_NEUTRON_INTERFERENCE]] Ship Stealth.
+• Black Hole: +5 Detection Range. [[value SPY_DECEPTION_BLACK_INTERFERENCE]] Ship Stealth.
+• Red Star: [[value SPY_DECEPTION_DIM_STAR_PENALTY]] Ship Stealth.
 • Orange Star: No Modifiers.
 • Yellow Star: -5 Detection Range.
 • White Star: -10 Detection Range.
@@ -15048,28 +15052,61 @@ SPY_PLANET_STEALTH_MOD
 Stealth Modifiers
 
 SPY_PLANET_STEALTH_MOD_DESC
-'''Modifiers affect stealth:
+'''Modifiers affect planetary [[metertype METER_STEALTH]]:
 
-• [[BASIC_PLANET_STEALTH]] gives [[value PLANET_BASIC_STEALTH]] [[metertype METER_STEALTH]] to all planets.
+[[PLANET_STEALTH_MODIFIERS]]
 
+For other kinds of object receiving stealth, have a look at the [[metertype METER_STEALTH]] entry.'''
+
+PLANET_STEALTH_MODIFIERS
+'''• [[BASIC_PLANET_STEALTH]] gives [[value PLANET_BASIC_STEALTH]] [[metertype METER_STEALTH]] to all planets.
 • Colonies may have an extra malus or bonus to [[metertype METER_STEALTH]] based on the colony's species.
+• Planetary stealth specials decrease [[metertype METER_STEALTH]] of the planet. The main source for these specials is the research of planetary stealth technologies.'''
 
-• Due to [[FLEET_UNSTEALTHINESS]], the [[metertype METER_STEALTH]] of an empire's ship is reduced by the number of other ships of that empire in the same system or on the same starlane.
-
+# Note: ship stealth decrease by stars is also shown in DETECTION_STAR_MODIFIERS
+SHIP_STEALTH_MODIFIERS
+'''
+• Larger fleets are easier to detect. Empire's ships will suffer a malus to [[metertype METER_STEALTH]] based on the number of ships in the system or on a starlane. See [[encyclopedia FLEET_UNSTEALTHINESS_TITLE]].
+• Stealth ship parts add a bonus to ship [[metertype METER_STEALTH]].
 • Ships in systems with [[STAR_NONE]] receive a [[value SPY_DECEPTION_EMPTY_SPACE_PENALTY]] penalty to [[metertype METER_STEALTH]] due to being [[SPY_DECEPTION_EMPTY_SPACE_PENALTY]].
-
 • Ships in systems with a [[STAR_RED]] star receive a [[value SPY_DECEPTION_DIM_STAR_PENALTY]] penalty to [[metertype METER_STEALTH]] due to being [[SPY_DECEPTION_DIM_STAR_PENALTY]].
-
 • Ships in systems with a [[STAR_NEUTRON]] star receive a [[value SPY_DECEPTION_NEUTRON_INTERFERENCE]] bonus to [[metertype METER_STEALTH]] due to [[SPY_DECEPTION_SUBSTELLAR_INTERFERENCE]].
-
-• Ships in systems with a [[STAR_BLACK]] star receive a [[value SPY_DECEPTION_BLACK_INTERFERENCE]] bonus to [[metertype METER_STEALTH]] due to [[SPY_DECEPTION_SUBSTELLAR_INTERFERENCE]].'''
+• Ships in systems with a [[STAR_BLACK]] star receive a [[value SPY_DECEPTION_BLACK_INTERFERENCE]] bonus to [[metertype METER_STEALTH]] due to [[SPY_DECEPTION_SUBSTELLAR_INTERFERENCE]].
+• Ships inside fields like [[fieldtype FLD_ION_STORM]] or [[fieldtype FLD_NEBULA_1]] can increase [[metertype METER_STEALTH]].
+• There are also buildings and policies which reduce [[metertype METER_STEALTH]]'''
 
 BASIC_PLANET_STEALTH
 Universal Basic Stealth
 
-FLEET_UNSTEALTHINESS
-Fleet Unstealthiness
+FLEET_UNSTEALTHINESS_INSYSTEM_LABEL
+Fleet Unstealthiness (In System)
 
+FLEET_UNSTEALTHINESS_ON_STARLANE_LABEL
+Fleet Unstealthiness (Starlane)
+
+FLEET_UNSTEALTHINESS_TITLE
+Fleet Unstealthiness (Game Concept)
+
+FLEET_UNSTEALTHINESS_TEXT
+'''Empire's ships will suffer a malus to [[metertype METER_STEALTH]] based on the number of those ships in the system or on a starlane. This effect is called fleet unstealthiness.
+
+
+Fleet unstealthiness decreases a ship's stealth meter by an amount equal to a count of ships:
+
+• Only ships of the ship's empire are counted. Other empires' ships are ignored, example given also allies' ships are ignored.
+
+• This gets counted for each starlane and each system separately. For each system all own ships in all fleets in that system are considered. For each starlane all own fleets on that starlane are considered, ignoring the direction of travel.
+
+• Only ships which have lower or equal stealth are counted for the malus. This is for gameplay reasons: without this restriction an observer would know the count of invisible ships. With this restriction one can hide higher stealth ships in a mixed fleet completely.
+
+• In case a ship after applying the fleet unstealthiness ends up with lower stealth than a ship which had lower stealth before applying the fleet unstealthiness, the ships' stealth is reduced to the lower stealth value. This is for consistency reasons: it would be confusing that a ship with lower stealth ends up with higher stealth.
+
+• The current ship also does count. A solitary ship in a system has a fleet unstealthiness value of -1 [[metertype METER_STEALTH]].
+
+Ships with lower stealth meter value can be detected more easily, see [[encyclopedia DETECTION_TITLE]].
+'''
+
+# Note: currently unused
 FLEET_UNSTEALTHY_SHIPS_THRESHOLD
 Number of ships in a system owned by the same empire, above which ships receive a stealth penalty
 


### PR DESCRIPTION
better pedia entries for stealth; adds fleet unstealthiness as a game concept to the pedia; adds two missing descriptions for bookkeeping specials

@geoffthemedio would be nice if a native speaker could have a look