### PR TITLE
[fix][5627] Unstealth planets and ships when they shoot in combat

### DIFF
--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -1821,7 +1821,7 @@ namespace {
 
 
         // Create weapon fire events and mark attackers as visible to other battle participants
-        const auto attacks_this_bout = bout_event->weapon_firings.SubEvents(ALL_EMPIRES);
+        const auto attacks_this_bout = bout_event->weapons_platform_firings.SubEvents(ALL_EMPIRES);
         for (const auto* this_event : attacks_this_bout) {
             if (const auto* naked_fire_event = dynamic_cast<const WeaponFireEvent*>(this_event)) {
                 handle_attack_event(naked_fire_event);


### PR DESCRIPTION
fixes one part of #5627 - switches the events used for unstealthing from the fighter events to the platform events 

weapon_firings was only fighter attacks, which we do not need. seems the event split in 0cc818d0769 was not completely correct/introduced a regression.

we need only ships and planets to unstealth;
weapon_platform_firings is ships and planets

tested that this works for unstealthing planets.

This should be tested also with stealthed ships/if I am correct, unstealthing of ships does not work with master currently.
The combat log should be tested with fighters.