### PR TITLE
tweak MSVC version checks for constexpr inheritance support

### DIFF
--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -2994,7 +2994,7 @@ std::unique_ptr<Condition> CreatedOnTurn::Clone() const {
 // Contains                                              //
 ///////////////////////////////////////////////////////////
 namespace StaticTests {
-#if defined(__cpp_lib_constexpr_vector) && (!defined(_MSC_VER) || (_MSC_VER >= 1942 && _MSC_FULL_VER <= 194434810)) && (!defined(__clang_major__) || (__clang_major__ >= 15)) && (!defined(__GNUC__) || (__GNUC__ > 12))
+#if defined(__cpp_lib_constexpr_vector) && (!defined(_MSC_VER) || ((_MSC_VER >= 1942 && _MSC_VER != 1944) || _MSC_VER >= 1950)) && (!defined(__clang_major__) || (__clang_major__ >= 15)) && (!defined(__GNUC__) || (__GNUC__ > 12))
     struct ContainerTestObj : public UniverseObjectCXBase {
         std::vector<int> contained_ids;
         constexpr explicit ContainerTestObj(std::vector<int> contained_ids_ = {}, int this_id = 2) :


### PR DESCRIPTION
A few versions of the MSVC compiler failed on inheritance in constexpr evaluation. Newer versions seem to fix it.

https://godbolt.org/z/bqb3f59cj