### PR TITLE
Threadpool Fallback / Workarounds

### DIFF
--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -853,11 +853,10 @@ void Universe::UpdateMeterEstimatesImpl(const std::vector<int>& objects_vec,
     // when iterating over the list in the following code
     auto object_ptrs = m_objects.find(objects_vec);
     if (objects_vec.empty()) {
-        object_ptrs.reserve(m_objects.allExisting().size());
-        std::transform(m_objects.allExisting().begin(), m_objects.allExisting().end(),
-                       std::back_inserter(object_ptrs), [](const auto& p) {
-            return std::const_pointer_cast<UniverseObject>(p.second);
-        });
+        static constexpr auto deconst_second = [](const auto& p) { return std::const_pointer_cast<UniverseObject>(p.second); };
+        auto& all_objs{m_objects.allExisting()};
+        object_ptrs.reserve(all_objs.size());
+        std::transform(all_objs.begin(), all_objs.end(), std::back_inserter(object_ptrs), deconst_second);
     }
 
     DebugLogger() << "UpdateMeterEstimatesImpl on " << object_ptrs.size() << " objects";

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -2976,6 +2976,10 @@ std::string StringCast<double>::Eval(const ScriptingContext& context) const
     auto Stringify = [](double num) -> std::string {
         if (std::isnan(num))
             return "";
+        else if (std::isinf(num))
+            return num > 0 ? "∞" : "-∞";
+        else if (!std::isfinite(num))
+            return "";
 
         const auto abs_num = std::abs(num);
         if (abs_num < 0.1 || abs_num >= 1000)

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -232,8 +232,7 @@ void serialize(Archive& ar, Universe& u, unsigned int const version)
             std::vector<int> allocating_empire_ids;
             allocating_empire_ids.reserve(u.m_empire_latest_known_objects.size());
             std::transform(u.m_empire_latest_known_objects.begin(), u.m_empire_latest_known_objects.end(),
-                           std::back_inserter(allocating_empire_ids),
-                           [](const auto& ii) { return ii.first; });
+                           std::back_inserter(allocating_empire_ids), [](const auto& ii) { return ii.first; });
 
             u.ResetAllIDAllocation(allocating_empire_ids);
         }

--- a/util/i18n.cpp
+++ b/util/i18n.cpp
@@ -532,8 +532,15 @@ std::string DoubleToString(double val, int digits, bool always_show_sign) {
     digits = std::max(digits, 2);
 
     // default result for sentinel value
-    if (val == UNKNOWN_UI_DISPLAY_VALUE)
+    if (val == UNKNOWN_UI_DISPLAY_VALUE) {
         return UserString("UNKNOWN_VALUE_SYMBOL");
+    } if (std::isnan(val)) {
+        return "";
+    } else if (std::isinf(val)) {
+        return val > 0 ? "∞" : "-∞";
+    } else if (!std::isfinite(val)) {
+        return "";
+    }
 
     double mag = std::abs(val);
 


### PR DESCRIPTION
Investigating #5404 revealed some issues with Boost Asio `thread_pool` construction:
-Constructing when `errno` is not 0 will fail
-Default constructing is broken in Boost 1.87

This resets `errno` before attempting to construct a `thread_pool` during effect evaluation, and provides a fallback in case that doesn't work (which won't work on Boost 1.87 but otherwise should).

This also avoids settings `errno` during number to text formatting with some safety checks.