### PR TITLE
Fix truncated log "Special Placement Summary"

### DIFF
--- a/default/python/universe_generation/universe_statistics.py
+++ b/default/python/universe_generation/universe_statistics.py
@@ -220,7 +220,9 @@ def log_specials_summary():
         table_name="Special Placement Summary",
     )
     for special in sorted(specials_summary):
-        special_placement_count_table.add_row(special, specials_summary[special])
+        # To help prevent truncation by the logger, don't log all of them
+        if fo.special_spawn_rate(special) > 0.0 and fo.special_spawn_limit(special) > 0:
+            special_placement_count_table.add_row(special, specials_summary[special])
     print(special_placement_count_table)
     print()
 

--- a/default/python/universe_generation/universe_statistics.py
+++ b/default/python/universe_generation/universe_statistics.py
@@ -220,10 +220,10 @@ def log_specials_summary():
         table_name="Special Placement Summary",
     )
     for special in sorted(specials_summary):
-        # To help prevent truncation by the logger, don't log all of them
         if fo.special_spawn_rate(special) > 0.0 and fo.special_spawn_limit(special) > 0:
             special_placement_count_table.add_row(special, specials_summary[special])
-    print(special_placement_count_table)
+    for line in special_placement_count_table:
+        print(line)
     print()
 
     special_placement = Table(


### PR DESCRIPTION
Another tiny thing from my playing branch.

Only relevant if you read logs - right now the "Special Placement Summary" is reliably truncated.

I couldn't find the `print_table` [this](https://github.com/freeorion/freeorion/blob/006715e6473433ac3600e47f7153c3f00a893ab3/default/python/common/print_utils/_table.py#L143-L144) refers to, so I chose an alternative.