### PR TITLE
Update hyperlink in stdafx.h comments

### DIFF
--- a/msvc2022/Common/StdAfx.h
+++ b/msvc2022/Common/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/
+// https://hownot2code.wordpress.com/2016/08/16/stdafx-h/
 
 // ----------------
 // includes from .h

--- a/msvc2022/FreeOrion/StdAfx.h
+++ b/msvc2022/FreeOrion/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/ 
+// https://hownot2code.wordpress.com/2016/08/16/stdafx-h/ 
 
 // ----------------
 // includes from .h

--- a/msvc2022/FreeOrionCA/StdAfx.h
+++ b/msvc2022/FreeOrionCA/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/ 
+// https://hownot2code.wordpress.com/2016/08/16/stdafx-h/ 
 
 // ----------------
 // includes from .h

--- a/msvc2022/FreeOrionD/StdAfx.h
+++ b/msvc2022/FreeOrionD/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/ 
+// https://hownot2code.wordpress.com/2016/08/16/stdafx-h/ 
 
 // ----------------
 // includes from .h

--- a/msvc2022/GiGi/StdAfx.h
+++ b/msvc2022/GiGi/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/ 
+// https://hownot2code.wordpress.com/2016/08/16/stdafx-h/ 
 
 // ----------------
 // includes from .h

--- a/msvc2022/Parsers/StdAfx.h
+++ b/msvc2022/Parsers/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus boost headers used in any .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/
+// https://hownot2code.wordpress.com/2016/08/16/stdafx-h/
 
 // ----------------
 // includes from .h or .cpp

--- a/msvc2022/Test/StdAfx.h
+++ b/msvc2022/Test/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/ 
+// https://hownot2code.wordpress.com/2016/08/16/stdafx-h/ 
 
 // ----------------
 // includes from .h

--- a/msvc2022/update_stdafx.py
+++ b/msvc2022/update_stdafx.py
@@ -13,7 +13,7 @@ PREAMBLE = """
 // We include all external headers used in any of the header files,
 // plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/
+// https://hownot2code.wordpress.com/2016/08/16/stdafx-h/
 
 """
 

--- a/msvc2026/Common/StdAfx.h
+++ b/msvc2026/Common/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/
+// https://hownot2code.wordpress.com/2016/08/16/stdafx-h/
 
 // ----------------
 // includes from .h

--- a/msvc2026/FreeOrion/StdAfx.h
+++ b/msvc2026/FreeOrion/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/ 
+// https://hownot2code.wordpress.com/2016/08/16/stdafx-h/ 
 
 // ----------------
 // includes from .h

--- a/msvc2026/FreeOrionCA/StdAfx.h
+++ b/msvc2026/FreeOrionCA/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/ 
+// https://hownot2code.wordpress.com/2016/08/16/stdafx-h/ 
 
 // ----------------
 // includes from .h

--- a/msvc2026/FreeOrionD/StdAfx.h
+++ b/msvc2026/FreeOrionD/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/ 
+// https://hownot2code.wordpress.com/2016/08/16/stdafx-h/ 
 
 // ----------------
 // includes from .h

--- a/msvc2026/GiGi/StdAfx.h
+++ b/msvc2026/GiGi/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/ 
+// https://hownot2code.wordpress.com/2016/08/16/stdafx-h/ 
 
 // ----------------
 // includes from .h

--- a/msvc2026/Parsers/StdAfx.h
+++ b/msvc2026/Parsers/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus boost headers used in any .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/
+// https://hownot2code.wordpress.com/2016/08/16/stdafx-h/
 
 // ----------------
 // includes from .h or .cpp

--- a/msvc2026/Test/StdAfx.h
+++ b/msvc2026/Test/StdAfx.h
@@ -4,7 +4,7 @@
 // We include all external headers used in any of the header files,
 // plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/ 
+// https://hownot2code.wordpress.com/2016/08/16/stdafx-h/ 
 
 // ----------------
 // includes from .h

--- a/msvc2026/update_stdafx.py
+++ b/msvc2026/update_stdafx.py
@@ -13,7 +13,7 @@ PREAMBLE = """
 // We include all external headers used in any of the header files,
 // plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/
+// https://hownot2code.wordpress.com/2016/08/16/stdafx-h/
 
 """
 


### PR DESCRIPTION
URLs to article, describing precompiled headers, are outdated, it seems that hownot2code blog had left 2nd level domain.