### PR TITLE
Use the fact that IsBuilding's name parameter is a list

### DIFF
--- a/default/scripting/buildings/ART_FACTORY_PLANET.focs.py
+++ b/default/scripting/buildings/ART_FACTORY_PLANET.focs.py
@@ -36,9 +36,7 @@ BuildingType(  # type: ignore[reportUnboundVariable]
     buildtime=12,
     location=(
         Planet()
-        & ~Contains(IsBuilding(name=["BLD_ART_PLANET"]))
-        & ~Contains(IsBuilding(name=["BLD_ART_FACTORY_PLANET"]))
-        & ~Contains(IsBuilding(name=["BLD_ART_PARADISE_PLANET"]))
+        & ~Contains(IsBuilding(name=["BLD_ART_PLANET", "BLD_ART_FACTORY_PLANET", "BLD_ART_PARADISE_PLANET"]))
         & OwnedBy(empire=Source.Owner)
         & Planet(type=[AsteroidsType, GasGiantType])
         & OwnerHasTech(name="PRO_EXOBOTS")

--- a/default/scripting/buildings/ART_PARADISE_PLANET.focs.py
+++ b/default/scripting/buildings/ART_PARADISE_PLANET.focs.py
@@ -33,9 +33,7 @@ BuildingType(  # type: ignore[reportUnboundVariable]
     buildtime=10,
     location=(
         Planet()
-        & ~Contains(IsBuilding(name=["BLD_ART_PLANET"]))
-        & ~Contains(IsBuilding(name=["BLD_ART_FACTORY_PLANET"]))
-        & ~Contains(IsBuilding(name=["BLD_ART_PARADISE_PLANET"]))
+        & ~Contains(IsBuilding(name=["BLD_ART_PLANET", "BLD_ART_FACTORY_PLANET", "BLD_ART_PARADISE_PLANET"]))
         & OwnedBy(empire=Source.Owner)
         & Planet(type=[AsteroidsType, GasGiantType])
         & OwnerHasTech(name="GRO_GAIA_TRANS")

--- a/default/scripting/buildings/ART_PLANET.focs.py
+++ b/default/scripting/buildings/ART_PLANET.focs.py
@@ -31,9 +31,7 @@ BuildingType(  # type: ignore[reportUnboundVariable]
     buildtime=8,
     location=(
         Planet()
-        & ~Contains(IsBuilding(name=["BLD_ART_PLANET"]))
-        & ~Contains(IsBuilding(name=["BLD_ART_FACTORY_PLANET"]))
-        & ~Contains(IsBuilding(name=["BLD_ART_PARADISE_PLANET"]))
+        & ~Contains(IsBuilding(name=["BLD_ART_PLANET", "BLD_ART_FACTORY_PLANET", "BLD_ART_PARADISE_PLANET"]))
         & OwnedBy(empire=Source.Owner)
         & Planet(type=[AsteroidsType, GasGiantType])
         & Population(high=0)

--- a/default/scripting/buildings/EVACUATION.focs.py
+++ b/default/scripting/buildings/EVACUATION.focs.py
@@ -47,8 +47,7 @@ BuildingType(  # type: ignore[reportUnboundVariable]
     location=(
         Planet()
         & OwnedBy(empire=Source.Owner)
-        & ~Contains(IsBuilding(name=["BLD_EVACUATION"]))
-        & ~Contains(IsBuilding(name=["BLD_CONC_CAMP"]))
+        & ~Contains(IsBuilding(name=["BLD_EVACUATION", "BLD_CONC_CAMP"]))
         & ~HasSpecial(name="CONC_CAMP_SLAVE_SPECIAL")
         & ~Enqueued(type=BuildBuilding, name="BLD_CONC_CAMP")
         & HasSpecies()
@@ -56,8 +55,7 @@ BuildingType(  # type: ignore[reportUnboundVariable]
     enqueuelocation=(
         Planet()
         & OwnedBy(empire=Source.Owner)
-        & ~Contains(IsBuilding(name=["BLD_EVACUATION"]))
-        & ~Contains(IsBuilding(name=["BLD_CONC_CAMP"]))
+        & ~Contains(IsBuilding(name=["BLD_EVACUATION", "BLD_CONC_CAMP"]))
         & ~HasSpecial(name="CONC_CAMP_SLAVE_SPECIAL")
         & ~Enqueued(type=BuildBuilding, name="BLD_EVACUATION")
         & ~Enqueued(type=BuildBuilding, name="BLD_CONC_CAMP")
@@ -74,8 +72,7 @@ BuildingType(  # type: ignore[reportUnboundVariable]
                     & ~Object(id=Source.PlanetID)
                     & ResourceSupplyConnected(empire=Source.Owner, condition=IsSource)
                     & Population(low=1, high=LocalCandidate.TargetPopulation - 1)
-                    & ~Contains(IsBuilding(name=["BLD_EVACUATION"]))
-                    & ~Contains(IsBuilding(name=["BLD_CONC_CAMP"]))
+                    & ~Contains(IsBuilding(name=["BLD_EVACUATION", "BLD_CONC_CAMP"]))
                 ),
             ),
             activation=(

--- a/default/scripting/buildings/NEUTRONIUM_FORGE.focs.py
+++ b/default/scripting/buildings/NEUTRONIUM_FORGE.focs.py
@@ -31,8 +31,7 @@ BuildingType(  # type: ignore[reportUnboundVariable]
             low=1,
             high=999,
             condition=(
-                OwnedBy(empire=Source.Owner)
-                & (IsBuilding(name=["BLD_NEUTRONIUM_EXTRACTOR"]) | IsBuilding(name=["BLD_NEUTRONIUM_SYNTH"]))
+                OwnedBy(empire=Source.Owner) & IsBuilding(name=["BLD_NEUTRONIUM_EXTRACTOR", "BLD_NEUTRONIUM_SYNTH"])
             ),
         )
         & TargetPopulation(low=1)

--- a/default/scripting/buildings/REGIONAL_ADMIN.focs.py
+++ b/default/scripting/buildings/REGIONAL_ADMIN.focs.py
@@ -30,14 +30,10 @@ BuildingType(  # type: ignore[reportUnboundVariable]
     location=(
         Planet()
         & OwnedBy(empire=Source.Owner)
-        & ~Contains(IsBuilding(name=["BLD_IMPERIAL_PALACE"]))
-        & ~Contains(IsBuilding(name=["BLD_REGIONAL_ADMIN"]))
+        & ~Contains(IsBuilding(name=["BLD_IMPERIAL_PALACE", "BLD_REGIONAL_ADMIN"]))
         & ~WithinStarlaneJumps(
             jumps=5,
-            condition=(
-                (IsBuilding(name=["BLD_IMPERIAL_PALACE"]) | IsBuilding(name=["BLD_REGIONAL_ADMIN"]))
-                & OwnedBy(empire=Source.Owner)
-            ),
+            condition=(IsBuilding(name=["BLD_IMPERIAL_PALACE", "BLD_REGIONAL_ADMIN"]) & OwnedBy(empire=Source.Owner)),
         )
     ),
     enqueuelocation=ENQUEUE_BUILD_ONE_PER_PLANET,

--- a/default/scripting/buildings/STARLANE_NEXUS.focs.py
+++ b/default/scripting/buildings/STARLANE_NEXUS.focs.py
@@ -32,8 +32,7 @@ BuildingType(  # type: ignore[reportUnboundVariable]
     buildtime=8,
     location=(
         Planet()
-        & ~Contains(IsBuilding(name=["BLD_STARLANE_NEXUS"]))
-        & ~Contains(IsBuilding(name=["BLD_STARLANE_BORE"]))
+        & ~Contains(IsBuilding(name=["BLD_STARLANE_NEXUS", "BLD_STARLANE_BORE"]))
         & ~Enqueued(type=BuildBuilding, name="BLD_STARLANE_BORE")
     ),
     enqueuelocation=ENQUEUE_BUILD_ONE_PER_PLANET,

--- a/default/scripting/macros/enqueue.py
+++ b/default/scripting/macros/enqueue.py
@@ -13,9 +13,7 @@ ENQUEUE_BUILD_ONE_PER_PLANET = (
 )
 
 ENQUEUE_ARTIFICIAL_PLANET_EXCLUSION = (
-    ~Contains(IsBuilding(name=["BLD_ART_PLANET"]))
-    & ~Contains(IsBuilding(name=["BLD_ART_FACTORY_PLANET"]))
-    & ~Contains(IsBuilding(name=["BLD_ART_PARADISE_PLANET"]))
+    ~Contains(IsBuilding(name=["BLD_ART_PLANET", "BLD_ART_FACTORY_PLANET", "BLD_ART_PARADISE_PLANET"]))
     & ~Enqueued(type=BuildBuilding, name="BLD_ART_PLANET")
     & ~Enqueued(type=BuildBuilding, name="BLD_ART_FACTORY_PLANET")
     & ~Enqueued(type=BuildBuilding, name="BLD_ART_PARADISE_PLANET")
@@ -36,15 +34,16 @@ def DO_NOT_CONTAIN_FOR_ALL_TERRAFORM_PLANET_TYPES():
         "BARREN",
     ]
 
-    expressions = []
-
+    names = []
     for planet_type in planet_types:
-        expressions.append(~Contains(IsBuilding(name=[f"BLD_TERRAFORM_{planet_type}"])))
+        names.append(f"BLD_TERRAFORM_{planet_type}")
+
+    expressions = [~Contains(IsBuilding(name=names))]
 
     # We add enqueue check in the second loop, because we want to preserve the same order of checks for better diff
     # Once conversion of building is done, we should refactor this code.
-    for planet_type in planet_types:
-        expressions.append(~Enqueued(type=BuildBuilding, name=f"BLD_TERRAFORM_{planet_type}"))
+    for building in names:
+        expressions.append(~Enqueued(type=BuildBuilding, name=building))
 
     return reduce(lambda x, y: x & y, expressions)
 


### PR DESCRIPTION
Currently, [the fact that `IsBuilding` accepts a list](https://github.com/freeorion/freeorion/blob/fd9b5a9ceeb20dd933c0201d236c148ef64e4a2f/default/scripting/focs/_effects.pyi#L310) is only used [in one place](https://github.com/freeorion/freeorion/blob/61de7441fe8e709b5fc2d3095879f2460e2e793f/default/scripting/species/species_macros/influence.py#L66-L100) out of over 1000, so I looked where else that might save a few cycles[^1].

### Testing Done (using old saved games)
- Queueing the various Terraforming variants behaves as normal
- Gaia still excludes Terraforming
- Nexus/Bore exclusion works
- The various Artificial Planet versions still exclude each other

### Note
This is a bit minimalistic and **refrains** from touching a few related places that beg for simplification and/or use of the list-capable argument:
- The species colony buildings / col_bld_gey.py: Tidbit - the current buildings don't match script output. Also - the list of existing species as used in influence.py should be central and referenced via macro, not copied into each and every BLD_COL_* script. Which in turn leads over to the next point:
- The [definition](https://github.com/freeorion/freeorion/blob/fd9b5a9ceeb20dd933c0201d236c148ef64e4a2f/default/scripting/focs/_effects.pyi#L310), combined with the fact that recommendations will pull in a pyright run, has CoVariance problems: You just can't pass in a literal list of strings pre-saved into a variable, but as in-place literal you can. [See e.g. this diatribe](https://blog.meadsteve.dev/programming/2023/09/09/typed-python-prefer-sequence-over-list/). So the neat logical next step in the details below can't currently be committed...
- Having such building lists centralized would beget a generalization of the DO_NOT_CONTAIN_FOR_ALL_TERRAFORM_PLANET_TYPES macro for arbitrary building lists
- I don't like that `reduce` in enqueue.py. Elsewhere (combine_ratings) the one from functools is in use, and the one in enqueue is single-use. IMHO converting it to a nested function without the lambda argument would be cleaner and more readable.

<details>

```patch
Subject: [PATCH] Centralize list of artificial planet buildings
---
Index: default/scripting/macros/enqueue.py
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/default/scripting/macros/enqueue.py b/default/scripting/macros/enqueue.py
--- a/default/scripting/macros/enqueue.py	(revision 8d9c11c270a2714693b9e8f4e0055ad063487c76)
+++ b/default/scripting/macros/enqueue.py	(date 1760195274750)
@@ -12,8 +12,10 @@
     & OwnedBy(empire=Source.Owner)
 )
 
+ARTIFICIAL_PLANET_BUILDINGS = ["BLD_ART_PLANET", "BLD_ART_FACTORY_PLANET", "BLD_ART_PARADISE_PLANET"]
+
 ENQUEUE_ARTIFICIAL_PLANET_EXCLUSION = (
-    ~Contains(IsBuilding(name=["BLD_ART_PLANET", "BLD_ART_FACTORY_PLANET", "BLD_ART_PARADISE_PLANET"]))
+    ~Contains(IsBuilding(name=ARTIFICIAL_PLANET_BUILDINGS))
     & ~Enqueued(type=BuildBuilding, name="BLD_ART_PLANET")
     & ~Enqueued(type=BuildBuilding, name="BLD_ART_FACTORY_PLANET")
     & ~Enqueued(type=BuildBuilding, name="BLD_ART_PARADISE_PLANET")
Index: default/scripting/buildings/ART_PLANET.focs.py
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/default/scripting/buildings/ART_PLANET.focs.py b/default/scripting/buildings/ART_PLANET.focs.py
--- a/default/scripting/buildings/ART_PLANET.focs.py	(revision 8d9c11c270a2714693b9e8f4e0055ad063487c76)
+++ b/default/scripting/buildings/ART_PLANET.focs.py	(date 1760195274724)
@@ -17,7 +17,7 @@
     Target,
 )
 from macros.base_prod import BUILDING_COST_MULTIPLIER
-from macros.enqueue import ENQUEUE_ARTIFICIAL_PLANET_EXCLUSION
+from macros.enqueue import ARTIFICIAL_PLANET_BUILDINGS, ENQUEUE_ARTIFICIAL_PLANET_EXCLUSION
 
 try:
     from focs._buildings import *
@@ -31,7 +31,7 @@
     buildtime=8,
     location=(
         Planet()
-        & ~Contains(IsBuilding(name=["BLD_ART_PLANET", "BLD_ART_FACTORY_PLANET", "BLD_ART_PARADISE_PLANET"]))
+        & ~Contains(IsBuilding(name=ARTIFICIAL_PLANET_BUILDINGS))
         & OwnedBy(empire=Source.Owner)
         & Planet(type=[AsteroidsType, GasGiantType])
         & Population(high=0)
Index: default/scripting/buildings/ART_FACTORY_PLANET.focs.py
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/default/scripting/buildings/ART_FACTORY_PLANET.focs.py b/default/scripting/buildings/ART_FACTORY_PLANET.focs.py
--- a/default/scripting/buildings/ART_FACTORY_PLANET.focs.py	(revision 8d9c11c270a2714693b9e8f4e0055ad063487c76)
+++ b/default/scripting/buildings/ART_FACTORY_PLANET.focs.py	(date 1760195274689)
@@ -20,7 +20,7 @@
     Target,
 )
 from macros.base_prod import BUILDING_COST_MULTIPLIER
-from macros.enqueue import ENQUEUE_ARTIFICIAL_PLANET_EXCLUSION
+from macros.enqueue import ARTIFICIAL_PLANET_BUILDINGS, ENQUEUE_ARTIFICIAL_PLANET_EXCLUSION
 from macros.priorities import POPULATION_OVERRIDE_PRIORITY
 from macros.upkeep import COLONY_UPKEEP_MULTIPLICATOR
 
@@ -36,7 +36,7 @@
     buildtime=12,
     location=(
         Planet()
-        & ~Contains(IsBuilding(name=["BLD_ART_PLANET", "BLD_ART_FACTORY_PLANET", "BLD_ART_PARADISE_PLANET"]))
+        & ~Contains(IsBuilding(name=ARTIFICIAL_PLANET_BUILDINGS))
         & OwnedBy(empire=Source.Owner)
         & Planet(type=[AsteroidsType, GasGiantType])
         & OwnerHasTech(name="PRO_EXOBOTS")
Index: default/scripting/buildings/ART_PARADISE_PLANET.focs.py
IDEA additional info:
Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
<+>UTF-8
===================================================================
diff --git a/default/scripting/buildings/ART_PARADISE_PLANET.focs.py b/default/scripting/buildings/ART_PARADISE_PLANET.focs.py
--- a/default/scripting/buildings/ART_PARADISE_PLANET.focs.py	(revision 8d9c11c270a2714693b9e8f4e0055ad063487c76)
+++ b/default/scripting/buildings/ART_PARADISE_PLANET.focs.py	(date 1760195274707)
@@ -19,7 +19,7 @@
     Target,
 )
 from macros.base_prod import BUILDING_COST_MULTIPLIER
-from macros.enqueue import ENQUEUE_ARTIFICIAL_PLANET_EXCLUSION
+from macros.enqueue import ARTIFICIAL_PLANET_BUILDINGS, ENQUEUE_ARTIFICIAL_PLANET_EXCLUSION
 
 try:
     from focs._buildings import *
@@ -33,7 +33,7 @@
     buildtime=10,
     location=(
         Planet()
-        & ~Contains(IsBuilding(name=["BLD_ART_PLANET", "BLD_ART_FACTORY_PLANET", "BLD_ART_PARADISE_PLANET"]))
+        & ~Contains(IsBuilding(name=ARTIFICIAL_PLANET_BUILDINGS))
         & OwnedBy(empire=Source.Owner)
         & Planet(type=[AsteroidsType, GasGiantType])
         & OwnerHasTech(name="GRO_GAIA_TRANS")
```

... this actually works in-game, but pre-commit running pyright will flag 4 errors "list[str]" is not assignable to "list[str | _BuildingType]"
</details>

[^1]: Implementation boils down to [Conditions.cpp line 2225](https://github.com/freeorion/freeorion/blob/0405dcba2cab690608b13926865ec4476f7ec875/universe/Conditions.cpp#L2225), so yes that's much cheaper than all that scripting interface overhead. IMHO.