### PR TITLE
Redundant Part Filtering Options

### DIFF
--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -558,11 +558,6 @@ namespace {
         db.Add("ui.fleet.multiple.enabled",                             UserStringNop("OPTIONS_DB_UI_MULTIPLE_FLEET_WINDOWS"),      false);
         db.Add("ui.quickclose.enabled",                                 UserStringNop("OPTIONS_DB_UI_WINDOW_QUICKCLOSE"),           true);
         db.Add("ui.reposition.auto.enabled",                            UserStringNop("OPTIONS_DB_UI_AUTO_REPOSITION_WINDOWS"),     true);
-
-        // UI behavior, hidden options
-        // currently lacking an options page widget, so can only be user-adjusted by manually editing config file or specifying on command line
-        db.Add("ui.design.pedia.title.dynamic.enabled",                 UserStringNop("OPTIONS_DB_DESIGN_PEDIA_DYNAMIC"),           false);
-        db.Add("ui.map.fleet.eta.shown",                                UserStringNop("OPTIONS_DB_SHOW_FLEET_ETA"),                 true);
         db.Add("ui.name.id.shown",                                      UserStringNop("OPTIONS_DB_SHOW_IDS_AFTER_NAMES"),           false);
 
         // Other

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -142,6 +142,7 @@ namespace {
         db.Add("ui.map.starlane.thickness.factor",          UserStringNop("OPTIONS_DB_STARLANE_CORE"),                          2.0,                            RangedStepValidator<double>(1.0, 1.0, 10.0));
         db.Add("ui.map.starlane.empire.color.shown",        UserStringNop("OPTIONS_DB_RESOURCE_STARLANE_COLOURING"),            true,                           Validator<bool>());
 
+        db.Add("ui.map.fleet.eta.shown",                    UserStringNop("OPTIONS_DB_SHOW_FLEET_ETA"),                         true);
         db.Add("ui.map.fleet.supply.shown",                 UserStringNop("OPTIONS_DB_FLEET_SUPPLY_LINES"),                     true,                           Validator<bool>());
         db.Add("ui.map.fleet.supply.width",                 UserStringNop("OPTIONS_DB_FLEET_SUPPLY_LINE_WIDTH"),                3.0,                            RangedStepValidator<double>(0.2, 0.2, 10.0));
         db.Add("ui.map.fleet.supply.dot.spacing",           UserStringNop("OPTIONS_DB_FLEET_SUPPLY_LINE_DOT_SPACING"),          20,                             RangedStepValidator<int>(1, 3, 40));

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -483,6 +483,12 @@ void OptionsWnd::CompleteConstruction() {
     DoubleOption(current_page, 0, "ui.research.tree.zoom.scale",        UserString("OPTIONS_TECH_LAYOUT_ZOOM"));
     DoubleOption(current_page, 0, "ui.research.control.graphic.size",   UserString("OPTIONS_TECH_CTRL_ICON_SIZE"));
 
+    CreateSectionHeader(current_page, 0,                                UserString("OPTIONS_DESIGN_WND"));
+    BoolOption(current_page, 0, "ui.design.pedia.title.dynamic.enabled",UserString("OPTIONS_DESIGN_PEDIA_DYNAMIC"));
+    DoubleOption(current_page, 0, "ui.design.functional.cost.ratio",    UserString("OPTIONS_DESIGN_FUNCTIONAL_MAX_COST_RATIO"));
+    DoubleOption(current_page, 0, "ui.design.functional.bargain.ratio", UserString("OPTIONS_DESIGN_FUNCTIONAL_MIN_BARGAIN_RATIO"));
+    DoubleOption(current_page, 0, "ui.design.functional.time.ratio",    UserString("OPTIONS_DESIGN_FUNCTIONAL_MAX_TIME_RATIO"));
+
     CreateSectionHeader(current_page, 0,                                UserString("OPTIONS_QUEUES"));
     IntOption(current_page,    0, "ui.queue.width",                     UserString("OPTIONS_UI_QUEUE_WIDTH"));
     BoolOption(current_page,   0, "ui.queue.production_location.shown", UserString("OPTIONS_UI_PROD_QUEUE_LOCATION"));

--- a/default/stringtables/common_user_customizations.txt
+++ b/default/stringtables/common_user_customizations.txt
@@ -4,30 +4,6 @@
 # To minimize potential conflict with stringtable tags, all keys here should begin with "FUNCTIONAL_"
 
 
-## DesignWnd Redundant Part Filtering
-## Default settings will deem a first part redundant to a second only if the second is all of (i) more powerful,
-## (ii) no more expensive, (iii) takes no longer to build, and (iv) has no Location restrictions not also required
-## by the first part (note that the checking on this point is currently over-conservative).
-## Adjusting the Max Cost Ratio above 1.0 allows the filtering to consider a superior part which might cost a bit
-## more, but whose Capacity/Cost ratio is at least equal to the Min Bargain Ratio.  For example, with the current content
-## as of the time of this writing, setting the Max Cost Ratio to 2.1 and leaving the Min Bargain Ratio at 1.0 woould cause
-## Zortrium armor to suppress Standard armor, and for Advanced Ground Troop Pods to suppress Standard Troop Pods.  Then
-## also increasing the Max Time Ratio to 1.4 or higher would cause N-Dimensional Engines to suppress Improved Engine Couplings.
-## Dropping the Max Cost Ratio below 2.0, or increasing the Min Bargain Ratio above 1.0, would prevent the redundancy filtering
-## for troop Pods.  If the Min Bargain Ratio were no higher than about 1.2 and the Max Cost Ratio at least about 1.4, then
-## some of the armor redundancy filtering would still occur.
-## Both settings have a minimum value of 1.0
- 
-FUNCTIONAL_MAX_COST_RATIO
-1.0
-
-FUNCTIONAL_MIN_BARGAIN_RATIO
-1.0
-
-FUNCTIONAL_MAX_TIME_RATIO
-1.0
-
-
 ## FUNCTIONAL_SITREP_PRIORITY_ORDER is an ordered, whitespace separated list, prioritizing
 ## these sitreps to be presented in the SitrepPanel in the order set below.
 ## Sitreps not specified below will appear in the SitrepPanel following those below.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -2150,6 +2150,15 @@ Automatically add game default ship designs to the player-empire known designs.
 OPTIONS_DB_DESIGN_PEDIA_DYNAMIC
 In the Design Window, dynamically update the pedia detail page while the design name is being edited.
 
+OPTIONS_DB_DESIGN_FUNCTIONAL_MAX_COST_RATIO
+Design window redundant part filtering max cost ratio. By default, parts are only considered redundant if all of (i) more powerful / greater capacity, (2) no more expensive, (iii) no greater minimum production time, and (iv) no additional location restrictions. Increasing max cost ratio above 1.0 allows the filtering to let a stronger / higher capacity part that costs that much more to make a cheaper part redundant.
+
+OPTIONS_DB_DESIGN_FUNCTIONAL_MIN_BARGAIN_RATIO
+Design window redundant part filtering minimum bargain ratio. Setting this above 1.0 will prevent small bargains (ratio of part strength / capacity) divided by (ratio of part costs) from making a part be redundant.
+
+OPTIONS_DB_DESIGN_FUNCTIONAL_MAX_TIME_RATIO
+Design window redundant part filtering max production time ratio. Increasing this above 1.0 allows the filtering to let a stronger / higher capacity part that is slower to produce to make a faster to produce part redundant.
+
 OPTIONS_DB_UI_SIDEPANEL_WIDTH
 Sets size of system side-panel.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -2151,7 +2151,14 @@ OPTIONS_DB_DESIGN_PEDIA_DYNAMIC
 In the Design Window, dynamically update the pedia detail page while the design name is being edited.
 
 OPTIONS_DB_DESIGN_FUNCTIONAL_MAX_COST_RATIO
-Design window redundant part filtering max cost ratio. By default, parts are only considered redundant if all of (i) more powerful / greater capacity, (2) no more expensive, (iii) no greater minimum production time, and (iv) no additional location restrictions. Increasing max cost ratio above 1.0 allows the filtering to let a stronger / higher capacity part that costs that much more to make a cheaper part redundant.
+'''Design window redundant part filtering max cost ratio. By default, parts are only considered redundant if another part of the same class is all of:
+
+• more powerful / greater capacity
+• no more expensive
+• no greater minimum production time
+• no additional location restrictions
+
+Increasing max cost ratio above 1.0 allows the filtering to let a stronger / higher capacity part that costs that much more to make a cheaper part redundant.'''
 
 OPTIONS_DB_DESIGN_FUNCTIONAL_MIN_BARGAIN_RATIO
 Design window redundant part filtering minimum bargain ratio. Setting this above 1.0 will prevent small bargains (ratio of part strength / capacity) divided by (ratio of part costs) from making a part be redundant.
@@ -3160,6 +3167,9 @@ Window titles
 OPTIONS_RESEARCH_WND
 Research Window
 
+OPTIONS_DESIGN_WND
+Ship Design Window
+
 OPTIONS_QUEUES
 Queues
 
@@ -3174,6 +3184,18 @@ Zoom
 
 OPTIONS_TECH_CTRL_ICON_SIZE
 Icon Size
+
+OPTIONS_DESIGN_PEDIA_DYNAMIC
+Editing dynamic pedia updates
+
+OPTIONS_DESIGN_FUNCTIONAL_MAX_COST_RATIO
+Redundancy maximum cost ratio
+
+OPTIONS_DESIGN_FUNCTIONAL_MIN_BARGAIN_RATIO
+Redundancy minimum bargain ratio
+
+OPTIONS_DESIGN_FUNCTIONAL_MAX_TIME_RATIO
+Redundancy maximum time ratio
 
 OPTIONS_TOOLTIP_DELAY
 Tooltip delay (ms)


### PR DESCRIPTION
Use options with UI controls instead of (effectively) stringtable entries to control client past list redundancy filtering.

Unlike ordering lists of content, this is effectively content independent, so can be implemented as options instead of in the stringtable via an #include.

Also moves definition of the map fleet ETA showing option nearer where it's relevant.