### PR TITLE
racial policy de-adoption turn workaround

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -586,6 +586,15 @@ std::vector<std::pair<std::string_view, int>> Empire::EmptyPolicySlots() const {
     return retval;
 }
 
+void Empire::CreateMeter(std::string_view name) {
+    auto it = range_find_if(m_meters, [name](const auto& e) noexcept { return e.first == name; });
+    // XXX probably a bad idea to insert into the map (invalidates all iterators)
+    if (it == m_meters.end())
+        m_meters.emplace(name, Meter());
+    else
+        ErrorLogger() << "Empire::CreateMeter trying to create existing empire meter " << name;
+}
+
 Meter* Empire::GetMeter(std::string_view name) {
     auto it = range_find_if(m_meters, [name](const auto& e) noexcept { return e.first == name; });
     if (it != m_meters.end())

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -612,8 +612,10 @@ const Meter* Empire::GetMeter(std::string_view name) const {
 }
 
 void Empire::BackPropagateMeters() noexcept {
-    for (auto& meter : m_meters | range_values)
-        meter.BackPropagate();
+    for (auto& meter : m_meters) {
+        ErrorLogger() << "BackPropagate " << meter.first << " which was " << meter.second.Initial() << " to " << meter.second.Current();
+        meter.second.BackPropagate();
+    }
 }
 
 bool Empire::ResearchableTech(std::string_view name) const {

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -125,6 +125,7 @@ public:
     [[nodiscard]] const std::string&           MostRPSpentResearchableTech() const;
     [[nodiscard]] const std::string&           MostRPCostLeftResearchableTech(const ScriptingContext& context) const;
 
+    void                                       CreateMeter(std::string_view name);
     [[nodiscard]] const Meter*                 GetMeter(std::string_view name) const;
     [[nodiscard]] const auto&                  GetMeters() const noexcept { return m_meters; }
 

--- a/default/scripting/policies/RACIAL_PURITY_helper.py
+++ b/default/scripting/policies/RACIAL_PURITY_helper.py
@@ -1,0 +1,36 @@
+from focs._effects import (
+    Conditional,
+    CurrentTurn,
+    EffectsGroup,
+    EmpireHasAdoptedPolicy,
+    GenerateSitRepMessage,
+    EmpireMeterValue,
+    IsSource,
+    SetEmpireMeter,
+    Source,
+    Value,
+)
+
+racial_purity_once_per_turn_effectgroups = [
+    EffectsGroup(
+        scope=IsSource,
+        effects=Conditional(
+            condition=(EmpireHasAdoptedPolicy(empire=Source.Owner, name="PLC_RACIAL_PURITY")),
+            effects=[
+                #SetEmpireMeter(empire=Source.Owner, meter="PLC_RACIAL_PURITY_TURN_ACTIVE", value=CurrentTurn),
+                SetEmpireMeter(empire=Source.Owner, meter="PLC_RACIAL_PURITY_TURN_ACTIVE", value=0.0+CurrentTurn),
+            ],
+            else_=[
+                SetEmpireMeter(empire=Source.Owner, meter="SOCIAL_CATEGORY_NUM_POLICY_SLOTS", value=Value+1),
+                GenerateSitRepMessage(
+                    message="Test ; last rac pur turn: %lastturn%",
+                    label="SITREP_WELCOME_LABEL",
+                    NoStringtableLookup=True,
+                    icon="icons/tech/categories/spy.png",
+                    parameters={"lastturn": EmpireMeterValue(empire=Source.Owner, meter="PLC_RACIAL_PURITY_TURN_ACTIVE")},
+                    empire=Source.Owner,
+                ),
+            ],
+        )
+    ),
+]

--- a/default/scripting/policies/RACIAL_PURITY_helper.py
+++ b/default/scripting/policies/RACIAL_PURITY_helper.py
@@ -18,12 +18,25 @@ racial_purity_once_per_turn_effectgroups = [
             condition=(EmpireHasAdoptedPolicy(empire=Source.Owner, name="PLC_RACIAL_PURITY")),
             effects=[
                 #SetEmpireMeter(empire=Source.Owner, meter="PLC_RACIAL_PURITY_TURN_ACTIVE", value=CurrentTurn),
-                SetEmpireMeter(empire=Source.Owner, meter="PLC_RACIAL_PURITY_TURN_ACTIVE", value=0.0+CurrentTurn),
+                SetEmpireMeter(empire=Source.Owner, meter="PLC_RACIAL_PURITY_TURN_ACTIVE", value=Value+CurrentTurn),
+                GenerateSitRepMessage(
+                    message="Test Set ; last rac pur turn: %rawtext:current% (was %rawtext:lastturn%) %rawtext:slcurrent% (w %rawtext:sllastturn%)",
+                    label="SITREP_WELCOME_LABEL",
+                    NoStringtableLookup=True,
+                    icon="icons/tech/categories/spy.png",
+                    parameters={
+                        "current": EmpireMeterValue(empire=Source.Owner, meter="PLC_RACIAL_PURITY_TURN_ACTIVE"),
+                        "lastturn": Value(EmpireMeterValue(empire=Source.Owner, meter="PLC_RACIAL_PURITY_TURN_ACTIVE")),
+                        "slcurrent": EmpireMeterValue(empire=Source.Owner, meter="SOCIAL_CATEGORY_NUM_POLICY_SLOTS"),
+                        "sllastturn": Value(EmpireMeterValue(empire=Source.Owner, meter="SOCIAL_CATEGORY_NUM_POLICY_SLOTS")),
+                    },
+                    empire=Source.Owner,
+                ),
             ],
             else_=[
                 SetEmpireMeter(empire=Source.Owner, meter="SOCIAL_CATEGORY_NUM_POLICY_SLOTS", value=Value+1),
                 GenerateSitRepMessage(
-                    message="Test ; last rac pur turn: %lastturn%",
+                    message="Test NoSet ; last rac pur turn: %rawtext:lastturn%",
                     label="SITREP_WELCOME_LABEL",
                     NoStringtableLookup=True,
                     icon="icons/tech/categories/spy.png",

--- a/default/scripting/techs/construction/ARCH_PSYCH.focs.py
+++ b/default/scripting/techs/construction/ARCH_PSYCH.focs.py
@@ -7,6 +7,7 @@ from focs._effects import (
 )
 from focs._tech import *
 from macros.base_prod import TECH_COST_MULTIPLIER
+from policies.RACIAL_PURITY_helper import racial_purity_once_per_turn_effectgroups
 
 Tech(
     name="CON_ARCH_PSYCH",
@@ -22,7 +23,8 @@ Tech(
         EffectsGroup(
             scope=IsSource,
             effects=SetEmpireMeter(empire=Source.Owner, meter="SOCIAL_CATEGORY_NUM_POLICY_SLOTS", value=Value + 1),
-        )
+        ),
+        *racial_purity_once_per_turn_effectgroups
     ],
     graphic="icons/tech/architecture_psychology.png",
 )

--- a/universe/Effects.cpp
+++ b/universe/Effects.cpp
@@ -995,9 +995,16 @@ namespace {
         } else if (Meter* m = empire->GetMeter(meter)) {
             return m;
         } else {
-            ErrorLogger(effects) << "SetEmpireMeter::Execute empire " << empire->Name()
-                                 << " doesn't have a meter named " << meter;
-            return nullptr;
+            InfoLogger(effects) << "SetEmpireMeter::Execute empire " << empire->Name()
+                                 << " doesn't have a meter named " << meter
+                                 << ". Adding it.";
+            empire->CreateMeter(meter);
+            if (Meter* m = empire->GetMeter(meter)) {
+                return m;
+            } else {
+                ErrorLogger(effects) << "SetEmpireMeter::Execute empire " << empire->Name()
+                                     << " after creating it still doesn't have a meter named " << meter;
+            }
         }
     }
 }


### PR DESCRIPTION
trying to use empire meter for storing de-adoption of policy.
could be a fix for #5245 

- currently this is only WIP / trying to figure out what would be necessary for the workaround to work 
- adds (dubious) on-the-fly creation of empire meters
- main problem currently: initial value of empire meters is always zero


 