### PR TITLE
Ignore Godot's .import files for textures

### DIFF
--- a/GG/GG/GUI.h
+++ b/GG/GG/GUI.h
@@ -337,6 +337,10 @@ public:
     static std::shared_ptr<Texture> GetTexture(const std::filesystem::path& path, bool mipmap = false)
     { return GetTextureManager().GetTexture(path, mipmap); }
 
+    /** Returns if file \a path is a supported texture format. */
+    static bool IsSupportedTextureFilenameExtension(const std::filesystem::path& path)
+    { return TextureManager::IsSupportedTextureFilenameExtension(path); }
+
     /** Removes the desired texture from the managed pool; since shared_ptr
       * are used, the texture may be deleted much later. */
     static void FreeTexture(const std::filesystem::path& path)

--- a/GG/GG/Texture.h
+++ b/GG/GG/Texture.h
@@ -235,6 +235,9 @@ public:
         from disk. */
     std::shared_ptr<Texture> GetTexture(const std::filesystem::path& path, bool mipmap = false);
 
+    /** Returns if file \a path is a supported texture format. */
+    static bool IsSupportedTextureFilenameExtension(const std::filesystem::path& path);
+
     /** Returns a shared_ptr to the texture created/stored with name \a texture_name
         or nullptr if not present in the manager's pool. */
     std::shared_ptr<Texture> GetTextureByName(const std::string& texture_name) const;

--- a/GG/src/Texture.cpp
+++ b/GG/src/Texture.cpp
@@ -511,6 +511,19 @@ std::shared_ptr<Texture> TextureManager::GetTexture(const std::filesystem::path&
     return LoadTexture(path, mipmap);
 }
 
+bool TextureManager::IsSupportedTextureFilenameExtension(const std::filesystem::path& path) {
+    std::string extension = boost::algorithm::to_lower_copy(path.extension().string());
+#if GG_HAVE_LIBPNG
+    if (extension == ".png")
+        return true;
+#endif
+#if GG_HAVE_LIBTIFF
+    if (extension == ".tif" || extension == ".tiff")
+        return true;
+#endif
+    return false;
+}
+
 std::shared_ptr<Texture> TextureManager::GetTextureByName(const std::string& texture_name) const
 {
     std::scoped_lock lock(m_texture_access_guard);

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -1197,7 +1197,7 @@ const std::vector<std::shared_ptr<GG::Texture>>& ClientUI::GetPrefixedTextures(
         try {
             if (fs::exists(*it) && !fs::is_directory(*it)) {
                 auto path_str = it->path().filename().string();
-                if (boost::algorithm::starts_with(path_str, prefix))
+                if (boost::algorithm::starts_with(path_str, prefix) && GG::GUI::IsSupportedTextureFilenameExtension(*it))
                     textures.emplace_back(std::move(path_str), m_app.GetTexture(*it, mipmap));
             }
         } catch (const fs::filesystem_error& e) {


### PR DESCRIPTION
Fixes #3571 