### PR TITLE
fix pop_back on empty string (undefined behavior) when building Condition string representation

### DIFF
--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -152,7 +152,8 @@ namespace Condition {
     }
 
     // remove empty line from the end of the string
-    retval.pop_back(); // was retval = retval.substr(0, retval.length() - 1);
+    if(!retval.empty())
+        retval.pop_back(); // was retval = retval.substr(0, retval.length() - 1);
 
     return retval;
 }

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -152,7 +152,7 @@ namespace Condition {
     }
 
     // remove empty line from the end of the string
-    if(!retval.empty())
+    if (!retval.empty())
         retval.pop_back(); // was retval = retval.substr(0, retval.length() - 1);
 
     return retval;


### PR DESCRIPTION
As an example, in my case (MSVC 2022, windows 11) my game crashes when hovering mouse over an item on build list. I tracked this down to this.

This tries to build string representation of failed condition, but since the conditions are actually met, the string comes out empty.

And then there's pop_back now on that empty string and it leads to game crash as if I gotten some 2 or 4 billion long string or whatever. I understand this is undefined behavior to pop_back empty string

Presumably previous instance of having substr(0, -1) wasn't exactly good either but was apparently working out better

This is fixing this case - just check if the string is empty and if it isn't (there are failed conditions made to text representation) only THEN remove the trailing newline with pop_back (otherwise leave the string empty)