### PR TITLE
Exobot colony can be build on uninhabited planets

### DIFF
--- a/default/scripting/buildings/colonies/col_bld_gen.focs.py
+++ b/default/scripting/buildings/colonies/col_bld_gen.focs.py
@@ -109,8 +109,8 @@ for sp_id, sp_graphic in species_list:
         sp_tags += ["CTRL_EXTINCT"]
 
     if sp_id == "SP_EXOBOT":
-        species_condition = None
-    if extinct_tech == "":
+        species_condition = Population(high=0)
+    elif extinct_tech == "":
         species_condition = ResourceSupplyConnected(
             empire=Source.Owner,
             condition=Planet()

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -16209,7 +16209,7 @@ BLD_COL_EXOBOT
 Colony of [[SP_EXOBOT]]
 
 BLD_COL_EXOBOT_DESC
-This building will construct an [[species SP_EXOBOT]] colony at an [[encyclopedia OUTPOSTS_TITLE]]. Contrary to the colony buildings of other species, an Exobot colony does not need an already existing Exobot colony within supply range, as the Exobots are constructed as part of the colony directly planetside. However, because of that they are more expensive to build, and they still need an empire owned planet within supply range.
+This building will construct an [[species SP_EXOBOT]] colony at an [[encyclopedia OUTPOSTS_TITLE]]. Contrary to the colony buildings of other species, an Exobot colony does not need an already existing Exobot colony within supply range, as the Exobots are constructed as part of the colony directly planetside. However, because of that they are more expensive to build, and they still need an empire owned planet within supply range or the imperial stockpile to provide the necessary Production Points.
 
 BLD_COL_SUPER_TEST
 Super Tester Colony


### PR DESCRIPTION
fix #5471 

code from trogdolyte  looks fine
need to check other exobot colony conditions

old location condition
```
    location=Planet()
    & OwnedBy(empire=Source.Owner)
    & Population(high=0)
    & ~Planet(environment=[Uninhabitable], species="SP_EXOBOT"),
    # no existing Exobot colony required!
    enqueuelocation=Planet()
    & OwnedBy(empire=Source.Owner)
    & Population(high=0)
    & ~Planet(environment=[Uninhabitable], species="SP_EXOBOT")
    & ~Contains(IsBuilding(subtype="colony") & OwnedBy(empire=Source.Owner))
    & ~Enqueued(subtype="colony"),
    # no existing Exobot colony required!
```