### PR TITLE
Dump true and false branches of COMPARE operations

### DIFF
--- a/test/dump/TestValueRefs.cpp
+++ b/test/dump/TestValueRefs.cpp
@@ -18,5 +18,14 @@ BOOST_AUTO_TEST_CASE(ComplexVariable) {
         nullptr).Dump());
 }
 
+BOOST_AUTO_TEST_CASE(OperationCompare) {
+    BOOST_CHECK_EQUAL("(4 >= 5) ? 6 : 7", ValueRef::Operation<int>(
+        ValueRef::OpType::COMPARE_GREATER_THAN_OR_EQUAL,
+        std::make_unique<ValueRef::Constant<int>>(4),
+        std::make_unique<ValueRef::Constant<int>>(5),
+        std::make_unique<ValueRef::Constant<int>>(6),
+        std::make_unique<ValueRef::Constant<int>>(7)).Dump());
+}
+
 BOOST_AUTO_TEST_SUITE_END();
 

--- a/universe/ValueRefs.h
+++ b/universe/ValueRefs.h
@@ -2961,7 +2961,7 @@ std::string Operation<T>::Dump(uint8_t ntabs) const
     if (this->m_op_type == OpType::SIGN)
         return "sign(" + LHS()->Dump(ntabs) + ")";
 
-    bool parenthesize_whole = [this]() {
+    bool parenthesize_compare = [this]() {
         switch (this->m_op_type) {
         case OpType::COMPARE_EQUAL: [[fallthrough]];
         case OpType::COMPARE_GREATER_THAN: [[fallthrough]];
@@ -3003,7 +3003,7 @@ std::string Operation<T>::Dump(uint8_t ntabs) const
             parenthesize_rhs = true;
     }
 
-    std::string retval = parenthesize_whole ? "(" : "";
+    std::string retval = parenthesize_compare ? "(" : "";
     retval += parenthesize_lhs ? ('(' + LHS()->Dump(ntabs) + ')') : LHS()->Dump(ntabs);
 
     switch (this->m_op_type) {
@@ -3025,7 +3025,14 @@ std::string Operation<T>::Dump(uint8_t ntabs) const
 
     retval += parenthesize_rhs ? ('(' + RHS()->Dump(ntabs) + ')') : RHS()->Dump(ntabs);
 
-    retval += parenthesize_whole ? ")" : "";
+    retval += parenthesize_compare ? ")" : "";
+
+    if (parenthesize_compare && m_operands.size() >= 3) {
+        retval += " ? " + m_operands[2]->Dump(ntabs);
+        if (m_operands.size() >= 4) {
+            retval += " : " + m_operands[3]->Dump(ntabs);
+        }
+    }
 
     return retval;
 }


### PR DESCRIPTION
Now `PLC_DESIGN_SIMPLICITY_COMPLEXITY_FACTOR_AAA` named value dumps as:

```
(2.000000 > 4.000000) ? 1.000000 : (2.000000 > 3.000000) ? 0.950000 : (2.000000 > 2.000000) ? 0.900000 : 0.800000
```

instead of just

```
(2.000000 > 4.000000)
```