### PR TITLE
initialize general select/copy/cut hotkeys in ClientUI constructor

### DIFF
--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -627,6 +627,23 @@ ClientUI::ClientUI() :
 
     // Set the root path for image tags in rich text.
     GG::ImageBlock::SetDefaultImagePath(ArtDir().string());
+
+
+    HotkeyManager& hkm = HotkeyManager::GetManager();
+
+    // general-use hotkeys, not specific to any particular bit of the UI
+    hkm.Connect(boost::bind(&GG::GUI::CutFocusWndText,            GG::GUI::GetGUI()), "ui.cut");
+    hkm.Connect(boost::bind(&GG::GUI::CopyFocusWndText,           GG::GUI::GetGUI()), "ui.copy");
+    hkm.Connect(boost::bind(&GG::GUI::PasteFocusWndClipboardText, GG::GUI::GetGUI()), "ui.paste");
+    hkm.Connect(boost::bind(&GG::GUI::FocusWndSelectAll,          GG::GUI::GetGUI()), "ui.select.all");
+    hkm.Connect(boost::bind(&GG::GUI::FocusWndDeselect,           GG::GUI::GetGUI()), "ui.select.none");
+
+    //hkm.Connect(boost::bind(&GG::GUI::SetPrevFocusWndInCycle,     GG::GUI::GetGUI()), "ui.focus.prev",
+    //            NoModalWndsOpenCondition);
+    //hkm.Connect(boost::bind(&GG::GUI::SetNextFocusWndInCycle,     GG::GUI::GetGUI()), "ui.focus.next",
+    //            NoModalWndsOpenCondition);
+
+    hkm.RebuildShortcuts();
 }
 
 ClientUI::~ClientUI()

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -7308,20 +7308,6 @@ void MapWnd::ConnectKeyboardAcceleratorSignals() {
     hkm.Connect(boost::bind(&ToggleBoolOption, "ui.map.scale.circle.shown"), "ui.map.scale.circle",
                 AndCondition(OrCondition(InvisibleWindowCondition(bl), VisibleWindowCondition(this)), NoModalWndsOpenCondition));
 
-
-    // these are general-use hotkeys, only connected here as a convenient location to do so once.
-    hkm.Connect(boost::bind(&GG::GUI::CutFocusWndText, GG::GUI::GetGUI()), "ui.cut");
-    hkm.Connect(boost::bind(&GG::GUI::CopyFocusWndText, GG::GUI::GetGUI()), "ui.copy");
-    hkm.Connect(boost::bind(&GG::GUI::PasteFocusWndClipboardText, GG::GUI::GetGUI()), "ui.paste");
-
-    hkm.Connect(boost::bind(&GG::GUI::FocusWndSelectAll, GG::GUI::GetGUI()), "ui.select.all");
-    hkm.Connect(boost::bind(&GG::GUI::FocusWndDeselect, GG::GUI::GetGUI()), "ui.select.none");
-
-    //hkm.Connect(boost::bind(&GG::GUI::SetPrevFocusWndInCycle, GG::GUI::GetGUI()), "ui.focus.prev",
-    //             NoModalWndsOpenCondition);
-    //hkm.Connect(boost::bind(&GG::GUI::SetNextFocusWndInCycle, GG::GUI::GetGUI()), "ui.focus.next",
-    //             NoModalWndsOpenCondition);
-
     hkm.RebuildShortcuts();
 }
 


### PR DESCRIPTION
...instead of MapWnd::ConnectKeyboardAcceleratorSignals so that they work before the MapWnd is created

This is cherry-picking 9bda2d79bb39bd6bbec85c7d0ae981bd5ef7971e from https://github.com/freeorion/freeorion/pull/5514 and applying it to the state of release branch to fix https://github.com/freeorion/freeorion/issues/5509 also on release branch.

While release branch does not include https://github.com/freeorion/freeorion/commit/fc5276773ed5d7861a0f7717a16f0591480a6ea4 which originally surfaced the defect on master branch, there is still new SDL2 picked up (newer SDK), and that surfaces the defect as well, because no initial "resize" signal is sent unlike older SDL2, and that was originally hooking up those keyboard shortcuts

