### PR TITLE
Limit planets counted for Colony Administration cost

### DIFF
--- a/default/scripting/game_rules.focs.py
+++ b/default/scripting/game_rules.focs.py
@@ -171,6 +171,17 @@ GameRule(
 )
 
 GameRule(
+    name="RULE_COLONY_ADMIN_COSTS_PLANET_LIMIT",
+    description="RULE_COLONY_ADMIN_COSTS_PLANET_LIMIT_DESC",
+    category="BALANCE",
+    type=int,
+    default=5000,
+    min=25,
+    max=5000,
+    rank=next(ranker),
+)
+
+GameRule(
     name="RULE_MINIMUM_MONSTER_DISTANCE_CAPITAL",
     description="RULE_MINIMUM_MONSTER_DISTANCE_CAPITAL_DESC",
     category="BALANCE",

--- a/default/scripting/species/species_macros/influence.py
+++ b/default/scripting/species/species_macros/influence.py
@@ -21,6 +21,8 @@ from focs._sources import LocalCandidate, Source, Target
 from focs._value_refs import (
     Abs,
     GalaxyMaxAIAggression,
+    GameRule,
+    MinOf,
     NamedReal,
     StatisticCount,
     Value,
@@ -46,69 +48,75 @@ _BASE_INFLUENCE_COSTS = [
             value=Value
             - NamedReal(name="COLONY_ADMIN_COSTS_PER_PLANET", value=0.4)
             * (
-                (
-                    StatisticCount(
-                        float,
-                        condition=Planet()
-                        & OwnedBy(empire=Source.Owner)
-                        & HasSpecies()
-                        & ~HasSpecies(name=["SP_EXOBOT"]),
-                    )
-                    + StatisticCount(
-                        float,
-                        condition=Ship & OwnedBy(empire=Source.Owner) & (LocalCandidate.OrderedColonizePlanetID != -1),
-                    )
-                    + StatisticCount(
-                        float,
-                        condition=IsBuilding()
-                        & OwnedBy(empire=Source.Owner)
-                        & IsBuilding(
-                            name=[
-                                "BLD_COL_SUPER_TEST",
-                                "BLD_COL_ABADDONI",
-                                "BLD_COL_BANFORO",
-                                "BLD_COL_CHATO",
-                                "BLD_COL_CRAY",
-                                "BLD_COL_DERTHREAN",
-                                "BLD_COL_EAXAW",
-                                "BLD_COL_EGASSEM",
-                                "BLD_COL_ETTY",
-                                "BLD_COL_FULVER",
-                                "BLD_COL_FURTHEST",
-                                "BLD_COL_GEORGE",
-                                "BLD_COL_GYSACHE",
-                                "BLD_COL_HAPPY",
-                                "BLD_COL_HHHOH",
-                                "BLD_COL_HUMAN",
-                                "BLD_COL_KILANDOW",
-                                "BLD_COL_KOBUNTURA",
-                                "BLD_COL_LAENFA",
-                                "BLD_COL_MISIORLA",
-                                "BLD_COL_MUURSH",
-                                "BLD_COL_PHINNERT",
-                                "BLD_COL_SCYLIOR",
-                                "BLD_COL_SETINON",
-                                "BLD_COL_SILEXIAN",
-                                "BLD_COL_SLY",
-                                "BLD_COL_SSLITH",
-                                "BLD_COL_TAEGHIRUS",
-                                "BLD_COL_TRITH",
-                                "BLD_COL_REPLICON",
-                                "BLD_COL_UGMORS",
-                            ]
-                        ),
-                    )
-                    + (
-                        NamedReal(name="OUTPOST_RELATIVE_ADMIN_COUNT", value=0.25)
-                        * (
-                            StatisticCount(
-                                float,
-                                condition=Planet()
-                                & OwnedBy(empire=Source.Owner)
-                                & (~HasSpecies() | HasSpecies(name=["SP_EXOBOT"])),
+                MinOf(
+                    float,
+                    GameRule(type=int, name="RULE_COLONY_ADMIN_COSTS_PLANET_LIMIT"),
+                    (
+                        StatisticCount(
+                            float,
+                            condition=Planet()
+                            & OwnedBy(empire=Source.Owner)
+                            & HasSpecies()
+                            & ~HasSpecies(name=["SP_EXOBOT"]),
+                        )
+                        + StatisticCount(
+                            float,
+                            condition=Ship
+                            & OwnedBy(empire=Source.Owner)
+                            & (LocalCandidate.OrderedColonizePlanetID != -1),
+                        )
+                        + StatisticCount(
+                            float,
+                            condition=IsBuilding()
+                            & OwnedBy(empire=Source.Owner)
+                            & IsBuilding(
+                                name=[
+                                    "BLD_COL_SUPER_TEST",
+                                    "BLD_COL_ABADDONI",
+                                    "BLD_COL_BANFORO",
+                                    "BLD_COL_CHATO",
+                                    "BLD_COL_CRAY",
+                                    "BLD_COL_DERTHREAN",
+                                    "BLD_COL_EAXAW",
+                                    "BLD_COL_EGASSEM",
+                                    "BLD_COL_ETTY",
+                                    "BLD_COL_FULVER",
+                                    "BLD_COL_FURTHEST",
+                                    "BLD_COL_GEORGE",
+                                    "BLD_COL_GYSACHE",
+                                    "BLD_COL_HAPPY",
+                                    "BLD_COL_HHHOH",
+                                    "BLD_COL_HUMAN",
+                                    "BLD_COL_KILANDOW",
+                                    "BLD_COL_KOBUNTURA",
+                                    "BLD_COL_LAENFA",
+                                    "BLD_COL_MISIORLA",
+                                    "BLD_COL_MUURSH",
+                                    "BLD_COL_PHINNERT",
+                                    "BLD_COL_SCYLIOR",
+                                    "BLD_COL_SETINON",
+                                    "BLD_COL_SILEXIAN",
+                                    "BLD_COL_SLY",
+                                    "BLD_COL_SSLITH",
+                                    "BLD_COL_TAEGHIRUS",
+                                    "BLD_COL_TRITH",
+                                    "BLD_COL_REPLICON",
+                                    "BLD_COL_UGMORS",
+                                ]
+                            ),
+                        )
+                        + (
+                            NamedReal(name="OUTPOST_RELATIVE_ADMIN_COUNT", value=0.25)
+                            * (
+                                StatisticCount(
+                                    float,
+                                    condition=Planet()
+                                    & OwnedBy(empire=Source.Owner)
+                                    & (~HasSpecies() | HasSpecies(name=["SP_EXOBOT"])),
+                                )
                             )
                         )
-                    )
+                    ),
                 )
                 ** 0.5
             )

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1207,6 +1207,12 @@ RULE_SINGULARITY_COST_FACTOR
 RULE_SINGULARITY_COST_FACTOR_DESC
 Adjusts costs of [[LRN_TRANSCEND]] tech
 
+RULE_COLONY_ADMIN_COSTS_PLANET_LIMIT
+Limit planetcount for Colony Administration.
+
+RULE_COLONY_ADMIN_COSTS_PLANET_LIMIT_DESC
+The Colony Administration influence costs will no longer increase for an empire that owns more than this amount of planets.
+
 RULE_ENABLE_EXPERIMENTORS
 Enable Experimentors
 


### PR DESCRIPTION
Limit the number of planets counted for the Colony Administration cost calculation.

This change is inspired by the work done by [Oberlus in PR 4094](https://github.com/freeorion/freeorion/pull/4094); but this change only provides a limit on the amount of planets considered.

I decided to use the number of planets as a limit, to allow the effects of policies, likes, dislikes and specials to still work as intended.