### PR TITLE
Without tech let owned nests spawn wild monsters. Add BLD_NEST_RESERVE

### DIFF
--- a/default/scripting/buildings/NEST_RESERVE.focs.py
+++ b/default/scripting/buildings/NEST_RESERVE.focs.py
@@ -1,0 +1,39 @@
+from focs._effects import (
+    BuildBuilding,
+    Contains,
+    Enqueued,
+    HasSpecial,
+    IsBuilding,
+    OwnedBy,
+    Planet,
+    Source,
+)
+from macros.base_prod import BUILDING_COST_MULTIPLIER
+
+try:
+    from focs._buildings import *
+except ModuleNotFoundError:
+    pass
+
+BuildingType(  # type: ignore[reportUnboundVariable]
+    name="BLD_NEST_RESERVE",
+    description="BLD_NEST_RESERVE_DESC",
+    buildcost=5 * BUILDING_COST_MULTIPLIER,
+    buildtime=2,
+    location=(
+        Planet()
+        & OwnedBy(empire=Source.Owner)
+        & ~Contains(IsBuilding(name=["BLD_NEST_RESERVE"]))
+        & (
+            HasSpecial(name="JUGGERNAUT_NEST_SPECIAL")
+            | HasSpecial(name="KRAKEN_NEST_SPECIAL")
+            | HasSpecial(name="SNOWFLAKE_NEST_SPECIAL")
+        )
+    ),
+    enqueuelocation=~Enqueued(
+        type=BuildBuilding,
+        name="BLD_NEST_RESERVE",
+    ),
+    effectsgroups=[],
+    icon="planets/rings/rings01.png",
+)

--- a/default/scripting/macros/named_values.focs.txt
+++ b/default/scripting/macros/named_values.focs.txt
@@ -87,6 +87,8 @@ NamedReal name = "DEF_SYST_DEF_MINE_3_DAMAGE" value = 14 * [[SYSTEM_MINES_DAMAGE
 
 NamedReal name = "FU_RAMSCOOP_REFUEL" value = 0.4
 
+NamedReal name = "BLD_NEST_RESERVE_WILD_SPAWN_FACTOR" value = 0.3
+
 #include "/scripting/ship_hulls/hull_structures.macros"
 #include "/scripting/macros/misc.macros"
 #include "/scripting/macros/base_prod.macros"

--- a/default/scripting/specials/planet/monster_nest/monster_nest.macros
+++ b/default/scripting/specials/planet/monster_nest/monster_nest.macros
@@ -29,16 +29,15 @@ MONSTER_NEST
                     ]
                     empire = Source.Owner
             ]
+
+        // if no tame monster can spawn, usually spawn wild monsters
         EffectsGroup
             scope = Source
             activation = And [
                 Planet
                 Turn low = 10
-                Or [
-                    Unowned
-                    ((GameRule name = "RULE_NESTS_ALWAYS_SPAWN_WILD") > 0)
-                ]
                 Random probability = 0.12 * (GameRule name = "RULE_WILD_NEST_MONSTER_SPAWN_FACTOR") * GalaxyMonsterFrequency / 2.0
+		   * ((NamedRealLookup name="BLD_NEST_RESERVE_WILD_SPAWN_FACTOR")^(Statistic If condition = And [ Object id = RootCandidate.ID Contains Building name = "BLD_NEST_RESERVE" ]))
                 Not Contains And [ Building name = "BLD_NEST_ERADICATOR" OwnedBy empire = Source.Owner ]
             ]
             stackinggroup = "@1@_NEST_STACK"  // groups with BLD_NEST_ERADICATOR

--- a/default/scripting/techs/growth/PLANETARY_ECOLOGY.focs.py
+++ b/default/scripting/techs/growth/PLANETARY_ECOLOGY.focs.py
@@ -21,6 +21,7 @@ Tech(
     researchcost=8 * TECH_COST_MULTIPLIER,
     researchturns=2,
     tags=["PEDIA_GROWTH_CATEGORY"],
+    unlock=Item(type=UnlockBuilding, name="BLD_NEST_RESERVE"),
     effectsgroups=[
         EffectsGroup(
             scope=Planet()

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -15601,6 +15601,12 @@ Nest Eradicator
 BLD_NEST_ERADICATOR_DESC
 Eradicates a [[encyclopedia KRAKEN_NEST_SPECIAL]], [[encyclopedia SNOWFLAKE_NEST_SPECIAL]], or [[encyclopedia JUGGERNAUT_NEST_SPECIAL]] from the planet it is built on. [[BUILDING_AVAILABLE_ON_OUTPOSTS]].
 
+BLD_NEST_RESERVE
+Mega-Fauna Sanctuary
+
+BLD_NEST_RESERVE_DESC
+A place to keep most native space-faring specimen from wandering off planet. Specimen from [[encyclopedia KRAKEN_NEST_SPECIAL]], [[encyclopedia SNOWFLAKE_NEST_SPECIAL]], or [[encyclopedia JUGGERNAUT_NEST_SPECIAL]] on the planet will hatch into space less often (x[[value BLD_NEST_RESERVE_WILD_SPAWN_FACTOR]]). [[BUILDING_AVAILABLE_ON_OUTPOSTS]].
+
 BLD_NEUTRONIUM_EXTRACTOR
 Neutronium Extractor
 

--- a/test/parse/TestDefaultPythonParser.cpp
+++ b/test/parse/TestDefaultPythonParser.cpp
@@ -127,7 +127,7 @@ BOOST_AUTO_TEST_CASE(parse_buildings_full) {
 
     BOOST_CHECK(!buildings.empty());
 
-    BOOST_REQUIRE_EQUAL(108, buildings.size());
+    BOOST_REQUIRE_EQUAL(109, buildings.size());
 
     if (const char *buildings_name = std::getenv("FO_CHECKSUM_BUILDINGS_NAME")) {
         const auto buildings_it = buildings.find(buildings_name);


### PR DESCRIPTION
* Without domestication let owned nests spawn wild monsters. 
* Add BLD_NEST_RESERVE to reduce such spawns to 30%.
* building is cheap and unlocks very early
* has stringtable entry for the building

fix #5335

tested the building
* researched and build fine
* with tech, owned monsters spawn
* without tech, bld nest reserve wild spawn factor influences spawn rates of unowned monsters 

followup could be: add suggestion to build the BLD_NEST_RESERVE