### PR TITLE
Meaningfully restrict queueing of starlane nexii or bores

### DIFF
--- a/default/scripting/buildings/STARLANE_BORE.focs.py
+++ b/default/scripting/buildings/STARLANE_BORE.focs.py
@@ -4,9 +4,13 @@ from buildings.buildings_macros import (
     SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS,
 )
 from focs._effects import (
+    BuildBuilding,
+    Contains,
     Destroy,
     EffectsGroup,
+    Enqueued,
     GenerateSitRepMessage,
+    IsBuilding,
     IsSource,
     Object,
     Planet,
@@ -25,7 +29,11 @@ BuildingType(  # type: ignore[reportUnboundVariable]
     description="BLD_STARLANE_BORE_DESC",
     buildcost=(200 + 50 * Target.System.NumStarlanes) * BUILDING_COST_MULTIPLIER,
     buildtime=Target.System.NumStarlanes + 1,
-    location=Planet(),
+    location=(
+        Planet()
+        & ~Contains(IsBuilding(name=["BLD_STARLANE_NEXUS"]))
+        & ~Enqueued(type=BuildBuilding, name="BLD_STARLANE_NEXUS")
+    ),
     effectsgroups=[
         *SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS,
         EffectsGroup(

--- a/default/scripting/buildings/STARLANE_NEXUS.focs.py
+++ b/default/scripting/buildings/STARLANE_NEXUS.focs.py
@@ -4,9 +4,13 @@ from buildings.buildings_macros import (
     SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS,
 )
 from focs._effects import (
+    BuildBuilding,
+    Contains,
     Destroy,
     EffectsGroup,
+    Enqueued,
     GenerateSitRepMessage,
+    IsBuilding,
     IsSource,
     Object,
     Planet,
@@ -14,6 +18,7 @@ from focs._effects import (
     Target,
 )
 from macros.base_prod import BUILDING_COST_MULTIPLIER
+from macros.enqueue import ENQUEUE_BUILD_ONE_PER_PLANET
 
 try:
     from focs._buildings import *
@@ -25,7 +30,13 @@ BuildingType(  # type: ignore[reportUnboundVariable]
     description="BLD_STARLANE_NEXUS_DESC",
     buildcost=1000 * BUILDING_COST_MULTIPLIER,
     buildtime=8,
-    location=(Planet()),
+    location=(
+        Planet()
+        & ~Contains(IsBuilding(name=["BLD_STARLANE_NEXUS"]))
+        & ~Contains(IsBuilding(name=["BLD_STARLANE_BORE"]))
+        & ~Enqueued(type=BuildBuilding, name="BLD_STARLANE_BORE")
+    ),
+    enqueuelocation=ENQUEUE_BUILD_ONE_PER_PLANET,
     effectsgroups=[
         *SPECIES_LIKES_OR_DISLIKES_BUILDING_STABILITY_EFFECTS,
         EffectsGroup(


### PR DESCRIPTION
Works for me, though I wouldn't be surprised there's better ways to do this.
- Cannot queue several nexuus[^1]
- Can't queue bores when a nexus is being built or vice versa

[^1]: Can't resist Latin jokes