### PR TITLE
Fix Boost Version Detection and C++ Version Selection for GG, compiler error workaround, and boost::optional replacement

### DIFF
--- a/GG/CMakeLists.txt
+++ b/GG/CMakeLists.txt
@@ -64,11 +64,24 @@ find_package(Boost ${MINIMUM_BOOST_VERSION} COMPONENTS filesystem regex REQUIRED
 
 message(STATUS "Compiler ID: ${CMAKE_CXX_COMPILER_ID}")
 message(STATUS "Compiler Version: ${CMAKE_CXX_COMPILER_VERSION}")
-message(STATUS "Boost version: ${Boost_VERSION}")
 
-if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 13 AND Boost_VERSION LESS 108000)
+# Normalize Boost_VERSION to a string like "1.81.0"
+if (Boost_VERSION MATCHES "^[0-9]+$")
+    message(STATUS "Boost version number: ${Boost_VERSION}")
+    math(EXPR Boost_MAJOR "${Boost_VERSION} / 100000")
+    math(EXPR Boost_MINOR "(${Boost_VERSION} / 100) % 1000")
+    math(EXPR Boost_PATCH "${Boost_VERSION} % 100")
+    set(Boost_VERSION_STRING "${Boost_MAJOR}.${Boost_MINOR}.${Boost_PATCH}")
+else()
+    set(Boost_VERSION_STRING "${Boost_VERSION}")
+endif()
+
+message(STATUS "Boost version string: ${Boost_VERSION_STRING}")
+
+
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU" AND Boost_VERSION_STRING VERSION_LESS "1.80.0")
     set(CMAKE_CXX_STANDARD 17)
-    message(STATUS "Using C++17 for GG for compatability with GCC <= 12 and Boost < 1.80")
+    message(STATUS "Using C++17 for GG for compatability Boost < 1.80")
 else()
     set(CMAKE_CXX_STANDARD 20)
     message(STATUS "Using C++20 for GG")

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -513,7 +513,7 @@ private:
         for that dimension. \p maybe_client_size might contain a precalculated client size.
 
         This is a private function that is a component of AdjustScrolls. */
-    std::pair<boost::optional<X>, boost::optional<Y>>
+    std::pair<std::optional<X>, std::optional<Y>>
         CheckIfScrollsRequired(std::pair<bool, bool> force_scrolls, Pt client_size) const;
 
     /** Add vscroll and/or hscroll if \p required_total_extents the x andor y dimension exists. The
@@ -524,7 +524,7 @@ private:
 
         This is a private function that is a component of AdjustScrolls. */
     std::pair<bool, bool> AddOrRemoveScrolls(
-        std::pair<boost::optional<X>, boost::optional<Y>> required_total_extents, Pt client_size);
+        std::pair<std::optional<X>, std::optional<Y>> required_total_extents, Pt client_size);
 
     /// m_rows is mutable to enable returning end() from const functions in constant time.
     mutable std::list<std::shared_ptr<Row>> m_rows;             ///< line item data
@@ -566,7 +566,7 @@ private:
     sort_func_t             m_sort_cmp;                 ///< the predicate used to sort the values in the m_sort_col column of two rows
 
     /** Set to boost::none to allow all types.  Otherwise each string is an allowed type.*/
-    boost::optional<std::unordered_set<std::string>> m_allowed_drop_types = boost::none;
+    std::optional<std::unordered_set<std::string>> m_allowed_drop_types = std::nullopt;
 
     Timer           m_auto_scroll_timer{250};
     unsigned int    m_auto_scroll_margin = 8;

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -514,8 +514,7 @@ private:
 
         This is a private function that is a component of AdjustScrolls. */
     std::pair<boost::optional<X>, boost::optional<Y>>
-        CheckIfScrollsRequired(std::pair<bool, bool> force_scrolls = {false, false},
-                               boost::optional<Pt> maybe_client_size = boost::none) const;
+        CheckIfScrollsRequired(std::pair<bool, bool> force_scrolls, Pt client_size) const;
 
     /** Add vscroll and/or hscroll if \p required_total_extents the x andor y dimension exists. The
         value of \p required_total_extents is the full x and y dimensions of the underlying ListBox
@@ -524,8 +523,8 @@ private:
         contain a precalculated client size as calculated in ClientSizeExcludingScrolls.
 
         This is a private function that is a component of AdjustScrolls. */
-    std::pair<bool, bool> AddOrRemoveScrolls(std::pair<boost::optional<X>, boost::optional<Y>> required_total_extents,
-                                             boost::optional<Pt> maybe_client_size = boost::none);
+    std::pair<bool, bool> AddOrRemoveScrolls(
+        std::pair<boost::optional<X>, boost::optional<Y>> required_total_extents, Pt client_size);
 
     /// m_rows is mutable to enable returning end() from const functions in constant time.
     mutable std::list<std::shared_ptr<Row>> m_rows;             ///< line item data

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -17,9 +17,9 @@
 
 
 #include <memory>
+#include <optional>
 #include <set>
 #include <unordered_set>
-#include <boost/optional/optional.hpp>
 #include <GG/AlignmentFlags.h>
 #include <GG/ClrConstants.h>
 #include <GG/Control.h>
@@ -509,7 +509,7 @@ private:
 
     /** Return a pair of optional X and/or Y dimensions of the scollable area iff vscroll and/or
         hscroll are required. If scrollbars are needed, the scrollable extent will be larger than the
-        client size.  If a scrollbar is not required in some dimension return boost::none
+        client size.  If a scrollbar is not required in some dimension return std::nullopt
         for that dimension. \p maybe_client_size might contain a precalculated client size.
 
         This is a private function that is a component of AdjustScrolls. */
@@ -565,7 +565,7 @@ private:
     using sort_func_t = std::function<bool (const Row&, const Row&, std::size_t)>;
     sort_func_t             m_sort_cmp;                 ///< the predicate used to sort the values in the m_sort_col column of two rows
 
-    /** Set to boost::none to allow all types.  Otherwise each string is an allowed type.*/
+    /** Set to std::nullopt to allow all types.  Otherwise each string is an allowed type.*/
     std::optional<std::unordered_set<std::string>> m_allowed_drop_types = std::nullopt;
 
     Timer           m_auto_scroll_timer{250};

--- a/GG/GG/ZList.h
+++ b/GG/GG/ZList.h
@@ -19,9 +19,9 @@
 #include <functional>
 #include <list>
 #include <memory>
+#include <optional>
 #include <set>
 #include <vector>
-#include <boost/optional/optional.hpp>
 #include <GG/Base.h>
 
 

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -9,7 +9,7 @@
 
 #include <iterator>
 #include <memory>
-#include <boost/optional/optional.hpp>
+#include <optional>
 #include <GG/DrawUtil.h>
 #include <GG/DropDownList.h>
 #include <GG/GUI.h>
@@ -57,19 +57,19 @@ public:
 
     /** If \p it is not none then select \p it in the LB().  Return the newly selected iterator or none if
         the selection did not change.*/
-    boost::optional<DropDownList::iterator> Select(boost::optional<DropDownList::iterator> it);
+    std::optional<DropDownList::iterator> Select(std::optional<DropDownList::iterator> it);
 
     /** Call SelChangedSignal if \p it is not none. */
-    void SignalChanged(boost::optional<DropDownList::iterator> it);
+    void SignalChanged(std::optional<DropDownList::iterator> it);
 
     /** A common KeyPress() for both ModalListPicker and its DropDownList.
         Examine \p key and return the new list iterator or none.*/
-    [[nodiscard]] boost::optional<DropDownList::iterator> KeyPressCommon(
+    [[nodiscard]] std::optional<DropDownList::iterator> KeyPressCommon(
         Key key, uint32_t key_code_point, Flags<ModKey> mod_keys);
 
     /** A common MouseWheel() for both ModalListPicker and its DropDownList.
         Examine \p pt and \p move and then return the new list iterator or none.*/
-    [[nodiscard]] boost::optional<DropDownList::iterator> MouseWheelCommon(
+    [[nodiscard]] std::optional<DropDownList::iterator> MouseWheelCommon(
         Pt pt, int move, Flags<ModKey> mod_keys);
 
     /** Set the drop down list to only mouse scroll if it is dropped. */
@@ -254,22 +254,22 @@ DropDownList::iterator ModalListPicker::CurrentItem() noexcept
     return end;
 }
 
-boost::optional<DropDownList::iterator> ModalListPicker::Select(boost::optional<DropDownList::iterator> it)
+std::optional<DropDownList::iterator> ModalListPicker::Select(std::optional<DropDownList::iterator> it)
 {
     if (!it)
-        return boost::none;
+        return std::nullopt;
 
     auto old_m_current_item = CurrentItem();
-    if (*it == LB()->end()) {
+    if (*it == LB()->end())
         LB()->DeselectAll();
-    } else {
+    else
         LB()->SelectRow(*it);
-    }
 
-    return (CurrentItem() != old_m_current_item) ? boost::optional<DropDownList::iterator>(CurrentItem()) : boost::none;
+    return (CurrentItem() != old_m_current_item) ?
+        std::optional(CurrentItem()) : std::nullopt;
 }
 
-void ModalListPicker::SignalChanged(boost::optional<DropDownList::iterator> it)
+void ModalListPicker::SignalChanged(std::optional<DropDownList::iterator> it)
 {
     if (!it)
         return;
@@ -371,7 +371,7 @@ void ModalListPicker::CorrectListSize() {
     lb->Hide();
 }
 
-boost::optional<DropDownList::iterator> ModalListPicker::KeyPressCommon(
+std::optional<DropDownList::iterator> ModalListPicker::KeyPressCommon(
     Key key, uint32_t key_code_point, Flags<ModKey> mod_keys)
 {
     const bool numlock_on = mod_keys & MOD_KEY_NUM;
@@ -450,28 +450,28 @@ boost::optional<DropDownList::iterator> ModalListPicker::KeyPressCommon(
     case Key::GGK_KP_ENTER:
     case Key::GGK_ESCAPE:
         EndRun();
-        return boost::none;
+        return std::nullopt;
         break;
     default:
-        return boost::none;
+        return std::nullopt;
     }
-    return boost::none;
+    return std::nullopt;
 }
 
 void ModalListPicker::SetOnlyMouseScrollWhenDropped(bool enable)
 { m_only_mouse_scroll_when_dropped = enable; }
 
-boost::optional<DropDownList::iterator> ModalListPicker::MouseWheelCommon(
+std::optional<DropDownList::iterator> ModalListPicker::MouseWheelCommon(
     Pt pt, int move, Flags<ModKey> mod_keys)
 {
     if (m_only_mouse_scroll_when_dropped && !Dropped())
-        return boost::none;
+        return std::nullopt;
 
     auto cur_it = CurrentItem();
     if (cur_it == LB()->end())
-        return boost::none;
+        return std::nullopt;
     if (move == 0)
-        return boost::none;
+        return std::nullopt;
 
     if (move > 0) {
         auto dist_to_last = std::distance(cur_it, LB()->end()) - 1; // end is one past last valid item
@@ -487,7 +487,7 @@ boost::optional<DropDownList::iterator> ModalListPicker::MouseWheelCommon(
         LB()->BringRowIntoView(cur_it);
         return cur_it;
     }
-    return boost::none;
+    return std::nullopt;
 }
 
 bool ModalListPicker::EventFilter(Wnd* w, const WndEvent& event) {
@@ -910,7 +910,7 @@ void DropDownList::LButtonDown(Pt pt, Flags<ModKey> mod_keys)
 void DropDownList::KeyPress(Key key, uint32_t key_code_point, Flags<ModKey> mod_keys)
 {
     if (!Disabled()) {
-        boost::optional<DropDownList::iterator> key_selected = m_modal_picker->KeyPressCommon(key, key_code_point, mod_keys);
+        const auto key_selected = m_modal_picker->KeyPressCommon(key, key_code_point, mod_keys);
         if (key_selected)
             m_modal_picker->SignalChanged(m_modal_picker->Select(key_selected));
         else

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -495,7 +495,7 @@ void ListBox::AllowDrops(bool allow)
 { m_allow_drops = allow; }
 
 void ListBox::AllowAllDropTypes(bool allow) {
-    // If all types are allow use boost::none as a sentinel
+    // If all types are allowed, use std::nullopt as a sentinel
     if (allow)
         m_allowed_drop_types = std::nullopt;
 

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -497,11 +497,11 @@ void ListBox::AllowDrops(bool allow)
 void ListBox::AllowAllDropTypes(bool allow) {
     // If all types are allow use boost::none as a sentinel
     if (allow)
-        m_allowed_drop_types = boost::none;
+        m_allowed_drop_types = std::nullopt;
 
     // Otherwise hold each allowed type in a set.
     else if (!m_allowed_drop_types)
-        m_allowed_drop_types = std::unordered_set<std::string>();
+        m_allowed_drop_types.emplace();
 }
 
 void ListBox::DropsAcceptable(DropsAcceptableIter first, DropsAcceptableIter last,
@@ -1965,7 +1965,7 @@ Pt ListBox::ClientSizeExcludingScrolls() const
     return cl_sz;
 }
 
-std::pair<boost::optional<X>, boost::optional<Y>> ListBox::CheckIfScrollsRequired(
+std::pair<std::optional<X>, std::optional<Y>> ListBox::CheckIfScrollsRequired(
     std::pair<bool, bool> force_hv, Pt client_size) const
 {
     X total_x_extent = std::accumulate(m_col_widths.begin(), m_col_widths.end(), X0);
@@ -2000,14 +2000,14 @@ std::pair<boost::optional<X>, boost::optional<Y>> ListBox::CheckIfScrollsRequire
             total_y_extent += client_size.y - m_rows.back()->Height();
     }
 
-    boost::optional<X> x_retval = horizontal_needed ? boost::optional<X>(total_x_extent) : boost::none;
-    boost::optional<Y> y_retval = vertical_needed   ? boost::optional<Y>(total_y_extent) : boost::none;
+    std::optional<X> x_retval = horizontal_needed ? std::optional<X>(total_x_extent) : std::nullopt;
+    std::optional<Y> y_retval = vertical_needed   ? std::optional<Y>(total_y_extent) : std::nullopt;
 
     return {x_retval, y_retval};
 }
 
 std::pair<bool, bool> ListBox::AddOrRemoveScrolls(
-    std::pair<boost::optional<X>, boost::optional<Y>> required_total_extents, Pt client_size)
+    std::pair<std::optional<X>, std::optional<Y>> required_total_extents, Pt client_size)
 {
     const auto& style = GetStyleFactory();
 

--- a/combat/CombatEvent.cpp
+++ b/combat/CombatEvent.cpp
@@ -6,5 +6,5 @@
 
 boost::optional<int> CombatEvent::PrincipalFaction(int viewing_empire_id) const {
     ErrorLogger() << "A combat logger expected this event to be associated with a faction";
-    return boost::optional<int>();
+    return boost::none;
 }

--- a/msvc2022/GiGi/StdAfx.h
+++ b/msvc2022/GiGi/StdAfx.h
@@ -24,6 +24,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <sstream>
 #include <stack>
@@ -40,7 +41,6 @@
 #include <boost/graph/graph_concepts.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/mpl/assert.hpp>
-#include <boost/optional/optional.hpp>
 #include <boost/signals2/signal.hpp>
 #include <boost/signals2/trackable.hpp>
 


### PR DESCRIPTION
-fix boost and C++ version selection
-compiler error workarounds
-replace boost::optional with std::optional