### PR TITLE
check if failed conditions string is empty before trying to remove trailing newline

### DIFF
--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -151,7 +151,8 @@ namespace Condition {
     }
 
     // remove empty line from the end of the string
-    retval = retval.substr(0, retval.length() - 1);
+    if (!retval.empty())
+        retval = retval.substr(0, retval.length() - 1);
 
     return retval;
 }


### PR DESCRIPTION


fixes https://github.com/freeorion/freeorion/issues/5606 on release branch

granted, per request of @geoffthemedio I am not porting in the whole push_back bit so without it, this was not crashing, but still bit iffy to do substr(0, -1) - this would turn into substr(0, max_size_t) and result in whole string, which was empty string, but somewhat convoluted

so better to stick in the explicit check for empty string, would prevent the #5606 bug to begin with