### PR TITLE
Don't allow queueing several field repellers empire-wide

### DIFF
--- a/default/scripting/buildings/FIELD_REPELLOR.focs.py
+++ b/default/scripting/buildings/FIELD_REPELLOR.focs.py
@@ -24,7 +24,8 @@ BuildingType(  # type: ignore[reportUnboundVariable]
     buildtime=5,
     location=(Number(high=0, condition=IsBuilding(name=[ThisBuilding]) & OwnedBy(empire=Source.Owner))),
     enqueuelocation=(
-        ENQUEUE_BUILD_ONE_PER_PLANET & Number(high=0, condition=Enqueued(type=BuildBuilding, name=ThisBuilding))
+        ENQUEUE_BUILD_ONE_PER_PLANET
+        & Number(high=0, condition=Enqueued(type=BuildBuilding, name=ThisBuilding, empire=Source.Owner))
     ),
     effectsgroups=[
         EffectsGroup(

--- a/default/scripting/buildings/FIELD_REPELLOR.focs.py
+++ b/default/scripting/buildings/FIELD_REPELLOR.focs.py
@@ -23,7 +23,9 @@ BuildingType(  # type: ignore[reportUnboundVariable]
     buildcost=1000 * BUILDING_COST_MULTIPLIER,
     buildtime=5,
     location=(Number(high=0, condition=IsBuilding(name=[ThisBuilding]) & OwnedBy(empire=Source.Owner))),
-    enqueuelocation=ENQUEUE_BUILD_ONE_PER_PLANET,
+    enqueuelocation=(
+        ENQUEUE_BUILD_ONE_PER_PLANET & Number(high=0, condition=Enqueued(type=BuildBuilding, name=ThisBuilding))
+    ),
     effectsgroups=[
         EffectsGroup(
             scope=IsField(


### PR DESCRIPTION
In master, you can queue several BLD_FIELD_REPELLOR on different planets, but finish only one. This makes it so you can't queue a second, no matter where. Am a bit unsure this is the correct way to do so, but holds up in my play-testing.