### PR TITLE
Allow Beginner AI Exploration

### DIFF
--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -95,12 +95,21 @@ def assign_scouts_to_explore_systems():  # noqa: C901
 
         # skip systems threatened by monsters
         sys_status = aistate.systemStatus.setdefault(sys_id, {})
-        if not aistate.character.may_explore_system(sys_status.setdefault("monsterThreat", 0)) or (
-            fo.currentTurn() < 20 and aistate.systemStatus[sys_id]["monsterThreat"] > 0
-        ):
+        sys_status.setdefault("monsterThreat", 0)
+        monsterThreat = aistate.systemStatus[sys_id]["monsterThreat"]
+
+        if not aistate.character.may_explore_system(monsterThreat):
             debug(
-                "Skipping exploration of system %d due to Big Monster, threat %d"
-                % (sys_id, aistate.systemStatus[sys_id]["monsterThreat"])
+                "Skipping exploration of system %d because AI character may not explore at monster threat %d"
+                % (sys_id, monsterThreat)
+            )
+            needs_coverage.remove(sys_id)
+            continue
+
+        if fo.currentTurn() < 20 and monsterThreat > 0:
+            debug(
+                "Skipping exploration of system %d on turn %d < 20 due to nonzero monster threat %d"
+                % (sys_id, fo.currentTurn(), monsterThreat)
             )
             needs_coverage.remove(sys_id)
             continue

--- a/default/python/AI/character/character_module.py
+++ b/default/python/AI/character/character_module.py
@@ -303,7 +303,7 @@ class Aggression(Trait):
         return self.aggression
 
     def may_explore_system(self, monster_threat):
-        return monster_threat < 2000 * self.aggression
+        return monster_threat <= 2000 * self.aggression
 
     def may_surge_industry(self, total_pp, total_rp):
         return (self.aggression > fo.aggression.cautious) and ((total_pp + 1.6 * total_rp) < (50 * self.aggression))


### PR DESCRIPTION
Currently beginner AIs don't (seem to?) explore at all, since beginner aggression level is numerically 0, and aggression * 2000 must be < threat level, which is 0 for an empty system.