### PR TITLE
refactor planet rendering state isolation

### DIFF
--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -405,15 +405,15 @@ namespace {
 
         const auto& [verts, norms, tex] = SphereVerticesNormalsTexCoords(radius);
 
-        verts.activate();
-        norms.activate();
-        tex.activate();
-
-        glPushClientAttrib(GL_CLIENT_ALL_ATTRIB_BITS);
+        glPushClientAttrib(GL_CLIENT_VERTEX_ARRAY_BIT);
         glEnableClientState(GL_VERTEX_ARRAY);
         glEnableClientState(GL_NORMAL_ARRAY);
         glDisableClientState(GL_COLOR_ARRAY);
         glEnableClientState(GL_TEXTURE_COORD_ARRAY);
+
+        verts.activate();
+        norms.activate();
+        tex.activate();
 
         glDrawArrays(GL_QUAD_STRIP, 0, verts.size());
 
@@ -494,24 +494,28 @@ namespace {
                       double initial_rotation, double RPM, float axial_tilt, float shininess,
                       StarType star_type)
     {
-        glPushAttrib(GL_ENABLE_BIT | GL_PIXEL_MODE_BIT | GL_TEXTURE_BIT | GL_SCISSOR_BIT);
-        GetApp().Exit2DMode();
+        // we change rendering state to render 3D rotating planet, but as long as we fully push the prior state that
+        // we are changing, and pop it later, this is isolated so no need to Exit/Enter 2D mode
+        //GetApp().Exit2DMode();
+        glPushAttrib(GL_ENABLE_BIT | GL_TEXTURE_BIT | GL_LIGHTING_BIT | GL_TRANSFORM_BIT | GL_COLOR_BUFFER_BIT | GL_POLYGON_BIT | GL_CURRENT_BIT);
 
         // slide the texture coords to simulate a rotating axis
         glMatrixMode(GL_TEXTURE);
+        glPushMatrix();
         glLoadIdentity();
         glTranslated(initial_rotation - GetApp().Ticks() / 1000.0 * RPM / 60.0, 0.0, 0.0);
 
         glMatrixMode(GL_PROJECTION);
+        glPushMatrix();
         glLoadIdentity();
         glOrtho(0.0, Value(GetApp().AppWidth()),
                 Value(GetApp().AppHeight()), 0.0,
                 0.0, Value(GetApp().AppWidth()));
 
         glMatrixMode(GL_MODELVIEW);
+        glPushMatrix();
         glLoadIdentity();
 
-        glPushAttrib(GL_LIGHTING_BIT | GL_ENABLE_BIT);
         const auto light_position = GetLightPosition();
         glLightfv(GL_LIGHT0, GL_POSITION, light_position);
         glEnable(GL_LIGHTING);
@@ -543,14 +547,19 @@ namespace {
             glDisable(GL_BLEND);
         }
 
-        glPopAttrib();
+        glMatrixMode(GL_MODELVIEW);
+        glPopMatrix();
+
+        glMatrixMode(GL_PROJECTION);
+        glPopMatrix();
 
         glMatrixMode(GL_TEXTURE);
-        glLoadIdentity();
-        glMatrixMode(GL_MODELVIEW);
+        glPopMatrix();
 
-        GetApp().Enter2DMode();
         glPopAttrib();
+
+        //local rendering state was isolated with pushes and pops, no need to explicitly exit/enter 2D mode
+        //GetApp().Enter2DMode();
     }
 
     int MaxPlanetDiameter()


### PR DESCRIPTION
Something I've noticed while poking around and felt compelled to tidy up, plus I got distracted and have more done around planet rendering. But trying maybe smaller separate changes than one bigger one?

So, what did I notice? `RenderPlanet` is pushing bunch of GL state:

https://github.com/freeorion/freeorion/blob/576bd8779c7f19b2cbe0b2df36fc28a596781f14/UI/SidePanel.cpp#L493-L499

but then

https://github.com/freeorion/freeorion/blob/576bd8779c7f19b2cbe0b2df36fc28a596781f14/UI/SDLGUI.cpp#L641-L649

So that state pushing gets immedietely popped by `Exit2DMode`. Similar (in reverse) thing at the end, where `Enter2DMode` is called first and pushes some state which is immedietely popped by `RenderPlanet` parting ways

https://github.com/freeorion/freeorion/blob/576bd8779c7f19b2cbe0b2df36fc28a596781f14/UI/SidePanel.cpp#L552-L553

the states that are actually noticeably changed by `RenderPlanet` are pushed and popped again separately between these

https://github.com/freeorion/freeorion/blob/576bd8779c7f19b2cbe0b2df36fc28a596781f14/UI/SidePanel.cpp#L514

https://github.com/freeorion/freeorion/blob/576bd8779c7f19b2cbe0b2df36fc28a596781f14/UI/SidePanel.cpp#L546

So Enter/Exit 2D mode should rather be on the outside of `glPushAttrib`/`glPopAttrib`. But also, enter/exit 2d mode is not necessary at all if the state is managed comprehensively.

Less defensive programming around that would be healthier for GL pipeline, as attribute pushing and popping tends to stall the pipeline, I gathered. But I am not going as far, just merging some glPushAttrib and pop and not going the whole enter/exit 2d mode

Also, client attrib push I limit to more relevant GL_CLIENT_VERTEX_ARRAY_BIT. I think being less defensive with gl client pushes/pops could also contribute to smoother pipeline processing, but also not trying to go in that direction

This tidies things up a bit and there would be more coming after this including some perf improvements but again trying to maybe more bite sized steps