### PR TITLE
remove redundant tech dependency after Physical Brain reshuffle

### DIFF
--- a/default/scripting/techs/learning/TRANSLING_THOUGHT.focs.py
+++ b/default/scripting/techs/learning/TRANSLING_THOUGHT.focs.py
@@ -9,7 +9,7 @@ Tech(
     researchcost=32 * TECH_COST_MULTIPLIER,
     researchturns=4,
     tags=["PEDIA_LEARNING_CATEGORY", "THEORY"],
-    prerequisites=["LRN_PHYS_BRAIN", "LRN_ALGO_ELEGANCE"],
+    prerequisites=["LRN_PHYS_BRAIN"],
     unlock=[
         Item(type=UnlockPolicy, name="PLC_MARINE_RECRUITMENT"),
         Item(type=UnlockPolicy, name="PLC_NATIVE_APPROPRIATION"),


### PR DESCRIPTION
[error] client : Tech.cpp:583 : ERROR: Redundant tech dependency found (A <-- B means A is a prerequisite of B): LRN_ALGO_ELEGANCE <-- LRN_PHYS_BRAIN, LRN_PHYS_BRAIN <-- LRN_TRANSLING_THT, LRN_ALGO_ELEGANCE <-- LRN_TRANSLING_THT; remove the LRN_ALGO_ELEGANCE <-- LRN_TRANSLING_THT dependency.

After physical Brain has moved to be after Algorithmic Elegance, there's redundant dependency left, per log above. This fixes that