### PR TITLE
Focus targets: Add focus_target for Planet Focus

### DIFF
--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -763,6 +763,9 @@ public:
     /** emitted when focus is changed */
     mutable boost::signals2::signal<void (std::string_view)> FocusChangedSignal;
 
+    /** emitted when focus_target is changed */
+    mutable boost::signals2::signal<void (int)> FocusTargetChangedSignal;
+
     mutable boost::signals2::signal<void (int)> BuildingRightClickedSignal;
 
     /** Emitted when an order button changes state, used to update controls
@@ -773,12 +776,14 @@ private:
     void DoLayout(PlanetType type, PlanetSize size);
     void RefreshPlanetGraphic(PlanetType type, PlanetSize size);
     void SetFocus(std::string focus) const; ///< set the focus of the planet to \a focus
+    void SetFocusTarget(int focus_target) const; ///< set the focus_target of the planet to \a focus_target
     void ClickAnnex();                      ///< called if annex button is pressed
     void ClickColonize();                   ///< called if colonize button is pressed
     void ClickInvade();                     ///< called if invade button is pressed
     void ClickBombard();                    ///< called if bombard button is pressed
 
-    void FocusDropListSelectionChangedSlot(GG::DropDownList::iterator selected); ///< called when droplist selection changes, emits FocusChangedSignal
+    void FocusDropListSelectionChangedSlot(GG::DropDownList::iterator selected); ///< called when focus droplist selection changes, emits FocusChangedSignal
+    void FocusTargetDropListSelectionChangedSlot(GG::DropDownList::iterator selected); ///< called when focus_target droplist selection changes, emits FocusTargetChangedSignal
 
     int                                     m_planet_id = INVALID_OBJECT_ID;///< id for the planet with is represented by this planet panel
     std::shared_ptr<GG::TextControl>        m_planet_name;                  ///< planet name;
@@ -791,6 +796,7 @@ private:
     std::shared_ptr<GG::StaticGraphic>      m_planet_status_graphic;        ///< gives information about the planet status, like supply disconnection
     std::shared_ptr<RotatingPlanetControl>  m_rotating_planet_graphic;      ///< a realtime-rendered planet that rotates, with a textured surface mapped onto it
     std::shared_ptr<GG::DropDownList>       m_focus_drop;                   ///< displays and allows selection of planetary focus;
+    std::shared_ptr<GG::DropDownList>       m_focus_target_drop;            ///< displays and allows selection of planetary focus target;
     std::shared_ptr<PopulationPanel>        m_population_panel;             ///< contains info about population and health
     std::shared_ptr<ResourcePanel>          m_resource_panel;               ///< contains info about resources production and focus selection UI
     std::shared_ptr<MilitaryPanel>          m_military_panel;               ///< contains icons representing military-related meters
@@ -1197,6 +1203,22 @@ void SidePanel::PlanetPanel::CompleteConstruction() {
 
     this->FocusChangedSignal.connect([this](std::string_view sv) { SetFocus(std::string{sv}); });
 
+    // focus-target-selection droplist
+    m_focus_target_drop = GG::Wnd::Create<CUIDropDownList>(6);
+    AttachChild(m_focus_target_drop);
+    m_focus_target_drop->SelChangedSignal.connect(boost::bind(
+        &SidePanel::PlanetPanel::FocusTargetDropListSelectionChangedSlot, this, ph::_1));
+    m_focus_target_drop->SetBrowseModeTime(GetOptionsDB().Get<int>("ui.tooltip.delay"));
+    m_focus_target_drop->SetStyle(GG::LIST_NOSORT | GG::LIST_SINGLESEL);
+    m_focus_target_drop->ManuallyManageColProps();
+    m_focus_target_drop->SetNumCols(2);
+    m_focus_target_drop->SetColWidth(0, m_focus_target_drop->DisplayedRowWidth());
+    m_focus_target_drop->SetColStretch(0, 0.0);
+    m_focus_target_drop->SetColStretch(1, 1.0);
+    m_focus_target_drop->SetOnlyMouseScrollWhenDropped(true);
+
+    this->FocusTargetChangedSignal.connect([this](int i) { SetFocusTarget(i); });
+
     // meter panels
     m_population_panel = GG::Wnd::Create<PopulationPanel>(panel_width, m_planet_id);
     AttachChild(m_population_panel);
@@ -1295,10 +1317,23 @@ void SidePanel::PlanetPanel::DoLayout(PlanetType type, PlanetSize size) {
         y += m_bombard_button->Height() + EDGE_PAD;
     }
 
-    if (m_focus_drop && m_focus_drop->Parent().get() == this) {
-        m_focus_drop->MoveTo(GG::Pt(left, y));
-        m_focus_drop->Resize(GG::Pt(MeterIconSize().x*4, MeterIconSize().y*3/2 + 4));
-        y += m_focus_drop->Height() + EDGE_PAD;
+    const bool has_focus_drop = (m_focus_drop && m_focus_drop->Parent().get() == this);
+    const bool has_focus_target_drop = (m_focus_target_drop && m_focus_target_drop->Parent().get() == this);
+    if (has_focus_drop || has_focus_target_drop) {
+        auto focus_drop_width = MeterIconSize().x*4;
+        auto focus_drops_height = MeterIconSize().y*3/2 + 4;
+        auto focus_target_drop_x = left + focus_drop_width;
+        auto focus_target_drop_width = std::max(focus_drop_width, right - focus_target_drop_x);
+
+        if (has_focus_drop) {
+            m_focus_drop->MoveTo(GG::Pt(left, y));
+            m_focus_drop->Resize(GG::Pt(focus_drop_width, focus_drops_height));
+        }
+        if (has_focus_target_drop) {
+            m_focus_target_drop->MoveTo(GG::Pt(focus_target_drop_x, y));
+            m_focus_target_drop->Resize(GG::Pt(focus_target_drop_width, focus_drops_height));
+        }
+        y += focus_drops_height + EDGE_PAD;
     }
 
     if (m_population_panel && m_population_panel->Parent().get() == this) {
@@ -1785,8 +1820,10 @@ namespace {
 void SidePanel::PlanetPanel::Clear() {
     m_planet_connection.disconnect();
     m_focus_drop->Close();
+    m_focus_target_drop->Close();
 
     DetachChild(m_focus_drop);
+    DetachChild(m_focus_target_drop);
     DetachChild(m_population_panel);
     DetachChild(m_resource_panel);
     DetachChild(m_military_panel);
@@ -2260,8 +2297,55 @@ void SidePanel::PlanetPanel::Refresh(ScriptingContext& context_in, int empire_id
             if (!planet->OwnedBy(empire_id))
                 m_focus_drop->Disable();
         }
-    }
 
+        const auto focus_targets = planet->AvailableFocusTargets(source_context);
+
+        AttachChild(m_focus_target_drop);
+        if(! focus_targets.size()){
+            // Only show when we have a target to choose.
+            m_focus_target_drop->Hide();
+        } else {
+            m_focus_target_drop->Show();
+
+            std::vector<std::shared_ptr<GG::DropDownList::Row>> targetRows;
+            for (const auto& focus_target : focus_targets) {
+                auto targetRow = GG::Wnd::Create<GG::DropDownList::Row>(GG::X(50),GG::Y(24));
+                std::string focus_target_text = std::to_string(focus_target);
+                auto* focus_target_object = objects.getRaw<const UniverseObject>(focus_target);
+                if(focus_target_object && !(focus_target_object->Name().empty()))
+                    targetRow->push_back(GG::Wnd::Create<CUILabel>(focus_target_object->Name()));
+                else
+                    targetRow->push_back(GG::Wnd::Create<CUILabel>(std::to_string(focus_target)));
+                targetRow->SetDragDropDataType("FOCUS_TARGET");
+                targetRow->SetBrowseModeTime(GetOptionsDB().Get<int>("ui.tooltip.delay"));
+                targetRows.push_back(std::move(targetRow));
+            }
+
+            if (m_focus_target_drop->Dropped())
+                m_focus_target_drop->Close();
+
+            if (!m_focus_target_drop->Dropped()) {
+                m_focus_target_drop->Clear();
+                m_focus_target_drop->Insert(std::move(targetRows));
+
+                // set browse text and select appropriate focus in droplist
+                if (!planet->Focus().empty()) {
+                    for (unsigned int i = 0; i < focus_targets.size(); ++i) {
+                        if (focus_targets[i] == planet->FocusTarget()) {
+                            m_focus_target_drop->Select(i);
+                            break;
+                        }
+                    }
+                } else {
+                    m_focus_target_drop->Select(m_focus_target_drop->end());
+                }
+
+                // prevent manipulation for unowned planets
+                if (!planet->OwnedBy(empire_id))
+                    m_focus_target_drop->Disable();
+            }
+        }
+    }
 
     // other panels...
     AttachChild(m_buildings_panel);
@@ -2431,6 +2515,17 @@ void SidePanel::PlanetPanel::SetFocus(std::string focus) const {
     species_colony_projections.clear();
 
     app.Orders().IssueOrder<ChangeFocusOrder>(context, app_empire_id, m_planet_id, std::move(focus));
+}
+
+void SidePanel::PlanetPanel::SetFocusTarget(int focus_target) const {
+    auto& app = GetApp();
+    const int app_empire_id = app.EmpireID();
+    ScriptingContext context = app.GetContext();
+    const auto planet = context.ContextObjects().get<const Planet>(m_planet_id);
+    if (!planet || !planet->OwnedBy(app_empire_id))
+        return;
+
+    app.Orders().IssueOrder<ChangeFocusTargetOrder>(context, app_empire_id, m_planet_id, focus_target);
 }
 
 bool SidePanel::PlanetPanel::InWindow(GG::Pt pt) const {
@@ -2974,6 +3069,38 @@ void SidePanel::PlanetPanel::FocusDropListSelectionChangedSlot(GG::DropDownList:
     DebugLogger() << "Returned from sending focus-changed signal.";
 }
 
+void SidePanel::PlanetPanel::FocusTargetDropListSelectionChangedSlot(GG::DropDownList::iterator selected) {
+    // all this funciton needs to do is emit FocusTargetChangedSignal.  The code
+    // preceeding that determines which focus was selected from the iterator
+    // parameter, does some safety checks, and disables UI sounds
+    DebugLogger() << "SidePanel::PlanetPanel::FocusTargetDropListSelectionChanged";
+    if (m_focus_target_drop->CurrentItem() == m_focus_target_drop->end()) {
+        ErrorLogger() << "PlanetPanel::FocusTargetDropListSelectionChanged passed end / invalid iterator";
+        return;
+    }
+
+    const auto& context = GetApp().GetContext();
+    const auto res = context.ContextObjects().getRaw<Planet>(m_planet_id);
+    if (!res) {
+        ErrorLogger() << "PlanetPanel::FocusTargetDropListSelectionChanged couldn't get planet with id " << m_planet_id;
+        return;
+    }
+
+    const auto focusTargets = res->AvailableFocusTargets(context);
+
+    const auto i = m_focus_target_drop->IteratorToIndex(selected);
+    if (i >= focusTargets.size() || i < 0) {
+        ErrorLogger() << "PlanetPanel::FocusTargetDropListSelectionChanged got invalid focus_target selected on index: " << i;
+        return;
+    }
+
+    const Sound::TempUISoundDisabler sound_disabler;
+    DebugLogger() << "About to send focus-target-changed signal from target selector.";
+    FocusTargetChangedSignal(focusTargets[i]);
+    DebugLogger() << "Returned from sending focus-target-changed signal from target selector.";
+}
+
+
 void SidePanel::PlanetPanel::EnableOrderIssuing(bool enable) {
     m_order_issuing_enabled = enable;
 
@@ -2986,14 +3113,21 @@ void SidePanel::PlanetPanel::EnableOrderIssuing(bool enable) {
 
     if (!enable) {
         m_focus_drop->Disable();
+        m_focus_target_drop->Disable();
         return;
     }
 
     const auto obj = GetApp().GetContext().ContextObjects().get(m_planet_id);
     if (!obj || !obj->OwnedBy(GetApp().EmpireID()))
+    {
         m_focus_drop->Disable();
+        m_focus_target_drop->Disable();
+    }
     else
+    {
         m_focus_drop->Disable(false);
+        m_focus_target_drop->Disable(false);
+    }
 }
 
 ////////////////////////////////////////////////

--- a/default/scripting/focs/_species.pyi
+++ b/default/scripting/focs/_species.pyi
@@ -9,6 +9,7 @@ def FocusType(
     name: str,
     description: str,
     location: _Condition,
+    focus_target: _Condition | None = None,
     graphic: str,
 ) -> _FocusType: ...
 def Species(

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -11847,6 +11847,12 @@ DESC_SOURCE
 DESC_SOURCE_NOT
 ''' that is not the source object'''
 
+DESC_FOCUS_TARGET
+''' that is the focus target object'''
+
+DESC_FOCUS_TARGET_NOT
+''' that is not the focus target object'''
+
 DESC_ROOT_CANDIDATE
 ''' that is the root candidate object'''
 

--- a/parse/ConditionPythonParser.cpp
+++ b/parse/ConditionPythonParser.cpp
@@ -1080,6 +1080,7 @@ void RegisterGlobalsConditions(boost::python::dict& globals) {
     globals["Armed"] = make_wrapped<Condition::Armed>();
 
     globals["IsSource"] = make_wrapped<Condition::Source>();
+    globals["IsFocusTarget"] = make_wrapped<Condition::FocusTarget>();
     globals["IsTarget"] = make_wrapped<Condition::Target>();
     globals["IsRootCandidate"] = make_wrapped<Condition::RootCandidate>();
     globals["IsAnyObject"] = make_wrapped<Condition::All>();

--- a/parse/EffectPythonParser.cpp
+++ b/parse/EffectPythonParser.cpp
@@ -710,11 +710,18 @@ namespace {
         auto name = boost::python::extract<std::string>(kw["name"])();
         auto description = boost::python::extract<std::string>(kw["description"])();
         auto location = boost::python::extract<condition_wrapper>(kw["location"])();
+        std::unique_ptr<Condition::Condition> focus_target;
+        if (kw.has_key("focus_target")) {
+            auto wrapped = boost::python::extract<condition_wrapper>(kw["focus_target"])();
+            if (wrapped.condition)
+                focus_target = ValueRef::CloneUnique(wrapped.condition);
+        }
         auto graphic = boost::python::extract<std::string>(kw["graphic"])();
 
         return {std::move(name),
             std::move(description),
             ValueRef::CloneUnique(location.condition),
+            std::move(focus_target),
             std::move(graphic)};
     }
 }

--- a/test/parse/TestPythonParser.cpp
+++ b/test/parse/TestPythonParser.cpp
@@ -418,9 +418,9 @@ BOOST_AUTO_TEST_CASE(parse_species) {
             "SP_ABADDONI_DESC",
             "SP_ABADDONI_GAMEPLAY_DESC",
             {
-                {"FOCUS_INDUSTRY", "FOCUS_INDUSTRY_DESC", std::make_unique<Condition::Type>(UniverseObjectType::OBJ_PLANET), "icons/focus/industry.png"},
-                {"FOCUS_RESEARCH", "FOCUS_RESEARCH_DESC", std::make_unique<Condition::Type>(UniverseObjectType::OBJ_PLANET), "icons/focus/research.png"},
-                {"FOCUS_INFLUENCE", "FOCUS_INFLUENCE_DESC", std::make_unique<Condition::Type>(UniverseObjectType::OBJ_PLANET), "icons/focus/influence.png"},
+                {"FOCUS_INDUSTRY", "FOCUS_INDUSTRY_DESC", std::make_unique<Condition::Type>(UniverseObjectType::OBJ_PLANET), std::make_unique<Condition::None>(), "icons/focus/industry.png"},
+                {"FOCUS_RESEARCH", "FOCUS_RESEARCH_DESC", std::make_unique<Condition::Type>(UniverseObjectType::OBJ_PLANET), std::make_unique<Condition::None>(), "icons/focus/research.png"},
+                {"FOCUS_INFLUENCE", "FOCUS_INFLUENCE_DESC", std::make_unique<Condition::Type>(UniverseObjectType::OBJ_PLANET), std::make_unique<Condition::None>(), "icons/focus/influence.png"},
                 {"FOCUS_GROWTH", "FOCUS_GROWTH_DESC", std::make_unique<Condition::Or>(array_to_vector<Condition::Condition, 10>({
                     std::make_unique<Condition::And>(
                         std::make_unique<Condition::Homeworld>(array_to_vector<ValueRef::ValueRef<std::string>, 1>({std::make_unique<ValueRef::Variable<std::string>>(ValueRef::ReferenceType::SOURCE_REFERENCE, "Species")})),
@@ -435,56 +435,56 @@ BOOST_AUTO_TEST_CASE(parse_species) {
                     std::make_unique<Condition::HasSpecial>("ELERIUM_SPECIAL"),
                     std::make_unique<Condition::HasSpecial>("CRYSTALS_SPECIAL"),
                     std::make_unique<Condition::HasSpecial>("MINERALS_SPECIAL")
-                })), "icons/focus/growth.png"},
-                {"FOCUS_PROTECTION", "FOCUS_PROTECTION_DESC", std::make_unique<Condition::Type>(UniverseObjectType::OBJ_PLANET), "icons/focus/protection.png"},
-                {"FOCUS_LOGISTICS", "FOCUS_LOGISTICS_DESC", std::make_unique<Condition::OwnerHasTech>(std::make_unique<ValueRef::Constant<std::string>>("SHP_INTSTEL_LOG")), "icons/focus/supply.png"},
-                {"FOCUS_STOCKPILE", "FOCUS_STOCKPILE_DESC", std::make_unique<Condition::OwnerHasTech>(std::make_unique<ValueRef::Constant<std::string>>("PRO_GENERIC_SUPPLIES")), "icons/focus/stockpile.png"},
+                })), std::make_unique<Condition::None>(), "icons/focus/growth.png"},
+                {"FOCUS_PROTECTION", "FOCUS_PROTECTION_DESC", std::make_unique<Condition::Type>(UniverseObjectType::OBJ_PLANET), std::make_unique<Condition::None>(), "icons/focus/protection.png"},
+                {"FOCUS_LOGISTICS", "FOCUS_LOGISTICS_DESC", std::make_unique<Condition::OwnerHasTech>(std::make_unique<ValueRef::Constant<std::string>>("SHP_INTSTEL_LOG")), std::make_unique<Condition::None>(), "icons/focus/supply.png"},
+                {"FOCUS_STOCKPILE", "FOCUS_STOCKPILE_DESC", std::make_unique<Condition::OwnerHasTech>(std::make_unique<ValueRef::Constant<std::string>>("PRO_GENERIC_SUPPLIES")), std::make_unique<Condition::None>(), "icons/focus/stockpile.png"},
                 {"FOCUS_STEALTH", "FOCUS_STEALTH_DESC", std::make_unique<Condition::Or>(
                     std::make_unique<Condition::Contains<>>(std::make_unique<Condition::Building>("BLD_PLANET_CLOAK")),
                     std::make_unique<Condition::And>(
                         std::make_unique<Condition::Contains<>>(std::make_unique<Condition::Building>("BLD_TRANSFORMER")),
                         std::make_unique<Condition::OwnerHasTech>(std::make_unique<ValueRef::Constant<std::string>>("DEF_PLANET_CLOAK"))
                     )
-                ), "icons/focus/stealth.png"},
+                ), std::make_unique<Condition::None>(), "icons/focus/stealth.png"},
                 {"FOCUS_BIOTERROR", "FOCUS_BIOTERROR_DESC", std::make_unique<Condition::Or>(
                     std::make_unique<Condition::Contains<>>(std::make_unique<Condition::Building>("BLD_BIOTERROR_PROJECTOR")),
                     std::make_unique<Condition::And>(
                         std::make_unique<Condition::Contains<>>(std::make_unique<Condition::Building>("BLD_TRANSFORMER")),
                         std::make_unique<Condition::OwnerHasTech>(std::make_unique<ValueRef::Constant<std::string>>("GRO_BIOTERROR"))
                     )
-                ), "icons/focus/bioterror.png"},
+                ), std::make_unique<Condition::None>(), "icons/focus/bioterror.png"},
                 {"FOCUS_STARGATE_SEND", "FOCUS_STARGATE_SEND_DESC", std::make_unique<Condition::Or>(
                     std::make_unique<Condition::Contains<>>(std::make_unique<Condition::Building>("BLD_STARGATE")),
                     std::make_unique<Condition::And>(
                         std::make_unique<Condition::Contains<>>(std::make_unique<Condition::Building>("BLD_TRANSFORMER")),
                         std::make_unique<Condition::OwnerHasTech>(std::make_unique<ValueRef::Constant<std::string>>("CON_STARGATE"))
                     )
-                ), "icons/focus/stargate_send.png"},
+                ), std::make_unique<Condition::None>(), "icons/focus/stargate_send.png"},
                 {"FOCUS_STARGATE_RECEIVE", "FOCUS_STARGATE_RECEIVE_DESC", std::make_unique<Condition::Or>(
                     std::make_unique<Condition::Contains<>>(std::make_unique<Condition::Building>("BLD_STARGATE")),
                     std::make_unique<Condition::And>(
                         std::make_unique<Condition::Contains<>>(std::make_unique<Condition::Building>("BLD_TRANSFORMER")),
                         std::make_unique<Condition::OwnerHasTech>(std::make_unique<ValueRef::Constant<std::string>>("CON_STARGATE"))
                     )
-                ), "icons/focus/stargate_receive.png"},
+                ), std::make_unique<Condition::None>(), "icons/focus/stargate_receive.png"},
                 {"FOCUS_PLANET_DRIVE", "FOCUS_PLANET_DRIVE_DESC", std::make_unique<Condition::Or>(
                     std::make_unique<Condition::Contains<>>(std::make_unique<Condition::Building>("BLD_PLANET_DRIVE")),
                     std::make_unique<Condition::And>(
                         std::make_unique<Condition::Contains<>>(std::make_unique<Condition::Building>("BLD_TRANSFORMER")),
                         std::make_unique<Condition::OwnerHasTech>(std::make_unique<ValueRef::Constant<std::string>>("CON_PLANET_DRIVE"))
                     )
-                ), "icons/building/planetary_stardrive.png"},
+                ), std::make_unique<Condition::None>(), "icons/building/planetary_stardrive.png"},
                 {"FOCUS_DISTORTION", "FOCUS_DISTORTION_DESC", std::make_unique<Condition::Or>(
                     std::make_unique<Condition::Contains<>>(std::make_unique<Condition::Building>("BLD_SPATIAL_DISTORT_GEN")),
                     std::make_unique<Condition::And>(
                         std::make_unique<Condition::Contains<>>(std::make_unique<Condition::Building>("BLD_TRANSFORMER")),
                         std::make_unique<Condition::OwnerHasTech>(std::make_unique<ValueRef::Constant<std::string>>("LRN_SPATIAL_DISTORT_GEN"))
                     )
-                ), "icons/focus/distortion.png"},
+                ), std::make_unique<Condition::None>(), "icons/focus/distortion.png"},
                 {"FOCUS_DOMINATION", "FOCUS_DOMINATION_DESC", std::make_unique<Condition::And>(
                     std::make_unique<Condition::HasTag>("TELEPATHIC"),
                     std::make_unique<Condition::OwnerHasTech>(std::make_unique<ValueRef::Constant<std::string>>("LRN_PSY_DOM"))
-                ), "icons/focus/psi_domination.png"}
+                ), std::make_unique<Condition::None>(), "icons/focus/psi_domination.png"}
             },
             "FOCUS_INDUSTRY",
             {

--- a/universe/ConditionSource.h
+++ b/universe/ConditionSource.h
@@ -36,6 +36,32 @@ private:
     { return local_context.source && local_context.source == local_context.condition_local_candidate; }
 };
 
+
+
+/** Matches the focus target of source object only (if it has a focus target, matches nothing otherwise). */
+struct FO_COMMON_API FocusTarget final : public Condition {
+    constexpr FocusTarget() noexcept : Condition(true, true, false) {}
+
+    [[nodiscard]] constexpr bool operator==(const Condition& rhs) const noexcept override
+    { return this == std::addressof(rhs) || dynamic_cast<decltype(this)>(&rhs); }
+    [[nodiscard]] constexpr bool operator==(const FocusTarget&) const noexcept { return true; }
+
+    [[nodiscard]] ObjectSet GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context) const override;
+    [[nodiscard]] constexpr uint16_t GetDefaultInitialCandidateObjectTypes() const noexcept override { return Impl::MatchesType::ANYOBJECTTYPE; }
+
+    [[nodiscard]] std::string Description(bool negated = false) const override;
+    [[nodiscard]] std::string Dump(uint8_t ntabs = 0) const override;
+    void SetTopLevelContent(const std::string&) noexcept override {}
+    [[nodiscard]] constexpr uint32_t GetCheckSum() const noexcept(noexcept(CheckSums::GetCheckSum(""))) override
+    { return CheckSums::GetCheckSum("Condition::FocusTarget"); }
+
+    [[nodiscard]] std::unique_ptr<Condition> Clone() const override;
+
+private:
+    [[nodiscard]] bool Match(const ScriptingContext& local_context) const noexcept override;
+};
+
+
 }
 
 

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1446,6 +1446,56 @@ std::unique_ptr<Condition> Source::Clone() const
 { return std::make_unique<Source>(); }
 
 ///////////////////////////////////////////////////////////
+// FocusTarget                                           //
+///////////////////////////////////////////////////////////
+std::string FocusTarget::Description(bool negated) const {
+    return (!negated)
+        ? UserString("DESC_FOCUS_TARGET")
+        : UserString("DESC_FOCUS_TARGET_NOT");
+}
+
+std::string FocusTarget::Dump(uint8_t ntabs) const
+{ return DumpIndent(ntabs) + "FocusTarget\n"; }
+
+ObjectSet FocusTarget::GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context) const {
+    if(!parent_context.source)
+        return {};
+
+    auto planet_source = dynamic_cast<const Planet*>(parent_context.source);
+    if (!planet_source)
+        return {};
+
+    auto focus_target_id = planet_source->FocusTarget();
+    if(focus_target_id == INVALID_OBJECT_ID)
+        return {};
+
+    const auto* focus_target_object = parent_context.ContextObjects().getRaw<const UniverseObject>(focus_target_id);
+    if (!focus_target_object)
+        return {};
+
+    return { focus_target_object };
+}
+
+std::unique_ptr<Condition> FocusTarget::Clone() const
+{ return std::make_unique<FocusTarget>(); }
+
+bool FocusTarget::Match(const ScriptingContext& local_context) const noexcept{
+    const auto* candidate = local_context.condition_local_candidate;
+    if (!candidate) {
+        ErrorLogger(conditions) << "FocusTarget::Match passed no candidate object";
+        return false;
+    }
+    if (!local_context.source)
+        return false;
+
+    auto planet_source = dynamic_cast<const Planet*>(local_context.source);
+    if (!planet_source)
+        return false;
+
+    return candidate->ID() == planet_source->FocusTarget();
+}
+
+///////////////////////////////////////////////////////////
 // RootCandidate                                         //
 ///////////////////////////////////////////////////////////
 std::string RootCandidate::Description(bool negated) const {

--- a/universe/Planet.cpp
+++ b/universe/Planet.cpp
@@ -114,8 +114,10 @@ void Planet::Copy(const Planet& copied_planet, const Universe& universe, int emp
         if (vis >= Visibility::VIS_PARTIAL_VISIBILITY) {
             this->m_species_name =                          copied_planet.m_species_name;
             this->m_focus =                                 copied_planet.m_focus;
+            this->m_focus_target =                          copied_planet.m_focus_target;
             this->m_last_turn_focus_changed =               copied_planet.m_last_turn_focus_changed;
             this->m_focus_turn_initial =                    copied_planet.m_focus_turn_initial;
+            this->m_focus_target_turn_initial =             copied_planet.m_focus_target_turn_initial;
             this->m_last_turn_focus_changed_turn_initial =  copied_planet.m_last_turn_focus_changed_turn_initial;
             this->m_last_turn_attacked_by_ship =            copied_planet.m_last_turn_attacked_by_ship;
             this->m_ordered_annexed_by_empire_id =          copied_planet.m_ordered_annexed_by_empire_id;
@@ -171,8 +173,8 @@ std::string Planet::Dump(uint8_t ntabs) const {
     std::string retval = UniverseObject::Dump(ntabs);
     retval.reserve(2048);
     retval.append(" species: ").append(m_species_name).append("  ");
-    retval.append(" focus: ").append(m_focus).append(" last changed on turn: ")
-          .append(std::to_string(m_last_turn_focus_changed));
+    retval.append(" focus: ").append(m_focus).append(" target: ").append(std::to_string(m_focus_target))
+          .append(" last changed on turn: ").append(std::to_string(m_last_turn_focus_changed));
     retval.append(" type: ").append(to_string(m_type))
           .append(" original type: ").append(to_string(m_original_type))
           .append(" size: ").append(to_string(m_size))
@@ -600,6 +602,31 @@ const std::string& Planet::FocusIcon(std::string_view focus_name, const Scriptin
     return EMPTY_STRING;
 }
 
+std::vector<int> Planet::AvailableFocusTargets(const ScriptingContext& context) const {
+    std::vector<int> retval;
+    const auto* species = context.species.GetSpecies(this->SpeciesName());
+    if (!species)
+        return retval;
+
+    const auto is_focus = [this](const FocusType& focus_type) noexcept { return focus_type.Name() == m_focus; };
+    const auto& foci = species->Foci();
+    const auto it = range_find_if(foci, is_focus);
+    if (it == foci.end())
+        return retval;
+
+    const ScriptingContext planet_context(context, ScriptingContext::Source{}, this);
+
+    const auto* focus_target = (*it).FocusTarget();
+    if (focus_target){
+        Condition::ObjectSet matches = focus_target->Eval(planet_context);
+        for (const auto &obj : matches){
+            retval.push_back(obj->ID());
+        }
+    }
+
+    return retval;
+}
+
 std::map<int, double> Planet::EmpireGroundCombatForces() const {
     std::map<int, double> empire_troops;
     if (UniverseObject::GetMeter(MeterType::METER_TROOPS)->Initial() > 0.0f) {
@@ -730,6 +757,7 @@ void Planet::Reset(ObjectMap& objects) {
     m_species_name.clear();
 
     m_focus.clear();
+    m_focus_target = INVALID_OBJECT_ID;
     m_last_turn_focus_changed = INVALID_GAME_TURN;
 
     GetMeter(MeterType::METER_INDUSTRY)->Reset();
@@ -877,7 +905,26 @@ void Planet::SetFocus(std::string focus, const ScriptingContext& context) {
     }
 
     m_focus = std::move(focus);
-    if (m_focus == m_focus_turn_initial)
+    // Changing focus resets any targets that were set.
+    m_focus_target = INVALID_OBJECT_ID;
+    HandleFocusChanged(context);
+}
+
+void Planet::SetFocusTarget(int target, const ScriptingContext& context){
+    if (target == m_focus_target)
+        return;
+
+    auto available_targets = AvailableFocusTargets(context);
+    if(std::find(available_targets.begin(), available_targets.end(), target) == available_targets.end())
+        m_focus_target = INVALID_OBJECT_ID;
+
+    m_focus_target = target;
+    HandleFocusChanged(context);
+}
+
+void Planet::HandleFocusChanged(const ScriptingContext& context)
+{
+    if ((m_focus == m_focus_turn_initial) && (m_focus_target == m_focus_target_turn_initial))
         m_last_turn_focus_changed = m_last_turn_focus_changed_turn_initial;
     else
         m_last_turn_focus_changed = context.current_turn;
@@ -886,16 +933,18 @@ void Planet::SetFocus(std::string focus, const ScriptingContext& context) {
 
 void Planet::ClearFocus(int current_turn) {
     m_focus.clear();
+    m_focus_target = INVALID_OBJECT_ID;
     m_last_turn_focus_changed = current_turn;
     ResourceCenterChangedSignal();
 }
 
 void Planet::UpdateFocusHistory() {
-    TraceLogger() << "Planet::UpdateFocusHistory: focus: " << m_focus
-        << "  initial focus: " << m_focus_turn_initial
+    TraceLogger() << "Planet::UpdateFocusHistory: focus: " << m_focus << " (target: " << m_focus_target << ")"
+        << "  initial focus: " << m_focus_turn_initial << " (target: " << m_focus_target_turn_initial << ")"
         << "  turns since change initial: " << m_last_turn_focus_changed_turn_initial;
-    if (m_focus != m_focus_turn_initial) {
+    if (m_focus != m_focus_turn_initial || m_focus_target != m_focus_target_turn_initial) {
         m_focus_turn_initial = m_focus;
+        m_focus_target_turn_initial = m_focus_target;
         m_last_turn_focus_changed_turn_initial = m_last_turn_focus_changed;
     }
 }

--- a/universe/Planet.h
+++ b/universe/Planet.h
@@ -92,6 +92,9 @@ public:
     [[nodiscard]] bool                          FocusAvailable(std::string_view focus, const ScriptingContext& context) const;
     [[nodiscard]] const std::string&            FocusIcon(std::string_view focus_name, const ScriptingContext& context) const;
 
+    [[nodiscard]] const auto&                   FocusTarget() const noexcept { return m_focus_target; }
+    [[nodiscard]] std::vector<int>              AvailableFocusTargets(const ScriptingContext& context) const;
+
     [[nodiscard]] bool                Populated() const noexcept;
     [[nodiscard]] auto&               SpeciesName() const noexcept { return m_species_name; }
 
@@ -165,6 +168,8 @@ public:
     void SetSpecies(std::string species_name, int turn, const SpeciesManager& sm);
 
     void SetFocus(std::string focus, const ScriptingContext& context);
+    void SetFocusTarget(int target, const ScriptingContext& context);
+    void HandleFocusChanged(const ScriptingContext& context);
     void ClearFocus(int current_turn);
     void UpdateFocusHistory();
 
@@ -247,8 +252,10 @@ private:
     std::string m_species_name;
 
     std::string m_focus;
+    int         m_focus_target = INVALID_OBJECT_ID;
     int         m_last_turn_focus_changed = INVALID_GAME_TURN;
     std::string m_focus_turn_initial;
+    int         m_focus_target_turn_initial = INVALID_OBJECT_ID;
     int         m_last_turn_focus_changed_turn_initial = INVALID_GAME_TURN;
 
     PlanetType  m_type = PlanetType::PT_SWAMP;

--- a/universe/Species.cpp
+++ b/universe/Species.cpp
@@ -24,10 +24,12 @@
 /////////////////////////////////////////////////
 FocusType::FocusType(std::string name, std::string description,
                      std::unique_ptr<Condition::Condition>&& location,
+                     std::unique_ptr<Condition::Condition>&& focus_target,
                      std::string graphic) :
     m_name(std::move(name)),
     m_description(std::move(description)),
     m_location(std::move(location)),
+    m_focus_target(std::move(focus_target)),
     m_graphic(std::move(graphic))
 {}
 
@@ -50,6 +52,14 @@ bool FocusType::operator==(const FocusType& rhs) const {
         return false;
     }
 
+    if (m_focus_target == rhs.m_focus_target) { // could be nullptr
+        // check next member
+    } else if (!m_focus_target || !rhs.m_focus_target) {
+        return false;
+    } else if (*m_focus_target != *(rhs.m_focus_target)) {
+        return false;
+    }
+
     return true;
 }
 
@@ -59,6 +69,10 @@ std::string FocusType::Dump(uint8_t ntabs) const {
     retval += DumpIndent(ntabs+1) + "description = \"" + m_description + "\"\n";
     retval += DumpIndent(ntabs+1) + "location = \n";
     retval += m_location->Dump(ntabs+2);
+    if(m_focus_target){
+        retval += DumpIndent(ntabs+1) + "focus_target = \n";
+        retval += m_focus_target->Dump(ntabs+2);
+	}
     retval += DumpIndent(ntabs+1) + "graphic = \"" + m_graphic + "\"\n";
     return retval;
 }
@@ -69,6 +83,9 @@ uint32_t FocusType::GetCheckSum() const {
     CheckSums::CheckSumCombine(retval, m_name);
     CheckSums::CheckSumCombine(retval, m_description);
     CheckSums::CheckSumCombine(retval, m_location);
+    // Backwards compatiblity; if the focus target is not changed from the default, then it is not checksummed.
+    if(m_focus_target.get() && (*(m_focus_target.get()) != Condition::None()))
+		CheckSums::CheckSumCombine(retval, m_focus_target);
     CheckSums::CheckSumCombine(retval, m_graphic);
 
     return retval;

--- a/universe/Species.h
+++ b/universe/Species.h
@@ -68,6 +68,7 @@ public:
     FocusType() = default;
     FocusType(std::string name, std::string description,
               std::unique_ptr<Condition::Condition>&& location,
+              std::unique_ptr<Condition::Condition>&& focus_target,
               std::string graphic);
     ~FocusType(); // needed due to forward-declared Condition held in unique_ptr
 
@@ -76,6 +77,7 @@ public:
     [[nodiscard]] const std::string&          Name() const noexcept        { return m_name; }          ///< returns the name for this focus type
     [[nodiscard]] const std::string&          Description() const noexcept { return m_description; }   ///< returns a text description of this focus type
     [[nodiscard]] const Condition::Condition* Location() const noexcept    { return m_location.get(); }///< returns the condition that determines whether an UniverseObject can use this FocusType
+    [[nodiscard]] const Condition::Condition* FocusTarget() const noexcept { return m_focus_target.get(); }///< returns the condition that gives the possible targets for this FocusType for this UniverseObject
     [[nodiscard]] const std::string&          Graphic() const noexcept     { return m_graphic; }       ///< returns the name of the grapic file for this focus type
     [[nodiscard]] std::string                 Dump(uint8_t ntabs = 0) const;                           ///< returns a data file format representation of this object
 
@@ -91,6 +93,7 @@ private:
     std::string                                 m_name;
     std::string                                 m_description;
     std::shared_ptr<const Condition::Condition> m_location; // TODO: make unique_ptr - requires tweaking SpeciesParser to not require copies
+    std::shared_ptr<const Condition::Condition> m_focus_target; // TODO: make unique_ptr - same as location above
     std::string                                 m_graphic;
 };
 

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -1418,6 +1418,51 @@ void ChangeFocusOrder::ExecuteImpl(ScriptingContext& context) const {
 }
 
 ////////////////////////////////////////////////
+// ChangeFocusTargetOrder
+////////////////////////////////////////////////
+ChangeFocusTargetOrder::ChangeFocusTargetOrder(int empire, int planet, int focus_target, const ScriptingContext& context) :
+    Order(empire),
+    m_planet(planet),
+    m_focus_target(focus_target)
+{ Check(empire, m_planet, m_focus_target, context); }
+
+std::string ChangeFocusTargetOrder::Dump() const
+{ return boost::io::str(FlexibleFormat(UserString("ORDER_FOCUS_TARGET_CHANGE")) % m_planet % m_focus_target) + ExecutedTag(this); }
+
+bool ChangeFocusTargetOrder::Check(int empire_id, int planet_id, int focus_target,
+                             const ScriptingContext& context)
+{
+    auto planet = context.ContextObjects().getRaw<Planet>(planet_id);
+
+    if (!planet) {
+        ErrorLogger() << "Invalid planet id " << planet_id << " specified in change planet focus target order.";
+        return false;
+    }
+
+    if (!planet->OwnedBy(empire_id)) {
+        ErrorLogger() << "Empire " << empire_id
+                      << " attempted to issue change planet focus target to another's planet: " << planet_id;
+        return false;
+    }
+
+    // TODO: add check that the focustarget is valid. (Currently caught at planet itself.)
+
+    return true;
+}
+
+void ChangeFocusTargetOrder::ExecuteImpl(ScriptingContext& context) const {
+    GetValidatedEmpire(context);
+
+    if (!Check(EmpireID(), m_planet, m_focus_target, context))
+        return;
+
+    auto planet = context.ContextObjects().getRaw<Planet>(m_planet);
+
+    planet->SetFocusTarget(m_focus_target, context);
+}
+
+
+////////////////////////////////////////////////
 // PolicyOrder
 ////////////////////////////////////////////////
 std::string PolicyOrder::Dump() const {

--- a/util/Order.h
+++ b/util/Order.h
@@ -490,7 +490,7 @@ public:
 
     [[nodiscard]] std::string Dump() const override;
 
-    /* Returns ID of the fleet to be deleted. */
+    /* Returns ID of the planet where to change the focus. */
     [[nodiscard]] int PlanetID() const noexcept { return m_planet; }
 
     static bool Check(int empire_id, int planet_id, const std::string& focus, const ScriptingContext& context);
@@ -509,6 +509,42 @@ private:
 
     int m_planet = INVALID_OBJECT_ID;
     std::string m_focus;
+
+    friend class boost::serialization::access;
+    template <typename Archive>
+    void serialize(Archive& ar, const unsigned int version);
+};
+
+/////////////////////////////////////////////////////
+// ChangeFocusTargetOrder
+/////////////////////////////////////////////////////
+/** the Order subclass that represents changing a planet focus*/
+class FO_COMMON_API ChangeFocusTargetOrder final : public Order {
+public:
+    ChangeFocusTargetOrder(int empire, int planet, int focus_target,
+                     const ScriptingContext& context);
+
+    [[nodiscard]] std::string Dump() const override;
+
+    /* Returns ID of the planet where to change the focus target. */
+    [[nodiscard]] int PlanetID() const noexcept { return m_planet; }
+
+    static bool Check(int empire_id, int planet_id, int focus_target, const ScriptingContext& context);
+
+private:
+    ChangeFocusTargetOrder() = default;
+
+    /**
+     * Preconditions of execute:
+     *    - the designated planet must exist, be owned by the issuing empire
+     *
+     *  Postconditions:
+     *    - the planet focus target is changed
+     */
+    void ExecuteImpl(ScriptingContext& context) const override;
+
+    int m_planet = INVALID_OBJECT_ID;
+    int m_focus_target = INVALID_OBJECT_ID;
 
     friend class boost::serialization::access;
     template <typename Archive>

--- a/util/SerializeOrderSet.cpp
+++ b/util/SerializeOrderSet.cpp
@@ -25,6 +25,7 @@ BOOST_CLASS_EXPORT(InvadeOrder)
 BOOST_CLASS_EXPORT(BombardOrder)
 BOOST_CLASS_EXPORT(StopBombardOrder)
 BOOST_CLASS_EXPORT(ChangeFocusOrder)
+BOOST_CLASS_EXPORT(ChangeFocusTargetOrder)
 BOOST_CLASS_EXPORT(PolicyOrder)
 BOOST_CLASS_VERSION(PolicyOrder, 2)
 BOOST_CLASS_EXPORT(ResearchQueueOrder)
@@ -145,6 +146,14 @@ void ChangeFocusOrder::serialize(Archive& ar, const unsigned int version)
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
         & BOOST_SERIALIZATION_NVP(m_planet)
         & BOOST_SERIALIZATION_NVP(m_focus);
+}
+
+template <typename Archive>
+void ChangeFocusTargetOrder::serialize(Archive& ar, const unsigned int version)
+{
+    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
+        & BOOST_SERIALIZATION_NVP(m_planet)
+        & BOOST_SERIALIZATION_NVP(m_focus_target);
 }
 
 template <typename Archive>

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -855,8 +855,10 @@ namespace {
 
     struct ResourceCenter {
         std::string m_focus;
+        int         m_focus_target = INVALID_OBJECT_ID;
         int         m_last_turn_focus_changed = INVALID_GAME_TURN;
         std::string m_focus_turn_initial;
+        int         m_focus_target_turn_initial = INVALID_OBJECT_ID;
         int         m_last_turn_focus_changed_turn_initial = INVALID_GAME_TURN;
     };
 
@@ -866,8 +868,10 @@ namespace {
         using namespace boost::serialization;
 
         ar  & make_nvp("m_focus", rs.m_focus)
+            & make_nvp("m_focus_target", rs.m_focus_target)
             & make_nvp("m_last_turn_focus_changed", rs.m_last_turn_focus_changed)
             & make_nvp("m_focus_turn_initial", rs.m_focus_turn_initial)
+            & make_nvp("m_focus_target_turn_initial", rs.m_focus_target_turn_initial)
             & make_nvp("m_last_turn_focus_changed_turn_initial", rs.m_last_turn_focus_changed_turn_initial);
     }
 }
@@ -896,8 +900,10 @@ void serialize(Archive& ar, Planet& obj, unsigned int const version)
             obj.m_last_turn_focus_changed_turn_initial = res.m_last_turn_focus_changed_turn_initial;
         } else {
             ar  & make_nvp("m_focus", obj.m_focus)
+                & make_nvp("m_focus_target", obj.m_focus_target)
                 & make_nvp("m_last_turn_focus_changed", obj.m_last_turn_focus_changed)
                 & make_nvp("m_focus_turn_initial", obj.m_focus_turn_initial)
+                & make_nvp("m_focus_target_turn_initial", obj.m_focus_target_turn_initial)
                 & make_nvp("m_last_turn_focus_changed_turn_initial", obj.m_last_turn_focus_changed_turn_initial);
         }
 
@@ -905,8 +911,10 @@ void serialize(Archive& ar, Planet& obj, unsigned int const version)
         ar  & make_nvp("m_species_name", obj.m_species_name);
 
         ar  & make_nvp("m_focus", obj.m_focus)
+            & make_nvp("m_focus_target", obj.m_focus_target)
             & make_nvp("m_last_turn_focus_changed", obj.m_last_turn_focus_changed)
             & make_nvp("m_focus_turn_initial", obj.m_focus_turn_initial)
+            & make_nvp("m_focus_target_turn_initial", obj.m_focus_target_turn_initial)
             & make_nvp("m_last_turn_focus_changed_turn_initial", obj.m_last_turn_focus_changed_turn_initial);
     }
 


### PR DESCRIPTION
### Feature
This (work-in-progress) PR is adding an option to allow selection of a focus-target to planet focus. Having a focus-target could help to make the interfaces for Planetary Stardrive and for Gateways simpler (since thos foci actually need a target, and targeting is now done by placing markers at the intended destinations).

### Screenshot
This is a screenshot from this PR (from a first test for checking the select box):
<img width="793" height="445" alt="focus_target_selection" src="https://github.com/user-attachments/assets/5d865396-dce0-4fea-af16-f6f0140b983d" />

And another screenshot after the planet was moved (from a later test with the v2 test-files below):
<img width="707" height="342" alt="planet_moved" src="https://github.com/user-attachments/assets/9b18138c-cbbe-4adb-9409-0d2192fd8114" />

### Tests done
Briefly checked:
* Functioning of focus_target Condition in Python focus code
* Persistence within turn
* Persistence over turn change
* Savegame saving/loading
* UI behaviour (does the selection field show/hide)
* Actually using the set-focus in scripting/effects
* Actually moving the planet using focus_target of the starlane drive (from the test-files).

I tested with the following modifications (use v2 for actually moving the planet):
[starting_planet_drive_targeted.zip](https://github.com/user-attachments/files/28251944/starting_planet_drive_targeted.zip)
[starting_planet_drive_targeted_v2.zip](https://github.com/user-attachments/files/28411071/starting_planet_drive_targeted_v2.zip)

### Compatiblity
This PR seems not backwards compatible and not forwards compatible; savegames created with the master branch cannot be loaded with the branch from this PR, and savegames created with the branch from this PR cannot be loaded with the main branch.