### PR TITLE
Fix 20% adjustment of outpost cost

### DIFF
--- a/default/scripting/buildings/colonies/col_bld_gen.focs.py
+++ b/default/scripting/buildings/colonies/col_bld_gen.focs.py
@@ -81,10 +81,10 @@ colony_gamerule_default = ""
 species_colony_gamerules = {"SP_SUPER_TEST": "RULE_ENABLE_SUPER_TESTER"}
 
 # default base buildcost
-buildcost_default = 50
+buildcost_default = 60
 
 # Species specific overrides to base buildcost
-species_buildcost = {"SP_EXOBOT": 60}
+species_buildcost = {"SP_EXOBOT": 70}
 
 # default buildtime factor
 buildtime_factor_default = 1.0

--- a/default/scripting/ship_parts/Colony/CO_COLONY_POD.focs.txt
+++ b/default/scripting/ship_parts/Colony/CO_COLONY_POD.focs.txt
@@ -4,7 +4,7 @@ Part
     class = Colony
     capacity = 1
     mountableSlotTypes = Internal
-    buildcost = 130 * [[COLONY_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]] * [[COLONIZATION_POLICY_MULTIPLIER]]
+    buildcost = 120 * [[COLONY_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]] * [[COLONIZATION_POLICY_MULTIPLIER]]
     buildtime = 8
     tags = [ "PEDIA_PC_COLONY" ]
     location = And [

--- a/default/scripting/ship_parts/Colony/CO_SUPEND_ANIM_POD.focs.txt
+++ b/default/scripting/ship_parts/Colony/CO_SUPEND_ANIM_POD.focs.txt
@@ -4,7 +4,7 @@ Part
     class = Colony
     capacity = [[MIN_RECOLONIZING_SIZE]]
     mountableSlotTypes = Internal
-    buildcost = 130 * [[COLONY_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]] * [[COLONIZATION_POLICY_MULTIPLIER]]
+    buildcost = 120 * [[COLONY_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]] * [[COLONIZATION_POLICY_MULTIPLIER]]
     buildtime = 10
     tags = [ "PEDIA_PC_COLONY" ]
     location = And [


### PR DESCRIPTION
fixes c4c7847dbae5e5cf1c6ea6f99700c1402a361acf, which should have decreased outpost cost while keeping the colonisation cost.

The commit increased the colony ship parts (which this one reverses) while not increasing the colony building cost.

[forum discussion](https://freeorion.org/forum/viewtopic.php?p=124065#p124065)