### PR TITLE
render diplomatic status indicators only once

### DIFF
--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -304,11 +304,6 @@ namespace {
             if (m_host)
                 HostIcon(ui)->OrthoBlit(UpperLeft() + m_host_icon_ul, UpperLeft() + m_host_icon_ul + ICON_SIZE);
 
-            // render diplomatic status indicators
-            m_war_indicator->Render();
-            m_peace_indicator->Render();
-            m_allied_indicator->Render();
-
             // render win/lose icon
             switch (m_win_status)
             {


### PR DESCRIPTION
remove explicit Render call from PlayerDataPanel's
Render standard Render loop on GG window stack will call their Render anyway

fixes https://github.com/freeorion/freeorion/issues/5563