### PR TITLE
FleetUtilsAI crash try-catch log

### DIFF
--- a/default/python/AI/CombatRatingsAI/_ship_combat_stats.py
+++ b/default/python/AI/CombatRatingsAI/_ship_combat_stats.py
@@ -1,5 +1,5 @@
 import freeOrionAIInterface as fo
-from logging import debug, error, warning
+from logging import error, warning
 
 from AIDependencies import CombatTarget
 from aistate_interface import get_aistate
@@ -130,10 +130,10 @@ class ShipCombatStats:
         launch_rate = enemy_stats._fighter_launch_rate
         damage = enemy_stats._fighter_damage
         if damage <= 0 or capacity < 1 or launch_rate < 1:
-            debug(f"flak factor 1.0 because enemy is not a carrier ({launch_rate}/{capacity} * {damage}d)")
+            # debug(f"flak factor 1.0 because enemy is not a carrier ({launch_rate}/{capacity} * {damage}d)")
             return (1.0, 0.0)
         if enemy_stats._has_interceptors:
-            debug("flak factor 1.0 because enemy is an interceptor carrier / unable to hurt us")
+            # debug("flak factor 1.0 because enemy is an interceptor carrier / unable to hurt us")
             return (1.0, 0.0)
         enemy_fighter_dmg = self._estimate_fighter_damage_vs_flak(capacity, launch_rate, damage, 0.0)
         if my_flak_shots <= 0.0:

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -256,15 +256,24 @@ def split_ship_from_fleet(fleet_id, ship_id) -> int:
         new_fleet = universe.getFleet(new_fleet_id)
         if not new_fleet:
             warning("Newly split fleet %d not available from universe" % new_fleet_id)
-        debug("Successfully split ship %d from fleet %d into new fleet %d", ship_id, fleet_id, new_fleet_id)
+        debug(
+            "Successfully split ship %d from fleet %d into new fleet %d at system %d",
+            ship_id,
+            fleet_id,
+            new_fleet_id,
+            fleet.systemID,
+        )
         fo.issueRenameOrder(new_fleet_id, "Fleet %4d" % new_fleet_id)  # to ease review of debugging logs
         fo.issueAggressionOrder(new_fleet_id, True)
         aistate.update_fleet_rating(new_fleet_id)
         aistate.newlySplitFleets[new_fleet_id] = True
         # register the new fleets so AI logic is aware of them
         sys_status = aistate.systemStatus.setdefault(fleet.systemID, {})
-        sys_status["myfleets"].append(new_fleet_id)
-        sys_status["myFleetsAccessible"].append(new_fleet_id)
+        try:
+            sys_status["myfleets"].append(new_fleet_id)
+            sys_status["myFleetsAccessible"].append(new_fleet_id)
+        except KeyError:
+            error("KeyError appending new fleet id to sys_status when splitting ship from fleet", exc_info=True)
     else:
         if fleet.systemID == INVALID_ID:
             warning("Tried to split ship id (%d) from fleet %d when fleet is in starlane" % (ship_id, fleet_id))


### PR DESCRIPTION
-try-catch around appending fleet ids in `split_ship_from_fleet` in FleetUtilsAI.py
-comment out flak-related AI log spam

With this, I can set up a local multiplayer game with AIs for all but one empire in the save file for the MP30 game (link here: https://www.freeorion.org/forum/viewtopic.php?p=122906#p122906 specifically `FreeOrion_0233_20260206_215854.mps`).

That is, the AIs are taking over for formerly human players.

Without it, the game mostly loads but then an AI disconnects, with exceptions in the log file:
````
10:28:30.990767 {0x00000f44} [error] python : FreeOrionAI.py:83 : Exception 'myfleets' occurred during generateOrders
10:28:30.990767 {0x00000f44} [error] python : FreeOrionAI.py:83 : Traceback (most recent call last):
10:28:30.990767 {0x00000f44} [error] python : FreeOrionAI.py:83 :   File "C:\Users\g_top\Desktop\FOSDK16\FreeOrion\default\python\AI\FreeOrionAI.py", line 80, in _error_handler
10:28:30.990767 {0x00000f44} [error] python : FreeOrionAI.py:83 :     res = func(*args, **kwargs)
10:28:30.990767 {0x00000f44} [error] python : FreeOrionAI.py:83 :   File "C:\Users/g_top/Desktop/FOSDK16/FreeOrion/default\python\common\listeners.py", line 42, in wrapper
10:28:30.990767 {0x00000f44} [error] python : FreeOrionAI.py:83 :     res = funct(*args)
10:28:30.990767 {0x00000f44} [error] python : FreeOrionAI.py:83 :   File "C:\Users\g_top\Desktop\FOSDK16\FreeOrion\default\python\AI\FreeOrionAI.py", line 322, in generateOrders
10:28:30.990767 {0x00000f44} [error] python : FreeOrionAI.py:83 :     aistate.prepare_for_new_turn()
10:28:30.990767 {0x00000f44} [error] python : FreeOrionAI.py:83 :   File "C:\Users\g_top\Desktop\FOSDK16\FreeOrion\default\python\AI\AIstate.py", line 1044, in prepare_for_new_turn
10:28:30.990767 {0x00000f44} [error] python : FreeOrionAI.py:83 :     self.__split_new_fleets()
10:28:30.990767 {0x00000f44} [error] python : FreeOrionAI.py:83 :   File "C:\Users\g_top\Desktop\FOSDK16\FreeOrion\default\python\AI\AIstate.py", line 1026, in __split_new_fleets
10:28:30.990767 {0x00000f44} [error] python : FreeOrionAI.py:83 :     new_fleets = FleetUtilsAI.split_fleet(fleet_id)
10:28:30.990767 {0x00000f44} [error] python : FreeOrionAI.py:83 :   File "C:\Users\g_top\Desktop\FOSDK16\FreeOrion\default\python\AI\FleetUtilsAI.py", line 226, in split_fleet
10:28:30.990767 {0x00000f44} [error] python : FreeOrionAI.py:83 :     new_fleet_id = split_ship_from_fleet(fleet_id, ship_id)
10:28:30.990767 {0x00000f44} [error] python : FreeOrionAI.py:83 :   File "C:\Users\g_top\Desktop\FOSDK16\FreeOrion\default\python\AI\FleetUtilsAI.py", line 266, in split_ship_from_fleet
10:28:30.990767 {0x00000f44} [error] python : FreeOrionAI.py:83 :     sys_status["myfleets"].append(new_fleet_id)
10:28:30.991767 {0x00000f44} [error] python : FreeOrionAI.py:83 : KeyError: 'myfleets'
10:28:30.991767 {0x00000f44} [error] python : FreeOrionAI.py:83 : Local context: {'fleet_id': 350380, 'ship_id': 90130, 'universe': <freeOrionAIInterface.universe object at 0x0000000006F06B20>, 'fleet': F_350380<Battle Fleet 350380>, 'new_fleet_id': 350404, 'aistate': <AIstate.AIstate object at 0x0000000002987D60>, 'new_fleet': F_350404<Fleet 350404>, 'sys_status': {}}
10:28:30.991767 {0x00000f44} [debug] ai : AIClientApp.cpp:111 : AIClientApp exited cleanly for ai client AI_6
10:28:30.991767 {0x00000f44} [debug] ai : PythonBase.cpp:104 : Cleaned up FreeOrion Python interface
10:28:30.991767 {0x000016c8} [debug] network : ClientNetworking.cpp:716 : ClientNetworking::Impl::DisconnectFromServerImpl
10:28:30.993281 {0x000016c8} [error] network : ClientNetworking.cpp:586 : ClientNetworking::NetworkingThread() : Networking thread will be terminated due to unhandled exception error #10053 "An established connection was aborted by the software in your host machine"
10:28:31.073303 {0x00000f44} [error] ai : camain.cpp:107 : main() caught unknown exception.
````

I get error chat messages, but at least the AIs don't fully crash:
````
[06 Mar 10:39:52] Player 3: We have been assigned an empire previously run by a human player. We can manage this.
[06 Mar 10:39:54] Player 1: AI_Error: AI script error : FleetUtilsAI.py:split_ship_from_fleet():276  - KeyError appending new fleet id to sys_status when splitting ship from fleet
Traceback (most recent call last):
  File "C:\Users\g_top\Desktop\FOSDK16\FreeOrion\default\python\AI\FleetUtilsAI.py", line 273, in split_ship_from_fleet
    sys_status["myfleets"].append(new_fleet_id)
KeyError: 'myfleets'
Local context: {'fleet_id': 350380, 'ship_id': 90130, 'universe': <freeOrionAIInterface.universe object at 0x0000000004465A10>, 'fleet': F_350380<Battle Fleet 350380>, 'new_fleet_id': 350404, 'aistate': <AIstate.AIstate object at 0x0000000002947D60>, 'new_fleet': F_350404<Fleet 350404>, 'sys_status': {}}
````
