### PR TITLE
Fix obvious copy mistakes in SHP_TRANSSPACE.focs.py

### DIFF
--- a/default/scripting/techs/ship_hulls/SHP_TRANSSPACE.focs.py
+++ b/default/scripting/techs/ship_hulls/SHP_TRANSSPACE.focs.py
@@ -19,11 +19,11 @@ Tech(
 Tech(
     name="SHP_TRANSSPACE_DRIVE",
     description="SHP_TRANSSPACE_DRIVE_DESC",
-    short_description="SHIP_HULL_UNLOCK_SHORT_DESC",
+    short_description="SHIP_PART_UNLOCK_SHORT_DESC",
     category="SHIP_PARTS_CATEGORY",
     researchcost=400 * TECH_COST_MULTIPLIER,
     researchturns=8,
-    tags=["PEDIA_ROBOTIC_HULL_TECHS"],
+    tags=["PEDIA_ENGINE_PART_TECHS"],
     prerequisites=["SHP_TRANSSPACE_HULL", "SHP_NANOROBO_MAINT"],
     unlock=[
         Item(type=UnlockShipPart, name="FU_TRANSPATIAL_DRIVE"),

--- a/default/scripting/techs/ship_hulls/SHP_TRANSSPACE.focs.py
+++ b/default/scripting/techs/ship_hulls/SHP_TRANSSPACE.focs.py
@@ -8,7 +8,7 @@ Tech(
     category="SHIP_HULLS_CATEGORY",
     researchcost=80 * TECH_COST_MULTIPLIER,
     researchturns=8,
-    tags=["PEDIA_ROBOTIC_HULL_TECHS"],
+    tags=["PEDIA_SHIP_HULLS_CATEGORY"],
     prerequisites=["PRO_NANOTECH_PROD"],
     unlock=[
         Item(type=UnlockShipHull, name="SH_TRANSSPATIAL"),


### PR DESCRIPTION
These two fields should be the same as in the erroneously named [SHP_SINGULATIRY_ENGINE_CORE](https://github.com/freeorion/freeorion/blob/master/default/scripting/techs/ship_parts/speed/SHP_SINGULATIRY_ENGINE_CORE.focs.py) - if not moved into its own file altogether.