### PR TITLE
Texture Safety Checks

### DIFF
--- a/GG/src/RichText/ImageBlock.cpp
+++ b/GG/src/RichText/ImageBlock.cpp
@@ -90,7 +90,9 @@ public:
         if (tex_name.empty())
             return nullptr;
 
-        if (auto tex = GetTextureManager().GetTextureByName(std::string{tex_name})) // TODO: avoid string construction
+        auto& tm = GetTextureManager();
+
+        if (auto tex = tm.GetTextureByName(std::string{tex_name})) // TODO: avoid string construction
             return Wnd::Create<ImageBlock>(std::move(tex), X0, Y0, X1, Flags<WndFlag>());
 
         // if not stored by name, interpet as a path
@@ -99,8 +101,10 @@ public:
         fs::path param_path = NameToPath(tex_name);
         fs::path combined_path = fs::exists(param_path) ? param_path : (m_root_path / param_path);
 
-        if (auto tex = GetTextureManager().GetTexture(combined_path, true))
-            return Wnd::Create<ImageBlock>(std::move(tex), X0, Y0, X1, Flags<WndFlag>());
+        try {
+            if (auto tex = tm.GetTexture(combined_path, true)) // throws if texture not loaded and path doesn't exist or is invalid
+                return Wnd::Create<ImageBlock>(std::move(tex), X0, Y0, X1, Flags<WndFlag>());
+        } catch (...) {}
 
         // no such texture found :(
         return nullptr;

--- a/GG/src/Texture.cpp
+++ b/GG/src/Texture.cpp
@@ -503,10 +503,12 @@ void TextureManager::StoreTexture(std::shared_ptr<Texture> texture, std::string 
 
 std::shared_ptr<Texture> TextureManager::GetTexture(const std::filesystem::path& path, bool mipmap)
 {
-    if (auto tex_maybe = GetTextureByName(path.generic_string()))
-        return tex_maybe;
-
     std::scoped_lock lock(m_texture_access_guard);
+
+    auto it = m_textures.find(path.generic_string());
+    if (it != m_textures.end())
+        return it->second;
+
     // if no such texture was found, attempt to load it now, using name as the filename
     //std::cout << "TextureManager::GetTexture storing new texture under name: " << path.generic_string();
     return LoadTexture(path, mipmap);

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -4383,10 +4383,14 @@ void EncyclopediaDetailPanel::RefreshImpl() {
     }
 
     if (!detailed_description.empty()) {
-        if (m_items_it->second == "ENC_STRINGS")
-            m_description_rich_text->SetUnformattedText(std::move(detailed_description));
-        else
-            m_description_rich_text->SetText(detailed_description);
+        try {
+            if (m_items_it->second == "ENC_STRINGS")
+                m_description_rich_text->SetUnformattedText(std::move(detailed_description));
+            else
+                m_description_rich_text->SetText(detailed_description);
+        } catch (const std::exception& e) {
+            ErrorLogger() << "Exception setting rich text: " << e.what();
+        }
     }
 
     m_scroll_panel->ScrollTo(GG::Y0);

--- a/client/human/GGHumanClientApp.cpp
+++ b/client/human/GGHumanClientApp.cpp
@@ -401,8 +401,7 @@ void GGHumanClientApp::Initialize() {
     GG::Wnd::SetDefaultBrowseInfoWnd(std::move(default_browse_info_wnd));
 
     auto cursor_texture = m_ui.GetTexture(ClientUI::ArtDir() / "cursors" / "default_cursor.png");
-    SetCursor(std::make_unique<GG::TextureCursor>(std::move(cursor_texture),
-                                                  GG::Pt(GG::X(6), GG::Y(3))));
+    SetCursor(std::make_unique<GG::TextureCursor>(std::move(cursor_texture), GG::Pt(GG::X(6), GG::Y(3))));
     RenderCursor(true);
 
     EnableKeyPressRepeat(GetOptionsDB().Get<int>("ui.input.keyboard.repeat.delay"),


### PR DESCRIPTION
fixes crash when setting an RichText ImageBlock with an invalid texture path