### PR TITLE
Manage if InitDir copies Python library in Godot Android

### DIFF
--- a/client/godot/FreeOrionNode.cpp
+++ b/client/godot/FreeOrionNode.cpp
@@ -106,7 +106,8 @@ FreeOrionNode::~FreeOrionNode()
 void FreeOrionNode::_init() {
 #if defined(FREEORION_ANDROID)
     SetAndroidEnvironment(s_android_api_struct->godot_android_get_env(),
-                          s_android_api_struct->godot_android_get_activity());
+                          s_android_api_struct->godot_android_get_activity(),
+                          true);
 #endif
     std::string executable_path = godot::OS::get_singleton()->get_executable_path().utf8().get_data();
 

--- a/client/godot4/cgmain.cpp
+++ b/client/godot4/cgmain.cpp
@@ -39,7 +39,7 @@ extern "C" GDExtensionBool GDE_EXPORT freeorion_library_init(GDExtensionInterfac
 #ifdef FREEORION_ANDROID
 // Called by org.freeorion.godot.FreeOrionPlugin#setAndroidActivity native function
 extern "C" JNIEXPORT void JNICALL
-Java_org_freeorion_godot_FreeOrionPlugin_setAndroidActivity(JNIEnv* env, jclass /*cls*/, jobject activity) {
-    SetAndroidEnvironment(env, activity);
+Java_org_freeorion_godot_FreeOrionPlugin_setAndroidActivity(JNIEnv* env, jclass, jobject activity) {
+    SetAndroidEnvironment(env, activity, true);
 }
 #endif

--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -75,6 +75,7 @@ namespace {
     AAssetManager* s_asset_manager;
     jobject        s_jni_asset_manager;
     JavaVM*        s_java_vm;
+    bool           s_copy_python_lib;
 
 #define PYTHON_LIB_PATH "lib/python" BOOST_PP_STRINGIZE(BOOST_PP_CAT(PY_MAJOR_VERSION, PY_MINOR_VERSION)) ".zip"
 
@@ -502,8 +503,10 @@ void InitDirs(std::string const& argv0, bool test)
     RedirectOutputLogAndroid(ANDROID_LOG_INFO, "stdout", 1);
 
     s_python_home = s_cache_dir / "python";
-    fs::create_directories(s_python_home / "lib");
-    CopyInitialResourceAndroid(PYTHON_LIB_PATH);
+    if (s_copy_python_lib) {
+        fs::create_directories(s_python_home / "lib");
+        CopyInitialResourceAndroid(PYTHON_LIB_PATH);
+    }
 #endif
 
     g_initialized = true;
@@ -611,11 +614,12 @@ auto GetPythonHome() -> fs::path const
 #endif
 
 #if defined(FREEORION_ANDROID)
-void SetAndroidEnvironment(JNIEnv* env, jobject activity)
+void SetAndroidEnvironment(JNIEnv* env, jobject activity, bool copy_python_lib)
 {
     s_jni_env = env;
     s_jni_env->GetJavaVM(&s_java_vm);
     s_activity = env->NewWeakGlobalRef(activity);
+    s_copy_python_lib = copy_python_lib;
 }
 
 std::string GetAndroidLang()

--- a/util/Directories.h
+++ b/util/Directories.h
@@ -157,7 +157,7 @@ FO_COMMON_API auto GetPythonHome() -> std::filesystem::path const;
 
 #if defined(FREEORION_ANDROID)
 //! Sets android environment to access directories
-FO_COMMON_API void SetAndroidEnvironment(JNIEnv* env, jobject activity);
+FO_COMMON_API void SetAndroidEnvironment(JNIEnv* env, jobject activity, bool copy_python_lib);
 
 //! Gets locale language from android anvironment
 FO_COMMON_API std::string GetAndroidLang();


### PR DESCRIPTION
Will be false for the server and AI, as Godot extension will copy it on start.