### PR TITLE
Fix unowned planet combat stealth problems

### DIFF
--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -1781,17 +1781,17 @@ namespace {
                     TraceLogger(combat) << "Pre-attack visibility of launching carrier id: " << attacker->ID()
                                         << " by empire: " << detector_empire_id << " was: " << initial_vis;
 
-                    if (initial_vis >= Visibility::VIS_BASIC_VISIBILITY)
+                    if (initial_vis >= Visibility::VIS_TARGETABLE_VISIBILITY)
                         continue;
 
-                    combat_info.empire_object_visibility[detector_empire_id].Set(attacker->ID(), Visibility::VIS_BASIC_VISIBILITY);
+                    combat_info.empire_object_visibility[detector_empire_id].Set(attacker->ID(), Visibility::VIS_TARGETABLE_VISIBILITY);
 
-                    DebugLogger(combat) << " ... Setting post-attack visability to " << Visibility::VIS_BASIC_VISIBILITY;
+                    DebugLogger(combat) << " ... Setting post-attack visability to " << Visibility::VIS_TARGETABLE_VISIBILITY;
 
                     // record visibility change event due to attack
                     // FIXME attacker, TARGET, attacker empire, target empire, visibility
                     stealth_change_event->AddEvent(attacker->ID(), attacker->Owner(), detector_empire_id,
-                                                   Visibility::VIS_BASIC_VISIBILITY);
+                                                   Visibility::VIS_TARGETABLE_VISIBILITY);
                 }
             }
         }
@@ -1806,16 +1806,16 @@ namespace {
                 TraceLogger(combat) << "Pre-attack visibility of attacker id: " << attack_event->attacker_id
                                     << " by empire: " << detector_empire_id << " was: " << initial_vis;
 
-                if (initial_vis >= Visibility::VIS_BASIC_VISIBILITY)
+                if (initial_vis >= Visibility::VIS_TARGETABLE_VISIBILITY)
                     continue;
 
-                combat_info.empire_object_visibility[detector_empire_id].Set(attack_event->attacker_id, Visibility::VIS_BASIC_VISIBILITY);
+                combat_info.empire_object_visibility[detector_empire_id].Set(attack_event->attacker_id, Visibility::VIS_TARGETABLE_VISIBILITY);
 
-                DebugLogger(combat) << " ... Setting post-attack visability to " << Visibility::VIS_BASIC_VISIBILITY;
+                DebugLogger(combat) << " ... Setting post-attack visability to " << Visibility::VIS_TARGETABLE_VISIBILITY;
 
                 // record visibility change event due to attack
                 stealth_change_event->AddEvent(attack_event->attacker_id, attack_event->target_id, attack_event->attacker_owner_id,
-                                               attack_event->target_owner_id, Visibility::VIS_BASIC_VISIBILITY);
+                                               attack_event->target_owner_id, Visibility::VIS_TARGETABLE_VISIBILITY);
             }
         };
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -11148,6 +11148,10 @@ VIS_BASIC_VISIBILITY
 Basic
 
 # Visibility levels
+VIS_TARGETABLE_VISIBILITY
+Targetable
+
+# Visibility levels
 VIS_PARTIAL_VISIBILITY
 Partial
 

--- a/parse/ConditionsPythonModuleParser.cpp
+++ b/parse/ConditionsPythonModuleParser.cpp
@@ -151,10 +151,16 @@ namespace {
         if (kw.has_key("turn"))
             throw std::runtime_error(std::string("Not implemented ") + __func__);
 
-        if (kw.has_key("visibility"))
-            throw std::runtime_error(std::string("Not implemented ") + __func__);
+        std::unique_ptr<ValueRef::ValueRef<Visibility>> visibility;
+        if (kw.has_key("visibility")) {
+            auto vis_arg = boost::python::extract<value_ref_wrapper<Visibility>>(kw["visibility"]);
+            if (vis_arg.check())
+                visibility = ValueRef::CloneUnique(vis_arg().value_ref);
+            else
+                visibility = std::make_unique<ValueRef::Constant<Visibility>>(boost::python::extract<enum_wrapper<Visibility>>(kw["visibility"])().value);
+        }
 
-        return make_wrapped<Condition::VisibleToEmpire>(std::move(empire));
+        return make_wrapped<Condition::VisibleToEmpire>(std::move(empire), /*since_turn*/ nullptr, std::move(visibility));
     }
 
     condition_wrapper insert_planet_(const boost::python::tuple& args, const boost::python::dict& kw) {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1312,6 +1312,7 @@ void EmpireAffiliation::Eval(const ScriptingContext& parent_context, ObjectSet& 
         EvalImpl(matches, non_matches, search_domain,
                  EmpireAffiliationSimpleMatch(empire_id, m_affiliation, parent_context));
     } else {
+
         // re-evaluate empire id for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
@@ -7481,7 +7482,7 @@ namespace {
                                    const ScriptingContext& context) :
             m_empire_id(empire_id),
             m_since_turn(since_turn),
-            m_vis(vis == Visibility::INVALID_VISIBILITY ? Visibility::VIS_BASIC_VISIBILITY : vis),
+            m_vis(vis == Visibility::INVALID_VISIBILITY ? Visibility::VIS_TARGETABLE_VISIBILITY : vis),
             m_context{context}
         {}
 
@@ -7540,8 +7541,7 @@ void VisibleToEmpire::Eval(const ScriptingContext& parent_context, ObjectSet& ma
         // evaluate empire id once, and use to check all candidate objects
         int empire_id = m_empire_id ? m_empire_id->Eval(parent_context) : ALL_EMPIRES;
         int since_turn = m_since_turn ? m_since_turn->Eval(parent_context) : INVALID_GAME_TURN;  // indicates current turn
-        Visibility vis = m_vis ? m_vis->Eval(parent_context) : Visibility::VIS_BASIC_VISIBILITY;
-
+        Visibility vis = m_vis ? m_vis->Eval(parent_context) : Visibility::VIS_TARGETABLE_VISIBILITY;
         // need to check visibility of each candidate object separately
         EvalImpl(matches, non_matches, search_domain,
                  VisibleToEmpireSimpleMatch(empire_id, since_turn, vis, parent_context));

--- a/universe/Planet.cpp
+++ b/universe/Planet.cpp
@@ -111,13 +111,15 @@ void Planet::Copy(const Planet& copied_planet, const Universe& universe, int emp
         this->m_turn_last_colonized =       copied_planet.m_turn_last_colonized;
         this->m_turn_last_annexed =         copied_planet.m_turn_last_annexed;
 
+        if (vis >= Visibility::VIS_TARGETABLE_VISIBILITY) {
+            this->m_last_turn_attacked_by_ship = copied_planet.m_last_turn_attacked_by_ship;
+        }
         if (vis >= Visibility::VIS_PARTIAL_VISIBILITY) {
             this->m_species_name =                          copied_planet.m_species_name;
             this->m_focus =                                 copied_planet.m_focus;
             this->m_last_turn_focus_changed =               copied_planet.m_last_turn_focus_changed;
             this->m_focus_turn_initial =                    copied_planet.m_focus_turn_initial;
             this->m_last_turn_focus_changed_turn_initial =  copied_planet.m_last_turn_focus_changed_turn_initial;
-            this->m_last_turn_attacked_by_ship =            copied_planet.m_last_turn_attacked_by_ship;
             this->m_ordered_annexed_by_empire_id =          copied_planet.m_ordered_annexed_by_empire_id;
             this->m_is_about_to_be_colonized =              copied_planet.m_is_about_to_be_colonized;
             this->m_is_about_to_be_invaded =                copied_planet.m_is_about_to_be_invaded;

--- a/universe/Planet.cpp
+++ b/universe/Planet.cpp
@@ -113,30 +113,31 @@ void Planet::Copy(const Planet& copied_planet, const Universe& universe, int emp
 
         if (vis >= Visibility::VIS_TARGETABLE_VISIBILITY) {
             this->m_last_turn_attacked_by_ship = copied_planet.m_last_turn_attacked_by_ship;
-        }
-        if (vis >= Visibility::VIS_PARTIAL_VISIBILITY) {
-            this->m_species_name =                          copied_planet.m_species_name;
-            this->m_focus =                                 copied_planet.m_focus;
-            this->m_last_turn_focus_changed =               copied_planet.m_last_turn_focus_changed;
-            this->m_focus_turn_initial =                    copied_planet.m_focus_turn_initial;
-            this->m_last_turn_focus_changed_turn_initial =  copied_planet.m_last_turn_focus_changed_turn_initial;
-            this->m_ordered_annexed_by_empire_id =          copied_planet.m_ordered_annexed_by_empire_id;
-            this->m_is_about_to_be_colonized =              copied_planet.m_is_about_to_be_colonized;
-            this->m_is_about_to_be_invaded =                copied_planet.m_is_about_to_be_invaded;
-            this->m_is_about_to_be_bombarded =              copied_planet.m_is_about_to_be_bombarded;
-            this->m_owner_before_last_conquered =           copied_planet.m_owner_before_last_conquered;
-            this->m_last_invaded_by_empire_id =             copied_planet.m_last_invaded_by_empire_id;
-            this->m_last_colonized_by_empire_id =           copied_planet.m_last_colonized_by_empire_id;
-            this->m_last_annexed_by_empire_id =             copied_planet.m_last_annexed_by_empire_id;
 
-            if (vis >= Visibility::VIS_FULL_VISIBILITY) {
-                this->m_ordered_given_to_empire_id = copied_planet.m_ordered_given_to_empire_id;
+            if (vis >= Visibility::VIS_PARTIAL_VISIBILITY) {
+                this->m_species_name =                          copied_planet.m_species_name;
+                this->m_focus =                                 copied_planet.m_focus;
+                this->m_last_turn_focus_changed =               copied_planet.m_last_turn_focus_changed;
+                this->m_focus_turn_initial =                    copied_planet.m_focus_turn_initial;
+                this->m_last_turn_focus_changed_turn_initial =  copied_planet.m_last_turn_focus_changed_turn_initial;
+                this->m_ordered_annexed_by_empire_id =          copied_planet.m_ordered_annexed_by_empire_id;
+                this->m_is_about_to_be_colonized =              copied_planet.m_is_about_to_be_colonized;
+                this->m_is_about_to_be_invaded =                copied_planet.m_is_about_to_be_invaded;
+                this->m_is_about_to_be_bombarded =              copied_planet.m_is_about_to_be_bombarded;
+                this->m_owner_before_last_conquered =           copied_planet.m_owner_before_last_conquered;
+                this->m_last_invaded_by_empire_id =             copied_planet.m_last_invaded_by_empire_id;
+                this->m_last_colonized_by_empire_id =           copied_planet.m_last_colonized_by_empire_id;
+                this->m_last_annexed_by_empire_id =             copied_planet.m_last_annexed_by_empire_id;
 
-            } else {
-                // copy system name if at partial visibility, as it won't be copied
-                // by UniverseObject::Copy unless at full visibility, but players
-                // should know planet names even if they don't own the planet
-                m_name = copied_planet.Name();
+                if (vis >= Visibility::VIS_FULL_VISIBILITY) {
+                    this->m_ordered_given_to_empire_id = copied_planet.m_ordered_given_to_empire_id;
+
+                } else {
+                    // copy system name if at partial visibility, as it won't be copied
+                    // by UniverseObject::Copy unless at full visibility, but players
+                    // should know planet names even if they don't own the planet
+                    m_name = copied_planet.Name();
+                }
             }
         }
     }

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2695,22 +2695,30 @@ namespace {
 
     auto GetBestNeutralDetectionAtSystems(const ObjectMap& objects) {
         // determine neutral / monster detection strengths at each system, which is
-        // the highest detection strength of unowned ships at each
+        // the highest detection strength of unowned ships or planets at that system
 
-        static constexpr auto is_unowned_ship_in_system = [](const Ship* ship) noexcept
+        static constexpr auto is_unowned_actor_in_system = [](const UniverseObject* ship) noexcept
         { return ship && ship->Unowned() && ship->SystemID() != INVALID_OBJECT_ID; };
 
-        const auto neutral_ships_in_systems = objects.findRaw<Ship>(is_unowned_ship_in_system);
+        const auto neutral_ships_in_systems = objects.findRaw<Ship>(is_unowned_actor_in_system);
+        const auto neutral_planets_in_systems = objects.findRaw<Planet>(is_unowned_actor_in_system);
 
-        static constexpr auto to_system_id_and_ship_detection = [](const Ship* ship) noexcept
+        static constexpr auto to_system_id_and_ship_detection = [](const UniverseObject* ship) noexcept
         { return std::pair{ship->SystemID(), ship->GetMeter(MeterType::METER_DETECTION)->Initial()}; };
 
+        // c++26 ranges::view::concat(neutral_ships_in_systems, neutral_planets_in_systems)
         auto neutral_ship_systems_detections = neutral_ships_in_systems
+            | range_transform(to_system_id_and_ship_detection);
+        auto neutral_planet_systems_detections = neutral_planets_in_systems
             | range_transform(to_system_id_and_ship_detection);
 
         std::map<int, float> best_neutral_detection_strengths_at_systems;
 
         for (const auto [sys_id, det] : neutral_ship_systems_detections) {
+            auto& best_det = best_neutral_detection_strengths_at_systems[sys_id];
+            best_det = std::max(best_det, det);
+        }
+        for (const auto [sys_id, det] : neutral_planet_systems_detections) {
             auto& best_det = best_neutral_detection_strengths_at_systems[sys_id];
             best_det = std::max(best_det, det);
         }

--- a/universe/Visibility.h
+++ b/universe/Visibility.h
@@ -18,6 +18,7 @@ FO_ENUM(
     ((INVALID_VISIBILITY, -1))
     ((VIS_NO_VISIBILITY))
     ((VIS_BASIC_VISIBILITY))
+    ((VIS_TARGETABLE_VISIBILITY))
     ((VIS_PARTIAL_VISIBILITY))
     ((VIS_FULL_VISIBILITY))
     ((NUM_VISIBILITIES))
@@ -86,6 +87,7 @@ using EmpireObjectVisibilityMap = std::map<int, Visibilities>; ///< map from emp
 struct ObjVisTurns {
     int obj_id = INVALID_OBJECT_ID;
     int basic = INVALID_GAME_TURN;
+    int targetable = INVALID_GAME_TURN;
     int partial = INVALID_GAME_TURN;
     int full = INVALID_GAME_TURN;
 
@@ -93,12 +95,13 @@ struct ObjVisTurns {
     constexpr explicit ObjVisTurns(int obj_id_) noexcept :
         obj_id(obj_id_)
     {}
-    constexpr ObjVisTurns(int obj_id_, int basic_turn, int partial_turn, int full_turn) noexcept :
-        obj_id(obj_id_), basic(basic_turn), partial(partial_turn), full(full_turn)
+    constexpr ObjVisTurns(int obj_id_, int basic_turn, int targetable_turn, int partial_turn, int full_turn) noexcept :
+        obj_id(obj_id_), basic(basic_turn), targetable(targetable_turn), partial(partial_turn), full(full_turn)
     {}
     constexpr ObjVisTurns(int obj_id_, Visibility vis, int turn) noexcept :
         obj_id(obj_id_),
         basic(vis >= Visibility::VIS_BASIC_VISIBILITY ? turn : INVALID_GAME_TURN),
+        targetable(vis >= Visibility::VIS_TARGETABLE_VISIBILITY ? turn : INVALID_GAME_TURN),
         partial(vis >= Visibility::VIS_PARTIAL_VISIBILITY ? turn : INVALID_GAME_TURN),
         full(vis >= Visibility::VIS_FULL_VISIBILITY ? turn : INVALID_GAME_TURN)
     {}
@@ -110,6 +113,7 @@ struct ObjVisTurns {
         switch (vis) {
         case Visibility::VIS_FULL_VISIBILITY:    return full;
         case Visibility::VIS_PARTIAL_VISIBILITY: return partial;
+        case Visibility::VIS_TARGETABLE_VISIBILITY: return targetable;
         default:                                 return basic;
         }
     }
@@ -117,6 +121,7 @@ struct ObjVisTurns {
         switch (vis) {
         case Visibility::VIS_FULL_VISIBILITY:    return full;
         case Visibility::VIS_PARTIAL_VISIBILITY: return partial;
+        case Visibility::VIS_TARGETABLE_VISIBILITY: return targetable;
         default:                                 return basic;
         }
     }
@@ -129,6 +134,7 @@ struct ObjVisTurns {
         switch (vis) {
         case Visibility::VIS_FULL_VISIBILITY:    full = std::max(full, turn); [[fallthrough]];
         case Visibility::VIS_PARTIAL_VISIBILITY: partial = std::max(partial, turn); [[fallthrough]];
+        case Visibility::VIS_TARGETABLE_VISIBILITY: targetable = std::max(targetable, turn); [[fallthrough]];
         case Visibility::VIS_BASIC_VISIBILITY:   basic = std::max(basic, turn); break;
         default: break;
         }

--- a/util/SerializeCombat.cpp
+++ b/util/SerializeCombat.cpp
@@ -378,6 +378,7 @@ namespace {
         switch (vis) {
         case Visibility::VIS_FULL_VISIBILITY:    return "f"; break;
         case Visibility::VIS_PARTIAL_VISIBILITY: return "p"; break;
+        case Visibility::VIS_TARGETABLE_VISIBILITY: return "t"; break;
         case Visibility::VIS_BASIC_VISIBILITY:   return "b"; break;
         default:                                 return "x";
         }
@@ -387,6 +388,7 @@ namespace {
         switch (c) {
         case 'f': return Visibility::VIS_FULL_VISIBILITY;    break;
         case 'p': return Visibility::VIS_PARTIAL_VISIBILITY; break;
+        case 't': return Visibility::VIS_TARGETABLE_VISIBILITY; break;
         case 'b': return Visibility::VIS_BASIC_VISIBILITY;   break;
         default:  return Visibility::VIS_NO_VISIBILITY;
         }

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -38,7 +38,7 @@
 
 BOOST_CLASS_EXPORT(Field)
 BOOST_CLASS_EXPORT(Universe)
-BOOST_CLASS_VERSION(Universe, 5)
+BOOST_CLASS_VERSION(Universe, 6)
 
 namespace {
 #if defined(__cpp_lib_to_chars) && defined(__cpp_lib_constexpr_charconv)
@@ -148,6 +148,7 @@ namespace {
         for (const auto& ovt : data) {
             retval.append("  ").append(std::to_string(ovt.obj_id));
             append_turn_or_x(ovt.basic);
+            append_turn_or_x(ovt.targetable);
             append_turn_or_x(ovt.partial);
             append_turn_or_x(ovt.full);
         }
@@ -155,6 +156,9 @@ namespace {
         return retval;
     }
 
+    /* returns a vector which contains the turn for each visibility,
+       created from a string with object id and the turn numbers.
+       garbage in may return garbage. */
     CONSTEXPR_VEC_AND_FROMCHARS auto ToObjVisTurnsVec(std::string_view buffer) {
         std::vector<ObjVisTurns> retval;
 
@@ -212,6 +216,7 @@ namespace {
         for (std::size_t idx = 0; idx < static_cast<std::size_t>(count) && next != buffer_end; ++idx) {
             int obj_id = INVALID_OBJECT_ID;
             int basic_turn = INVALID_GAME_TURN;
+            int targetable_turn = INVALID_GAME_TURN;
             int partial_turn = INVALID_GAME_TURN;
             int full_turn = INVALID_GAME_TURN;
 
@@ -221,6 +226,9 @@ namespace {
             std::tie(basic_turn, success, next) = get_int_from_chars(next, INVALID_GAME_TURN);
             if (!success)
                 break;
+            std::tie(targetable_turn, success, next) = get_int_from_chars(next, INVALID_GAME_TURN);
+            if (!success)
+                break;
             std::tie(partial_turn, success, next) = get_int_from_chars(next, INVALID_GAME_TURN);
             if (!success)
                 break;
@@ -228,7 +236,7 @@ namespace {
             if (!success)
                 break;
 
-            retval.emplace_back(obj_id, basic_turn, partial_turn, full_turn);
+            retval.emplace_back(obj_id, basic_turn, targetable_turn, partial_turn, full_turn);
         }
 
         return retval;
@@ -240,18 +248,18 @@ namespace {
     static_assert(ToObjVisTurnsVec("0  ").empty());
     static_assert(ToObjVisTurnsVec("0 1 2 3 4").empty());
     static_assert(ToObjVisTurnsVec("1 -1  ").empty());
-    static_assert(ToObjVisTurnsVec("1 -1 2 x 4").size() == 1);
-    static_assert(ToObjVisTurnsVec("3 x x x x x x x x x x x x").size() == 3);
-    static_assert(ToObjVisTurnsVec("1  x   x  x xxx").size() == 1);
-    static_assert(ToObjVisTurnsVec("1 -1 2 3 4  ").size() == 1);
+    static_assert(ToObjVisTurnsVec("1 -1 2 x 4 5").size() == 1);
+    static_assert(ToObjVisTurnsVec("3 x x x x x x x x x x x x x x x").size() == 3);
+    static_assert(ToObjVisTurnsVec("1  x   x  x x xxx").size() == 1);
+    static_assert(ToObjVisTurnsVec("1 -1 2 3 4 5  ").size() == 1);
     static_assert(ToObjVisTurnsVec("  9999 -1 2 3 4 5").size() == 1);
-    static_assert(ToObjVisTurnsVec("99999  -1 2 3 4  99 98 97 96").back() == ObjVisTurns{99, 0, 0, 0}); // only first param (id) is checked
+    static_assert(ToObjVisTurnsVec("99999  -1 2 3 4 5  99 98 97 96 95").back() == ObjVisTurns{99, 0, 0, 0, 0}); // only first param (id) is checked
     static_assert([]() {
-        const auto vec = ToObjVisTurnsVec("  3  x x x 4  x x x x  x 10 11 x  ");
+        const auto vec = ToObjVisTurnsVec("  3  x x x x 5  x x x x x  x 10 11 12 x  ");
         return vec.size() == 3 &&
-               vec.front()[Visibility::VIS_FULL_VISIBILITY] == 4 &&
+               vec.front()[Visibility::VIS_FULL_VISIBILITY] == 5 &&
                vec.back()[Visibility::INVALID_VISIBILITY] == 10 &&
-               vec.back().partial == 11 &&
+               vec.back().partial == 12 &&
                vec.back().obj_id == INVALID_OBJECT_ID;
     }());
 #endif
@@ -279,12 +287,14 @@ namespace {
     template <typename Archive>
     void Serialize(Archive& ar, EmpireObjectVisibilityTurnsVecMap& eovtm, unsigned int const universe_version)
     {
+        bool do_serialize = true;
         if (Archive::is_loading::value && universe_version < 4) {
             using OldVisibilityTurnMap = std::map<Visibility, int>;
             using OldObjectVisibilityTurnMap = std::map<int, OldVisibilityTurnMap>;
             using OldEmpireObjectVisibilityTurnMap = std::map<int, OldObjectVisibilityTurnMap>;
             OldEmpireObjectVisibilityTurnMap scratch;
             ar & boost::serialization::make_nvp("empire_object_visibility_turns", scratch);
+            do_serialize = false;
 
             // copy to eovtm
             for (auto& [eid, old_ovtm] : scratch) {
@@ -295,9 +305,21 @@ namespace {
                         ovtm.SetVisTurnsCascade(vis, turn);
                 }
             }
-        } else {
-            Serialize(ar, eovtm);
         }
+        if (Archive::is_loading::value && universe_version <= 5) {
+            // VIS_TARGETABLE_VISIBILITY got inserted as third int into the struct
+            for (auto& [eid, ovt_vec] : eovtm) {
+                for (auto& ovtm : ovt_vec) {
+                  ovtm.full = ovtm.partial;
+                  ovtm.partial = ovtm.targetable;
+                  // combat unstealth meant basic visibility; use it for targetable
+                  ovtm.targetable = ovtm.basic;
+                  // ovtm.basic // no change
+                }
+            }
+        }
+        if (do_serialize)
+            Serialize(ar, eovtm);
     }
 }
 
@@ -365,6 +387,7 @@ void serialize(Archive& ar, ObjVisTurns& ovtm, unsigned int const)
 {
     ar  & boost::serialization::make_nvp("obj_id", ovtm.obj_id)
         & boost::serialization::make_nvp("basic", ovtm.basic)
+        & boost::serialization::make_nvp("targetable", ovtm.partial)
         & boost::serialization::make_nvp("partial", ovtm.partial)
         & boost::serialization::make_nvp("full", ovtm.full);
 }


### PR DESCRIPTION
Fixes some combat problems especially with stealthed planets.

Changes the planetary targeting condition to not completely rely on the VisibleTo empire condition, where we have some intel that it does not always work as intended; imperial ships were not visible to the unowned planet, but the stealth did not exceed the detection. This is a workaround; probably there should be a round of analysis before battle which adds imperial ships to the visibility map of unowned if there is a unowned ship or planet which is able to detect the imperial ships (maybe this exists and is broken).

Adds a new VIS_TARGETABLE_VISIBILITY between basic and partial. So now stealthed planets can have basic visibility without being targetable. Before, imperial ships could attack stealthed unowned planets.

Also adds support for the visibility keyword in VisibleTo Empire condition.