### PR TITLE
Minor Fix: Augmentation allowing certain buildings on uninhabited planets

### DIFF
--- a/default/scripting/policies/AUGMENTATION.focs.txt
+++ b/default/scripting/policies/AUGMENTATION.focs.txt
@@ -13,6 +13,7 @@ Policy
                 Planet
                 OwnedBy empire = Source.Owner
                 Not Planet environment = [Uninhabitable]
+                Species
             ]
             priority = [[TARGET_POPULATION_OVERRIDE_PRIORITY]]
             effects = SetTargetPopulation value = max(Value, Target.HabitableSize)


### PR DESCRIPTION
To reproduce:
- Set up an outpost on a gas giant
- Adopt Augmentation (and pass a turn to activate the effect)
- Check "producible items" before and after
- Nearly-Universal-Translator can be built though it shouldn't

Notes:
- Not sure whether the preceding line is obsoleted by the change
- Also affects other buildings, though I can't remember which
- The focs.txt format is planned to be deprecated, right? This test would be `HasSpecies()` instead in focs.py, a regrettable divergence.