### PR TITLE
BuildingAndFocusTargets: Add GUI support for selecting buildings

### DIFF
--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -168,7 +168,7 @@ void BuildingsPanel::EnableOrderIssuing(bool enable) {
 }
 
 void BuildingsPanel::SelectBuilding(int building_id) {
-    if(m_selected_building_id == building_id)
+    if (m_selected_building_id == building_id)
         return;
 
     m_selected_building_id = building_id;
@@ -308,9 +308,9 @@ void BuildingIndicator::Render() {
 
     // Draw outline and background...
     // TODO: don't hardcode color here, but put it near WndOuterBorderColor() (WndSelectedBorderColor?).
-    auto &borderColor = m_selected ? GG::CLR_GRAY : ClientUI::WndOuterBorderColor();
+    auto border_color = m_selected ? GG::CLR_GRAY : ClientUI::WndOuterBorderColor();
 
-    GG::FlatRectangle(ul, lr, ClientUI::WndColor(), borderColor, 1);
+    GG::FlatRectangle(ul, lr, ClientUI::WndColor(), border_color , 1);
 }
 
 void BuildingIndicator::PreRender() {
@@ -396,7 +396,7 @@ void BuildingIndicator::LClick(GG::Pt pt, GG::Flags<GG::ModKey> mod_keys) {
     if (!m_order_issuing_enabled)
         return;
 
-    if(!m_selected)
+    if (!m_selected)
         LeftClickedSignal(m_building_id);
     else
         LeftClickedSignal(INVALID_OBJECT_ID);
@@ -468,9 +468,8 @@ void BuildingIndicator::RClick(GG::Pt pt, GG::Flags<GG::ModKey> mod_keys) {
 void BuildingIndicator::EnableOrderIssuing(bool enable)
 { m_order_issuing_enabled = enable; }
 
-void BuildingIndicator::SelectBuilding(int building_id){
-    m_selected = (m_building_id == building_id);
-}
+void BuildingIndicator::SelectBuilding(int building_id) noexcept
+{ m_selected = (m_building_id == building_id); }
 
 void BuildingIndicator::DoLayout() {
     GG::Pt child_lr = Size() - GG::Pt(GG::X1, GG::Y1);   // extra pixel prevents graphic from overflowing border box

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -120,7 +120,9 @@ void BuildingsPanel::Update() {
             continue;
 
         auto ind = GG::Wnd::Create<BuildingIndicator>(GG::X(indicator_size), object_id);
+        ind->LeftClickedSignal.connect(BuildingSelectedSignal);
         ind->RightClickedSignal.connect(BuildingRightClickedSignal);
+        ind->SelectBuilding(m_selected_building_id);
         m_building_indicators.push_back(std::move(ind));
     }
 
@@ -163,6 +165,15 @@ void BuildingsPanel::RefreshImpl() {
 void BuildingsPanel::EnableOrderIssuing(bool enable) {
     for (auto& indicator : m_building_indicators)
         indicator->EnableOrderIssuing(enable);
+}
+
+void BuildingsPanel::SelectBuilding(int building_id) {
+    if(m_selected_building_id == building_id)
+        return;
+
+    m_selected_building_id = building_id;
+    for (auto& indicator : m_building_indicators)
+        indicator->SelectBuilding(m_selected_building_id);
 }
 
 void BuildingsPanel::ExpandCollapseButtonPressed()
@@ -296,7 +307,10 @@ void BuildingIndicator::Render() {
     GG::Pt lr = LowerRight();
 
     // Draw outline and background...
-    GG::FlatRectangle(ul, lr, ClientUI::WndColor(), ClientUI::WndOuterBorderColor(), 1);
+    // TODO: don't hardcode color here, but put it near WndOuterBorderColor() (WndSelectedBorderColor?).
+    auto &borderColor = m_selected ? GG::CLR_GRAY : ClientUI::WndOuterBorderColor();
+
+    GG::FlatRectangle(ul, lr, ClientUI::WndColor(), borderColor, 1);
 }
 
 void BuildingIndicator::PreRender() {
@@ -367,6 +381,27 @@ void BuildingIndicator::SizeMove(GG::Pt ul, GG::Pt lr) {
 void BuildingIndicator::MouseWheel(GG::Pt pt, int move, GG::Flags<GG::ModKey> mod_keys)
 { ForwardEventToParent(); }
 
+void BuildingIndicator::LClick(GG::Pt pt, GG::Flags<GG::ModKey> mod_keys) {
+    // verify that this indicator represents an existing building, and not a
+    // queued production item, and that the owner of the building is this
+    // client's player's empire
+    auto& app = GetApp();
+    const auto& context = app.GetContext();
+    const auto& objects = context.ContextObjects();
+
+    auto building = objects.get<Building>(m_building_id);
+    if (!building)
+        return;
+
+    if (!m_order_issuing_enabled)
+        return;
+
+    if(!m_selected)
+        LeftClickedSignal(m_building_id);
+    else
+        LeftClickedSignal(INVALID_OBJECT_ID);
+}
+
 void BuildingIndicator::RClick(GG::Pt pt, GG::Flags<GG::ModKey> mod_keys) {
     // verify that this indicator represents an existing building, and not a
     // queued production item, and that the owner of the building is this
@@ -432,6 +467,10 @@ void BuildingIndicator::RClick(GG::Pt pt, GG::Flags<GG::ModKey> mod_keys) {
 
 void BuildingIndicator::EnableOrderIssuing(bool enable)
 { m_order_issuing_enabled = enable; }
+
+void BuildingIndicator::SelectBuilding(int building_id){
+    m_selected = (m_building_id == building_id);
+}
 
 void BuildingIndicator::DoLayout() {
     GG::Pt child_lr = Size() - GG::Pt(GG::X1, GG::Y1);   // extra pixel prevents graphic from overflowing border box

--- a/UI/BuildingsPanel.h
+++ b/UI/BuildingsPanel.h
@@ -81,7 +81,7 @@ public:
     /** Enables, or disables if \a enable is false, issuing orders via this BuildingIndicator. */
     void EnableOrderIssuing(bool enable = true);
 
-    void SelectBuilding(int building_id);
+    void SelectBuilding(int building_id) noexcept;
 
     mutable boost::signals2::signal<void (int)> LeftClickedSignal;
     mutable boost::signals2::signal<void (int)> RightClickedSignal;

--- a/UI/BuildingsPanel.h
+++ b/UI/BuildingsPanel.h
@@ -29,6 +29,10 @@ public:
     /** Enables, or disables if \a enable is false, issuing orders via this panel. */
     void EnableOrderIssuing(bool enable = true);
 
+    /** Handles selection(marker) of building. */
+    void SelectBuilding(int building_id);
+
+    mutable boost::signals2::signal<void (int)> BuildingSelectedSignal;
     mutable boost::signals2::signal<void (int)> BuildingRightClickedSignal;
 
 protected:
@@ -44,6 +48,7 @@ private:
     void ExpandCollapseButtonPressed();
 
     int m_planet_id = INVALID_OBJECT_ID; // object id for the Planet whose buildings this panel displays
+    int m_selected_building_id = INVALID_OBJECT_ID; ///< Cached value for selected building.
     int m_columns = 1; // number of columns in which to display building indicators
     std::vector<std::shared_ptr<BuildingIndicator>> m_building_indicators;
     boost::signals2::scoped_connection m_queue_connection;
@@ -70,11 +75,15 @@ public:
     void Render() override;
     void SizeMove(GG::Pt ul, GG::Pt lr) override;
     void MouseWheel(GG::Pt pt, int move, GG::Flags<GG::ModKey> mod_keys) override;
+    void LClick(GG::Pt pt, GG::Flags<GG::ModKey> mod_keys) override;
     void RClick(GG::Pt pt, GG::Flags<GG::ModKey> mod_keys) override;
 
     /** Enables, or disables if \a enable is false, issuing orders via this BuildingIndicator. */
     void EnableOrderIssuing(bool enable = true);
 
+    void SelectBuilding(int building_id);
+
+    mutable boost::signals2::signal<void (int)> LeftClickedSignal;
     mutable boost::signals2::signal<void (int)> RightClickedSignal;
 
 private:
@@ -88,6 +97,7 @@ private:
     boost::signals2::scoped_connection      m_signal_connection;
     int                                     m_building_id = INVALID_OBJECT_ID;
     bool                                    m_order_issuing_enabled = true;
+    bool                                    m_selected = false; ///< is this building (indicator) selected
 };
 
 #endif

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -1677,7 +1677,7 @@ int MapWnd::SelectedPlanetID() const // TODO: noexcept ?
 { return m_production_wnd->SelectedPlanetID(); }
 
 int MapWnd::SelectedBuildingID() const
-{ return SidePanel::BuildingID(); }
+{ return SidePanel::SelectedBuildingID(); }
 
 int MapWnd::SelectedFleetID() const {
     if (!m_selected_fleet_ids.empty())

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -1676,6 +1676,9 @@ int MapWnd::SelectedSystemID() const
 int MapWnd::SelectedPlanetID() const // TODO: noexcept ?
 { return m_production_wnd->SelectedPlanetID(); }
 
+int MapWnd::SelectedBuildingID() const
+{ return SidePanel::BuildingID(); }
+
 int MapWnd::SelectedFleetID() const {
     if (!m_selected_fleet_ids.empty())
         return *m_selected_fleet_ids.begin();

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -110,6 +110,7 @@ public:
     /** Returns the id of the currently-selected object or INVALID_OBJECT_ID if no planet is selected */
     int SelectedSystemID() const;
     int SelectedPlanetID() const;
+    int SelectedBuildingID() const;
     int SelectedFleetID() const;
     int SelectedShipID() const;
 

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -4137,7 +4137,7 @@ void SidePanel::SelectBuilding(int building_id) {
 
     // Setting the selected building to invalid is always possible.
     // In other cases we check if the building can be selected.
-    if(building_id != INVALID_OBJECT_ID) {
+    if (building_id != INVALID_OBJECT_ID) {
         auto& app = GetApp();
         auto& context = app.GetContext();
         auto& objects = context.ContextObjects();
@@ -4154,10 +4154,11 @@ void SidePanel::SelectBuilding(int building_id) {
         s_building_id = building_id;
     }
 
-    for (auto& weak_panel : s_side_panels)
+    for (auto& weak_panel : s_side_panels) {
         if (auto panel = weak_panel.lock())
             // Refresh will cause the buildingpanel to be redrawn (with the correct buildingID selected).
             panel->Refresh();
+    }
 }
 
 void SidePanel::SetSystem(int system_id, const ObjectMap& objects) {

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -4129,7 +4129,7 @@ void SidePanel::SelectPlanet(int planet_id, const ObjectMap& objects) {
     PlanetSelectedSignal(s_planet_id);
 }
 
-void SidePanel::SelectBuilding(int building_id){
+void SidePanel::SelectBuilding(int building_id) {
     if (s_building_id == building_id)
         return;
 
@@ -4137,7 +4137,7 @@ void SidePanel::SelectBuilding(int building_id){
 
     // Setting the selected building to invalid is always possible.
     // In other cases we check if the building can be selected.
-    if(building_id != INVALID_OBJECT_ID){
+    if(building_id != INVALID_OBJECT_ID) {
         auto& app = GetApp();
         auto& context = app.GetContext();
         auto& objects = context.ContextObjects();

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -763,6 +763,8 @@ public:
     /** emitted when focus is changed */
     mutable boost::signals2::signal<void (std::string_view)> FocusChangedSignal;
 
+    mutable boost::signals2::signal<void (int)> BuildingSelectedSignal;
+
     mutable boost::signals2::signal<void (int)> BuildingRightClickedSignal;
 
     /** Emitted when an order button changes state, used to update controls
@@ -867,6 +869,8 @@ public:
 
     /** emitted when a planet panel is right-clicked */
     mutable boost::signals2::signal<void (int)> PlanetRightClickedSignal;
+
+    mutable boost::signals2::signal<void (int)> BuildingSelectedSignal;
 
     mutable boost::signals2::signal<void (int)> BuildingRightClickedSignal;
 
@@ -1217,6 +1221,8 @@ void SidePanel::PlanetPanel::CompleteConstruction() {
     AttachChild(m_buildings_panel);
     m_buildings_panel->ExpandCollapseSignal.connect(
         boost::bind(&SidePanel::PlanetPanel::RequirePreRender, this));
+    m_buildings_panel->BuildingSelectedSignal.connect(
+        BuildingSelectedSignal);
     m_buildings_panel->BuildingRightClickedSignal.connect(
         BuildingRightClickedSignal);
 
@@ -1247,6 +1253,8 @@ void SidePanel::PlanetPanel::CompleteConstruction() {
 
     ScriptingContext planet_context(context, ScriptingContext::Source{}, planet);
     Refresh(planet_context, app.EmpireID());
+
+    m_buildings_panel->SelectBuilding(s_building_id);
 
     RequirePreRender();
 
@@ -2466,17 +2474,25 @@ bool SidePanel::PlanetPanel::InWindow(GG::Pt pt) const {
 }
 
 void SidePanel::PlanetPanel::LClick(GG::Pt pt, GG::Flags<GG::ModKey> mod_keys) {
+    // Clicking on the planet panel should invalidate any building selection.
+    BuildingSelectedSignal(INVALID_OBJECT_ID);
     //std::cout << "SidePanel::PlanetPanel::LClick m_planet_id: " << m_planet_id << std::endl;
     if (!Disabled())
         LeftClickedSignal(m_planet_id);
 }
 
 void SidePanel::PlanetPanel::LDoubleClick(GG::Pt pt, GG::Flags<GG::ModKey> mod_keys) {
+    // Clicking on the planet panel should invalidate any building selection.
+    BuildingSelectedSignal(INVALID_OBJECT_ID);
+
     if (!Disabled())
         LeftDoubleClickedSignal(m_planet_id);
 }
 
 void SidePanel::PlanetPanel::RClick(GG::Pt pt, GG::Flags<GG::ModKey> mod_keys) {
+    // Clicking on the planet panel should invalidate any building selection.
+    BuildingSelectedSignal(INVALID_OBJECT_ID);
+
     auto& app = GetApp();
     ScriptingContext& context = app.GetContext();
     const ObjectMap& objects = context.ContextObjects();
@@ -3108,6 +3124,8 @@ void SidePanel::PlanetPanelContainer::SetPlanets(
             PlanetLeftDoubleClickedSignal);
         m_planet_panels.back()->RightClickedSignal.connect(
             PlanetRightClickedSignal);
+        m_planet_panels.back()->BuildingSelectedSignal.connect(
+            BuildingSelectedSignal);
         m_planet_panels.back()->BuildingRightClickedSignal.connect(
             BuildingRightClickedSignal);
         m_planet_panels.back()->ResizedSignal.connect(
@@ -3444,6 +3462,7 @@ namespace {
 // static(s)
 int                                        SidePanel::s_system_id = INVALID_OBJECT_ID;
 int                                        SidePanel::s_planet_id = INVALID_OBJECT_ID;
+int                                        SidePanel::s_building_id = INVALID_OBJECT_ID;
 bool                                       SidePanel::s_needs_update = false;
 bool                                       SidePanel::s_needs_refresh = false;
 std::set<std::weak_ptr<SidePanel>, std::owner_less<std::weak_ptr<SidePanel>>> SidePanel::s_side_panels;
@@ -3453,6 +3472,7 @@ boost::signals2::signal<void ()>           SidePanel::ResourceCenterChangedSigna
 boost::signals2::signal<void (int)>        SidePanel::PlanetSelectedSignal;
 boost::signals2::signal<void (int)>        SidePanel::PlanetRightClickedSignal;
 boost::signals2::signal<void (int)>        SidePanel::PlanetDoubleClickedSignal;
+boost::signals2::signal<void (int)>        SidePanel::BuildingSelectedSignal;
 boost::signals2::signal<void (int)>        SidePanel::BuildingRightClickedSignal;
 boost::signals2::signal<void (int)>        SidePanel::SystemSelectedSignal;
 
@@ -3515,8 +3535,13 @@ void SidePanel::CompleteConstruction() {
         PlanetDoubleClickedSignal);
     m_connections[7] = m_planet_panel_container->PlanetRightClickedSignal.connect(
         PlanetRightClickedSignal);
-    m_connections[8] = m_planet_panel_container->BuildingRightClickedSignal.connect(
+    m_connections[8] = m_planet_panel_container->BuildingSelectedSignal.connect(
+        BuildingSelectedSignal);
+    m_connections[9] = m_planet_panel_container->BuildingRightClickedSignal.connect(
         BuildingRightClickedSignal);
+
+    // Can affect selection over buildings from all planets in the panels, so handle at this level.
+    BuildingSelectedSignal.connect(SelectBuilding);
 
     SetMinSize(GG::Pt(GG::X(MaxPlanetDiameter() + BORDER_LEFT + BORDER_RIGHT + 120),
                       PLANET_PANEL_TOP + GG::Y(MaxPlanetDiameter())));
@@ -4075,6 +4100,8 @@ bool SidePanel::PlanetSelectable(int planet_id, const ObjectMap& objects) const 
 }
 
 void SidePanel::SelectPlanet(int planet_id, const ObjectMap& objects) {
+    // Selecting a planet should invalidate any indivual building selections.
+    SelectBuilding(INVALID_OBJECT_ID);
     if (s_planet_id == planet_id)
         return;
 
@@ -4100,6 +4127,37 @@ void SidePanel::SelectPlanet(int planet_id, const ObjectMap& objects) {
             panel->RequirePreRender();
 
     PlanetSelectedSignal(s_planet_id);
+}
+
+void SidePanel::SelectBuilding(int building_id){
+    if (s_building_id == building_id)
+        return;
+
+    s_building_id = INVALID_OBJECT_ID;
+
+    // Setting the selected building to invalid is always possible.
+    // In other cases we check if the building can be selected.
+    if(building_id != INVALID_OBJECT_ID){
+        auto& app = GetApp();
+        auto& context = app.GetContext();
+        auto& objects = context.ContextObjects();
+
+        auto building = objects.get<Building>(building_id);
+        if (!building)
+            return;
+
+        int planet_id = building->ContainerObjectID();
+        if (planet_id == INVALID_OBJECT_ID)
+            return;
+
+        // TODO: Check the owner of the building?
+        s_building_id = building_id;
+    }
+
+    for (auto& weak_panel : s_side_panels)
+        if (auto panel = weak_panel.lock())
+            // Refresh will cause the buildingpanel to be redrawn (with the correct buildingID selected).
+            panel->Refresh();
 }
 
 void SidePanel::SetSystem(int system_id, const ObjectMap& objects) {

--- a/UI/SidePanel.h
+++ b/UI/SidePanel.h
@@ -37,7 +37,7 @@ public:
 
     /** Returns the id of the building selected in the SidePanels, or
       * INVALID_OBJECT_ID if no building is selected */
-    static int BuildingID() noexcept { return s_building_id; }
+    static int SelectedBuildingID() noexcept { return s_building_id; }
 
     /** Returns whether this SidePanel contains an object with the indicated
       * \a object_id that can be selected within the SidePanel. */

--- a/UI/SidePanel.h
+++ b/UI/SidePanel.h
@@ -35,10 +35,17 @@ public:
       * INVALID_OBJECT_ID if no planet is selected */
     int SelectedPlanetID() const noexcept { return (m_selection_enabled ? s_planet_id : INVALID_OBJECT_ID); }
 
+    /** Returns the id of the building selected in the SidePanels, or
+      * INVALID_OBJECT_ID if no building is selected */
+    static int BuildingID() noexcept { return s_building_id; }
 
     /** Returns whether this SidePanel contains an object with the indicated
       * \a object_id that can be selected within the SidePanel. */
     bool PlanetSelectable(int planet_id, const ObjectMap& objects) const;
+
+    /** Returns whether this SidePanel contains an object with the indicated
+      * \a object_id that can be selected within the SidePanel. */
+    bool BuildingSelectable(int building_id, const ObjectMap& objects) const;
 
     void PreRender() override;
 
@@ -57,6 +64,11 @@ public:
       * such a planet exists.  All SidePanels' selected planets are set, if
       * those panels have planet selection enabled. */
     static void SelectPlanet(int planet_id, const ObjectMap& objects);
+
+    /** Selects the building with id \a building_id within the current system, if
+      * it exists.  All SidePanels' selected buildings are set, if those panels
+      * have building selection enabled. */
+    static void SelectBuilding(int building_id);
 
     /** Sets the system currently being viewed in all side panels */
     static void SetSystem(int system_id, const ObjectMap& objects);
@@ -88,6 +100,9 @@ public:
 
     /** emitted when a planet is right clicked */
     static boost::signals2::signal<void (int)>    PlanetRightClickedSignal;
+
+    /** emitted when a building in the side panel is (left) clicked by the user */
+    static boost::signals2::signal<void (int)>    BuildingSelectedSignal;
 
     /** emitted when a building is right clicked */
     static boost::signals2::signal<void (int)>    BuildingRightClickedSignal;
@@ -139,7 +154,7 @@ private:
     std::shared_ptr<PlanetPanelContainer>       m_planet_panel_container;
     std::shared_ptr<MultiIconValueIndicator>    m_system_resource_summary;
 
-    std::array<boost::signals2::scoped_connection, 9> m_connections;
+    std::array<boost::signals2::scoped_connection, 10> m_connections;
 
     bool        m_selection_enabled = false;
 
@@ -150,6 +165,9 @@ private:
 
     /** The id of the currently-selected planet, or INVALID_OBJECT_ID if no planet is selected. */
     static int  s_planet_id;
+
+    /** The id of the currently-selected building, or INVALID_OBJECT_ID if no building is selected. */
+    static int  s_building_id;
 
     static std::set<std::weak_ptr<SidePanel>, std::owner_less<std::weak_ptr<SidePanel>>> s_side_panels;
 

--- a/client/AI/AIClientApp.h
+++ b/client/AI/AIClientApp.h
@@ -28,6 +28,7 @@ public:
 
     [[nodiscard]] [[noreturn]] int SelectedSystemID() const override { throw std::runtime_error{"AI client cannot access selected object ID"}; }
     [[nodiscard]] [[noreturn]] int SelectedPlanetID() const override { throw std::runtime_error{"AI client cannot access selected object ID"}; }
+    [[nodiscard]] [[noreturn]] int SelectedBuildingID() const override { throw std::runtime_error{"AI client cannot access selected object ID"}; }
     [[nodiscard]] [[noreturn]] int SelectedFleetID() const override { throw std::runtime_error{"AI client cannot access selected object ID"}; }
     [[nodiscard]] [[noreturn]] int SelectedShipID() const override { throw std::runtime_error{"AI client cannot access selected object ID"}; }
     [[nodiscard]] int              EffectsProcessingThreads() const override;

--- a/client/human/GGHumanClientApp.cpp
+++ b/client/human/GGHumanClientApp.cpp
@@ -1628,6 +1628,12 @@ int GGHumanClientApp::SelectedPlanetID() const {
     return INVALID_OBJECT_ID;
 }
 
+int GGHumanClientApp::SelectedBuildingID() const {
+    if (auto mapwnd = m_ui.GetMapWndConst())
+        return mapwnd->SelectedBuildingID();
+    return INVALID_OBJECT_ID;
+}
+
 int GGHumanClientApp::SelectedFleetID() const {
     if (auto mapwnd = m_ui.GetMapWndConst())
         return mapwnd->SelectedFleetID();

--- a/client/human/GGHumanClientApp.h
+++ b/client/human/GGHumanClientApp.h
@@ -44,6 +44,7 @@ public:
 
     [[nodiscard]] int SelectedSystemID() const override;
     [[nodiscard]] int SelectedPlanetID() const override;
+    [[nodiscard]] int SelectedBuildingID() const override;
     [[nodiscard]] int SelectedFleetID() const override;
     [[nodiscard]] int SelectedShipID() const override;
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -55,6 +55,7 @@ public:
 
     [[nodiscard]] int SelectedSystemID() const override { throw std::runtime_error{"Server cannot access selected object ID"}; }
     [[nodiscard]] int SelectedPlanetID() const override { throw std::runtime_error{"Server cannot access selected object ID"}; }
+    [[nodiscard]] int SelectedBuildingID() const override { throw std::runtime_error{"Server cannot access selected object ID"}; }
     [[nodiscard]] int SelectedFleetID() const override { throw std::runtime_error{"Server cannot access selected object ID"}; }
     [[nodiscard]] int SelectedShipID() const override { throw std::runtime_error{"Server cannot access selected object ID"}; }
 

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -1004,10 +1004,10 @@ int Variable<int>::Eval(const ScriptingContext& context) const
             return IApp::GetApp()->SelectedSystemID();
         else if (m_property == Property::SelectedPlanetID)
             return IApp::GetApp()->SelectedPlanetID();
+        else if (m_property == Property::SelectedBuildingID)
+            return IApp::GetApp()->SelectedBuildingID();
         else if (m_property == Property::SelectedFleetID)
             return IApp::GetApp()->SelectedFleetID();
-        else if (m_property == Property::SelectedPlanetID)
-            return IApp::GetApp()->SelectedPlanetID();
         else if (m_property == Property::ThisClientEmpireID)
             return IApp::GetApp()->EmpireID();
 

--- a/universe/ValueRefs.h
+++ b/universe/ValueRefs.h
@@ -396,6 +396,7 @@ FO_ENUM_BIG(
     ((RandomEnqueuedTech))
     ((RandomResearchableTech))
     ((RandomTransferrableTech))
+    ((SelectedBuildingID))
     ((SelectedFleetID))
     ((SelectedPlanetID))
     ((SelectedSystemID))

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -74,6 +74,7 @@ public:
       * On UI clients, returns the ID of the object currently selected. */
     [[nodiscard]] virtual int SelectedSystemID() const { return INVALID_OBJECT_ID; }
     [[nodiscard]] virtual int SelectedPlanetID() const { return INVALID_OBJECT_ID; }
+    [[nodiscard]] virtual int SelectedBuildingID() const { return INVALID_OBJECT_ID; }
     [[nodiscard]] virtual int SelectedFleetID() const { return INVALID_OBJECT_ID; }
     [[nodiscard]] virtual int SelectedShipID() const { return INVALID_OBJECT_ID; }
 


### PR DESCRIPTION
Adds GUI support for selecting buildings.

Example with the cultural archives selected:
<img width="334" height="205" alt="Screenshot_20260618_234248" src="https://github.com/user-attachments/assets/1f4fafac-c00b-40f4-958d-981629c839ce" />

Tested (by clicking in the SidePanel):
- Left-Clicking on a building selects it.
- Left-Clicking on a selected building deselects it.
- Left-Clicking on another building selects the other.
- Left/Right/Double-Clicking on the planet deselects the building.

If we can select individual buildings, then we can add an option in the future to set targets for those buildings in a similar way as the Right-Clicking on the map that fleets use to get the targets to move to. (This PR is part of the feature as discussed in https://www.freeorion.org/forum/viewtopic.php?t=13570)