### PR TITLE
render diplomatic status indicators only once

### DIFF
--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -339,11 +339,6 @@ namespace {
             if (m_host)
                 HostIcon()->OrthoBlit(UpperLeft() + m_host_icon_ul, UpperLeft() + m_host_icon_ul + ICON_SIZE);
 
-            // render diplomatic status indicators
-            m_war_indicator->Render();
-            m_peace_indicator->Render();
-            m_allied_indicator->Render();
-
             // render win/lose icon
             switch (m_win_status)
             {


### PR DESCRIPTION
remove explicit Render call from PlayerDataPanel's Render standard Render loop on GG window stack will call their Render anyway

https://github.com/freeorion/freeorion/pull/5564 but for done for 0.5.1 relase branch