### PR TITLE
Fix checksum evaluation and PlanetType condition in FOCS Python parser

### DIFF
--- a/parse/ConditionsPythonModuleParser.cpp
+++ b/parse/ConditionsPythonModuleParser.cpp
@@ -148,10 +148,14 @@ namespace {
                     types.push_back(std::move(constant));
                 }
             }
-            if (have_refs)
+            if (have_refs) {
                 return make_wrapped<Condition::PlanetType<>>(std::move(types));
-            else // have only constants
-                return make_wrapped<Condition::PlanetType<::PlanetType>>(std::move(type_vals));
+            } else { // have only constants
+                if (type_vals.size() == 1)
+                    return make_wrapped<Condition::PlanetType<::PlanetType, 1>>(std::move(type_vals[0]));
+                else
+                    return make_wrapped<Condition::PlanetType<::PlanetType>>(std::move(type_vals));
+            }
 
         } else if (kw.has_key("size")) {
             std::vector<std::unique_ptr<ValueRef::ValueRef< ::PlanetSize>>> sizes;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -10881,13 +10881,13 @@ namespace StaticTests {
 
     constexpr auto pt_cx = PlanetType{::PlanetType::PT_INFERNO};
     constexpr auto pt_cx_cs = pt_cx.GetCheckSum();
-    static_assert(pt_cx_cs == 2114u);
+    static_assert(pt_cx_cs == 2115u);
     static_assert(pt_cx.GetDefaultInitialCandidateObjectTypes() == ::Condition::Impl::MatchesType::PLANETS_BUILDINGS);
 
     constexpr auto contains_pt_cx0 = Contains{PlanetType{::PlanetType::PT_OCEAN}};
     constexpr auto contains_pt_cx1 = Contains<PlanetType<::PlanetType, 1>>{::PlanetType::PT_OCEAN};
     constexpr auto ct_pt_cx1_cs = contains_pt_cx1.GetCheckSum();
-    static_assert(ct_pt_cx1_cs == 4021u);
+    static_assert(ct_pt_cx1_cs == 4022u);
     static_assert(contains_pt_cx0 == contains_pt_cx1);
     static_assert(contains_pt_cx0.GetDefaultInitialCandidateObjectTypes() == ::Condition::Impl::MatchesType::PLANETS_SYSTEMS);
 

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1822,7 +1822,7 @@ public:
                                             [](const auto& e) { return e->LocalCandidateInvariant(); }))
     {}
     constexpr explicit PlanetType(::PlanetType type) requires ((N == 1) && have_pt_values) :
-        PlanetTypeBase(true, true, true, CheckSums::GetCheckSum("Condition::PlanetType", type)),
+        PlanetTypeBase(true, true, true, CheckSums::GetCheckSum("Condition::PlanetType", type, 1u)),
         m_types(type)
     {}
     CONSTEXPR_VEC explicit PlanetType(std::vector<::PlanetType> types) requires ((N == 0) && have_pt_values) :


### PR DESCRIPTION
Single constant have same semantic, evaluation and checksum as array/vector of single constant.