### PR TITLE
Allow forcing of unavailable build items to the queue

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1700,34 +1700,28 @@ void Empire::PlaceProductionOnQueue(const ProductionQueue::ProductionItem& item,
         ErrorLogger() << "Empire::PlaceProductionOnQueue() : Maximum queue size reached. Aborting enqueue";
         return;
     }
-
     if (item.build_type == BuildType::BT_BUILDING) {
         // only buildings have a distinction between enqueuable and producible...
         if (!EnqueuableItem(BuildType::BT_BUILDING, item.name, location, context)) {
-            ErrorLogger() << "Empire::PlaceProductionOnQueue() : Attempted to place non-enqueuable item in queue: build_type: Building"
+            InfoLogger() << "Empire::PlaceProductionOnQueue() : Attempted to place non-enqueuable item in queue: build_type: Building"
                           << "  name: " << item.name << "  location: " << location;
-            return;
         }
         if (!ProducibleItem(BuildType::BT_BUILDING, item.name, location, context)) {
-            ErrorLogger() << "Empire::PlaceProductionOnQueue() : Placed a non-buildable item in queue: build_type: Building"
+            InfoLogger() << "Empire::PlaceProductionOnQueue() : Placed a non-buildable item in queue: build_type: Building"
                           << "  name: " << item.name << "  location: " << location;
-            return;
         }
 
     } else if (item.build_type == BuildType::BT_SHIP) {
         if (!ProducibleItem(BuildType::BT_SHIP, item.design_id, location, context)) {
-            ErrorLogger() << "Empire::PlaceProductionOnQueue() : Placed a non-buildable item in queue: build_type: Ship"
+            InfoLogger() << "Empire::PlaceProductionOnQueue() : Placed a non-buildable item in queue: build_type: Ship"
                           << "  design_id: " << item.design_id << "  location: " << location;
-            return;
         }
 
     } else if (item.build_type == BuildType::BT_STOCKPILE) {
         if (!ProducibleItem(BuildType::BT_STOCKPILE, location, context)) {
-            ErrorLogger() << "Empire::PlaceProductionOnQueue() : Placed a non-buildable item in queue: build_type: Stockpile"
+            InfoLogger() << "Empire::PlaceProductionOnQueue() : Placed a non-buildable item in queue: build_type: Stockpile"
                           << "  location: " << location;
-            return;
         }
-
     } else {
         throw std::invalid_argument("Empire::PlaceProductionOnQueue was passed a ProductionQueue::ProductionItem with an invalid BuildType");
     }

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -1168,8 +1168,6 @@ void BuildDesignatorWnd::BuildSelector::BuildItemLeftClicked(GG::ListBox::iterat
 }
 
 void BuildDesignatorWnd::BuildSelector::AddBuildItemToQueue(GG::ListBox::iterator it, bool top) {
-    if ((*it)->Disabled())
-        return;
     if (ProductionItemRow* item_row = dynamic_cast<ProductionItemRow*>(it->get()))
         RequestBuildItemSignal(item_row->Item(), 1, top ? 0 : -1);
 }
@@ -1203,7 +1201,10 @@ void BuildDesignatorWnd::BuildSelector::BuildItemRightClicked(GG::ListBox::itera
 
     auto popup = GG::Wnd::Create<CUIPopupMenu>(pt.x, pt.y);
 
-    if (!((*it)->Disabled())) {
+    if ((*it)->Disabled()) {
+        popup->AddMenuItem(UserString("PRODUCTION_DETAIL_ADD_TO_QUEUE_FORCE"), false, false, add_bottom_queue_action);
+        popup->AddMenuItem(UserString("PRODUCTION_DETAIL_ADD_TO_TOP_OF_QUEUE_FORCE"), false, false, add_top_queue_action);
+    } else {
         popup->AddMenuItem(UserString("PRODUCTION_DETAIL_ADD_TO_QUEUE"), false, false, add_bottom_queue_action);
         popup->AddMenuItem(UserString("PRODUCTION_DETAIL_ADD_TO_TOP_OF_QUEUE"), false, false, add_top_queue_action);
     }
@@ -1584,7 +1585,8 @@ void BuildDesignatorWnd::BuildItemRequested(ProductionQueue::ProductionItem item
     const auto& app = GetApp();
     const auto& context = app.GetContext();
     auto empire = context.GetEmpire(app.EmpireID());
-    if (empire && empire->EnqueuableItem(item, BuildLocation(), context))
+    // not checking if the item is enqueable or producable - visibility should have sufficed
+    if (empire)
         AddBuildToQueueSignal(std::move(item), num_to_build, BuildLocation(), pos);
 }
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -4916,6 +4916,12 @@ Add to Queue
 PRODUCTION_DETAIL_ADD_TO_TOP_OF_QUEUE
 Add to Top of Queue
 
+PRODUCTION_DETAIL_ADD_TO_QUEUE_FORCE
+Force Unavailable Item to Queue
+
+PRODUCTION_DETAIL_ADD_TO_TOP_OF_QUEUE_FORCE
+Force Unavailable Item to Top of Queue
+
 PRODUCTION_QUEUE_PROMPT
 Double-click on an available item to add it to the production queue.
 


### PR DESCRIPTION
Helps with the following tasks:
* adding an item which is actually producible but the client thinks otherwise
* planned adding of items to the queue for advanced player

== Gameplay considerations ==

This won't allow anything to be build which should not be allowed.

== UI considerations ==

Normal left-click enqueue is still disabled so there is no confusion if both Available and Unavailable items are shown in the build designator. (Not sure this really necessary)

The right-click enqueues have their own text to tell the user that this not the enqueue of an Available item.