### PR TITLE
pedia planet detail - take current species name from species manager not planet

### DIFF
--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -3134,8 +3134,13 @@ namespace {
         // -- planet's current species, if any
         {
             const std::string_view planet_current_species = planet.SpeciesName();
-            if (!planet_current_species.empty())
-                retval.push_back(planet_current_species);
+            if (!planet_current_species.empty()) {
+                if (const auto species = species_manager.GetSpecies(planet_current_species)) {
+                    // intentionally taking name string_view from Species, not Planet
+                    // the planet's species is subject to change when simulating max pop
+                    retval.push_back(species->Name());
+                }
+            }
         }
 
         const auto empire_id = app.EmpireID();


### PR DESCRIPTION
current species name is subject to change when simulating population under new management

fixes https://github.com/freeorion/freeorion/issues/5527

previously local planet species was not leaking out of the method that gathers species for consideration, but after https://github.com/freeorion/freeorion/commit/7636e022aa21dd666d2ac4f6cbf2077f6e9ff991 it is a feature to always include planet's current species

except during simulation of max pop under new management, the planet's species gets replaced by the various candidates and I gather string_view is losing the plot a bit

taking the string_view out of SpeciesManager is more stable, and other places are doing so (or making a local std::string copy)