### PR TITLE
20260530 fix fleet unstealthiness

### DIFF
--- a/default/scripting/specials/UNSTEALTHED_STEALTH_SPECIAL.focs.txt
+++ b/default/scripting/specials/UNSTEALTHED_STEALTH_SPECIAL.focs.txt
@@ -1,0 +1,8 @@
+Special
+    name = "UNSTEALTHED_STEALTH_SPECIAL"
+    description = "UNSTEALTHED_STEALTH_SPECIAL_DESC"
+    stealth = 5
+    spawnrate = 0.0
+    spawnlimit = 0
+    graphic = "icons/ship_parts/cloak-4.png"
+

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -192,19 +192,12 @@ Tech(
         # apply the lowest resulting stealth of ships of higher/equal stealth
         EffectsGroup(
             scope=Ship & InSystem() & OwnedBy(empire=Source.Owner) & HasSpecial(name=base_stealth_special),
-            priority=LATE_AFTER_ALL_TARGET_MAX_METERS_PRIORITY-1,
-            effects=[
-                SetStealth(value=SpecialCapacity(name=stealthed_stealth_special, object=Target.ID)),# comes from server FIXME use other special
-                AddSpecial(name=unstealthed_stealth_special, capacity=min_effective_stealth_of_more_stealthy_ships_valref_other_own_ships_in_targetz_system()),
-            ],
-        ),
-        EffectsGroup(
-            scope=Ship & InSystem() & OwnedBy(empire=Source.Owner) & HasSpecial(name=unstealthed_stealth_special),
             accountinglabel="FLEET_UNSTEALTHINESS_INSYSTEM_LABEL",
             priority=LATE_AFTER_ALL_TARGET_MAX_METERS_PRIORITY,
             effects=[
+                AddSpecial(name=unstealthed_stealth_special, capacity=min_effective_stealth_of_more_stealthy_ships_valref_other_own_ships_in_targetz_system()),
                 SetStealth(
-                    value=SpecialCapacity(name=unstealthed_stealth_special, object=Target.ID),# comes from server FIXME use other special
+                    value=SpecialCapacity(name=unstealthed_stealth_special, object=Target.ID),# comes from server
                 ),
             ],
         ),

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -115,17 +115,23 @@ def min_effective_stealth_of_more_stealthy_ships_valref(base_cond):
     ) + min_effective_stealth_of_more_stealthy_ships_valref_for_not_max_stealth_ships(base_cond)
 
 def min_effective_stealth_of_more_stealthy_ships_valref_other_own_ships_in_targetz_system():
-    return StatisticElse(float, condition=Ship & InSystem(id=Target.SystemID) & ~IsTarget & OwnedBy(empire=Source.Owner) & (
+    return  (0.0 < SpecialCapacity(name=base_stealth_special, object=Target.ID)
+    ) * StatisticElse(float, condition=Ship & InSystem() & InSystem(id=Target.SystemID) & ~IsTarget & OwnedBy(empire=Source.Owner) & (
         SpecialCapacity(name=base_stealth_special, object=Target.ID)
         < SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID)
     )) * ( SpecialCapacity(name=base_stealth_special, object=Target.ID)
            - SpecialCapacity(name=lower_stealth_count_special, object=Target.ID)
     ) + MinOf(float, Statistic(float,Min,
-            value=SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID)
+            value=
+                #min special caps aller anderen im ... oh hier werden  
+                SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID)
                   - SpecialCapacity(name=lower_stealth_count_special, object=LocalCandidate.ID),
             condition=Ship & InSystem(id=Target.SystemID) & ~IsTarget
+                      & InSystem()
                       & OwnedBy(empire=Source.Owner)
-                      & (Value(Target.Stealth) < Value(LocalCandidate.Stealth)),
+                      #& (Value(Target.Stealth) < Value(LocalCandidate.Stealth)),
+                     & (SpecialCapacity(name=base_stealth_special, object=Target.ID)
+                        < SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID)),
         ),
         SpecialCapacity(name=base_stealth_special, object=Target.ID)
             - SpecialCapacity(name=lower_stealth_count_special, object=Target.ID),

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -174,7 +174,9 @@ Tech(
                 ),
                 AddSpecial(name=base_stealth_special, capacity=Value(Target.Stealth)), # record server value
                 Conditional( # if there is a discrepancy between server and client value, sync to server value
-                    condition=0.01 > Abs(SpecialCapacity(name=base_stealth_special, object=Target.ID) - Value(Target.Stealth)),
+                    #condition=0.01 > Abs(SpecialCapacity(name=base_stealth_special, object=Target.ID) - Value(Target.Stealth)),
+                    condition=0.001 > ((SpecialCapacity(name=base_stealth_special, object=Target.ID) - Value(Target.Stealth))
+                                     *(SpecialCapacity(name=base_stealth_special, object=Target.ID) - Value(Target.Stealth))),
                     effects=[
                         SetStealth(value=SpecialCapacity(name=base_stealth_special, object=Target.ID)),
                     ],

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -205,7 +205,7 @@ Tech(
             effects=[
                 AddSpecial(name=unstealthed_stealth_special, capacity=min_effective_stealth_of_more_stealthy_ships_valref_other_own_ships_in_targetz_system()),
                 SetStealth(
-                    value=SpecialCapacity(name=unstealthed_stealth_special, object=Target.ID),# comes from server
+                    value=min_effective_stealth_of_more_stealthy_ships_valref_other_own_ships_in_targetz_system()
                 ),
             ],
         ),

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -1,5 +1,5 @@
 from focs._conditions import HasSpecial, InSystem, IsTarget, OwnedBy, Ship, Star
-from focs._effects_new import AddSpecial, EffectsGroup, SetSpecialCapacity, SetStealth
+from focs._effects_new import AddSpecial, Conditional, EffectsGroup, SetSpecialCapacity, SetStealth
 from focs._enums import BlackHole, Min, Neutron, NoStar, Red
 from focs._sources import LocalCandidate, Source, Target
 from focs._techs import Tech
@@ -161,7 +161,7 @@ Tech(
             accountinglabel="SPY_DECEPTION_SUBSTELLAR_INTERFERENCE",
             effects=SetStealth(value=Value + NamedReal(name="SPY_DECEPTION_BLACK_INTERFERENCE", value=10.0)),
         ),
-        # temporarily note amount of fleet unstealthiness before capping
+        # note amount of fleet unstealthiness before capping and sync client/server for effect accounting
         EffectsGroup(
             scope=Ship & InSystem() & OwnedBy(empire=Source.Owner),
             accountinglabel="FLEET_UNSTEALTHINESS_PRESYNC_LABEL",
@@ -171,8 +171,13 @@ Tech(
                     name=lower_stealth_count_special,
                     capacity=count_lower_stealth_ships_statistic_valref(own_ships_in_targetz_system),
                 ),
-                AddSpecial(name=base_stealth_special, capacity=Value(Target.Stealth)),
-                SetStealth(value=SpecialCapacity(name=base_stealth_special, object=Target.ID)),# sync client to server value - redundant on server
+                AddSpecial(name=base_stealth_special, capacity=Value(Target.Stealth)), # record server value
+                Conditional( # if there is a discrepancy between server and client value, sync to server value
+                    condition=SpecialCapacity(name=base_stealth_special, object=Target.ID) != Value(Target.Stealth),
+                    effects=[
+                        SetStealth(value=SpecialCapacity(name=base_stealth_special, object=Target.ID)),
+                    ],
+                ),
             ],
         ),
         # Check InGame(), this should not trigger in e.g. ShipDesigner (where the ship is ~InSystem). No meter effects - not strictly necessary

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -175,8 +175,8 @@ Tech(
                 AddSpecial(name=base_stealth_special, capacity=Value(Target.Stealth)), # record server value
                 Conditional( # if there is a discrepancy between server and client value, sync to server value
                     #condition=0.01 > Abs(SpecialCapacity(name=base_stealth_special, object=Target.ID) - Value(Target.Stealth)),
-                    condition=0.001 > ((SpecialCapacity(name=base_stealth_special, object=Target.ID) - Value(Target.Stealth))
-                                     *(SpecialCapacity(name=base_stealth_special, object=Target.ID) - Value(Target.Stealth))),
+                    condition=0.001 > ((SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID) - Value(LocalCandidate.Stealth))
+                                     *(SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID) - Value(LocalCandidate.Stealth))),
                     effects=[
                         SetStealth(value=SpecialCapacity(name=base_stealth_special, object=Target.ID)),
                     ],

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -175,7 +175,7 @@ Tech(
                 AddSpecial(name=base_stealth_special, capacity=Value(Target.Stealth)), # record server value
                 Conditional( # if there is a discrepancy between server and client value, sync to server value
                     #condition=0.01 > Abs(SpecialCapacity(name=base_stealth_special, object=Target.ID) - Value(Target.Stealth)),
-                    condition=0.001 > ((SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID) - Value(LocalCandidate.Stealth))
+                    condition=0.001 < ((SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID) - Value(LocalCandidate.Stealth))
                                      *(SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID) - Value(LocalCandidate.Stealth))),
                     effects=[
                         SetStealth(value=SpecialCapacity(name=base_stealth_special, object=Target.ID)),

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -112,6 +112,23 @@ def min_effective_stealth_of_more_stealthy_ships_valref(base_cond):
         Target.ID
     ) + min_effective_stealth_of_more_stealthy_ships_valref_for_not_max_stealth_ships(base_cond)
 
+def min_effective_stealth_of_more_stealthy_ships_valref_other_own_ships_in_targetz_system():
+    return StatisticElse(float, condition=Ship & InSystem(id=Target.SystemID) & ~IsTarget & OwnedBy(empire=Source.Owner) & (
+        SpecialCapacity(name=base_stealth_special, object=Target.ID)
+        < SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID)
+    )) * ( SpecialCapacity(name=base_stealth_special, object=Target.ID)
+           - SpecialCapacity(name=lower_stealth_count_special, object=Target.ID)
+    ) + MinOf(float, Statistic(float,Min,
+            value=stealth_result(LocalCandidate.ID),
+            condition=Ship & InSystem(id=Target.SystemID) & ~IsTarget
+                      & OwnedBy(empire=Source.Owner)
+                      & (Value(Target.Stealth) < Value(LocalCandidate.Stealth)),
+        ),
+        SpecialCapacity(name=base_stealth_special, object=Target.ID)
+            - SpecialCapacity(name=lower_stealth_count_special, object=Target.ID),
+    )
+
+
 
 Tech(
     name="SPY_ROOT_DECEPTION",
@@ -173,7 +190,7 @@ Tech(
             priority=LATE_AFTER_ALL_TARGET_MAX_METERS_PRIORITY,
             effects=[
                 SetStealth(
-                    value=min_effective_stealth_of_more_stealthy_ships_valref(other_own_ships_in_targetz_system)
+                    value=min_effective_stealth_of_more_stealthy_ships_valref_other_own_ships_in_targetz_system
                 ),
             ],
         ),

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -119,7 +119,8 @@ def min_effective_stealth_of_more_stealthy_ships_valref_other_own_ships_in_targe
     )) * ( SpecialCapacity(name=base_stealth_special, object=Target.ID)
            - SpecialCapacity(name=lower_stealth_count_special, object=Target.ID)
     ) + MinOf(float, Statistic(float,Min,
-            value=stealth_result(LocalCandidate.ID),
+            value=SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID)
+                  - SpecialCapacity(name=lower_stealth_count_special, object=LocalCandidate.ID),
             condition=Ship & InSystem(id=Target.SystemID) & ~IsTarget
                       & OwnedBy(empire=Source.Owner)
                       & (Value(Target.Stealth) < Value(LocalCandidate.Stealth)),
@@ -190,7 +191,7 @@ Tech(
             priority=LATE_AFTER_ALL_TARGET_MAX_METERS_PRIORITY,
             effects=[
                 SetStealth(
-                    value=min_effective_stealth_of_more_stealthy_ships_valref_other_own_ships_in_targetz_system
+                    value=min_effective_stealth_of_more_stealthy_ships_valref_other_own_ships_in_targetz_system()
                 ),
             ],
         ),

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -4,6 +4,7 @@ from focs._enums import BlackHole, Min, Neutron, NoStar, Red
 from focs._sources import LocalCandidate, Source, Target
 from focs._techs import Tech
 from focs._value_refs import (
+    Abs,
     MinOf,
     NamedReal,
     NoOpValue,
@@ -173,7 +174,7 @@ Tech(
                 ),
                 AddSpecial(name=base_stealth_special, capacity=Value(Target.Stealth)), # record server value
                 Conditional( # if there is a discrepancy between server and client value, sync to server value
-                    condition=SpecialCapacity(name=base_stealth_special, object=Target.ID) != Value(Target.Stealth),
+                    condition=0.01 > Abs(SpecialCapacity(name=base_stealth_special, object=Target.ID) - Value(Target.Stealth)),
                     effects=[
                         SetStealth(value=SpecialCapacity(name=base_stealth_special, object=Target.ID)),
                     ],

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -20,6 +20,7 @@ from macros.priorities import (
 
 lower_stealth_count_special = "LOWER_STEALTH_COUNT_SPECIAL"
 base_stealth_special = "BASE_STEALTH_SPECIAL"
+unstealthed_stealth_special = "UNSTEALTHED_STEALTH_SPECIAL"
 
 
 def InGame():
@@ -163,6 +164,7 @@ Tech(
         # temporarily note amount of fleet unstealthiness before capping
         EffectsGroup(
             scope=Ship & InSystem() & OwnedBy(empire=Source.Owner),
+            accountinglabel="FLEET_UNSTEALTHINESS_PRESYNC_LABEL",
             priority=AFTER_ALL_TARGET_MAX_METERS_PRIORITY,
             effects=[
                 SetSpecialCapacity(
@@ -170,11 +172,13 @@ Tech(
                     capacity=count_lower_stealth_ships_statistic_valref(own_ships_in_targetz_system),
                 ),
                 AddSpecial(name=base_stealth_special, capacity=Value(Target.Stealth)),
+                SetStealth(value=SpecialCapacity(name=base_stealth_special, object=Target.ID)),# sync client to server value - redundant on server
             ],
         ),
         # Check InGame(), this should not trigger in e.g. ShipDesigner (where the ship is ~InSystem). No meter effects - not strictly necessary
         EffectsGroup(
             scope=Ship & InGame() & ~InSystem() & OwnedBy(empire=Source.Owner),
+            accountinglabel="FLEET_UNSTEALTHINESS_PRESYNC_LABEL",
             priority=AFTER_ALL_TARGET_MAX_METERS_PRIORITY,
             effects=[
                 SetSpecialCapacity(
@@ -182,16 +186,25 @@ Tech(
                     capacity=count_lower_stealth_ships_statistic_valref(own_ships_on_targetz_starlane),
                 ),
                 AddSpecial(name=base_stealth_special, capacity=Value(Target.Stealth)),
+                SetStealth(value=SpecialCapacity(name=base_stealth_special, object=Target.ID)),# sync client to server value - redundant on server
             ],
         ),
         # apply the lowest resulting stealth of ships of higher/equal stealth
         EffectsGroup(
             scope=Ship & InSystem() & OwnedBy(empire=Source.Owner) & HasSpecial(name=base_stealth_special),
+            priority=LATE_AFTER_ALL_TARGET_MAX_METERS_PRIORITY-1,
+            effects=[
+                SetStealth(value=SpecialCapacity(name=stealthed_stealth_special, object=Target.ID)),# comes from server FIXME use other special
+                AddSpecial(name=unstealthed_stealth_special, capacity=min_effective_stealth_of_more_stealthy_ships_valref_other_own_ships_in_targetz_system()),
+            ],
+        ),
+        EffectsGroup(
+            scope=Ship & InSystem() & OwnedBy(empire=Source.Owner) & HasSpecial(name=unstealthed_stealth_special),
             accountinglabel="FLEET_UNSTEALTHINESS_INSYSTEM_LABEL",
             priority=LATE_AFTER_ALL_TARGET_MAX_METERS_PRIORITY,
             effects=[
                 SetStealth(
-                    value=min_effective_stealth_of_more_stealthy_ships_valref_other_own_ships_in_targetz_system()
+                    value=SpecialCapacity(name=unstealthed_stealth_special, object=Target.ID),# comes from server FIXME use other special
                 ),
             ],
         ),

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -44,8 +44,10 @@ def count_lower_stealth_ships_statistic_valref(base_cond):
 
 
 def target_has_less_stealth_cond(base_cond):
-    return base_cond & (Value(Target.Stealth) < Value(LocalCandidate.Stealth))
-
+    return base_cond & (
+        SpecialCapacity(name=base_stealth_special, object=Target.ID)
+        < SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID)
+    )
 
 own_ships_in_targetz_system = Ship & InSystem(id=Target.SystemID) & OwnedBy(empire=Source.Owner)
 other_own_ships_in_targetz_system = Ship & InSystem(id=Target.SystemID) & ~IsTarget & OwnedBy(empire=Source.Owner)

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -162,10 +162,8 @@ Tech(
                 ),
                 AddSpecial(name=base_stealth_special, capacity=Value(Target.Stealth)), # record server value
                 Conditional( # if there is a discrepancy between server and client value, sync to server value
-                    #condition=0.01 > Abs(SpecialCapacity(name=base_stealth_special, object=Target.ID) - Value(Target.Stealth)),
                     condition=HasSpecial(name=base_stealth_special) # should be false iff the ship was built this turn
-                        & (0.001 < ((SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID) - Value(LocalCandidate.Stealth))
-                                     *(SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID) - Value(LocalCandidate.Stealth)))),
+                        & (0.01 < Abs(float, SpecialCapacity(name=base_stealth_special, object=Target.ID) - Value(Target.Stealth))),
                     effects=[
                         SetStealth(value=SpecialCapacity(name=base_stealth_special, object=Target.ID)),
                     ],

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -6,6 +6,7 @@ from focs._techs import Tech
 from focs._value_refs import (
     Abs,
     MinOf,
+    MaxOf,
     NamedReal,
     NoOpValue,
     SpecialCapacity,
@@ -99,9 +100,10 @@ def min_effective_stealth_of_more_stealthy_ships_valref_for_not_max_stealth_ship
             value=stealth_result(LocalCandidate.ID),
             condition=target_has_less_stealth_cond(base_cond),
         ),
-        (
-            SpecialCapacity(name=base_stealth_special, object=Target.ID)
-            - SpecialCapacity(name=lower_stealth_count_special, object=Target.ID)
+        MaxOf(
+            float,
+            0.0,
+            stealth_result(Target.ID),
         ),
     )
 
@@ -111,12 +113,17 @@ def min_effective_stealth_of_more_stealthy_ships_valref_for_not_max_stealth_ship
 #    this results in a stealth decrease which does not leak information about unseen higher-stealth ships
 #    if there are a lot higher-stealth ships, normal linear unstealthiness would lead to the higher-stealth ships ending with lower stealth
 #    perfect ignorance linear unstealthiness solves this weirdness by lowering stealth to the lowest stealth of initially-higher stealth ships
+#    Implementation note:
+#      - min_effective_stealth_of_more_stealthy_... will return zero if the target is at maximum stealth,
+#        so we add the target stealth_result in that case
 def min_effective_stealth_of_more_stealthy_ships_valref(base_cond):
     return StatisticElse(float, condition=candidate_has_less_stealth_cond(base_cond)) * stealth_result(
         Target.ID
     ) + min_effective_stealth_of_more_stealthy_ships_valref_for_not_max_stealth_ships(base_cond)
 
 def min_effective_stealth_of_more_stealthy_ships_valref_other_own_ships_in_targetz_system():
+    # not adding stealth_result in case of negative stealth_result was tested OK,
+    # got refactored when backporting into min_effective_stealth_of_more_stealthy_ships_valref_for_not_max_stealth_ships
     return  (0.0 < SpecialCapacity(name=base_stealth_special, object=Target.ID)
     ) * StatisticElse(float, condition=Ship & InSystem() & InSystem(id=Target.SystemID) & ~IsTarget & OwnedBy(empire=Source.Owner) & (
         SpecialCapacity(name=base_stealth_special, object=Target.ID)

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -6,7 +6,6 @@ from focs._techs import Tech
 from focs._value_refs import (
     Abs,
     MinOf,
-    MaxOf,
     NamedReal,
     NoOpValue,
     SpecialCapacity,
@@ -49,6 +48,7 @@ def target_has_less_stealth_cond(base_cond):
         SpecialCapacity(name=base_stealth_special, object=Target.ID)
         < SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID)
     )
+
 
 own_ships_in_targetz_system = Ship & InSystem(id=Target.SystemID) & OwnedBy(empire=Source.Owner)
 other_own_ships_in_targetz_system = Ship & InSystem(id=Target.SystemID) & ~IsTarget & OwnedBy(empire=Source.Owner)
@@ -116,10 +116,12 @@ def min_effective_stealth_of_more_stealthy_ships_valref_for_not_max_stealth_ship
 #         will return the target stealth if that is negative
 #            so we skip adding the target stealth_result
 def min_effective_stealth_of_more_stealthy_ships_valref(base_cond):
-    return (0.0 < SpecialCapacity(name=base_stealth_special, object=Target.ID)
-    ) * StatisticElse(float, condition=candidate_has_less_stealth_cond(base_cond)) * stealth_result(
-        Target.ID
-    ) + min_effective_stealth_of_more_stealthy_ships_valref_for_not_max_stealth_ships(base_cond)
+    return (0.0 < SpecialCapacity(name=base_stealth_special, object=Target.ID)) * StatisticElse(
+        float, condition=candidate_has_less_stealth_cond(base_cond)
+    ) * stealth_result(Target.ID) + min_effective_stealth_of_more_stealthy_ships_valref_for_not_max_stealth_ships(
+        base_cond
+    )
+
 
 Tech(
     name="SPY_ROOT_DECEPTION",
@@ -160,10 +162,15 @@ Tech(
                     name=lower_stealth_count_special,
                     capacity=count_lower_stealth_ships_statistic_valref(own_ships_in_targetz_system),
                 ),
-                AddSpecial(name=base_stealth_special, capacity=Value(Target.Stealth)), # record server value
-                Conditional( # if there is a discrepancy between server and client value, sync to server value
-                    condition=HasSpecial(name=base_stealth_special) # should be false iff the ship was built this turn
-                        & (0.01 < Abs(float, SpecialCapacity(name=base_stealth_special, object=Target.ID) - Value(Target.Stealth))),
+                AddSpecial(name=base_stealth_special, capacity=Value(Target.Stealth)),  # record server value
+                Conditional(  # if there is a discrepancy between server and client value, sync to server value
+                    condition=HasSpecial(name=base_stealth_special)  # should be false iff the ship was built this turn
+                    & (
+                        0.01
+                        < Abs(
+                            float, SpecialCapacity(name=base_stealth_special, object=Target.ID) - Value(Target.Stealth)
+                        )
+                    ),
                     effects=[
                         SetStealth(value=SpecialCapacity(name=base_stealth_special, object=Target.ID)),
                     ],
@@ -181,7 +188,9 @@ Tech(
                     capacity=count_lower_stealth_ships_statistic_valref(own_ships_on_targetz_starlane),
                 ),
                 AddSpecial(name=base_stealth_special, capacity=Value(Target.Stealth)),
-                SetStealth(value=SpecialCapacity(name=base_stealth_special, object=Target.ID)),# sync client to server value - redundant on server
+                SetStealth(
+                    value=SpecialCapacity(name=base_stealth_special, object=Target.ID)
+                ),  # sync client to server value - redundant on server
             ],
         ),
         # apply the lowest resulting stealth of ships of higher/equal stealth
@@ -190,7 +199,10 @@ Tech(
             accountinglabel="FLEET_UNSTEALTHINESS_INSYSTEM_LABEL",
             priority=LATE_AFTER_ALL_TARGET_MAX_METERS_PRIORITY,
             effects=[
-                AddSpecial(name=unstealthed_stealth_special, capacity=min_effective_stealth_of_more_stealthy_ships_valref(other_own_ships_in_targetz_system)),
+                AddSpecial(
+                    name=unstealthed_stealth_special,
+                    capacity=min_effective_stealth_of_more_stealthy_ships_valref(other_own_ships_in_targetz_system),
+                ),
                 SetStealth(
                     value=min_effective_stealth_of_more_stealthy_ships_valref(other_own_ships_in_targetz_system)
                 ),

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -190,8 +190,9 @@ Tech(
                 AddSpecial(name=base_stealth_special, capacity=Value(Target.Stealth)), # record server value
                 Conditional( # if there is a discrepancy between server and client value, sync to server value
                     #condition=0.01 > Abs(SpecialCapacity(name=base_stealth_special, object=Target.ID) - Value(Target.Stealth)),
-                    condition=0.001 < ((SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID) - Value(LocalCandidate.Stealth))
-                                     *(SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID) - Value(LocalCandidate.Stealth))),
+                    condition=HasSpecial(name=base_stealth_special) # should be false iff the ship was built this turn
+                        & (0.001 < ((SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID) - Value(LocalCandidate.Stealth))
+                                     *(SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID) - Value(LocalCandidate.Stealth)))),
                     effects=[
                         SetStealth(value=SpecialCapacity(name=base_stealth_special, object=Target.ID)),
                     ],

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -110,40 +110,16 @@ def min_effective_stealth_of_more_stealthy_ships_valref_for_not_max_stealth_ship
 #    if there are a lot higher-stealth ships, normal linear unstealthiness would lead to the higher-stealth ships ending with lower stealth
 #    perfect ignorance linear unstealthiness solves this weirdness by lowering stealth to the lowest stealth of initially-higher stealth ships
 #    Implementation note:
-#      - min_effective_stealth_of_more_stealthy_... will return zero if the target is at maximum stealth,
-#        so we add the target stealth_result in that case
+#      - min_effective_stealth_of_more_stealthy_...
+#         will return zero if the target is stealth positive and at maximum,
+#            so we add the target stealth_result in that case
+#         will return the target stealth if that is negative
+#            so we skip adding the target stealth_result
 def min_effective_stealth_of_more_stealthy_ships_valref(base_cond):
     return (0.0 < SpecialCapacity(name=base_stealth_special, object=Target.ID)
     ) * StatisticElse(float, condition=candidate_has_less_stealth_cond(base_cond)) * stealth_result(
         Target.ID
     ) + min_effective_stealth_of_more_stealthy_ships_valref_for_not_max_stealth_ships(base_cond)
-
-def min_effective_stealth_of_more_stealthy_ships_valref_other_own_ships_in_targetz_system():
-    # not adding stealth_result in case of negative stealth_result was tested OK,
-    # got refactored when backporting into min_effective_stealth_of_more_stealthy_ships_valref_for_not_max_stealth_ships
-    return  (0.0 < SpecialCapacity(name=base_stealth_special, object=Target.ID)
-    ) * StatisticElse(float, condition=Ship & InSystem() & InSystem(id=Target.SystemID) & ~IsTarget & OwnedBy(empire=Source.Owner) & (
-        SpecialCapacity(name=base_stealth_special, object=Target.ID)
-        < SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID)
-    )) * ( SpecialCapacity(name=base_stealth_special, object=Target.ID)
-           - SpecialCapacity(name=lower_stealth_count_special, object=Target.ID)
-    ) + MinOf(float, Statistic(float,Min,
-            value=
-                #min special caps aller anderen im ... oh hier werden  
-                SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID)
-                  - SpecialCapacity(name=lower_stealth_count_special, object=LocalCandidate.ID),
-            condition=Ship & InSystem(id=Target.SystemID) & ~IsTarget
-                      & InSystem()
-                      & OwnedBy(empire=Source.Owner)
-                      #& (Value(Target.Stealth) < Value(LocalCandidate.Stealth)),
-                     & (SpecialCapacity(name=base_stealth_special, object=Target.ID)
-                        < SpecialCapacity(name=base_stealth_special, object=LocalCandidate.ID)),
-        ),
-        SpecialCapacity(name=base_stealth_special, object=Target.ID)
-            - SpecialCapacity(name=lower_stealth_count_special, object=Target.ID),
-    )
-
-
 
 Tech(
     name="SPY_ROOT_DECEPTION",

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -1,5 +1,5 @@
 from focs._conditions import HasSpecial, InSystem, IsTarget, OwnedBy, Ship, Star
-from focs._effects import AddSpecial, EffectsGroup, SetSpecialCapacity, SetStealth
+from focs._effects import AddSpecial, Conditional, EffectsGroup, SetSpecialCapacity, SetStealth
 from focs._enums import BlackHole, Min, Neutron, NoStar, Red
 from focs._sources import LocalCandidate, Source, Target
 from focs._techs import Tech
@@ -161,7 +161,7 @@ Tech(
             accountinglabel="SPY_DECEPTION_SUBSTELLAR_INTERFERENCE",
             effects=SetStealth(value=Value + NamedReal(name="SPY_DECEPTION_BLACK_INTERFERENCE", value=10.0)),
         ),
-        # temporarily note amount of fleet unstealthiness before capping
+        # note amount of fleet unstealthiness before capping and sync client/server for effect accounting
         EffectsGroup(
             scope=Ship & InSystem() & OwnedBy(empire=Source.Owner),
             accountinglabel="FLEET_UNSTEALTHINESS_PRESYNC_LABEL",
@@ -171,8 +171,13 @@ Tech(
                     name=lower_stealth_count_special,
                     capacity=count_lower_stealth_ships_statistic_valref(own_ships_in_targetz_system),
                 ),
-                AddSpecial(name=base_stealth_special, capacity=Value(Target.Stealth)),
-                SetStealth(value=SpecialCapacity(name=base_stealth_special, object=Target.ID)),# sync client to server value - redundant on server
+                AddSpecial(name=base_stealth_special, capacity=Value(Target.Stealth)), # record server value
+                Conditional( # if there is a discrepancy between server and client value, sync to server value
+                    condition=SpecialCapacity(name=base_stealth_special, object=Target.ID) != Value(Target.Stealth),
+                    effects=[
+                        SetStealth(value=SpecialCapacity(name=base_stealth_special, object=Target.ID)),
+                    ],
+                ),
             ],
         ),
         # Check InGame(), this should not trigger in e.g. ShipDesigner (where the ship is ~InSystem). No meter effects - not strictly necessary

--- a/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
+++ b/default/scripting/techs/spy/ROOT_DECEPTION.focs.py
@@ -90,7 +90,7 @@ def stealth_result(obj, debug=False):
         )
 
 
-#    iff the target does have the maximum stealth of all base_cond matches this returns 0
+#    iff the target does have the maximum stealth of all base_cond matches (and its stealth is non-negative) this returns 0
 def min_effective_stealth_of_more_stealthy_ships_valref_for_not_max_stealth_ships(base_cond):
     return MinOf(
         float,
@@ -100,11 +100,7 @@ def min_effective_stealth_of_more_stealthy_ships_valref_for_not_max_stealth_ship
             value=stealth_result(LocalCandidate.ID),
             condition=target_has_less_stealth_cond(base_cond),
         ),
-        MaxOf(
-            float,
-            0.0,
-            stealth_result(Target.ID),
-        ),
+        stealth_result(Target.ID),
     )
 
 
@@ -117,7 +113,8 @@ def min_effective_stealth_of_more_stealthy_ships_valref_for_not_max_stealth_ship
 #      - min_effective_stealth_of_more_stealthy_... will return zero if the target is at maximum stealth,
 #        so we add the target stealth_result in that case
 def min_effective_stealth_of_more_stealthy_ships_valref(base_cond):
-    return StatisticElse(float, condition=candidate_has_less_stealth_cond(base_cond)) * stealth_result(
+    return (0.0 < SpecialCapacity(name=base_stealth_special, object=Target.ID)
+    ) * StatisticElse(float, condition=candidate_has_less_stealth_cond(base_cond)) * stealth_result(
         Target.ID
     ) + min_effective_stealth_of_more_stealthy_ships_valref_for_not_max_stealth_ships(base_cond)
 
@@ -219,9 +216,9 @@ Tech(
             accountinglabel="FLEET_UNSTEALTHINESS_INSYSTEM_LABEL",
             priority=LATE_AFTER_ALL_TARGET_MAX_METERS_PRIORITY,
             effects=[
-                AddSpecial(name=unstealthed_stealth_special, capacity=min_effective_stealth_of_more_stealthy_ships_valref_other_own_ships_in_targetz_system()),
+                AddSpecial(name=unstealthed_stealth_special, capacity=min_effective_stealth_of_more_stealthy_ships_valref(other_own_ships_in_targetz_system)),
                 SetStealth(
-                    value=min_effective_stealth_of_more_stealthy_ships_valref_other_own_ships_in_targetz_system()
+                    value=min_effective_stealth_of_more_stealthy_ships_valref(other_own_ships_in_targetz_system)
                 ),
             ],
         ),

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -15328,6 +15328,10 @@ SHIP_STEALTH_MODIFIERS
 BASIC_PLANET_STEALTH
 Universal Basic Stealth
 
+# stealth as reported by the server before applying fleet unstealthiness
+FLEET_UNSTEALTHINESS_PRESYNC_LABEL
+Unexpected Effect
+
 FLEET_UNSTEALTHINESS_INSYSTEM_LABEL
 Fleet Unstealthiness (In System)
 

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -1051,7 +1051,8 @@ void serialize(Archive& ar, UniverseObject& o, unsigned int const version)
         std::string info_str;
         ar >> make_nvp("info", info_str)
            >> make_nvp("x", o.m_x)
-           >> make_nvp("y", o.m_y);
+           >> make_nvp("y", o.m_y)
+           >> make_nvp("m_specials", o.m_specials);
 
         std::tie(o.m_id, o.m_owner_empire_id, o.m_system_id,
                  o.m_created_on_turn, o.m_name) = ExtractIntsAndRestFromString<4>(std::move(info_str));
@@ -1063,7 +1064,8 @@ void serialize(Archive& ar, UniverseObject& o, unsigned int const version)
 
         ar << make_nvp("info", str)
            << make_nvp("x", o.m_x) // not included in str because as of this writing m_x and m_y are floating-point types, which are not portably serialized by standard library to/from text converters
-           << make_nvp("y", o.m_y);
+           << make_nvp("y", o.m_y)
+           << make_nvp("m_specials", o.m_specials);
 
         Serialize(ar, o.m_meters, version);
 


### PR DESCRIPTION
I am trying to fix fleet unstealthiness UI. The main nonsense stems from client and server values getting out of touch. The theory is that AddSpecial and SetSpecialCapacity are actually not executed on the client.

So the current approach is:
- note the Stealth value before applying unstealthiness in a BASE_STEALTH_SPECIAL
- iff the current Stealth meter is not at BASE_STEALTH_SPECIAL capacity, this means the client and server calculated differently, so SetStealth to the BASE_STEALTH_SPECIAL capacity, so the difference shows up as Unaccounted Effects or Unknown Effects or similar
- then calculate unstealthiness the normal way (or use the server value via UNSTEALTHED_STEALTH_SPECIAL)

WIP to start discussion how Conditional effect actually works - my wiki entry was guesswork and i think it is wrong.
@geoffthemedio can you tell me if the following is correct(?): Conditional effect gets passed in the TargetSet of the effect group. The target set gets passed to the "condition" Condition, which divides the targets into matching and not-matching targets. The if-effect gets executed on the matches and the else-effect gets executed on the non-matches.