### PR TITLE
Hotkey Init and MapWnd creation

### DIFF
--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -1327,7 +1327,7 @@ void BuildDesignatorWnd::CenterOnBuild(int queue_idx, bool open) {
         if (auto build_location = objects.get(location_id)) {
             // centre map on system of build location
             const int system_id = build_location->SystemID();
-            if (auto map = app.GetUI().GetMapWnd(false)) {
+            if (auto map = app.GetUI().GetMapWnd(ClientUI::ConstructFlag::NEVER)) {
                 map->CenterOnObject(system_id, objects);
                 if (open) {
                     map->SelectSystem(system_id, context);

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -379,7 +379,7 @@ void BuildingIndicator::RClick(GG::Pt pt, GG::Flags<GG::ModKey> mod_keys) {
     if (!building)
         return;
 
-    auto map_wnd = app.GetUI().GetMapWnd(false);
+    auto map_wnd = app.GetUI().GetMapWnd(ClientUI::ConstructFlag::NEVER);
     if (ClientPlayerIsModerator() &&
         map_wnd && map_wnd->GetModeratorActionSetting() != ModeratorActionSetting::MAS_NoAction)
     {

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -615,6 +615,23 @@ ClientUI::ClientUI(GGHumanClientApp& app) :
 
     // Set the root path for image tags in rich text.
     GG::ImageBlock::SetDefaultImagePath(ArtDir().string());
+
+
+    HotkeyManager& hkm = HotkeyManager::GetManager();
+
+    // general-use hotkeys, not specific to any particular bit of the UI
+    hkm.Connect(boost::bind(&GGHumanClientApp::CutFocusWndText,            std::addressof(m_app)), "ui.cut");
+    hkm.Connect(boost::bind(&GGHumanClientApp::CopyFocusWndText,           std::addressof(m_app)), "ui.copy");
+    hkm.Connect(boost::bind(&GGHumanClientApp::PasteFocusWndClipboardText, std::addressof(m_app)), "ui.paste");
+    hkm.Connect(boost::bind(&GGHumanClientApp::FocusWndSelectAll,          std::addressof(m_app)), "ui.select.all");
+    hkm.Connect(boost::bind(&GGHumanClientApp::FocusWndDeselect,           std::addressof(m_app)), "ui.select.none");
+
+    //hkm.Connect(boost::bind(&GGHumanClientApp::SetPrevFocusWndInCycle,     std::addressof(m_app)), "ui.focus.prev",
+    //            NoModalWndsOpenCondition);
+    //hkm.Connect(boost::bind(&GGHumanClientApp::SetNextFocusWndInCycle,     std::addressof(m_app)), "ui.focus.next",
+    //            NoModalWndsOpenCondition);
+
+    hkm.RebuildShortcuts();
 }
 
 

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -618,8 +618,8 @@ ClientUI::ClientUI(GGHumanClientApp& app) :
 }
 
 
-MapWnd* ClientUI::GetMapWnd(bool construct) {
-    if (!m_map_wnd && construct)
+MapWnd* ClientUI::GetMapWnd(ConstructFlag construct) {
+    if (!m_map_wnd && construct == ConstructFlag::IF_NOT_YET_DONE)
         m_map_wnd = GG::Wnd::Create<MapWnd>();
     return m_map_wnd.get();
 }
@@ -724,7 +724,7 @@ std::string ClientUI::GetFilenameWithSaveFileDialog(
 }
 
 void ClientUI::GetSaveGameUIData(SaveGameUIData& data) {
-    auto mapwnd = GetMapWnd(true);
+    auto mapwnd = GetMapWnd(ConstructFlag::IF_NOT_YET_DONE);
     if (!mapwnd) {
         ErrorLogger() << "GetSaveGameUIData couldn't get mapwnd";
         return;
@@ -789,7 +789,7 @@ bool ClientUI::ZoomToObject(int id, ScriptingContext& context, int client_empire
 }
 
 bool ClientUI::ZoomToPlanet(int id, ScriptingContext& context) {
-    if (auto mapwnd = GetMapWnd(false)) {
+    if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER)) {
         if (auto planet = std::as_const(context).ContextObjects().getRaw<Planet>(id)) {
             mapwnd->CenterOnMapCoord(planet->X(), planet->Y());
             mapwnd->SelectSystem(planet->SystemID(), context);
@@ -802,7 +802,7 @@ bool ClientUI::ZoomToPlanet(int id, ScriptingContext& context) {
 
 bool ClientUI::ZoomToPlanetPedia(int id, const ObjectMap& objects) {
     if (objects.get<Planet>(id)) {
-        if (auto mapwnd = GetMapWnd(false)) {
+        if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER)) {
             mapwnd->ShowPlanet(id);
             return true;
         }
@@ -816,7 +816,7 @@ bool ClientUI::ZoomToSystem(int id, ScriptingContext& context) {
 }
 
 bool ClientUI::ZoomToSystem(const System& system, ScriptingContext& context) {
-    if (auto mapwnd = GetMapWnd(false)) {
+    if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER)) {
         mapwnd->CenterOnMapCoord(system.X(), system.Y());
         mapwnd->SelectSystem(std::addressof(system), context);
         return true;
@@ -829,7 +829,7 @@ bool ClientUI::ZoomToFleet(int id, const ScriptingContext& context, int client_e
     auto fleet = context.ContextObjects().get<Fleet>(id);
     if (!fleet) return false;
 
-    if (auto mapwnd = GetMapWnd(false)) {
+    if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER)) {
         mapwnd->CenterOnObject(*fleet);
         mapwnd->SelectFleet(id, context, client_empire_id);
     }
@@ -854,14 +854,14 @@ bool ClientUI::ZoomToBuilding(int id, ScriptingContext& context) {
 
 bool ClientUI::ZoomToField(int id, const ObjectMap& objects) {
     if (auto field = objects.get<Field>(id))
-        if (auto mapwnd = GetMapWnd(false))
+        if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER))
             mapwnd->CenterOnObject(*field);
     return false;
 }
 
 bool ClientUI::ZoomToCombatLog(int id) {
     if (GetCombatLogManager().GetLog(id)) {
-        if (auto mapwnd = GetMapWnd(false))
+        if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER))
             mapwnd->ShowCombatLog(id);
         return true;
     }
@@ -916,7 +916,7 @@ bool ClientUI::ZoomToContent(const std::string& name, bool reverse_lookup) {
 bool ClientUI::ZoomToTech(std::string tech_name) {
     if (!GetTech(tech_name))
         return false;
-    if (auto mapwnd = GetMapWnd(false))
+    if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER))
         mapwnd->ShowTech(std::move(tech_name));
     return true;
 }
@@ -924,7 +924,7 @@ bool ClientUI::ZoomToTech(std::string tech_name) {
 bool ClientUI::ZoomToPolicy(std::string policy_name) {
     if (!GetPolicy(policy_name))
         return false;
-    if (auto mapwnd = GetMapWnd(false))
+    if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER))
         mapwnd->ShowPolicy(std::move(policy_name));
     return true;
 }
@@ -932,7 +932,7 @@ bool ClientUI::ZoomToPolicy(std::string policy_name) {
 bool ClientUI::ZoomToBuildingType(std::string building_type_name) {
     if (!GetBuildingType(building_type_name))
         return false;
-    if (auto mapwnd = GetMapWnd(false))
+    if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER))
         mapwnd->ShowBuildingType(std::move(building_type_name));
     return true;
 }
@@ -940,7 +940,7 @@ bool ClientUI::ZoomToBuildingType(std::string building_type_name) {
 bool ClientUI::ZoomToSpecial(std::string special_name) {
     if (!GetSpecial(special_name))
         return false;
-    if (auto mapwnd = GetMapWnd(false))
+    if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER))
         mapwnd->ShowSpecial(std::move(special_name));
     return true;
 }
@@ -948,7 +948,7 @@ bool ClientUI::ZoomToSpecial(std::string special_name) {
 bool ClientUI::ZoomToShipHull(std::string hull_name) {
     if (!GetShipHull(hull_name))
         return false;
-    if (auto mapwnd = GetMapWnd(false))
+    if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER))
         mapwnd->ShowShipHull(std::move(hull_name));
     return true;
 }
@@ -956,7 +956,7 @@ bool ClientUI::ZoomToShipHull(std::string hull_name) {
 bool ClientUI::ZoomToShipPart(std::string part_name) {
     if (!GetShipPart(part_name))
         return false;
-    if (auto mapwnd = GetMapWnd(false))
+    if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER))
         mapwnd->ShowShipPart(std::move(part_name));
     return true;
 }
@@ -964,7 +964,7 @@ bool ClientUI::ZoomToShipPart(std::string part_name) {
 bool ClientUI::ZoomToSpecies(std::string species_name) {
     if (!m_app.GetSpeciesManager().GetSpecies(species_name))
         return false;
-    if (auto mapwnd = GetMapWnd(false))
+    if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER))
         mapwnd->ShowSpecies(std::move(species_name));
     return true;
 }
@@ -972,7 +972,7 @@ bool ClientUI::ZoomToSpecies(std::string species_name) {
 bool ClientUI::ZoomToFieldType(std::string field_type_name) {
     if (!GetFieldType(field_type_name))
         return false;
-    if (auto mapwnd = GetMapWnd(false))
+    if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER))
         mapwnd->ShowFieldType(std::move(field_type_name));
     return true;
 }
@@ -981,7 +981,7 @@ bool ClientUI::ZoomToShipDesign(int design_id) {
     const auto& universe = m_app.GetContext().ContextUniverse();
     if (!universe.GetShipDesign(design_id))
         return false;
-    if (auto mapwnd = GetMapWnd(false))
+    if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER))
         mapwnd->ShowShipDesign(design_id);
     return true;
 }
@@ -989,25 +989,25 @@ bool ClientUI::ZoomToShipDesign(int design_id) {
 bool ClientUI::ZoomToEmpire(int empire_id) {
     if (!m_app.GetContext().GetEmpire(empire_id))
         return false;
-    if (auto mapwnd = GetMapWnd(false))
+    if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER))
         mapwnd->ShowEmpire(empire_id);
     return true;
 }
 
 bool ClientUI::ZoomToMeterTypeArticle(std::string meter_string) {
-    if (auto mapwnd = GetMapWnd(false))
+    if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER))
         mapwnd->ShowMeterTypeArticle(std::move(meter_string));
     return true;
 }
 
 bool ClientUI::ZoomToMeterTypeArticle(MeterType meter_type) {
-    if (auto mapwnd = GetMapWnd(false))
+    if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER))
         mapwnd->ShowMeterTypeArticle(meter_type);
     return true;
 }
 
 bool ClientUI::ZoomToEncyclopediaEntry(std::string str) {
-    if (auto mapwnd = GetMapWnd(false))
+    if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER))
         mapwnd->ShowEncyclopediaEntry(std::move(str));
     return true;
 }
@@ -1077,7 +1077,7 @@ std::shared_ptr<GG::Texture> ClientUI::GetModuloTexture(const std::filesystem::p
 }
 
 void ClientUI::RestoreFromSaveData(const SaveGameUIData& ui_data) {
-    if (auto mapwnd = GetMapWnd(false))
+    if (auto mapwnd = GetMapWnd(ConstructFlag::NEVER))
         mapwnd->RestoreFromSaveData(ui_data);
     m_ship_designs->Load(ui_data);
 }

--- a/UI/ClientUI.h
+++ b/UI/ClientUI.h
@@ -43,7 +43,9 @@ public:
     ClientUI(const ClientUI&) = delete;
     ClientUI(ClientUI&&) = delete;
 
-    MapWnd*                                 GetMapWnd(bool construct);  //!< Returns the main map window. if \a is true, creates a MapWnd if one doesn't already exist. if \a is false, may return nullptr
+    enum class ConstructFlag : bool { NEVER, IF_NOT_YET_DONE };
+
+    MapWnd*                                 GetMapWnd(ConstructFlag construct); //!< Returns the main map window. if \a construct is IF_NOT_YET_DONE, creates a MapWnd if one doesn't already exist. if \a is NEVER, may return nullptr
     const MapWnd*                           GetMapWndConst() const noexcept { return m_map_wnd.get(); }
     std::shared_ptr<MapWnd>                 GetMapWndShared();          //!< Returns the main map window, constructing one if not already available
     std::shared_ptr<MessageWnd>             GetMessageWnd();            //!< Returns the chat / message window.

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -4155,7 +4155,7 @@ void EncyclopediaDetailPanel::HandleSearchTextEntered() {
     timer.EnterSection("Find words in search text");
 
     // force MapWnd construction before possible parallel accesses below...
-    GetApp().GetUI().GetMapWnd(true);
+    GetApp().GetUI().GetMapWnd(ClientUI::ConstructFlag::IF_NOT_YET_DONE);
 
     const unsigned int num_threads = static_cast<unsigned int>(std::max(1, EffectsProcessingThreads()));
     boost::asio::thread_pool thread_pool(num_threads);

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2610,7 +2610,7 @@ void FleetDetailPanel::ShipRightClicked(GG::ListBox::iterator it, GG::Pt pt,
         return;
     auto fleet = objects.get<Fleet>(m_fleet_id);
 
-    const auto map_wnd = app.GetUI().GetMapWnd(false);
+    const auto map_wnd = app.GetUI().GetMapWnd(ClientUI::ConstructFlag::NEVER);
 
     if (ClientPlayerIsModerator() &&
         map_wnd && map_wnd->GetModeratorActionSetting() != ModeratorActionSetting::MAS_NoAction)
@@ -2896,7 +2896,7 @@ void FleetWnd::CompleteConstruction() {
 FleetWnd::~FleetWnd() {
     // FleetWnd is registered as a top level window, the same as ClientUI and MapWnd.
     // Consequently, when the GUI shutsdown either could be destroyed before this Wnd
-    if (auto mapwnd = GetApp().GetUI().GetMapWnd(false))
+    if (auto mapwnd = GetApp().GetUI().GetMapWnd(ClientUI::ConstructFlag::NEVER))
         mapwnd->ClearProjectedFleetMovementLines();
     ClosingSignal(this);
 }
@@ -3497,7 +3497,7 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, GG::Pt pt, GG::Flags<
 
     auto popup = GG::Wnd::Create<CUIPopupMenu>(pt.x, pt.y);
 
-    const auto mapwnd = app.GetUI().GetMapWnd(false);
+    const auto mapwnd = app.GetUI().GetMapWnd(ClientUI::ConstructFlag::NEVER);
 
     // add a fleet popup command to send the fleet exploring, and stop it from exploring
     if (system && mapwnd

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -7301,20 +7301,6 @@ void MapWnd::ConnectKeyboardAcceleratorSignals() {
     hkm.Connect(boost::bind(&ToggleBoolOption, "ui.map.scale.circle.shown"), "ui.map.scale.circle",
                 AndCondition(OrCondition(InvisibleWindowCondition(bl), VisibleWindowCondition(this)), NoModalWndsOpenCondition));
 
-
-    // these are general-use hotkeys, only connected here as a convenient location to do so once.
-    hkm.Connect(boost::bind(&GG::GUI::CutFocusWndText, GG::GUI::GetGUI()), "ui.cut");
-    hkm.Connect(boost::bind(&GG::GUI::CopyFocusWndText, GG::GUI::GetGUI()), "ui.copy");
-    hkm.Connect(boost::bind(&GG::GUI::PasteFocusWndClipboardText, GG::GUI::GetGUI()), "ui.paste");
-
-    hkm.Connect(boost::bind(&GG::GUI::FocusWndSelectAll, GG::GUI::GetGUI()), "ui.select.all");
-    hkm.Connect(boost::bind(&GG::GUI::FocusWndDeselect, GG::GUI::GetGUI()), "ui.select.none");
-
-    //hkm.Connect(boost::bind(&GG::GUI::SetPrevFocusWndInCycle, GG::GUI::GetGUI()), "ui.focus.prev",
-    //             NoModalWndsOpenCondition);
-    //hkm.Connect(boost::bind(&GG::GUI::SetNextFocusWndInCycle, GG::GUI::GetGUI()), "ui.focus.next",
-    //             NoModalWndsOpenCondition);
-
     hkm.RebuildShortcuts();
 }
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -855,7 +855,7 @@ void MapWndPopup::CompleteConstruction() {
 
     // MapWndPopupWnd is registered as a top level window, the same as ClientUI and MapWnd.
     // Consequently, when the GUI shutsdown either could be destroyed before this Wnd
-    if (auto mapwnd = GetApp().GetUI().GetMapWnd(false))
+    if (auto mapwnd = GetApp().GetUI().GetMapWnd(ClientUI::ConstructFlag::NEVER))
         mapwnd->RegisterPopup(std::static_pointer_cast<MapWndPopup>(shared_from_this()));
 }
 
@@ -874,7 +874,7 @@ MapWndPopup::~MapWndPopup() {
 
     // MapWndPopupWnd is registered as a top level window, the same as ClientUI and MapWnd.
     // Consequently, when the GUI shutsdown either could be destroyed before this Wnd
-    if (auto mapwnd = GetApp().GetUI().GetMapWnd(false))
+    if (auto mapwnd = GetApp().GetUI().GetMapWnd(ClientUI::ConstructFlag::NEVER))
         mapwnd->RemovePopup(this);
 }
 

--- a/UI/SystemIcon.cpp
+++ b/UI/SystemIcon.cpp
@@ -688,7 +688,7 @@ void SystemIcon::ShowName() {
 
     // get font size
     int name_pts = ClientUI::Pts();
-    if (auto map_wnd = GetApp().GetUI().GetMapWnd(true))
+    if (auto map_wnd = GetApp().GetUI().GetMapWnd(ClientUI::ConstructFlag::IF_NOT_YET_DONE))
         name_pts = map_wnd->SystemNamePts();
 
     auto it = m_colored_names.find(name_pts);

--- a/client/human/GGHumanClientApp.cpp
+++ b/client/human/GGHumanClientApp.cpp
@@ -1152,7 +1152,7 @@ void GGHumanClientApp::HandleWindowResize(GG::X w, GG::Y h) {
 
     SetAppSize(GG::Pt{w, h});
 
-    if (auto* map_wnd = m_ui.GetMapWnd(false))
+    if (auto* map_wnd = m_ui.GetMapWnd(ClientUI::ConstructFlag::NEVER))
         map_wnd->DoLayout();
     if (auto intro_screen = m_ui.GetIntroScreen())
         intro_screen->Resize(GG::Pt(w, h));
@@ -1232,7 +1232,7 @@ bool GGHumanClientApp::ToggleFullscreen() {
 void GGHumanClientApp::StartGame(bool is_new_game) {
     m_game_started = true;
 
-    if (auto map_wnd = m_ui.GetMapWnd(false))
+    if (auto map_wnd = m_ui.GetMapWnd(ClientUI::ConstructFlag::NEVER))
         map_wnd->ResetEmpireShown();
 
     if (auto* sdm = m_ui.GetShipDesignManager())
@@ -1489,7 +1489,7 @@ void GGHumanClientApp::ResetClientData(bool save_connection) {
         m_networking->SetHostPlayerID(Networking::INVALID_PLAYER_ID);
     }
     SetEmpireID(ALL_EMPIRES);
-    if (auto map_wnd = m_ui.GetMapWnd(false))
+    if (auto map_wnd = m_ui.GetMapWnd(ClientUI::ConstructFlag::NEVER))
         map_wnd->Sanitize();
 
     m_universe.Clear();

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -199,7 +199,7 @@ boost::statechart::result WaitingForSPHostAck::react(const HostSPGame& msg) {
         // Logging configuration can only be sent after receiving host id.
         Client().SendLoggingConfigToServer();
 
-        if (auto mapwnd = Client().GetUI().GetMapWnd(false))
+        if (auto mapwnd = Client().GetUI().GetMapWnd(ClientUI::ConstructFlag::NEVER))
             mapwnd->Sanitize();
 
         return transit<PlayingGame>();
@@ -558,7 +558,7 @@ boost::statechart::result MPLobby::react(const GameStart& msg) {
     auto& client_ui = Client().GetUI();
 
 
-    if (auto mapwnd = client_ui.GetMapWnd(false))
+    if (auto mapwnd = client_ui.GetMapWnd(ClientUI::ConstructFlag::NEVER))
         mapwnd->Sanitize();
     Client().Remove(client_ui.GetMultiPlayerLobbyWnd());
 
@@ -835,7 +835,7 @@ boost::statechart::result PlayingGame::react(const Error& msg) {
     //Note: transit<> frees this pointer so Client() must be called before.
     GGHumanClientApp& client = Client();
     // Stop auto-advance turn on error
-    if (auto mapwnd = client.GetUI().GetMapWnd(true)) {
+    if (auto mapwnd = client.GetUI().GetMapWnd(ClientUI::ConstructFlag::IF_NOT_YET_DONE)) {
         if (mapwnd->AutoEndTurnEnabled()) {
             mapwnd->ToggleAutoEndTurn();
             client.InitAutoTurns(0);
@@ -869,7 +869,7 @@ boost::statechart::result PlayingGame::react(const TurnPartialUpdate& msg) {
 
     try {
         ExtractTurnPartialUpdateMessageData(msg.m_message, Client().EmpireID(), Client().GetUniverse());
-        if (auto mapwnd = Client().GetUI().GetMapWnd(false))
+        if (auto mapwnd = Client().GetUI().GetMapWnd(ClientUI::ConstructFlag::NEVER))
             mapwnd->MidTurnUpdate();
     } catch (...) {}
 
@@ -898,7 +898,7 @@ boost::statechart::result PlayingGame::react(const TurnTimeout& msg) {
     } catch (const boost::bad_lexical_cast&) {
         ErrorLogger(FSM) << "PlayingGame::react(const TurnTimeout& msg) could not convert \"" << text << "\" to timeout";
     }
-    if (auto mapwnd = Client().GetUI().GetMapWnd(false))
+    if (auto mapwnd = Client().GetUI().GetMapWnd(ClientUI::ConstructFlag::NEVER))
         mapwnd->ResetTimeoutClock(timeout_remain);
     return discard_event();
 }
@@ -953,7 +953,7 @@ WaitingForGameStart::WaitingForGameStart(my_context ctx) :
 {
     TraceLogger(FSM) << "(HumanClientFSM) WaitingForGameStart";
     Client().Register(Client().GetUI().GetPlayerListWnd());
-    if (auto mapwnd = Client().GetUI().GetMapWnd(true))
+    if (auto mapwnd = Client().GetUI().GetMapWnd(ClientUI::ConstructFlag::IF_NOT_YET_DONE))
         mapwnd->EnableOrderIssuing(false);
 }
 
@@ -962,7 +962,7 @@ WaitingForGameStart::~WaitingForGameStart()
 
 boost::statechart::result WaitingForGameStart::react(const GameStart& msg) {
     TraceLogger(FSM) << "(HumanClientFSM) WaitingForGameStart.GameStart";
-    if (auto mapwnd = Client().GetUI().GetMapWnd(true))
+    if (auto mapwnd = Client().GetUI().GetMapWnd(ClientUI::ConstructFlag::IF_NOT_YET_DONE))
         mapwnd->ResetTimeoutClock(0);
     Client().Orders().Reset();
 
@@ -1032,7 +1032,7 @@ boost::statechart::result WaitingForGameStart::react(const GameStartDataUnpacked
         TraceLogger(FSM) << "UI data from save data restored";
 
         Client().GetUI().GetPlayerListWnd()->Refresh(Client());
-        if (auto mapwnd = Client().GetUI().GetMapWnd(true))
+        if (auto mapwnd = Client().GetUI().GetMapWnd(ClientUI::ConstructFlag::IF_NOT_YET_DONE))
             mapwnd->ResetTimeoutClock(0);
 
     } catch (const std::exception& e) {
@@ -1072,7 +1072,7 @@ WaitingForTurnData::WaitingForTurnData(my_context ctx) :
     Base(ctx)
 {
     TraceLogger(FSM) << "(HumanClientFSM) WaitingForTurnData";
-    if (auto mapwnd = Client().GetUI().GetMapWnd(true))
+    if (auto mapwnd = Client().GetUI().GetMapWnd(ClientUI::ConstructFlag::IF_NOT_YET_DONE))
         mapwnd->EnableOrderIssuing(false);
 }
 
@@ -1098,7 +1098,7 @@ boost::statechart::result WaitingForTurnData::react(const SaveGameComplete& msg)
 boost::statechart::result WaitingForTurnData::react(const TurnUpdate& msg) {
     TraceLogger(FSM) << "(HumanClientFSM) PlayingGame.TurnUpdate";
 
-    if (auto mapwnd = Client().GetUI().GetMapWnd(true))
+    if (auto mapwnd = Client().GetUI().GetMapWnd(ClientUI::ConstructFlag::IF_NOT_YET_DONE))
         mapwnd->ResetTimeoutClock(0);
     Client().Orders().Reset();
 


### PR DESCRIPTION
-init general hotkeys in ClientUI instead of in MapWnd
-use enum instead of bool to specify whether to create MapWnd when getting it

should address #5509

might also be partly back-portable to v0.5.1 ?