### PR TITLE
Pedia: Field Repellor shows you can only have one

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -15487,7 +15487,8 @@ BLD_FIELD_REPELLOR
 Field Repellor
 
 BLD_FIELD_REPELLOR_DESC
-Pushes mobile fields (those not in systems) away from its location.
+'''Pushes mobile fields (those not in systems) away from its location.
+Can only be built once per empire.'''
 
 BLD_HYPER_DAM
 Hyperspatial Dam

--- a/default/stringtables/fr.txt
+++ b/default/stringtables/fr.txt
@@ -15401,7 +15401,8 @@ BLD_FIELD_REPELLOR
 Répulseur de Milieux Interstellaires
 
 BLD_FIELD_REPELLOR_DESC
-Repousse les milieux interstellaires mobiles (ceux n'étant pas dans un système) loin de leur emplacement actuel.
+'''Repousse les milieux interstellaires mobiles (ceux n'étant pas dans un système) loin de son emplacement.
+Ne peut être construit qu'une seule fois par empire.'''
 
 BLD_HYPER_DAM
 Barrage Hyperspatial


### PR DESCRIPTION
btw, I think it's "repeller", but maybe the "o" makes it more sci-fi-ey...

The french was saying the fields were pushed away from their current location, not away from the device, so I think this is actually easier to understand, even if still not absolutely clear. Also, I think "champs" would be better for "fields", but that would go too far here.