### PR TITLE
Introduce Python FOCS parser module with effects and MoveInOrbit effect

### DIFF
--- a/msvc2022/Parsers/Parsers.vcxproj
+++ b/msvc2022/Parsers/Parsers.vcxproj
@@ -280,6 +280,7 @@
       <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4180</DisableSpecificWarnings>
     </ClCompile>
     <ClCompile Include="..\..\parse\ValueRefsPythonModuleParser.cpp" />
+    <ClCompile Include="..\..\parse\EffectsPythonModuleParser.cpp" />
     <ClCompile Include="..\..\parse\ConditionPythonParser.cpp">
       <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4180;%(DisableSpecificWarnings)</DisableSpecificWarnings>
       <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4180</DisableSpecificWarnings>
@@ -323,6 +324,7 @@
     <ClInclude Include="..\..\parse\PythonParser.h" />
     <ClInclude Include="..\..\parse\ValueRefPythonParser.h" />
     <ClInclude Include="..\..\parse\ValueRefsPythonModuleParser.h" />
+    <ClInclude Include="..\..\parse\EffectsPythonModuleParser.h" />
     <ClInclude Include="..\..\parse\ConditionPythonParser.h" />
     <ClInclude Include="..\..\parse\EffectPythonParser.h" />
     <ClInclude Include="..\..\parse\EnumPythonParser.h" />

--- a/msvc2022/Parsers/Parsers.vcxproj.filters
+++ b/msvc2022/Parsers/Parsers.vcxproj.filters
@@ -186,6 +186,9 @@
     <ClCompile Include="..\..\parse\ValueRefsPythonModuleParser.cpp">
       <Filter>Source Files\parse</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\parse\ValueRefsPythonModuleParser.cpp">
+      <Filter>Source Files\parse</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\parse\ConditionParser.h">
@@ -274,6 +277,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\parse\ValueRefsPythonModuleParser.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\parse\EffectsPythonModuleParser.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\parse\ConditionPythonParser.h">

--- a/msvc2026/Parsers/Parsers.vcxproj
+++ b/msvc2026/Parsers/Parsers.vcxproj
@@ -276,6 +276,7 @@
     <ClCompile Include="..\..\parse\UniverseObjectTypeValueRefParser.cpp" />
     <ClCompile Include="..\..\parse\ValueRefParser.cpp" />
     <ClCompile Include="..\..\parse\ValueRefsPythonModuleParser.cpp" />
+    <ClCompile Include="..\..\parse\EffectsPythonModuleParser.cpp" />
     <ClCompile Include="..\..\parse\VisibilityValueRefParser.cpp" />
     <ClCompile Include="..\..\parse\ValueRefPythonParser.cpp">
       <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4180;%(DisableSpecificWarnings)</DisableSpecificWarnings>
@@ -327,6 +328,7 @@
     <ClInclude Include="..\..\parse\EnumPythonParser.h" />
     <ClInclude Include="..\..\parse\SourcePythonParser.h" />
     <ClInclude Include="..\..\parse\ValueRefsPythonModuleParser.h" />
+    <ClInclude Include="..\..\parse\EffectsPythonModuleParser.h" />
     <ClInclude Include="StdAfx.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/msvc2026/Parsers/Parsers.vcxproj.filters
+++ b/msvc2026/Parsers/Parsers.vcxproj.filters
@@ -186,6 +186,9 @@
     <ClCompile Include="..\..\parse\ValueRefsPythonModuleParser.cpp">
       <Filter>Source Files\parse</Filter>
     </ClCompile>
+    <ClCompile Include="..\..\parse\EffectsPythonModuleParser.cpp">
+      <Filter>Source Files\parse</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\parse\ConditionParser.h">
@@ -286,6 +289,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="..\..\parse\ValueRefsPythonModuleParser.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\parse\EffectsPythonModuleParser.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/parse/CMakeLists.txt
+++ b/parse/CMakeLists.txt
@@ -88,12 +88,14 @@ if(BUILD_PARSERS)
             ${CMAKE_CURRENT_LIST_DIR}/SourcePythonParser.cpp
             ${CMAKE_CURRENT_LIST_DIR}/ConditionPythonParser.cpp
             ${CMAKE_CURRENT_LIST_DIR}/ValueRefsPythonModuleParser.cpp
+            ${CMAKE_CURRENT_LIST_DIR}/EffectsPythonModuleParser.cpp
             ${CMAKE_CURRENT_LIST_DIR}/ConditionPythonParser.h
             ${CMAKE_CURRENT_LIST_DIR}/EffectPythonParser.h
             ${CMAKE_CURRENT_LIST_DIR}/EnumPythonParser.h
             ${CMAKE_CURRENT_LIST_DIR}/SourcePythonParser.h
             ${CMAKE_CURRENT_LIST_DIR}/ValueRefPythonParser.h
             ${CMAKE_CURRENT_LIST_DIR}/ValueRefsPythonModuleParser.h
+            ${CMAKE_CURRENT_LIST_DIR}/EffectsPythonModuleParser.h
     )
     if(CMAKE_CXX_COMPILER_ID MATCHES "GNU")
         target_compile_options(freeorionparseobj PRIVATE -Wno-comma-subscript -Wno-maybe-uninitialized)

--- a/parse/EffectsPythonModuleParser.cpp
+++ b/parse/EffectsPythonModuleParser.cpp
@@ -1,0 +1,41 @@
+#include "EffectsPythonModuleParser.h"
+
+#include <boost/python/def.hpp>
+#include <boost/python/docstring_options.hpp>
+#include <boost/python/module.hpp>
+#include <boost/python/raw_function.hpp>
+
+#include "EffectPythonParser.h"
+#include "ValueRefPythonParser.h"
+
+#include "../universe/Effects.h"
+
+namespace py = boost::python;
+
+namespace {
+    effect_wrapper insert_move_in_orbit(const boost::python::tuple& args, const boost::python::dict& kw) {
+        std::unique_ptr<ValueRef::ValueRef<double>> speed = pyobject_to_vref_or_cast<double, int>(kw["speed"]);
+
+        if (kw.has_key("focus")) {
+            auto focus = py::extract<condition_wrapper>(kw["focus"])();
+            return effect_wrapper(std::make_shared<Effect::MoveInOrbit>(std::move(speed),
+                ValueRef::CloneUnique(focus.condition)));
+        } else if (kw.has_key("x") && kw.has_key("y")) {
+            std::unique_ptr<ValueRef::ValueRef<double>> x = pyobject_to_vref_or_cast<double, int>(kw["x"]);
+            std::unique_ptr<ValueRef::ValueRef<double>> y = pyobject_to_vref_or_cast<double, int>(kw["y"]);
+            return effect_wrapper(std::make_shared<Effect::MoveInOrbit>(std::move(speed),
+                std::move(x),
+                std::move(y)));
+        }
+
+        throw std::runtime_error(std::string("Not implemented in ") + __func__);
+    }
+}
+
+BOOST_PYTHON_MODULE(_effects_new) {
+    boost::python::docstring_options doc_options(true, true, false);
+
+    boost::python::def("MoveInOrbit", boost::python::raw_function(insert_move_in_orbit));
+}
+
+

--- a/parse/EffectsPythonModuleParser.h
+++ b/parse/EffectsPythonModuleParser.h
@@ -1,0 +1,10 @@
+#ifndef _Python_Effects_Module_h_
+#define _Python_Effects_Module_h_
+
+#include <boost/config.hpp>
+#include <boost/python/object_fwd.hpp>
+
+extern "C" BOOST_SYMBOL_EXPORT PyObject* PyInit__effects_new(); // ToDo: remove _new
+
+#endif // _Python_Effects_Module_h_
+

--- a/parse/FieldsParser.cpp
+++ b/parse/FieldsParser.cpp
@@ -144,6 +144,7 @@ namespace {
             RegisterGlobalsEnums(globals);
 
             parser.LoadValueRefsModule();
+            parser.LoadEffectsModule();
 
             module.attr("__grammar") = boost::cref(*this);
         }

--- a/parse/PythonParser.cpp
+++ b/parse/PythonParser.cpp
@@ -14,6 +14,7 @@
 #include "EffectPythonParser.h"
 #include "EnumPythonParser.h"
 #include "SourcePythonParser.h"
+#include "EffectsPythonModuleParser.h"
 #include "ValueRefsPythonModuleParser.h"
 
 #include <boost/algorithm/string.hpp>
@@ -472,6 +473,9 @@ void PythonParser::UnloadModule(py::object module) const {
 
 void PythonParser::LoadValueRefsModule() const
 { (void)LoadModule(&PyInit__value_refs); } // marked [[nodiscard]] but result not needed in this case
+
+void PythonParser::LoadEffectsModule() const
+{ (void)LoadModule(&PyInit__effects_new); } // marked [[nodiscard]] but result not needed in this case
 
 py::object PythonParser::find_spec(const std::string& fullname, const py::object& path, const py::object& target) const {
     auto module_path(m_scripting_dir);

--- a/parse/PythonParser.h
+++ b/parse/PythonParser.h
@@ -35,6 +35,7 @@ public:
     [[nodiscard]] boost::python::object LoadModule(PyObject* (*)()) const;
     void UnloadModule(boost::python::object module) const;
     void LoadValueRefsModule() const;
+    void LoadEffectsModule() const;
 
     boost::python::object type_int;
     boost::python::object type_float;


### PR DESCRIPTION
I've added module with name `_effects_new` because `_effects` is already actively used. I'll change it to `_effects` when we'll manage to get rid of current `_effects` module.