### PR TITLE
Reduce CurrentTurn in UI by tweaking MapWnd::TurnInit

### DIFF
--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2790,12 +2790,15 @@ void MapWnd::EnableOrderIssuing(bool enable) {
     FleetUIManager::GetFleetUIManager().EnableOrderIssuing(enable);
 }
 
-void MapWnd::InitTurn(ScriptingContext& context) {
-    DebugLogger() << "Initializing turn " << context.current_turn;
+void MapWnd::InitTurn(ScriptingContext& orig_context) {
+    DebugLogger() << "Initializing turn " << orig_context.current_turn;
     SectionedScopedTimer timer("MapWnd::InitTurn");
     timer.EnterSection("init");
 
     //DebugLogger() << GetSupplyManager().Dump();
+    ScriptingContext context{orig_context};
+        context.current_turn--;
+    TraceLogger() << "Faking previous turn for UI - calculation of current values depended on last turn: " << context.current_turn;
 
     auto& app = GetApp();
     const auto client_empire_id = app.EmpireID();
@@ -2857,7 +2860,7 @@ void MapWnd::InitTurn(ScriptingContext& context) {
 
     // set turn button to current turn
     m_btn_turn->SetText(boost::io::str(FlexibleFormat(UserString("MAP_BTN_TURN_UPDATE")) %
-                                       std::to_string(context.current_turn)));
+                                       std::to_string(orig_context.current_turn)));
     RefreshTurnButtonTooltip();
 
     m_ready_turn = false;
@@ -2870,7 +2873,7 @@ void MapWnd::InitTurn(ScriptingContext& context) {
         GetOptionsDB().Get<Aggression>("setup.ai.aggression") <= Aggression::TYPICAL;
     DebugLogger() << "showing intro sitreps : " << show_intro_sitreps;
     if (show_intro_sitreps || m_sitrep_panel->NumVisibleSitrepsThisTurn() > 0) {
-        m_sitrep_panel->ShowSitRepsForTurn(context.current_turn);
+        m_sitrep_panel->ShowSitRepsForTurn(orig_context.current_turn);
         if (!m_design_wnd->Visible() && !m_research_wnd->Visible()
             && !m_production_wnd->Visible())
         { ShowSitRep(); }


### PR DESCRIPTION
fixes #5489  , for spatial flux interference the stealth values are consistent with the shown effects accounting 

The fix makes sense: the values shown are all supposed to be based on the previous turn, so CurrentTurn should return the previous turn in most cases.

Hopefully nothing gets broken. 

I tested flying around, staying at planets and combinations thereof on spatial bubble hull.

Any ideas where this might break something?  

There are still some code points which directly get context from the app; those would get the new current turn as CurrentTurn. This may be wrong or it might be correct. For a fix in those cases we either need to pass in the context or change the m_current_turn increase or add another way to retrieve a ~current turn which does get increased at a different point in time. But i did not observe a bug triggered yet.