### PR TITLE
Disable +5 influence gain from The Hunt on outposts

### DIFF
--- a/default/scripting/policies/THE_HUNT.focs.txt
+++ b/default/scripting/policies/THE_HUNT.focs.txt
@@ -13,6 +13,7 @@ Policy
             scope = And [
                 Planet
                 OwnedBy empire = Source.Owner
+                Species
                 ContainedBy Contains And [
                     InSystem id = RootCandidate.SystemID
                     Planet


### PR DESCRIPTION
To fix https://github.com/freeorion/freeorion/issues/5460