### PR TITLE
Fix missing #include

### DIFF
--- a/util/CheckSums.h
+++ b/util/CheckSums.h
@@ -6,6 +6,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstdint>
 #include <limits>
 #include <limits.h>
 #include <memory>


### PR DESCRIPTION
Hopefully fixes `error: 'uint32_t' was not declared in this scope` on Fedora Rawhide