### PR TITLE
TextControl - use shared render cache for font like other controls

### DIFF
--- a/GG/GG/TextControl.h
+++ b/GG/GG/TextControl.h
@@ -154,7 +154,6 @@ public:
         m_text_elements = that.m_text_elements;
         m_code_points = that.m_code_points;
         m_font = that.m_font;
-        m_render_cache.clear();
         m_cached_minusable_size_width = that.m_cached_minusable_size_width;
         m_cached_minusable_size = that.m_cached_minusable_size;
 
@@ -334,14 +333,11 @@ protected:
     /** Returns the line data for the text in this TextControl. */
     [[nodiscard]] const Font::LineVec& GetLineData() const noexcept { return m_line_data; }
 
-    Font::RenderCache m_render_cache;///< Cache much of text rendering.
-
     friend class StateButtonRepresenter;
 
 private:
     void AdjustMinimumSize();
     void RecomputeTextBounds(); ///< recalculates m_text_ul and m_text_lr
-    void RefreshCache();
 
     /** Recompute line data, code points, text extent and minusable size cache when
         m_text_elements changes.*/

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -76,25 +76,19 @@ void TextControl::Render()
     if (!m_font)
         return;
 
-    RefreshCache();
+    Font::RenderState render_state(TextColor());
+
     if (m_clip_text)
         BeginClipping();
 
     glPushMatrix();
     Pt ul = ClientUpperLeft();
     glTranslated(Value(ul.x), Value(ul.y), 0);
-    m_font->RenderCachedText(m_render_cache);
+    m_font->RenderText(Pt0, Size(), m_format, m_line_data, render_state);
     glPopMatrix();
 
     if (m_clip_text)
         EndClipping();
-}
-
-void TextControl::RefreshCache() {
-    m_render_cache.clear();
-    Font::RenderState rs(TextColor());
-    if (m_font)
-        m_font->PreRenderText(Pt0, Size(), m_format, m_render_cache, m_line_data, rs);
 }
 
 void TextControl::SetText(std::string str)
@@ -146,7 +140,6 @@ void TextControl::RecomputeLineData() {
     Pt text_sz = m_font->TextExtent(m_line_data);
     m_text_ul = Pt0;
     m_text_lr = text_sz;
-    m_render_cache.clear();
     if (m_format & FORMAT_NOWRAP)
         Resize(text_sz);
     else
@@ -195,7 +188,6 @@ void TextControl::SizeMove(Pt ul, Pt lr)
         Pt text_sz = m_font->TextExtent(m_line_data);
         m_text_ul = Pt();
         m_text_lr = text_sz;
-        m_render_cache.clear();
     }
     RecomputeTextBounds();
 }
@@ -211,14 +203,12 @@ void TextControl::SetTextFormat(Flags<TextFormat> format)
 void TextControl::SetTextColor(Clr color)
 {
     m_text_color = color;
-    m_render_cache.clear();
 }
 
 void TextControl::SetColor(Clr c) noexcept
 {
     Control::SetColor(c);
     m_text_color = c;
-    m_render_cache.clear();
 }
 
 void TextControl::ClipText(bool b)


### PR DESCRIPTION
helps with memory usage when plenty of those are rendered - like in Objects window with thousands of objects to show

to fix https://github.com/freeorion/freeorion/issues/5499