### PR TITLE
Make RULE_ALLOW_REPEATED_SPECIES behave as narratively expected

### DIFF
--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -42,13 +42,14 @@ def get_empire_name_generator():
 empire_name_generator = get_empire_name_generator()
 
 
-def get_starting_species_pool():
+def get_starting_species_pool(already_used = None):
     """
     Empire species pool generator, return random empire species and ensure somewhat even distribution
+    @param alreadyUsed - if set, then RULE_ALLOW_REPEATED_SPECIES is false and it contains the species already in use e.g. by player's choice
     """
     # fill the initial pool of playable species, without repetitions unless RULE_ALLOW_REPEATED_SPECIES is true
-    if not fo.getGameRules().getToggle("RULE_ALLOW_REPEATED_SPECIES"):
-        pool = fo.get_playable_species()
+    if already_used:
+        pool = [species for species in fo.get_playable_species() if species not in already_used]
     else:
         pool = fo.get_playable_species() * 2
 
@@ -64,10 +65,6 @@ def get_starting_species_pool():
             random.shuffle(pool)
         # pick and return next species, and remove it from our pool
         yield pool.pop()
-
-
-# generates starting species for empires, use next(starting_species_pool) to get next species
-starting_species_pool = get_starting_species_pool()
 
 
 def count_planets_in_systems(systems, planet_types_filter=HS_ACCEPTABLE_PLANET_TYPES):
@@ -545,7 +542,7 @@ def compile_home_system_list(num_home_systems, systems, gsd):  # noqa: C901
 
 
 # noqa: C901
-def setup_empire(empire, empire_name, home_system, starting_species, player_name, gsd):  # noqa: C901
+def setup_empire(empire, empire_name, home_system, starting_species, player_name, gsd, starting_species_pool):  # noqa: C901
     """
     Sets up various aspects of an empire, like empire name, homeworld, etc.
     """

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -42,7 +42,7 @@ def get_empire_name_generator():
 empire_name_generator = get_empire_name_generator()
 
 
-def get_starting_species_pool(already_used = None):
+def get_starting_species_pool(already_used=None):
     """
     Empire species pool generator, return random empire species and ensure somewhat even distribution
     @param alreadyUsed - if set, then RULE_ALLOW_REPEATED_SPECIES is false and it contains the species already in use e.g. by player's choice

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -10,7 +10,7 @@ import universe_statistics
 from common.handlers import init_handlers
 from common.listeners import listener
 from common.option_tools import parse_config
-from empires import compile_home_system_list, setup_empire
+from empires import compile_home_system_list, setup_empire, get_starting_species_pool
 from fields import generate_fields
 from galaxy import calc_star_system_positions
 from monsters import generate_monsters
@@ -120,6 +120,11 @@ def create_universe(psd_map):  # noqa: C901
         raise Exception(err_msg)
     print("Home systems:", home_systems)
 
+    usedSpecies = None if fo.getGameRules().getToggle("RULE_ALLOW_REPEATED_SPECIES") else \
+        {psd.starting_species for psd in psd_map.values() if psd.starting_species and psd.starting_species != "RANDOM"}
+    # generates starting species for empires, use next(starting_species_pool) to get next species
+    starting_species_pool = get_starting_species_pool(usedSpecies)
+
     teams = {}
     for psd in psd_map.values():
         if psd.starting_team >= 0:
@@ -141,7 +146,7 @@ def create_universe(psd_map):  # noqa: C901
                 else:
                     placed = True
                     if not setup_empire(
-                        empire, psd.empire_name, home_system, psd.starting_species, psd.player_name, gsd
+                        empire, psd.empire_name, home_system, psd.starting_species, psd.player_name, gsd, starting_species_pool
                     ):
                         report_error("Python create_universe: couldn't set up empire for player %s" % psd.player_name)
             if not placed:
@@ -149,12 +154,12 @@ def create_universe(psd_map):  # noqa: C901
             psds = psds_new
         # place leftovers
         for (empire, psd), home_system in zip(psds, hs):
-            if not setup_empire(empire, psd.empire_name, home_system, psd.starting_species, psd.player_name, gsd):
+            if not setup_empire(empire, psd.empire_name, home_system, psd.starting_species, psd.player_name, gsd, starting_species_pool):
                 report_error("Python create_universe: couldn't set up empire for player %s" % psd.player_name)
     else:
         # set up empires for each player
         for empire, psd, home_system in zip(psd_map.keys(), psd_map.values(), home_systems):
-            if not setup_empire(empire, psd.empire_name, home_system, psd.starting_species, psd.player_name, gsd):
+            if not setup_empire(empire, psd.empire_name, home_system, psd.starting_species, psd.player_name, gsd, starting_species_pool):
                 report_error("Python create_universe: couldn't set up empire for player %s" % psd.player_name)
 
     # assign names to all star systems and their planets

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -10,7 +10,7 @@ import universe_statistics
 from common.handlers import init_handlers
 from common.listeners import listener
 from common.option_tools import parse_config
-from empires import compile_home_system_list, setup_empire, get_starting_species_pool
+from empires import compile_home_system_list, get_starting_species_pool, setup_empire
 from fields import generate_fields
 from galaxy import calc_star_system_positions
 from monsters import generate_monsters

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -120,8 +120,15 @@ def create_universe(psd_map):  # noqa: C901
         raise Exception(err_msg)
     print("Home systems:", home_systems)
 
-    usedSpecies = None if fo.getGameRules().getToggle("RULE_ALLOW_REPEATED_SPECIES") else \
-        {psd.starting_species for psd in psd_map.values() if psd.starting_species and psd.starting_species != "RANDOM"}
+    usedSpecies = (
+        None
+        if fo.getGameRules().getToggle("RULE_ALLOW_REPEATED_SPECIES")
+        else {
+            psd.starting_species
+            for psd in psd_map.values()
+            if psd.starting_species and psd.starting_species != "RANDOM"
+        }
+    )
     # generates starting species for empires, use next(starting_species_pool) to get next species
     starting_species_pool = get_starting_species_pool(usedSpecies)
 
@@ -146,7 +153,13 @@ def create_universe(psd_map):  # noqa: C901
                 else:
                     placed = True
                     if not setup_empire(
-                        empire, psd.empire_name, home_system, psd.starting_species, psd.player_name, gsd, starting_species_pool
+                        empire,
+                        psd.empire_name,
+                        home_system,
+                        psd.starting_species,
+                        psd.player_name,
+                        gsd,
+                        starting_species_pool,
                     ):
                         report_error(f"Python create_universe: couldn't set up empire for player {psd.player_name}")
             if not placed:
@@ -154,12 +167,16 @@ def create_universe(psd_map):  # noqa: C901
             psds = psds_new
         # place leftovers
         for (empire, psd), home_system in zip(psds, hs):
-            if not setup_empire(empire, psd.empire_name, home_system, psd.starting_species, psd.player_name, gsd, starting_species_pool):
+            if not setup_empire(
+                empire, psd.empire_name, home_system, psd.starting_species, psd.player_name, gsd, starting_species_pool
+            ):
                 report_error(f"Python create_universe: couldn't set up empire for player {psd.player_name}")
     else:
         # set up empires for each player
         for empire, psd, home_system in zip(psd_map.keys(), psd_map.values(), home_systems):
-            if not setup_empire(empire, psd.empire_name, home_system, psd.starting_species, psd.player_name, gsd, starting_species_pool):
+            if not setup_empire(
+                empire, psd.empire_name, home_system, psd.starting_species, psd.player_name, gsd, starting_species_pool
+            ):
                 report_error(f"Python create_universe: couldn't set up empire for player {psd.player_name}")
 
     # assign names to all star systems and their planets


### PR DESCRIPTION
Closes #5222

I've played more games than is healthy using this by now, and it seems stable and keeps its promise: "If I say I want to play the only Trith in the galaxy, then I'll be the only Trith-founded empire, period[^1]."

[^1]: Of course, if I request more AI empires than there are playable species it'll recycle as before